### PR TITLE
Improve testing for typeclasses laws

### DIFF
--- a/Bow.xcodeproj/project.pbxproj
+++ b/Bow.xcodeproj/project.pbxproj
@@ -1037,10 +1037,10 @@
 		8BA0F38E217E2DEF00969984 /* Arrow */ = {
 			isa = PBXGroup;
 			children = (
-				8BA0F38F217E2DEF00969984 /* Function1Test.swift */,
 				8BA0F390217E2DEF00969984 /* Function0Test.swift */,
-				8BA0F391217E2DEF00969984 /* KleisliTest.swift */,
+				8BA0F38F217E2DEF00969984 /* Function1Test.swift */,
 				8BA0F392217E2DEF00969984 /* KleisliOperatorTest.swift */,
+				8BA0F391217E2DEF00969984 /* KleisliTest.swift */,
 			);
 			path = Arrow;
 			sourceTree = "<group>";
@@ -1048,10 +1048,10 @@
 		8BA0F394217E2DEF00969984 /* Transformers */ = {
 			isa = PBXGroup;
 			children = (
-				8BA0F395217E2DEF00969984 /* WriterTTest.swift */,
-				8BA0F396217E2DEF00969984 /* StateTTest.swift */,
 				8BA0F397217E2DEF00969984 /* EitherTTest.swift */,
 				8BA0F398217E2DEF00969984 /* OptionTTest.swift */,
+				8BA0F396217E2DEF00969984 /* StateTTest.swift */,
+				8BA0F395217E2DEF00969984 /* WriterTTest.swift */,
 			);
 			path = Transformers;
 			sourceTree = "<group>";
@@ -1060,8 +1060,8 @@
 			isa = PBXGroup;
 			children = (
 				8BA0F39A217E2DEF00969984 /* BoolInstancesTest.swift */,
-				8BA0F39B217E2DEF00969984 /* StringInstancesTest.swift */,
 				8BA0F39C217E2DEF00969984 /* NumberInstancesTest.swift */,
+				8BA0F39B217E2DEF00969984 /* StringInstancesTest.swift */,
 			);
 			path = Instances;
 			sourceTree = "<group>";
@@ -1069,10 +1069,10 @@
 		8BA0F39D217E2DEF00969984 /* Effects */ = {
 			isa = PBXGroup;
 			children = (
-				8BA0F39E217E2DEF00969984 /* BrightFutures */,
 				8BA0F3A0217E2DEF00969984 /* IOTest.swift */,
-				8BA0F3A1217E2DEF00969984 /* Typeclasses */,
+				8BA0F39E217E2DEF00969984 /* BrightFutures */,
 				8BA0F3A3217E2DEF00969984 /* Rx */,
+				8BA0F3A1217E2DEF00969984 /* Typeclasses */,
 			);
 			path = Effects;
 			sourceTree = "<group>";
@@ -1096,8 +1096,8 @@
 		8BA0F3A3217E2DEF00969984 /* Rx */ = {
 			isa = PBXGroup;
 			children = (
-				8BA0F3A4217E2DEF00969984 /* ObservableKTest.swift */,
 				8BA0F3A5217E2DEF00969984 /* MaybeKTest.swift */,
+				8BA0F3A4217E2DEF00969984 /* ObservableKTest.swift */,
 				8BA0F3A6217E2DEF00969984 /* SingleKTest.swift */,
 			);
 			path = Rx;
@@ -1106,23 +1106,23 @@
 		8BA0F3A8217E2DEF00969984 /* Data */ = {
 			isa = PBXGroup;
 			children = (
+				8BA0F3B9217E2DEF00969984 /* ConstTest.swift */,
 				8BA0F3A9217E2DEF00969984 /* CoproductTest.swift */,
-				8BA0F3AA217E2DEF00969984 /* MooreTest.swift */,
+				8BA0F3B7217E2DEF00969984 /* DayTest.swift */,
 				8BA0F3AB217E2DEF00969984 /* EitherTest.swift */,
-				8BA0F3AC217E2DEF00969984 /* SetKTest.swift */,
-				8BA0F3AD217E2DEF00969984 /* SumTest.swift */,
-				8BA0F3AE217E2DEF00969984 /* TupleTest.swift */,
 				8BA0F3AF217E2DEF00969984 /* EvalTest.swift */,
 				8BA0F3B0217E2DEF00969984 /* IdTest.swift */,
-				8BA0F3B1217E2DEF00969984 /* StoreTest.swift */,
 				8BA0F3B2217E2DEF00969984 /* IorTest.swift */,
-				8BA0F3B3217E2DEF00969984 /* ValidatedTest.swift */,
-				8BA0F3B4217E2DEF00969984 /* TryTest.swift */,
-				8BA0F3B5217E2DEF00969984 /* OptionTest.swift */,
 				8BA0F3B6217E2DEF00969984 /* ListKTest.swift */,
-				8BA0F3B7217E2DEF00969984 /* DayTest.swift */,
+				8BA0F3AA217E2DEF00969984 /* MooreTest.swift */,
 				8BA0F3B8217E2DEF00969984 /* NonEmptyListTest.swift */,
-				8BA0F3B9217E2DEF00969984 /* ConstTest.swift */,
+				8BA0F3B5217E2DEF00969984 /* OptionTest.swift */,
+				8BA0F3AC217E2DEF00969984 /* SetKTest.swift */,
+				8BA0F3B1217E2DEF00969984 /* StoreTest.swift */,
+				8BA0F3AD217E2DEF00969984 /* SumTest.swift */,
+				8BA0F3B4217E2DEF00969984 /* TryTest.swift */,
+				8BA0F3AE217E2DEF00969984 /* TupleTest.swift */,
+				8BA0F3B3217E2DEF00969984 /* ValidatedTest.swift */,
 			);
 			path = Data;
 			sourceTree = "<group>";
@@ -1130,34 +1130,34 @@
 		8BA0F3BA217E2DEF00969984 /* Typeclasses */ = {
 			isa = PBXGroup;
 			children = (
-				8BA0F3BB217E2DEF00969984 /* TraverseLaws.swift */,
-				8BA0F3BC217E2DEF00969984 /* MonadErrorLaws.swift */,
-				8BA0F3BD217E2DEF00969984 /* MonoidLaws.swift */,
-				8BA0F3BE217E2DEF00969984 /* SemigroupLaws.swift */,
-				8BA0F3BF217E2DEF00969984 /* EqLaws.swift */,
-				8BA0F3C0217E2DEF00969984 /* MonadLaws.swift */,
-				8BA0F3C1217E2DEF00969984 /* FunctorFilterLaws.swift */,
-				8BA0F3C2217E2DEF00969984 /* OrderLaws.swift */,
-				8BA0F3C3217E2DEF00969984 /* BifunctorLaws.swift */,
-				8BA0F3C4217E2DEF00969984 /* ApplicativeErrorLaws.swift */,
-				8BA0F3C5217E2DEF00969984 /* MonadWriterLaws.swift */,
 				8BA0F3C6217E2DEF00969984 /* AlternativeLaws.swift */,
-				8BA0F3C7217E2DEF00969984 /* MonadFilterLaws.swift */,
-				8BA0F3C8217E2DEF00969984 /* ProfunctorLaws.swift */,
-				8BA0F3C9217E2DEF00969984 /* ContravariantLaws.swift */,
-				8BA0F3CA217E2DEF00969984 /* BimonadLaws.swift */,
-				8BA0F3CB217E2DEF00969984 /* MonadStateLaws.swift */,
-				8BA0F3CC217E2DEF00969984 /* FunctorLaws.swift */,
-				8BA0F3CD217E2DEF00969984 /* MonadCombineLaws.swift */,
+				8BA0F3C4217E2DEF00969984 /* ApplicativeErrorLaws.swift */,
 				8BA0F3CE217E2DEF00969984 /* ApplicativeLaws.swift */,
-				8BA0F3CF217E2DEF00969984 /* SemigroupKLaws.swift */,
+				8BA0F3C3217E2DEF00969984 /* BifunctorLaws.swift */,
+				8BA0F3CA217E2DEF00969984 /* BimonadLaws.swift */,
 				8BA0F3D0217E2DEF00969984 /* CategoryLaws.swift */,
-				8BA0F3D1217E2DEF00969984 /* ShowLaws.swift */,
 				8BA0F3D2217E2DEF00969984 /* ComonadLaws.swift */,
-				8BA0F3D3217E2DEF00969984 /* TraverseFilterLaws.swift */,
-				8BA0F3D4217E2DEF00969984 /* MonoidKLaws.swift */,
-				8BA0F3D5217E2DEF00969984 /* InvariantLaws.swift */,
+				8BA0F3C9217E2DEF00969984 /* ContravariantLaws.swift */,
+				8BA0F3BF217E2DEF00969984 /* EqLaws.swift */,
 				8BA0F3D6217E2DEF00969984 /* FoldableLaws.swift */,
+				8BA0F3C1217E2DEF00969984 /* FunctorFilterLaws.swift */,
+				8BA0F3CC217E2DEF00969984 /* FunctorLaws.swift */,
+				8BA0F3D5217E2DEF00969984 /* InvariantLaws.swift */,
+				8BA0F3CD217E2DEF00969984 /* MonadCombineLaws.swift */,
+				8BA0F3BC217E2DEF00969984 /* MonadErrorLaws.swift */,
+				8BA0F3C7217E2DEF00969984 /* MonadFilterLaws.swift */,
+				8BA0F3C0217E2DEF00969984 /* MonadLaws.swift */,
+				8BA0F3CB217E2DEF00969984 /* MonadStateLaws.swift */,
+				8BA0F3C5217E2DEF00969984 /* MonadWriterLaws.swift */,
+				8BA0F3D4217E2DEF00969984 /* MonoidKLaws.swift */,
+				8BA0F3BD217E2DEF00969984 /* MonoidLaws.swift */,
+				8BA0F3C2217E2DEF00969984 /* OrderLaws.swift */,
+				8BA0F3C8217E2DEF00969984 /* ProfunctorLaws.swift */,
+				8BA0F3CF217E2DEF00969984 /* SemigroupKLaws.swift */,
+				8BA0F3BE217E2DEF00969984 /* SemigroupLaws.swift */,
+				8BA0F3D1217E2DEF00969984 /* ShowLaws.swift */,
+				8BA0F3D3217E2DEF00969984 /* TraverseFilterLaws.swift */,
+				8BA0F3BB217E2DEF00969984 /* TraverseLaws.swift */,
 			);
 			path = Typeclasses;
 			sourceTree = "<group>";
@@ -1166,15 +1166,15 @@
 			isa = PBXGroup;
 			children = (
 				8BA0F3D8217E2DEF00969984 /* FoldTest.swift */,
-				8BA0F3D9217E2DEF00969984 /* IsoTest.swift */,
-				8BA0F3DA217E2DEF00969984 /* Laws */,
-				8BA0F3E1217E2DEF00969984 /* SetterTest.swift */,
-				8BA0F3E2217E2DEF00969984 /* TraversalTest.swift */,
-				8BA0F3E3217E2DEF00969984 /* PrismTest.swift */,
 				8BA0F3E4217E2DEF00969984 /* GetterTest.swift */,
-				8BA0F3E5217E2DEF00969984 /* OptionalTest.swift */,
+				8BA0F3D9217E2DEF00969984 /* IsoTest.swift */,
 				8BA0F3E6217E2DEF00969984 /* LensTest.swift */,
+				8BA0F3E5217E2DEF00969984 /* OptionalTest.swift */,
+				8BA0F3E3217E2DEF00969984 /* PrismTest.swift */,
+				8BA0F3E1217E2DEF00969984 /* SetterTest.swift */,
 				8BA0F3E7217E2DEF00969984 /* TestDomain.swift */,
+				8BA0F3E2217E2DEF00969984 /* TraversalTest.swift */,
+				8BA0F3DA217E2DEF00969984 /* Laws */,
 			);
 			path = Optics;
 			sourceTree = "<group>";
@@ -1182,12 +1182,12 @@
 		8BA0F3DA217E2DEF00969984 /* Laws */ = {
 			isa = PBXGroup;
 			children = (
+				8BA0F3DD217E2DEF00969984 /* IsoLaws.swift */,
 				8BA0F3DB217E2DEF00969984 /* LensLaws.swift */,
 				8BA0F3DC217E2DEF00969984 /* OptionalLaws.swift */,
-				8BA0F3DD217E2DEF00969984 /* IsoLaws.swift */,
-				8BA0F3DE217E2DEF00969984 /* TraversalLaws.swift */,
-				8BA0F3DF217E2DEF00969984 /* SetterLaws.swift */,
 				8BA0F3E0217E2DEF00969984 /* PrismLaws.swift */,
+				8BA0F3DF217E2DEF00969984 /* SetterLaws.swift */,
+				8BA0F3DE217E2DEF00969984 /* TraversalLaws.swift */,
 			);
 			path = Laws;
 			sourceTree = "<group>";
@@ -1215,10 +1215,10 @@
 		8BA0F43D217E2E9200969984 /* Free */ = {
 			isa = PBXGroup;
 			children = (
-				8BA0F43E217E2E9200969984 /* Yoneda.swift */,
-				8BA0F43F217E2E9200969984 /* Coyoneda.swift */,
 				8BA0F440217E2E9200969984 /* Cofree.swift */,
+				8BA0F43F217E2E9200969984 /* Coyoneda.swift */,
 				8BA0F441217E2E9200969984 /* Free.swift */,
+				8BA0F43E217E2E9200969984 /* Yoneda.swift */,
 			);
 			path = Free;
 			sourceTree = "<group>";
@@ -1226,12 +1226,12 @@
 		8BA0F442217E2E9200969984 /* Arrow */ = {
 			isa = PBXGroup;
 			children = (
-				8BA0F443217E2E9200969984 /* FunctionK.swift */,
-				8BA0F444217E2E9200969984 /* Kleisli.swift */,
+				8BA0F448217E2E9200969984 /* Cokleisli.swift */,
 				8BA0F445217E2E9200969984 /* Function0.swift */,
 				8BA0F446217E2E9200969984 /* Function1.swift */,
+				8BA0F443217E2E9200969984 /* FunctionK.swift */,
+				8BA0F444217E2E9200969984 /* Kleisli.swift */,
 				8BA0F447217E2E9200969984 /* KleisliOperator.swift */,
-				8BA0F448217E2E9200969984 /* Cokleisli.swift */,
 			);
 			path = Arrow;
 			sourceTree = "<group>";
@@ -1241,8 +1241,8 @@
 			children = (
 				8BA0F44C217E2E9200969984 /* EitherT.swift */,
 				8BA0F44D217E2E9200969984 /* OptionT.swift */,
-				8BA0F44E217E2E9200969984 /* WriterT.swift */,
 				8BA0F44F217E2E9200969984 /* StateT.swift */,
+				8BA0F44E217E2E9200969984 /* WriterT.swift */,
 			);
 			path = Transformers;
 			sourceTree = "<group>";
@@ -1260,9 +1260,9 @@
 		8BA0F453217E2E9200969984 /* Data */ = {
 			isa = PBXGroup;
 			children = (
-				8BA0F454217E2E9200969984 /* Nu.swift */,
 				8BA0F455217E2E9200969984 /* Fix.swift */,
 				8BA0F456217E2E9200969984 /* Mu.swift */,
+				8BA0F454217E2E9200969984 /* Nu.swift */,
 			);
 			path = Data;
 			sourceTree = "<group>";
@@ -1270,9 +1270,9 @@
 		8BA0F457217E2E9200969984 /* Typeclasses */ = {
 			isa = PBXGroup;
 			children = (
-				8BA0F458217E2E9200969984 /* Recursive.swift */,
 				8BA0F459217E2E9200969984 /* Birecursive.swift */,
 				8BA0F45A217E2E9200969984 /* Corecursive.swift */,
+				8BA0F458217E2E9200969984 /* Recursive.swift */,
 			);
 			path = Typeclasses;
 			sourceTree = "<group>";
@@ -1280,9 +1280,9 @@
 		8BA0F45C217E2E9200969984 /* Generic */ = {
 			isa = PBXGroup;
 			children = (
-				8BA0F45D217E2E9200969984 /* Product.swift */,
-				8BA0F45E217E2E9200969984 /* HList.swift */,
 				8BA0F45F217E2E9200969984 /* Generic.swift */,
+				8BA0F45E217E2E9200969984 /* HList.swift */,
+				8BA0F45D217E2E9200969984 /* Product.swift */,
 			);
 			path = Generic;
 			sourceTree = "<group>";
@@ -1291,9 +1291,9 @@
 			isa = PBXGroup;
 			children = (
 				8BA0F461217E2E9200969984 /* BoolInstances.swift */,
-				8BA0F462217E2E9200969984 /* StringInstances.swift */,
 				8BA0F463217E2E9200969984 /* MaybeInstances.swift */,
 				8BA0F464217E2E9200969984 /* NumberInstances.swift */,
+				8BA0F462217E2E9200969984 /* StringInstances.swift */,
 			);
 			path = Instances;
 			sourceTree = "<group>";
@@ -1301,10 +1301,10 @@
 		8BA0F465217E2E9200969984 /* Effects */ = {
 			isa = PBXGroup;
 			children = (
-				8BA0F466217E2E9200969984 /* BrightFutures */,
 				8BA0F468217E2E9200969984 /* IO.swift */,
-				8BA0F469217E2E9200969984 /* Typeclasses */,
+				8BA0F466217E2E9200969984 /* BrightFutures */,
 				8BA0F46E217E2E9200969984 /* Rx */,
+				8BA0F469217E2E9200969984 /* Typeclasses */,
 			);
 			path = Effects;
 			sourceTree = "<group>";
@@ -1320,9 +1320,9 @@
 		8BA0F469217E2E9200969984 /* Typeclasses */ = {
 			isa = PBXGroup;
 			children = (
+				8BA0F46C217E2E9200969984 /* Async.swift */,
 				8BA0F46A217E2E9200969984 /* ConcurrentEffect.swift */,
 				8BA0F46B217E2E9200969984 /* Effect.swift */,
-				8BA0F46C217E2E9200969984 /* Async.swift */,
 				8BA0F46D217E2E9200969984 /* MonadDefer.swift */,
 			);
 			path = Typeclasses;
@@ -1331,9 +1331,9 @@
 		8BA0F46E217E2E9200969984 /* Rx */ = {
 			isa = PBXGroup;
 			children = (
-				8BA0F46F217E2E9200969984 /* SingleK.swift */,
 				8BA0F470217E2E9200969984 /* MaybeK.swift */,
 				8BA0F471217E2E9200969984 /* ObservableK.swift */,
+				8BA0F46F217E2E9200969984 /* SingleK.swift */,
 			);
 			path = Rx;
 			sourceTree = "<group>";
@@ -1341,29 +1341,29 @@
 		8BA0F472217E2E9200969984 /* Data */ = {
 			isa = PBXGroup;
 			children = (
-				8BA0F473217E2E9200969984 /* Reader.swift */,
-				8BA0F474217E2E9200969984 /* Either.swift */,
-				8BA0F475217E2E9200969984 /* Id.swift */,
-				8BA0F476217E2E9200969984 /* MapK.swift */,
-				8BA0F477217E2E9200969984 /* Ior.swift */,
-				8BA0F478217E2E9200969984 /* Option.swift */,
-				8BA0F479217E2E9200969984 /* NonEmptyList.swift */,
-				8BA0F47A217E2E9200969984 /* Coproduct.swift */,
-				8BA0F47B217E2E9200969984 /* Day.swift */,
-				8BA0F47C217E2E9200969984 /* FlatmapOperator.swift */,
-				8BA0F47D217E2E9200969984 /* Moore.swift */,
-				8BA0F47E217E2E9200969984 /* Eval.swift */,
-				8BA0F47F217E2E9200969984 /* State.swift */,
-				8BA0F480217E2E9200969984 /* Try.swift */,
-				8BA0F481217E2E9200969984 /* Extensions */,
-				8BA0F483217E2E9200969984 /* Sum.swift */,
-				8BA0F484217E2E9200969984 /* Validated.swift */,
-				8BA0F485217E2E9200969984 /* Coreader.swift */,
-				8BA0F486217E2E9200969984 /* Store.swift */,
-				8BA0F487217E2E9200969984 /* SetK.swift */,
-				8BA0F488217E2E9200969984 /* Tuple.swift */,
 				8BA0F489217E2E9200969984 /* Const.swift */,
+				8BA0F47A217E2E9200969984 /* Coproduct.swift */,
+				8BA0F485217E2E9200969984 /* Coreader.swift */,
+				8BA0F47B217E2E9200969984 /* Day.swift */,
+				8BA0F474217E2E9200969984 /* Either.swift */,
+				8BA0F47E217E2E9200969984 /* Eval.swift */,
+				8BA0F47C217E2E9200969984 /* FlatmapOperator.swift */,
+				8BA0F475217E2E9200969984 /* Id.swift */,
+				8BA0F477217E2E9200969984 /* Ior.swift */,
 				8BA0F48A217E2E9200969984 /* ListK.swift */,
+				8BA0F476217E2E9200969984 /* MapK.swift */,
+				8BA0F47D217E2E9200969984 /* Moore.swift */,
+				8BA0F479217E2E9200969984 /* NonEmptyList.swift */,
+				8BA0F478217E2E9200969984 /* Option.swift */,
+				8BA0F473217E2E9200969984 /* Reader.swift */,
+				8BA0F487217E2E9200969984 /* SetK.swift */,
+				8BA0F47F217E2E9200969984 /* State.swift */,
+				8BA0F486217E2E9200969984 /* Store.swift */,
+				8BA0F483217E2E9200969984 /* Sum.swift */,
+				8BA0F480217E2E9200969984 /* Try.swift */,
+				8BA0F488217E2E9200969984 /* Tuple.swift */,
+				8BA0F484217E2E9200969984 /* Validated.swift */,
+				8BA0F481217E2E9200969984 /* Extensions */,
 			);
 			path = Data;
 			sourceTree = "<group>";
@@ -1380,39 +1380,39 @@
 			isa = PBXGroup;
 			children = (
 				8BA0F48D217E2E9200969984 /* Alternative.swift */,
-				8BA0F48E217E2E9200969984 /* ApplicativeError.swift */,
-				8BA0F48F217E2E9200969984 /* MonoidK.swift */,
-				8BA0F490217E2E9200969984 /* MonadFilter.swift */,
-				8BA0F491217E2E9200969984 /* MonadState.swift */,
-				8BA0F492217E2E9200969984 /* Contravariant.swift */,
-				8BA0F493217E2E9200969984 /* Order.swift */,
-				8BA0F494217E2E9200969984 /* Inject.swift */,
-				8BA0F495217E2E9200969984 /* Bifoldable.swift */,
-				8BA0F496217E2E9200969984 /* SemigroupK.swift */,
-				8BA0F497217E2E9200969984 /* MonadWriter.swift */,
-				8BA0F498217E2E9200969984 /* MonadError.swift */,
-				8BA0F499217E2E9200969984 /* Invariant.swift */,
-				8BA0F49A217E2E9200969984 /* TraverseFilter.swift */,
-				8BA0F49B217E2E9200969984 /* Traverse.swift */,
-				8BA0F49C217E2E9200969984 /* MonadReader.swift */,
-				8BA0F49D217E2E9200969984 /* Reducible.swift */,
-				8BA0F49E217E2E9200969984 /* Show.swift */,
-				8BA0F49F217E2E9200969984 /* Category.swift */,
-				8BA0F4A0217E2E9200969984 /* Foldable.swift */,
-				8BA0F4A1217E2E9200969984 /* NonEmptyReducible.swift */,
-				8BA0F4A2217E2E9200969984 /* Bimonad.swift */,
-				8BA0F4A3217E2E9200969984 /* Monoid.swift */,
-				8BA0F4A4217E2E9200969984 /* Monad.swift */,
-				8BA0F4A5217E2E9200969984 /* Composed */,
 				8BA0F4A8217E2E9200969984 /* Applicative.swift */,
-				8BA0F4A9217E2E9200969984 /* Comonad.swift */,
+				8BA0F48E217E2E9200969984 /* ApplicativeError.swift */,
+				8BA0F495217E2E9200969984 /* Bifoldable.swift */,
 				8BA0F4AA217E2E9200969984 /* Bifunctor.swift */,
-				8BA0F4AB217E2E9200969984 /* Functor.swift */,
-				8BA0F4AC217E2E9200969984 /* Semigroup.swift */,
-				8BA0F4AD217E2E9200969984 /* MonadCombine.swift */,
-				8BA0F4AE217E2E9200969984 /* FunctorFilter.swift */,
+				8BA0F4A2217E2E9200969984 /* Bimonad.swift */,
+				8BA0F49F217E2E9200969984 /* Category.swift */,
+				8BA0F4A9217E2E9200969984 /* Comonad.swift */,
+				8BA0F492217E2E9200969984 /* Contravariant.swift */,
 				8BA0F4AF217E2E9200969984 /* Eq.swift */,
+				8BA0F4A0217E2E9200969984 /* Foldable.swift */,
+				8BA0F4AB217E2E9200969984 /* Functor.swift */,
+				8BA0F4AE217E2E9200969984 /* FunctorFilter.swift */,
+				8BA0F494217E2E9200969984 /* Inject.swift */,
+				8BA0F499217E2E9200969984 /* Invariant.swift */,
+				8BA0F4A4217E2E9200969984 /* Monad.swift */,
+				8BA0F4AD217E2E9200969984 /* MonadCombine.swift */,
+				8BA0F498217E2E9200969984 /* MonadError.swift */,
+				8BA0F490217E2E9200969984 /* MonadFilter.swift */,
+				8BA0F49C217E2E9200969984 /* MonadReader.swift */,
+				8BA0F491217E2E9200969984 /* MonadState.swift */,
+				8BA0F497217E2E9200969984 /* MonadWriter.swift */,
+				8BA0F4A3217E2E9200969984 /* Monoid.swift */,
+				8BA0F48F217E2E9200969984 /* MonoidK.swift */,
+				8BA0F4A1217E2E9200969984 /* NonEmptyReducible.swift */,
+				8BA0F493217E2E9200969984 /* Order.swift */,
 				8BA0F4B0217E2E9200969984 /* Profunctor.swift */,
+				8BA0F49D217E2E9200969984 /* Reducible.swift */,
+				8BA0F4AC217E2E9200969984 /* Semigroup.swift */,
+				8BA0F496217E2E9200969984 /* SemigroupK.swift */,
+				8BA0F49E217E2E9200969984 /* Show.swift */,
+				8BA0F49B217E2E9200969984 /* Traverse.swift */,
+				8BA0F49A217E2E9200969984 /* TraverseFilter.swift */,
+				8BA0F4A5217E2E9200969984 /* Composed */,
 			);
 			path = Typeclasses;
 			sourceTree = "<group>";
@@ -1430,18 +1430,18 @@
 			isa = PBXGroup;
 			children = (
 				8BA0F4B2217E2E9200969984 /* BoundSetter.swift */,
-				8BA0F4B3217E2E9200969984 /* Getter.swift */,
-				8BA0F4B4217E2E9200969984 /* Traversal.swift */,
-				8BA0F4B5217E2E9200969984 /* STD */,
 				8BA0F4BE217E2E9200969984 /* Fold.swift */,
+				8BA0F4B3217E2E9200969984 /* Getter.swift */,
 				8BA0F4BF217E2E9200969984 /* Iso.swift */,
-				8BA0F4C0217E2E9200969984 /* Setter.swift */,
-				8BA0F4C1217E2E9200969984 /* Instances */,
+				8BA0F4D2217E2E9200969984 /* Lens.swift */,
 				8BA0F4C8217E2E9200969984 /* Optional.swift */,
 				8BA0F4C9217E2E9200969984 /* Prism.swift */,
-				8BA0F4CA217E2E9200969984 /* Typeclasses */,
+				8BA0F4C0217E2E9200969984 /* Setter.swift */,
+				8BA0F4B4217E2E9200969984 /* Traversal.swift */,
 				8BA0F4CF217E2E9200969984 /* DSL */,
-				8BA0F4D2217E2E9200969984 /* Lens.swift */,
+				8BA0F4C1217E2E9200969984 /* Instances */,
+				8BA0F4B5217E2E9200969984 /* STD */,
+				8BA0F4CA217E2E9200969984 /* Typeclasses */,
 			);
 			path = Optics;
 			sourceTree = "<group>";
@@ -1449,14 +1449,14 @@
 		8BA0F4B5217E2E9200969984 /* STD */ = {
 			isa = PBXGroup;
 			children = (
-				8BA0F4B6217E2E9200969984 /* Id+Optics.swift */,
-				8BA0F4B7217E2E9200969984 /* Try+Optics.swift */,
-				8BA0F4B8217E2E9200969984 /* Maybe+Optics.swift */,
-				8BA0F4B9217E2E9200969984 /* String+Optics.swift */,
-				8BA0F4BA217E2E9200969984 /* Validated+Optics.swift */,
-				8BA0F4BB217E2E9200969984 /* ListK+Optics.swift */,
-				8BA0F4BC217E2E9200969984 /* NonEmptyList+Optics.swift */,
 				8BA0F4BD217E2E9200969984 /* Either+Optics.swift */,
+				8BA0F4B6217E2E9200969984 /* Id+Optics.swift */,
+				8BA0F4BB217E2E9200969984 /* ListK+Optics.swift */,
+				8BA0F4B8217E2E9200969984 /* Maybe+Optics.swift */,
+				8BA0F4BC217E2E9200969984 /* NonEmptyList+Optics.swift */,
+				8BA0F4B9217E2E9200969984 /* String+Optics.swift */,
+				8BA0F4B7217E2E9200969984 /* Try+Optics.swift */,
+				8BA0F4BA217E2E9200969984 /* Validated+Optics.swift */,
 			);
 			path = STD;
 			sourceTree = "<group>";
@@ -1464,11 +1464,11 @@
 		8BA0F4C1217E2E9200969984 /* Instances */ = {
 			isa = PBXGroup;
 			children = (
+				8BA0F4C5217E2E9200969984 /* EitherOpticsInstances.swift */,
+				8BA0F4C6217E2E9200969984 /* ListKOpticsInstances.swift */,
 				8BA0F4C2217E2E9200969984 /* MaybeOpticsInstances.swift */,
 				8BA0F4C3217E2E9200969984 /* NonEmptyListOpticsInstances.swift */,
 				8BA0F4C4217E2E9200969984 /* StringOpticsInstances.swift */,
-				8BA0F4C5217E2E9200969984 /* EitherOpticsInstances.swift */,
-				8BA0F4C6217E2E9200969984 /* ListKOpticsInstances.swift */,
 				8BA0F4C7217E2E9200969984 /* TryOpticsInstances.swift */,
 			);
 			path = Instances;
@@ -1477,10 +1477,10 @@
 		8BA0F4CA217E2E9200969984 /* Typeclasses */ = {
 			isa = PBXGroup;
 			children = (
-				8BA0F4CB217E2E9200969984 /* Each.swift */,
-				8BA0F4CC217E2E9200969984 /* Index.swift */,
-				8BA0F4CD217E2E9200969984 /* FilterIndex.swift */,
 				8BA0F4CE217E2E9200969984 /* At.swift */,
+				8BA0F4CB217E2E9200969984 /* Each.swift */,
+				8BA0F4CD217E2E9200969984 /* FilterIndex.swift */,
+				8BA0F4CC217E2E9200969984 /* Index.swift */,
 			);
 			path = Typeclasses;
 			sourceTree = "<group>";

--- a/Sources/Bow/Syntax/Curry.swift
+++ b/Sources/Bow/Syntax/Curry.swift
@@ -1,49 +1,49 @@
 import Foundation
 
-func curry<A, B, C>(_ fun : @escaping (A, B) -> C) -> (A) -> (B) -> C {
+public func curry<A, B, C>(_ fun : @escaping (A, B) -> C) -> (A) -> (B) -> C {
     return { a in { b in fun(a, b) }}
 }
 
-func uncurry<A, B, C>(_ fun : @escaping (A) -> (B) -> C) -> (A, B) -> C {
+public func uncurry<A, B, C>(_ fun : @escaping (A) -> (B) -> C) -> (A, B) -> C {
     return { a, b in fun(a)(b) }
 }
 
-func curry<A, B, C, D>(_ fun : @escaping (A, B, C) -> D) -> (A) -> (B) -> (C) -> D {
+public func curry<A, B, C, D>(_ fun : @escaping (A, B, C) -> D) -> (A) -> (B) -> (C) -> D {
     return { a in { b in { c in fun(a,b,c) } } }
 }
 
-func uncurry<A, B, C, D>(_ fun : @escaping (A) -> (B) -> (C) -> D) -> (A, B, C) -> D {
+public func uncurry<A, B, C, D>(_ fun : @escaping (A) -> (B) -> (C) -> D) -> (A, B, C) -> D {
     return { a, b, c in fun(a)(b)(c) }
 }
 
-func curry<A, B, C, D, E>(_ fun : @escaping (A, B, C, D) -> E) -> (A) -> (B) -> (C) -> (D) -> E {
+public func curry<A, B, C, D, E>(_ fun : @escaping (A, B, C, D) -> E) -> (A) -> (B) -> (C) -> (D) -> E {
     return { a in { b in { c in { d in fun(a,b,c,d) } } } }
 }
 
-func uncurry<A, B, C, D, E>(_ fun : @escaping (A) -> (B) -> (C) -> (D) -> E) -> (A, B, C, D) -> E {
+public func uncurry<A, B, C, D, E>(_ fun : @escaping (A) -> (B) -> (C) -> (D) -> E) -> (A, B, C, D) -> E {
     return { a, b, c, d in fun(a)(b)(c)(d) }
 }
 
-func curry<A, B, C, D, E, F>(_ fun : @escaping (A, B, C, D, E) -> F) -> (A) -> (B) -> (C) -> (D) -> (E) -> F {
+public func curry<A, B, C, D, E, F>(_ fun : @escaping (A, B, C, D, E) -> F) -> (A) -> (B) -> (C) -> (D) -> (E) -> F {
     return { a in { b in { c in { d in { e in fun(a,b,c,d,e) } } } } }
 }
 
-func uncurry<A, B, C, D, E, F>(_ fun : @escaping (A) -> (B) -> (C) -> (D) -> (E) -> F) -> (A, B, C, D, E) -> F {
+public func uncurry<A, B, C, D, E, F>(_ fun : @escaping (A) -> (B) -> (C) -> (D) -> (E) -> F) -> (A, B, C, D, E) -> F {
     return { a, b, c, d, e in fun(a)(b)(c)(d)(e) }
 }
 
-func curry<A, B, C, D, E, F, G>(_ fun : @escaping (A, B, C, D, E, F) -> G) -> (A) -> (B) -> (C) -> (D) -> (E) -> (F) -> G {
+public func curry<A, B, C, D, E, F, G>(_ fun : @escaping (A, B, C, D, E, F) -> G) -> (A) -> (B) -> (C) -> (D) -> (E) -> (F) -> G {
     return { a in { b in { c in { d in { e in { f in fun(a,b,c,d,e,f) } } } } } }
 }
 
-func uncurry<A, B, C, D, E, F, G>(_ fun : @escaping (A) -> (B) -> (C) -> (D) -> (E) -> (F) -> G) -> (A, B, C, D, E, F) -> G {
+public func uncurry<A, B, C, D, E, F, G>(_ fun : @escaping (A) -> (B) -> (C) -> (D) -> (E) -> (F) -> G) -> (A, B, C, D, E, F) -> G {
     return { a, b, c, d, e, f in fun(a)(b)(c)(d)(e)(f) }
 }
 
-func curry<A, B, C, D, E, F, G, H>(_ fun : @escaping (A, B, C, D, E, F, G) -> H) -> (A) -> (B) -> (C) -> (D) -> (E) -> (F) -> (G) -> H {
+public func curry<A, B, C, D, E, F, G, H>(_ fun : @escaping (A, B, C, D, E, F, G) -> H) -> (A) -> (B) -> (C) -> (D) -> (E) -> (F) -> (G) -> H {
     return { a in { b in { c in { d in { e in { f in { g in fun(a,b,c,d,e,f,g) } } } } } } }
 }
 
-func uncurry<A, B, C, D, E, F, G, H>(_ fun : @escaping (A) -> (B) -> (C) -> (D) -> (E) -> (F) -> (G) -> H) -> (A, B, C, D, E, F, G) -> H {
+public func uncurry<A, B, C, D, E, F, G, H>(_ fun : @escaping (A) -> (B) -> (C) -> (D) -> (E) -> (F) -> (G) -> H) -> (A, B, C, D, E, F, G) -> H {
     return { a, b, c, d, e, f, g in fun(a)(b)(c)(d)(e)(f)(g) }
 }

--- a/Sources/Bow/Syntax/Predef.swift
+++ b/Sources/Bow/Syntax/Predef.swift
@@ -7,23 +7,23 @@ public func id<A>(_ a : A) -> A {
     return a
 }
 
-func constant<A>(_ a : A) -> () -> A {
+public func constant<A>(_ a : A) -> () -> A {
     return { a }
 }
 
-func constant<A, B>(_ a : A) -> (B) -> A {
+public func constant<A, B>(_ a : A) -> (B) -> A {
     return { _ in a }
 }
 
-func constant<A, B, C>(_ a : A) -> (B, C) -> A {
+public func constant<A, B, C>(_ a : A) -> (B, C) -> A {
     return { _, _ in a }
 }
 
-func constant<A, B, C, D>(_ a : A) -> (B, C, D) -> A {
+public func constant<A, B, C, D>(_ a : A) -> (B, C, D) -> A {
     return { _, _, _ in a }
 }
 
-func constant<A, B, C, D, E>(_ a : A) -> (B, C, D, E) -> A {
+public func constant<A, B, C, D, E>(_ a : A) -> (B, C, D, E) -> A {
     return { _, _, _, _ in a }
 }
 

--- a/Tests/BowTests/Typeclasses/ApplicativeErrorLaws.swift
+++ b/Tests/BowTests/Typeclasses/ApplicativeErrorLaws.swift
@@ -127,7 +127,7 @@ class ApplicativeErrorLaws<F, E> {
         property("Catch") <- forAll { (_ : Int) in
             let error = gen()
             if error is Error {
-                let f : () throws -> Int = { if error is Error { throw error as! Error } else { return 0 }}
+                let f : () throws -> Int = { throw error as! Error }
                 return eq.eqv(applicativeError.catchError(f, recover: { e in e as! E }),
                               applicativeError.raiseError(error))
             } else {

--- a/Tests/BowTests/Typeclasses/ApplicativeLaws.swift
+++ b/Tests/BowTests/Typeclasses/ApplicativeLaws.swift
@@ -22,10 +22,9 @@ class ApplicativeLaws<F> {
     }
     
     private static func homomorphism<Appl, EqA>(applicative : Appl, eq : EqA) where Appl : Applicative, Appl.F == F, EqA : Eq, EqA.A == Kind<F, Int> {
-        property("homomorphism") <- forAll() { (a : Int, b : Int) in
-            let f : (Int) -> Int = constant(b)
-            return eq.eqv(applicative.ap(applicative.pure(a), applicative.pure(f)),
-                          applicative.pure(f(a)))
+        property("homomorphism") <- forAll() { (a : Int, f : ArrowOf<Int, Int>) in
+            return eq.eqv(applicative.ap(applicative.pure(a), applicative.pure(f.getArrow)),
+                          applicative.pure(f.getArrow(a)))
         }
     }
     
@@ -38,11 +37,10 @@ class ApplicativeLaws<F> {
     }
     
     private static func mapDerived<Appl, EqA>(applicative : Appl, eq : EqA) where Appl : Applicative, Appl.F == F, EqA : Eq, EqA.A == Kind<F, Int> {
-        property("mad derived") <- forAll() { (a : Int, b : Int) in
-            let f : (Int) -> Int = constant(b)
+        property("mad derived") <- forAll() { (a : Int, f : ArrowOf<Int, Int>) in
             let fa = applicative.pure(a)
-            return eq.eqv(applicative.map(fa, f),
-                          applicative.ap(fa, applicative.pure(f)))
+            return eq.eqv(applicative.map(fa, f.getArrow),
+                          applicative.ap(fa, applicative.pure(f.getArrow)))
             
         }
     }

--- a/Tests/BowTests/Typeclasses/ComonadLaws.swift
+++ b/Tests/BowTests/Typeclasses/ComonadLaws.swift
@@ -31,11 +31,10 @@ class ComonadLaws<F> {
     }
     
     private static func mapAndCoflatMapCoherence<Comon, EqF>(_ comonad : Comon, _ generator : @escaping (Int) -> Kind<F, Int>, _ eq : EqF) where Comon : Comonad, Comon.F == F, EqF : Eq, EqF.A == Kind<F, Int> {
-        property("map and coflatMap coherence") <- forAll { (a : Int, b : Int) in
+        property("map and coflatMap coherence") <- forAll { (a : Int, f : ArrowOf<Int, Int>) in
             let fa = generator(a)
-            let f = { (_ : Int) in b }
-            return eq.eqv(comonad.map(fa, f),
-                          comonad.coflatMap(fa, { a in f(comonad.extract(a)) }))
+            return eq.eqv(comonad.map(fa, f.getArrow),
+                          comonad.coflatMap(fa, { a in f.getArrow(comonad.extract(a)) }))
         }
     }
     

--- a/Tests/BowTests/Typeclasses/FunctorLaws.swift
+++ b/Tests/BowTests/Typeclasses/FunctorLaws.swift
@@ -21,11 +21,9 @@ class FunctorLaws<F> {
     }
     
     private static func covariantComposition<Func, EqA>(_ functor : Func, _ generator : @escaping (Int) -> Kind<F, Int>, _ eq : EqA) where Func : Functor, Func.F == F, EqA : Eq, EqA.A == Kind<F, Int> {
-        property("Composition is preserved under functor transformation") <- forAll() { (a : Int, b : Int, c : Int) in
-            let f : (Int) -> Int = constant(b)
-            let g : (Int) -> Int = constant(c)
+        property("Composition is preserved under functor transformation") <- forAll() { (a : Int, f : ArrowOf<Int, Int>, g : ArrowOf<Int, Int>) in
             let fa = generator(a)
-            return eq.eqv(functor.map(functor.map(fa, f), g), functor.map(fa, f >>> g))
+            return eq.eqv(functor.map(functor.map(fa, f.getArrow), g.getArrow), functor.map(fa, f.getArrow >>> g.getArrow))
         }
     }
     

--- a/Tests/BowTests/Typeclasses/FunctorLaws.swift
+++ b/Tests/BowTests/Typeclasses/FunctorLaws.swift
@@ -30,20 +30,18 @@ class FunctorLaws<F> {
     }
     
     private static func void<Func, EqA>(_ functor : Func, _ generator : @escaping (Int) -> Kind<F, Int>, _ eq : EqA) where Func : Functor, Func.F == F, EqA : Eq, EqA.A == Kind<F, ()> {
-        property("Void") <- forAll() { (a : Int, b : Int) in
+        property("Void") <- forAll() { (a : Int, f : ArrowOf<Int, Int>) in
             let fa = generator(a)
-            let f = { (_ : Int) in b }
             return eq.eqv(functor.void(fa),
-                          functor.void(functor.map(fa, f)))
+                          functor.void(functor.map(fa, f.getArrow)))
         }
     }
     
     private static func fproduct<Func, EqA>(_ functor : Func, _ generator : @escaping (Int) -> Kind<F, Int>, _ eq : EqA) where Func : Functor, Func.F == F, EqA : Eq, EqA.A == Kind<F, Int> {
-        property("fproduct") <- forAll { (a : Int, b : Int) in
+        property("fproduct") <- forAll { (a : Int, f : ArrowOf<Int, Int>) in
             let fa = generator(a)
-            let f = { (_ : Int) in b }
-            return eq.eqv(functor.map(functor.fproduct(fa, f), { x in x.1 }),
-                          functor.map(fa, f))
+            return eq.eqv(functor.map(functor.fproduct(fa, f.getArrow), { x in x.1 }),
+                          functor.map(fa, f.getArrow))
         }
     }
     

--- a/Tests/BowTests/Typeclasses/MonadErrorLaws.swift
+++ b/Tests/BowTests/Typeclasses/MonadErrorLaws.swift
@@ -10,9 +10,9 @@ class MonadErrorLaws<F, E> {
     }
     
     private static func leftZero<MonErr, EqF>(_ monadError : MonErr, _ eq : EqF, _ gen : @escaping () -> E) where MonErr : MonadError, MonErr.F == F, MonErr.E == E, EqF : Eq, EqF.A == Kind<F, Int> {
-        property("Left zero") <- forAll { (a : Int) in
+        property("Left zero") <- forAll { (a : Int, g : ArrowOf<Int, Int>) in
             let error = gen()
-            let f = { (_ : Int) in monadError.pure(a) }
+            let f = g.getArrow >>> monadError.pure
             return eq.eqv(monadError.flatMap(monadError.raiseError(error), f),
                           monadError.raiseError(error))
         }
@@ -22,7 +22,7 @@ class MonadErrorLaws<F, E> {
         property("Ensure consistency") <- forAll { (a : Int, p : ArrowOf<Int, Bool>) in
             let error = gen()
             let fa = monadError.pure(a)
-            return eq.eqv(monadError.ensure(fa, error: { error }, predicate: p.getArrow),
+            return eq.eqv(monadError.ensure(fa, error: constant(error), predicate: p.getArrow),
                           monadError.flatMap(fa, { a in p.getArrow(a) ? monadError.pure(a) : monadError.raiseError(error) }))
         }
     }

--- a/Tests/BowTests/Typeclasses/MonadErrorLaws.swift
+++ b/Tests/BowTests/Typeclasses/MonadErrorLaws.swift
@@ -19,12 +19,11 @@ class MonadErrorLaws<F, E> {
     }
     
     private static func ensureConsistency<MonErr, EqF>(_ monadError : MonErr, _ eq : EqF, _ gen : @escaping () -> E) where MonErr : MonadError, MonErr.F == F, MonErr.E == E, EqF : Eq, EqF.A == Kind<F, Int> {
-        property("Ensure consistency") <- forAll { (a : Int, bool : Bool) in
+        property("Ensure consistency") <- forAll { (a : Int, p : ArrowOf<Int, Bool>) in
             let error = gen()
             let fa = monadError.pure(a)
-            let p = { (_ : Int) in bool }
-            return eq.eqv(monadError.ensure(fa, error: { error }, predicate: p),
-                          monadError.flatMap(fa, { a in p(a) ? monadError.pure(a) : monadError.raiseError(error) }))
+            return eq.eqv(monadError.ensure(fa, error: { error }, predicate: p.getArrow),
+                          monadError.flatMap(fa, { a in p.getArrow(a) ? monadError.pure(a) : monadError.raiseError(error) }))
         }
     }
     

--- a/Tests/BowTests/Typeclasses/MonadFilterLaws.swift
+++ b/Tests/BowTests/Typeclasses/MonadFilterLaws.swift
@@ -26,11 +26,10 @@ class MonadFilterLaws<F> {
     }
     
     private static func consistency<MonFil, EqF>(_ monadFilter : MonFil, _ generator : @escaping (Int) -> Kind<F, Int>, _ eq : EqF) where MonFil : MonadFilter, MonFil.F == F, EqF : Eq, EqF.A == Kind<F, Int> {
-        property("Consistency") <- forAll { (a : Int, b : Bool) in
-            let f = { (_ : Int) in b }
+        property("Consistency") <- forAll { (a : Int, f : ArrowOf<Int, Bool>) in
             let fa = generator(a)
-            return eq.eqv(monadFilter.filter(fa, f),
-                          monadFilter.flatMap(fa, { a in f(a) ? monadFilter.pure(a) : monadFilter.empty() }))
+            return eq.eqv(monadFilter.filter(fa, f.getArrow),
+                          monadFilter.flatMap(fa, { a in f.getArrow(a) ? monadFilter.pure(a) : monadFilter.empty() }))
         }
     }
 }

--- a/Tests/BowTests/Typeclasses/MonadLaws.swift
+++ b/Tests/BowTests/Typeclasses/MonadLaws.swift
@@ -17,10 +17,10 @@ class MonadLaws<F> {
     }
     
     private static func leftIdentity<Mon, EqF>(_ monad : Mon, _ eq : EqF) where Mon : Monad, Mon.F == F, EqF : Eq, EqF.A == Kind<F, Int> {
-        property("Monad left identity") <- forAll { (a : Int, b : Int) in
-            let f = { (_ : Int) in monad.pure(a) }
-            return eq.eqv(monad.flatMap(monad.pure(b), f),
-                          f(b))
+        property("Monad left identity") <- forAll { (a : Int, f : ArrowOf<Int, Int>) in
+            let g = f.getArrow >>> monad.pure
+            return eq.eqv(monad.flatMap(monad.pure(a), g),
+                          g(a))
         }
     }
     
@@ -33,27 +33,27 @@ class MonadLaws<F> {
     }
     
     private static func kleisliLeftIdentity<Mon, EqF>(_ monad : Mon, _ eq : EqF) where Mon : Monad, Mon.F == F, EqF : Eq, EqF.A == Kind<F, Int> {
-        property("Kleisli left identity") <- forAll { (a : Int, b : Int) in
-            let f = { (_ : Int) in monad.pure(a) }
-            return eq.eqv(Kleisli({ (n : Int) in monad.pure(n) }).andThen(Kleisli(f), monad).invoke(b),
-                          f(b))
+        property("Kleisli left identity") <- forAll { (a : Int, f : ArrowOf<Int, Int>) in
+            let g = f.getArrow >>> monad.pure
+            return eq.eqv(Kleisli({ (n : Int) in monad.pure(n) }).andThen(Kleisli(g), monad).invoke(a),
+                          g(a))
         }
     }
     
     private static func kleisliRightIdentity<Mon, EqF>(_ monad : Mon, _ eq : EqF) where Mon : Monad, Mon.F == F, EqF : Eq, EqF.A == Kind<F, Int> {
-        property("Kleisli right identity") <- forAll { (a : Int, b : Int) in
-            let f = { (_ : Int) in monad.pure(a) }
-            return eq.eqv(Kleisli(f).andThen(monad.pure, monad).invoke(b),
-                          f(b))
+        property("Kleisli right identity") <- forAll { (a : Int, f : ArrowOf<Int, Int>) in
+            let g = f.getArrow >>> monad.pure
+            return eq.eqv(Kleisli(g).andThen(monad.pure, monad).invoke(a),
+                          g(a))
         }
     }
     
     private static func flatMapCoherence<Mon, EqF>(_ monad : Mon, _ eq : EqF) where Mon : Monad, Mon.F == F, EqF : Eq, EqF.A == Kind<F, Int> {
-        property("Monad flatMap coherence") <- forAll { (a : Int, b : Int) in
-            let f = { (_ : Int) in a }
-            let fb = monad.pure(b)
-            return eq.eqv(monad.flatMap(fb, f >>> monad.pure),
-                          monad.map(fb, f))
+        property("Monad flatMap coherence") <- forAll { (a : Int, f : ArrowOf<Int, Int>) in
+            let g = f.getArrow >>> monad.pure
+            let fa = monad.pure(a)
+            return eq.eqv(monad.flatMap(fa, g),
+                          monad.map(fa, f.getArrow))
         }
     }
     


### PR DESCRIPTION
Previous version used constant functions in property-based tests for typeclasses laws. This PR replaces those constant functions (where possible) by `ArrowOf<A, B>`, provided by SwiftCheck, which generates functions with signature `(A) -> B`, making the tests of properties more robust.