### PR TITLE
Missing convenience methods

### DIFF
--- a/Sources/Bow/Arrow/Kleisli.swift
+++ b/Sources/Bow/Arrow/Kleisli.swift
@@ -92,6 +92,10 @@ public extension Kleisli {
         return KleisliMonadReader<F, D, MonF>(monad)
     }
     
+    public static func applicativeError<E, ApplEF>(_ applicativeError : ApplEF) -> KleisliMonadError<F, D, E, ApplEF> {
+        return KleisliMonadError<F, D, E, ApplEF>(applicativeError)
+    }
+    
     public static func monadError<E, MonEF>(_ monadError : MonEF) -> KleisliMonadError<F, D, E, MonEF> {
         return KleisliMonadError<F, D, E, MonEF>(monadError)
     }

--- a/Sources/Bow/Data/Either.swift
+++ b/Sources/Bow/Data/Either.swift
@@ -158,6 +158,10 @@ public extension Either {
         return EitherMonad<A>()
     }
     
+    public static func applicativeError() -> EitherMonadError<A> {
+        return EitherMonadError<A>()
+    }
+    
     public static func monadError() -> EitherMonadError<A> {
         return EitherMonadError<A>()
     }

--- a/Sources/Bow/Data/Option.swift
+++ b/Sources/Bow/Data/Option.swift
@@ -187,6 +187,10 @@ public extension Option {
         return OptionMonoid<A, SemiG>(semigroup)
     }
     
+    public static func applicativeError() -> OptionMonadError {
+        return OptionMonadError()
+    }
+    
     public static func monadError() -> OptionMonadError {
         return OptionMonadError()
     }

--- a/Sources/Bow/Data/State.swift
+++ b/Sources/Bow/Data/State.swift
@@ -1,6 +1,9 @@
 import Foundation
 
-public class State<S, A> : StateT<ForId, S, A> {
+public typealias StatePartial<S> = StateTPartial<ForId, S>
+public typealias StateOf<S, A> = StateT<ForId, S, A>
+
+public class State<S, A> : StateOf<S, A> {
     
     public init(_ run : @escaping (S) -> (S, A)) {
         super.init(Id.pure({ s in Id.pure(run(s)) }))

--- a/Sources/Bow/Data/State.swift
+++ b/Sources/Bow/Data/State.swift
@@ -4,6 +4,9 @@ public typealias StatePartial<S> = StateTPartial<ForId, S>
 public typealias StateOf<S, A> = StateT<ForId, S, A>
 
 public class State<S, A> : StateOf<S, A> {
+    public static func fix(_ value : StateOf<S, A>) -> State<S, A> {
+        return value as! State<S, A>
+    }
     
     public init(_ run : @escaping (S) -> (S, A)) {
         super.init(Id.pure({ s in Id.pure(run(s)) }))
@@ -19,6 +22,22 @@ public class State<S, A> : StateOf<S, A> {
     
     public func runS(_ s : S) -> S {
         return run(s).0
+    }
+    
+    public func map<B>(_ f : @escaping (A) -> B) -> StateOf<S, B> {
+        return self.map(f, Id<A>.functor())
+    }
+    
+    public func ap<B>(_ ff : StateOf<S, (A) -> B>) -> StateOf<S, B> {
+        return self.ap(ff, Id<A>.monad())
+    }
+    
+    public func flatMap<B>(_ f : @escaping (A) -> StateOf<S, B>) -> StateOf<S, B> {
+        return self.flatMap(f, Id<A>.monad())
+    }
+    
+    public func product<B>(_ sb : State<S, B>) -> StateOf<S, (A, B)> {
+        return self.product(sb, Id<A>.monad())
     }
 }
 

--- a/Sources/Bow/Data/State.swift
+++ b/Sources/Bow/Data/State.swift
@@ -10,7 +10,7 @@ public class State<S, A> : StateOf<S, A> {
     }
     
     public func run(_ initial : S) -> (S, A) {
-        return self.run(initial, Id<S>.monad()).fix().extract()
+        return self.runM(initial, Id<S>.monad()).fix().extract()
     }
     
     public func runA(_ s : S) -> A {
@@ -19,5 +19,23 @@ public class State<S, A> : StateOf<S, A> {
     
     public func runS(_ s : S) -> S {
         return run(s).0
+    }
+}
+
+public extension State {
+    public static func functor() -> StateTFunctor<ForId, S, IdFunctor> {
+        return StateT<ForId, S, A>.functor(Id<A>.functor())
+    }
+    
+    public static func applicative() -> StateTApplicative<ForId, S, IdMonad> {
+        return StateT<ForId, S, A>.applicative(Id<A>.monad())
+    }
+    
+    public static func monad() -> StateTMonad<ForId, S, IdMonad> {
+        return StateT<ForId, S, A>.monad(Id<A>.monad())
+    }
+    
+    public static func monadState() -> StateTMonadState<ForId, S, IdMonad> {
+        return StateT<ForId, S, A>.monadState(Id<A>.monad())
     }
 }

--- a/Sources/Bow/Data/Try.swift
+++ b/Sources/Bow/Data/Try.swift
@@ -168,6 +168,10 @@ public extension Try {
         return TryMonad()
     }
     
+    public static func applicativeError<E>() -> TryMonadError<E> {
+        return TryMonadError<E>()
+    }
+    
     public static func monadError<E>() -> TryMonadError<E> {
         return TryMonadError<E>()
     }

--- a/Sources/Bow/Instances/BoolInstances.swift
+++ b/Sources/Bow/Instances/BoolInstances.swift
@@ -37,8 +37,16 @@ public class BoolEq : Eq {
 }
 
 public extension Bool {
+    public static var andSemigroup : AndSemigroup {
+        return AndSemigroup()
+    }
+    
     public static var andMonoid : AndMonoid {
         return AndMonoid()
+    }
+    
+    public static var orSemigroup : OrSemigroup {
+        return OrSemigroup()
     }
     
     public static var orMonoid : OrMonoid {

--- a/Sources/Bow/Instances/NumberInstances.swift
+++ b/Sources/Bow/Instances/NumberInstances.swift
@@ -53,6 +53,10 @@ public extension Int {
         return IntProductMonoid()
     }
     
+    public static var eq : IntEq {
+        return IntEq()
+    }
+    
     public static var order : IntOrder {
         return IntOrder()
     }
@@ -109,6 +113,10 @@ public extension Int8 {
     
     public static var productMonoid : Int8ProductMonoid {
         return Int8ProductMonoid()
+    }
+    
+    public static var eq : Int8Eq {
+        return Int8Eq()
     }
     
     public static var order : Int8Order {
@@ -169,6 +177,10 @@ public extension Int16 {
         return Int16ProductMonoid()
     }
     
+    public static var eq : Int16Eq {
+        return Int16Eq()
+    }
+    
     public static var order : Int16Order {
         return Int16Order()
     }
@@ -227,6 +239,10 @@ public extension Int32 {
         return Int32ProductMonoid()
     }
     
+    public static var eq : Int32Eq {
+        return Int32Eq()
+    }
+    
     public static var order : Int32Order {
         return Int32Order()
     }
@@ -283,6 +299,10 @@ public extension Int64 {
     
     public static var productMonoid : Int64ProductMonoid {
         return Int64ProductMonoid()
+    }
+    
+    public static var eq : Int64Eq {
+        return Int64Eq()
     }
     
     public static var order : Int64Order {
@@ -348,6 +368,10 @@ public extension UInt {
         return UIntProductMonoid()
     }
     
+    public static var eq : UIntEq {
+        return UIntEq()
+    }
+    
     public static var order : UIntOrder {
         return UIntOrder()
     }
@@ -409,6 +433,10 @@ public extension UInt8 {
     
     public static var productMonoid : UInt8ProductMonoid {
         return UInt8ProductMonoid()
+    }
+    
+    public static var eq : UInt8Eq {
+        return UInt8Eq()
     }
     
     public static var order : UInt8Order {
@@ -474,6 +502,10 @@ public extension UInt16 {
         return UInt16ProductMonoid()
     }
     
+    public static var eq : UInt16Eq {
+        return UInt16Eq()
+    }
+    
     public static var order : UInt16Order {
         return UInt16Order()
     }
@@ -535,6 +567,10 @@ public extension UInt32 {
     
     public static var productMonoid : UInt32ProductMonoid {
         return UInt32ProductMonoid()
+    }
+    
+    public static var eq : UInt32Eq {
+        return UInt32Eq()
     }
     
     public static var order : UInt32Order {
@@ -600,6 +636,10 @@ public extension UInt64 {
         return UInt64ProductMonoid()
     }
     
+    public static var eq : UInt64Eq {
+        return UInt64Eq()
+    }
+    
     public static var order : UInt64Order {
         return UInt64Order()
     }
@@ -663,6 +703,10 @@ public extension Float {
         return FloatProductMonoid()
     }
     
+    public static var eq : FloatEq {
+        return FloatEq()
+    }
+    
     public static var order : FloatOrder {
         return FloatOrder()
     }
@@ -724,6 +768,10 @@ public extension Double {
     
     public static var productMonoid : DoubleProductMonoid {
         return DoubleProductMonoid()
+    }
+    
+    public static var eq : DoubleEq {
+        return DoubleEq()
     }
     
     public static var order : DoubleOrder {

--- a/Sources/Bow/Instances/NumberInstances.swift
+++ b/Sources/Bow/Instances/NumberInstances.swift
@@ -45,8 +45,16 @@ public class IntOrder : IntEq, Order {
 }
 
 public extension Int {
+    public static var sumSemigroup : IntSumSemigroup {
+        return IntSumSemigroup()
+    }
+    
     public static var sumMonoid : IntSumMonoid {
         return IntSumMonoid()
+    }
+    
+    public static var productSemigroup : IntProductSemigroup {
+        return IntProductSemigroup()
     }
     
     public static var productMonoid : IntProductMonoid {
@@ -107,8 +115,16 @@ public class Int8Order : Int8Eq, Order {
 }
 
 public extension Int8 {
+    public static var sumSemigroup : Int8SumSemigroup {
+        return Int8SumSemigroup()
+    }
+    
     public static var sumMonoid : Int8SumMonoid {
         return Int8SumMonoid()
+    }
+    
+    public static var productSemigroup : Int8ProductSemigroup {
+        return Int8ProductSemigroup()
     }
     
     public static var productMonoid : Int8ProductMonoid {
@@ -169,8 +185,16 @@ public class Int16Order : Int16Eq, Order {
 }
 
 public extension Int16 {
+    public static var sumSemigroup : Int16SumSemigroup {
+        return Int16SumSemigroup()
+    }
+    
     public static var sumMonoid : Int16SumMonoid {
         return Int16SumMonoid()
+    }
+    
+    public static var productSemigroup : Int16ProductSemigroup {
+        return Int16ProductSemigroup()
     }
     
     public static var productMonoid : Int16ProductMonoid {
@@ -231,8 +255,16 @@ public class Int32Order : Int32Eq, Order {
 }
 
 public extension Int32 {
+    public static var sumSemigroup : Int32SumSemigroup {
+        return Int32SumSemigroup()
+    }
+    
     public static var sumMonoid : Int32SumMonoid {
         return Int32SumMonoid()
+    }
+
+    public static var productSemigroup : Int32ProductSemigroup {
+        return Int32ProductSemigroup()
     }
     
     public static var productMonoid : Int32ProductMonoid {
@@ -293,8 +325,16 @@ public class Int64Order : Int64Eq, Order {
 }
 
 public extension Int64 {
+    public static var sumSemigroup : Int64SumSemigroup {
+        return Int64SumSemigroup()
+    }
+    
     public static var sumMonoid : Int64SumMonoid {
         return Int64SumMonoid()
+    }
+    
+    public static var productSemigroup : Int64ProductSemigroup {
+        return Int64ProductSemigroup()
     }
     
     public static var productMonoid : Int64ProductMonoid {
@@ -360,8 +400,16 @@ public class UIntOrder : UIntEq, Order {
 }
 
 public extension UInt {
+    public static var sumSemigroup : UIntSumSemigroup {
+        return UIntSumSemigroup()
+    }
+    
     public static var sumMonoid : UIntSumMonoid {
         return UIntSumMonoid()
+    }
+    
+    public static var productSemigroup : UIntProductSemigroup {
+        return UIntProductSemigroup()
     }
     
     public static var productMonoid : UIntProductMonoid {
@@ -427,8 +475,16 @@ public class UInt8Order : UInt8Eq, Order {
 }
 
 public extension UInt8 {
+    public static var sumSemigroup : UInt8SumSemigroup {
+        return UInt8SumSemigroup()
+    }
+    
     public static var sumMonoid : UInt8SumMonoid {
         return UInt8SumMonoid()
+    }
+    
+    public static var productSemigroup : UIntProductSemigroup {
+        return UIntProductSemigroup()
     }
     
     public static var productMonoid : UInt8ProductMonoid {
@@ -494,8 +550,16 @@ public class UInt16Order : UInt16Eq, Order {
 }
 
 public extension UInt16 {
+    public static var sumSemigroup : UInt16SumSemigroup {
+        return UInt16SumSemigroup()
+    }
+    
     public static var sumMonoid : UInt16SumMonoid {
         return UInt16SumMonoid()
+    }
+    
+    public static var productSemigroup : UInt16ProductSemigroup {
+        return UInt16ProductSemigroup()
     }
     
     public static var productMonoid : UInt16ProductMonoid {
@@ -561,8 +625,16 @@ public class UInt32Order : UInt32Eq, Order {
 }
 
 public extension UInt32 {
+    public static var sumSemigroup : UInt32SumSemigroup {
+        return UInt32SumSemigroup()
+    }
+    
     public static var sumMonoid : UInt32SumMonoid {
         return UInt32SumMonoid()
+    }
+    
+    public static var productSemigroup : UInt32ProductSemigroup {
+        return UInt32ProductSemigroup()
     }
     
     public static var productMonoid : UInt32ProductMonoid {
@@ -628,8 +700,16 @@ public class UInt64Order : UInt64Eq, Order {
 }
 
 public extension UInt64 {
+    public static var sumSemigroup : UInt64SumSemigroup {
+        return UInt64SumSemigroup()
+    }
+    
     public static var sumMonoid : UInt64SumMonoid {
         return UInt64SumMonoid()
+    }
+    
+    public static var productSemigroup : UInt64ProductSemigroup {
+        return UInt64ProductSemigroup()
     }
     
     public static var productMonoid : UInt64ProductMonoid {
@@ -695,8 +775,16 @@ public class FloatOrder : FloatEq, Order {
 }
 
 public extension Float {
+    public static var sumSemigroup : FloatSumSemigroup {
+        return FloatSumSemigroup()
+    }
+    
     public static var sumMonoid : FloatSumMonoid {
         return FloatSumMonoid()
+    }
+    
+    public static var productSemigroup : FloatProductSemigroup {
+        return FloatProductSemigroup()
     }
     
     public static var productMonoid : FloatProductMonoid {
@@ -762,8 +850,16 @@ public class DoubleOrder : DoubleEq, Order {
 }
 
 public extension Double {
+    public static var sumSemigroup : DoubleSumSemigroup {
+        return DoubleSumSemigroup()
+    }
+    
     public static var sumMonoid : DoubleSumMonoid {
         return DoubleSumMonoid()
+    }
+    
+    public static var productSemigroup : DoubleProductSemigroup {
+        return DoubleProductSemigroup()
     }
     
     public static var productMonoid : DoubleProductMonoid {

--- a/Sources/Bow/Instances/StringInstances.swift
+++ b/Sources/Bow/Instances/StringInstances.swift
@@ -33,8 +33,16 @@ public class StringOrder : StringEq, Order {
 }
 
 public extension String {
+    public static var concatSemigroup : StringConcatSemigroup {
+        return StringConcatSemigroup()
+    }
+    
     public static var concatMonoid : StringConcatMonoid {
         return StringConcatMonoid()
+    }
+    
+    public static var eq : StringEq {
+        return StringEq()
     }
     
     public static var order : StringOrder {

--- a/Sources/Bow/Transformers/EitherT.swift
+++ b/Sources/Bow/Transformers/EitherT.swift
@@ -114,6 +114,10 @@ public extension EitherT {
         return EitherTMonad<F, A, Mon>(monad)
     }
     
+    public static func applicativeError<Mon>(_ monad : Mon) -> EitherTMonadError<F, A, Mon> {
+        return EitherTMonadError<F, A, Mon>(monad)
+    }
+    
     public static func monadError<Mon>(_ monad : Mon) -> EitherTMonadError<F, A, Mon> {
         return EitherTMonadError<F, A, Mon>(monad)
     }

--- a/Sources/Bow/Transformers/StateT.swift
+++ b/Sources/Bow/Transformers/StateT.swift
@@ -149,6 +149,10 @@ public extension StateT {
         return StateTMonadCombine<F, S, MonComF>(monadCombine)
     }
     
+    public static func applicativeError<Err, MonErrF>(_ monadError : MonErrF) -> StateTMonadError<F, S, Err, MonErrF> {
+        return StateTMonadError<F, S, Err, MonErrF>(monadError)
+    }
+    
     public static func monadError<Err, MonErrF>(_ monadError : MonErrF) -> StateTMonadError<F, S, Err, MonErrF> {
         return StateTMonadError<F, S, Err, MonErrF>(monadError)
     }

--- a/Sources/Bow/Transformers/StateT.swift
+++ b/Sources/Bow/Transformers/StateT.swift
@@ -82,7 +82,7 @@ public class StateT<F, S, A> : StateTOf<F, S, A> {
             monad.map(runF) { sfsa in
                 sfsa >>> { fsa in
                     monad.flatMap(fsa) { (s, a) in
-                        f(a).run(s, monad)
+                        f(a).runM(s, monad)
                     }
                 }
             }
@@ -103,24 +103,20 @@ public class StateT<F, S, A> : StateTOf<F, S, A> {
     
     public func combineK<Mon, SemiG>(_ y : StateT<F, S, A>, _ monad : Mon, _ semigroup : SemiG) -> StateT<F, S, A> where Mon : Monad, Mon.F == F, SemiG : SemigroupK, SemiG.F == F {
         return StateT(
-            monad.pure({ s in semigroup.combineK(self.run(s, monad), y.run(s, monad)) })
+            monad.pure({ s in semigroup.combineK(self.runM(s, monad), y.runM(s, monad)) })
         )
     }
     
-    public func run<Mon>(_ initial : S, _ monad : Mon) -> Kind<F, (S, A)> where Mon : Monad, Mon.F == F {
-        return monad.flatMap(runF, { f in f(initial) })
-    }
-    
     public func runA<Mon>(_ s : S, _ monad : Mon) -> Kind<F, A> where Mon : Monad, Mon.F == F {
-        return monad.map(run(s, monad)){ (_, a) in a }
+        return monad.map(runM(s, monad)){ (_, a) in a }
     }
     
     public func runS<Mon>(_ s : S, _ monad : Mon) -> Kind<F, S> where Mon : Monad, Mon.F == F {
-        return monad.map(run(s, monad)){ (s, _) in s }
+        return monad.map(runM(s, monad)){ (s, _) in s }
     }
     
     public func runM<Mon>(_ initial : S, _ monad : Mon) -> Kind<F, (S, A)> where Mon : Monad, Mon.F == F {
-        return self.run(initial, monad)
+        return monad.flatMap(runF, { f in f(initial) })
     }
 }
 

--- a/Sources/BowEffects/IO.swift
+++ b/Sources/BowEffects/IO.swift
@@ -307,6 +307,10 @@ public extension IO {
         return IOAsync<E>()
     }
     
+    public static func applicativeError<E>() -> IOMonadError<E> {
+        return IOMonadError<E>()
+    }
+    
     public static func monadError<E>() -> IOMonadError<E> {
         return IOMonadError<E>()
     }

--- a/Tests/BowEffectsTests/IOTest.swift
+++ b/Tests/BowEffectsTests/IOTest.swift
@@ -30,6 +30,7 @@ class IOTest: XCTestCase {
     let generator = { (a : Int) in IO.pure(a) }
     let eq = IO.eq(Int.order, ErrorEq())
     let eqUnit = IO.eq(UnitEq(), ErrorEq())
+    let eqEither = IO.eq(Either.eq(CategoryError.eq, Int.eq), ErrorEq())
     
     func testEqLaws() {
         EqLaws.check(eq: self.eq, generator: self.generator)
@@ -45,6 +46,10 @@ class IOTest: XCTestCase {
     
     func testMonadLaws() {
         MonadLaws<ForIO>.check(monad: IO<Int>.monad(), eq: self.eq)
+    }
+    
+    func testApplicativeErrorLaws() {
+        ApplicativeErrorLaws<ForIO, CategoryError>.check(applicativeError: IO<Int>.applicativeError(), eq: self.eq, eqEither: self.eqEither, gen: { CategoryError.arbitrary.generate })
     }
     
     func testMonadErrorLaws() {

--- a/Tests/BowTests/Arrow/KleisliTest.swift
+++ b/Tests/BowTests/Arrow/KleisliTest.swift
@@ -66,7 +66,7 @@ class KleisliTest: XCTestCase {
     
     func testApplicativeErrorLaws() {
         ApplicativeErrorLaws<KleisliPartial<ForOption, ()>, ()>.check(
-            applicativeError: Kleisli<ForOption, (), Int>.monadError(Option<Any>.monadError()),
+            applicativeError: Kleisli<ForOption, (), Int>.applicativeError(Option<Any>.monadError()),
             eq: KleisliUnitEq(),
             eqEither: KleisliEitherEq(),
             gen: { () })

--- a/Tests/BowTests/Data/EitherTest.swift
+++ b/Tests/BowTests/Data/EitherTest.swift
@@ -31,7 +31,7 @@ class EitherTest: XCTestCase {
     
     func testApplicativeErrorLaws() {
         ApplicativeErrorLaws<EitherPartial<CategoryError>, CategoryError>.check(
-            applicativeError: Either<CategoryError, Int>.monadError(),
+            applicativeError: Either<CategoryError, Int>.applicativeError(),
             eq: Either.eq(CategoryError.eq, Int.order),
             eqEither: Either.eq(CategoryError.eq, Either.eq(CategoryError.eq, Int.order)),
             gen: { CategoryError.arbitrary.generate })

--- a/Tests/BowTests/Data/OptionTest.swift
+++ b/Tests/BowTests/Data/OptionTest.swift
@@ -37,7 +37,7 @@ class OptionTest: XCTestCase {
     }
     
     func testApplicativeErrorLaws() {
-        ApplicativeErrorLaws<ForOption, Bow.Unit>.check(applicativeError: Option<Int>.monadError(), eq: Option.eq(Int.order), eqEither: Option.eq(Either.eq(UnitEq(), Int.order)), gen: { () } )
+        ApplicativeErrorLaws<ForOption, Bow.Unit>.check(applicativeError: Option<Int>.applicativeError(), eq: Option.eq(Int.order), eqEither: Option.eq(Either.eq(UnitEq(), Int.order)), gen: { () } )
     }
     
     func testMonadErrorLaws() {

--- a/Tests/BowTests/Data/TryTest.swift
+++ b/Tests/BowTests/Data/TryTest.swift
@@ -28,7 +28,7 @@ class TryTest: XCTestCase {
     }
     
     func testApplicativeErrorLaws() {
-        ApplicativeErrorLaws<ForTry, CategoryError>.check(applicativeError: Try<Int>.monadError(), eq: self.eq, eqEither: Try.eq(Either.eq(CategoryError.eq, Int.order)), gen: { CategoryError.arbitrary.generate })
+        ApplicativeErrorLaws<ForTry, CategoryError>.check(applicativeError: Try<Int>.applicativeError(), eq: self.eq, eqEither: Try.eq(Either.eq(CategoryError.eq, Int.order)), gen: { CategoryError.arbitrary.generate })
     }
     
     func testMonadErrorLaws() {

--- a/Tests/BowTests/Instances/BoolInstancesTest.swift
+++ b/Tests/BowTests/Instances/BoolInstancesTest.swift
@@ -7,11 +7,11 @@ class BoolInstancesTest: XCTestCase {
     
     func testBoolSemigroupLaws() {
         property("And semigroup laws") <- forAll { (a : Bool, b : Bool, c : Bool) in
-            return SemigroupLaws.check(semigroup: Bool.andMonoid, a: a, b: b, c: c, eq: Bool.eq)
+            return SemigroupLaws.check(semigroup: Bool.andSemigroup, a: a, b: b, c: c, eq: Bool.eq)
         }
         
         property("Or semigroup laws") <- forAll { (a : Bool, b : Bool, c : Bool) in
-            return SemigroupLaws.check(semigroup: Bool.orMonoid, a: a, b: b, c: c, eq: Bool.eq)
+            return SemigroupLaws.check(semigroup: Bool.orSemigroup, a: a, b: b, c: c, eq: Bool.eq)
         }
     }
     

--- a/Tests/BowTests/Instances/NumberInstancesTest.swift
+++ b/Tests/BowTests/Instances/NumberInstancesTest.swift
@@ -6,7 +6,7 @@ import SwiftCheck
 class NumberInstancesTest: XCTestCase {
     
     func testIntEqLaws() {
-        EqLaws.check(eq: Int.order, generator: id)
+        EqLaws.check(eq: Int.eq, generator: id)
     }
     
     func testIntOrderLaws() {
@@ -14,7 +14,7 @@ class NumberInstancesTest: XCTestCase {
     }
     
     func testInt8EqLaws() {
-        EqLaws.check(eq: Int8.order, generator: id)
+        EqLaws.check(eq: Int8.eq, generator: id)
     }
     
     func testInt8OrderLaws() {
@@ -22,7 +22,7 @@ class NumberInstancesTest: XCTestCase {
     }
     
     func testInt16EqLaws() {
-        EqLaws.check(eq: Int16.order, generator: id)
+        EqLaws.check(eq: Int16.eq, generator: id)
     }
     
     func testInt16OrderLaws() {
@@ -30,7 +30,7 @@ class NumberInstancesTest: XCTestCase {
     }
     
     func testInt32EqLaws() {
-        EqLaws.check(eq: Int32.order, generator: id)
+        EqLaws.check(eq: Int32.eq, generator: id)
     }
     
     func testInt32OrderLaws() {
@@ -38,7 +38,7 @@ class NumberInstancesTest: XCTestCase {
     }
     
     func testInt64EqLaws() {
-        EqLaws.check(eq: Int64.order, generator: id)
+        EqLaws.check(eq: Int64.eq, generator: id)
     }
     
     func testInt64OrderLaws() {
@@ -46,7 +46,7 @@ class NumberInstancesTest: XCTestCase {
     }
     
     func testUIntEqLaws() {
-        EqLaws.check(eq: Int.order, generator: id)
+        EqLaws.check(eq: Int.eq, generator: id)
     }
     
     func testUIntOrderLaws() {
@@ -54,7 +54,7 @@ class NumberInstancesTest: XCTestCase {
     }
     
     func testUInt8EqLaws() {
-        EqLaws.check(eq: Int8.order, generator: id)
+        EqLaws.check(eq: Int8.eq, generator: id)
     }
     
     func testUInt8OrderLaws() {
@@ -62,7 +62,7 @@ class NumberInstancesTest: XCTestCase {
     }
     
     func testUInt16EqLaws() {
-        EqLaws.check(eq: Int16.order, generator: id)
+        EqLaws.check(eq: Int16.eq, generator: id)
     }
     
     func testUInt16OrderLaws() {
@@ -70,7 +70,7 @@ class NumberInstancesTest: XCTestCase {
     }
     
     func testUInt32EqLaws() {
-        EqLaws.check(eq: Int32.order, generator: id)
+        EqLaws.check(eq: Int32.eq, generator: id)
     }
     
     func testUInt32OrderLaws() {
@@ -78,7 +78,7 @@ class NumberInstancesTest: XCTestCase {
     }
     
     func testUInt64EqLaws() {
-        EqLaws.check(eq: Int64.order, generator: id)
+        EqLaws.check(eq: Int64.eq, generator: id)
     }
     
     func testUInt64OrderLaws() {
@@ -86,7 +86,7 @@ class NumberInstancesTest: XCTestCase {
     }
     
     func testFloatEqLaws() {
-        EqLaws.check(eq: Float.order, generator: id)
+        EqLaws.check(eq: Float.eq, generator: id)
     }
     
     func testFloatOrderLaws() {
@@ -94,7 +94,7 @@ class NumberInstancesTest: XCTestCase {
     }
     
     func testDoubleEqLaws() {
-        EqLaws.check(eq: Double.order, generator: id)
+        EqLaws.check(eq: Double.eq, generator: id)
     }
     
     func testDoubleOrderLaws() {

--- a/Tests/BowTests/Instances/NumberInstancesTest.swift
+++ b/Tests/BowTests/Instances/NumberInstancesTest.swift
@@ -103,67 +103,67 @@ class NumberInstancesTest: XCTestCase {
     
     func testIntSemigroupLaws() {
         property("Sum semigroup laws") <- forAll { (a : Int, b : Int, c : Int) in
-            return SemigroupLaws.check(semigroup: Int.sumMonoid, a: a, b: b, c: c, eq: Int.order)
+            return SemigroupLaws.check(semigroup: Int.sumSemigroup, a: a, b: b, c: c, eq: Int.order)
         }
         
         property("Product semigroup laws") <- forAll { (a : Int, b : Int, c : Int) in
-            return SemigroupLaws.check(semigroup: Int.productMonoid, a: a, b: b, c: c, eq: Int.order)
+            return SemigroupLaws.check(semigroup: Int.productSemigroup, a: a, b: b, c: c, eq: Int.order)
         }
     }
     
     func testInt8SemigroupLaws() {
         property("Sum semigroup laws") <- forAll { (a : Int8, b : Int8, c : Int8) in
-            return SemigroupLaws.check(semigroup: Int8.sumMonoid, a: a, b: b, c: c, eq: Int8.order)
+            return SemigroupLaws.check(semigroup: Int8.sumSemigroup, a: a, b: b, c: c, eq: Int8.order)
         }
         
         property("Product semigroup laws") <- forAll { (a : Int8, b : Int8, c : Int8) in
-            return SemigroupLaws.check(semigroup: Int8.productMonoid, a: a, b: b, c: c, eq: Int8.order)
+            return SemigroupLaws.check(semigroup: Int8.productSemigroup, a: a, b: b, c: c, eq: Int8.order)
         }
     }
     
     func testInt16SemigroupLaws() {
         property("Sum semigroup laws") <- forAll { (a : Int16, b : Int16, c : Int16) in
-            return SemigroupLaws.check(semigroup: Int16.sumMonoid, a: a, b: b, c: c, eq: Int16.order)
+            return SemigroupLaws.check(semigroup: Int16.sumSemigroup, a: a, b: b, c: c, eq: Int16.order)
         }
         
         property("Product semigroup laws") <- forAll { (a : Int16, b : Int16, c : Int16) in
-            return SemigroupLaws.check(semigroup: Int16.productMonoid, a: a, b: b, c: c, eq: Int16.order)
+            return SemigroupLaws.check(semigroup: Int16.productSemigroup, a: a, b: b, c: c, eq: Int16.order)
         }
     }
     
     func testInt32SemigroupLaws() {
         property("Sum semigroup laws") <- forAll { (a : Int32, b : Int32, c : Int32) in
-            return SemigroupLaws.check(semigroup: Int32.sumMonoid, a: a, b: b, c: c, eq: Int32.order)
+            return SemigroupLaws.check(semigroup: Int32.sumSemigroup, a: a, b: b, c: c, eq: Int32.order)
         }
         
         property("Product semigroup laws") <- forAll { (a : Int32, b : Int32, c : Int32) in
-            return SemigroupLaws.check(semigroup: Int32.productMonoid, a: a, b: b, c: c, eq: Int32.order)
+            return SemigroupLaws.check(semigroup: Int32.productSemigroup, a: a, b: b, c: c, eq: Int32.order)
         }
     }
     
     func testInt64SemigroupLaws() {
         property("Sum semigroup laws") <- forAll { (a : Int64, b : Int64, c : Int64) in
-            return SemigroupLaws.check(semigroup: Int64.sumMonoid, a: a, b: b, c: c, eq: Int64.order)
+            return SemigroupLaws.check(semigroup: Int64.sumSemigroup, a: a, b: b, c: c, eq: Int64.order)
         }
         
         property("Product semigroup laws") <- forAll { (a : Int64, b : Int64, c : Int64) in
-            return SemigroupLaws.check(semigroup: Int64.productMonoid, a: a, b: b, c: c, eq: Int64.order)
+            return SemigroupLaws.check(semigroup: Int64.productSemigroup, a: a, b: b, c: c, eq: Int64.order)
         }
     }
     
     func testUIntSemigroupLaws() {
         property("Sum semigroup laws") <- forAll { (a : UInt, b : UInt, c : UInt) in
-            return SemigroupLaws.check(semigroup: UInt.sumMonoid, a: a, b: b, c: c, eq: UInt.order)
+            return SemigroupLaws.check(semigroup: UInt.sumSemigroup, a: a, b: b, c: c, eq: UInt.order)
         }
         
         property("Product semigroup laws") <- forAll { (a : UInt, b : UInt, c : UInt) in
-            return SemigroupLaws.check(semigroup: UInt.productMonoid, a: a, b: b, c: c, eq: UInt.order)
+            return SemigroupLaws.check(semigroup: UInt.productSemigroup, a: a, b: b, c: c, eq: UInt.order)
         }
     }
     
     func testUInt8SemigroupLaws() {
         property("Sum semigroup laws") <- forAll { (a : UInt8, b : UInt8, c : UInt8) in
-            return SemigroupLaws.check(semigroup: UInt8.sumMonoid, a: a, b: b, c: c, eq: UInt8.order)
+            return SemigroupLaws.check(semigroup: UInt8.sumSemigroup, a: a, b: b, c: c, eq: UInt8.order)
         }
         
         property("Product semigroup laws") <- forAll { (a : UInt8, b : UInt8, c : UInt8) in
@@ -173,7 +173,7 @@ class NumberInstancesTest: XCTestCase {
     
     func testUInt16SemigroupLaws() {
         property("Sum semigroup laws") <- forAll { (a : UInt16, b : UInt16, c : UInt16) in
-            return SemigroupLaws.check(semigroup: UInt16.sumMonoid, a: a, b: b, c: c, eq: UInt16.order)
+            return SemigroupLaws.check(semigroup: UInt16.sumSemigroup, a: a, b: b, c: c, eq: UInt16.order)
         }
         
         property("Product semigroup laws") <- forAll { (a : UInt16, b : UInt16, c : UInt16) in
@@ -183,7 +183,7 @@ class NumberInstancesTest: XCTestCase {
     
     func testUInt32SemigroupLaws() {
         property("Sum semigroup laws") <- forAll { (a : UInt32, b : UInt32, c : UInt32) in
-            return SemigroupLaws.check(semigroup: UInt32.sumMonoid, a: a, b: b, c: c, eq: UInt32.order)
+            return SemigroupLaws.check(semigroup: UInt32.sumSemigroup, a: a, b: b, c: c, eq: UInt32.order)
         }
         
         property("Product semigroup laws") <- forAll { (a : UInt32, b : UInt32, c : UInt32) in
@@ -193,7 +193,7 @@ class NumberInstancesTest: XCTestCase {
     
     func testUInt64SemigroupLaws() {
         property("Sum semigroup laws") <- forAll { (a : UInt64, b : UInt64, c : UInt64) in
-            return SemigroupLaws.check(semigroup: UInt64.sumMonoid, a: a, b: b, c: c, eq: UInt64.order)
+            return SemigroupLaws.check(semigroup: UInt64.sumSemigroup, a: a, b: b, c: c, eq: UInt64.order)
         }
         
         property("Product semigroup laws") <- forAll { (a : UInt64, b : UInt64, c : UInt64) in

--- a/Tests/BowTests/Instances/StringInstancesTest.swift
+++ b/Tests/BowTests/Instances/StringInstancesTest.swift
@@ -6,12 +6,12 @@ import SwiftCheck
 class StringInstancesTest: XCTestCase {
     
     func testEqLaws() {
-        EqLaws.check(eq: String.order, generator: id)
+        EqLaws.check(eq: String.eq, generator: id)
     }
     
     func testSemigroupLaws() {
         property("String concatenation semigroup") <- forAll { (a : String, b : String, c : String) in
-            return SemigroupLaws.check(semigroup: String.concatMonoid, a: a, b: b, c: c, eq: String.order)
+            return SemigroupLaws.check(semigroup: String.concatSemigroup, a: a, b: b, c: c, eq: String.order)
         }
     }
     

--- a/Tests/BowTests/Transformers/EitherTTest.swift
+++ b/Tests/BowTests/Transformers/EitherTTest.swift
@@ -35,7 +35,7 @@ class EitherTTest: XCTestCase {
     
     func testApplicativeErrorLaws() {
         ApplicativeErrorLaws<EitherTPartial<ForOption, ()>, ()>.check(
-            applicativeError: EitherT<ForOption, (), Int>.monadError(Option<Int>.monadError()),
+            applicativeError: EitherT<ForOption, (), Int>.applicativeError(Option<Int>.monadError()),
             eq: EitherT<ForOption, (), Int>.eq(Option.eq(Either.eq(UnitEq(), Int.order)), Option<Int>.functor()),
             eqEither: EitherT.eq(Option.eq(Either.eq(UnitEq(), Either.eq(UnitEq(), Int.order))), Option<Any>.functor()),
             gen: { () })

--- a/Tests/BowTests/Transformers/StateTTest.swift
+++ b/Tests/BowTests/Transformers/StateTTest.swift
@@ -75,7 +75,7 @@ class StateTTest: XCTestCase {
     
     func testApplicativeErrorLaws() {
         ApplicativeErrorLaws<StateTPartial<ForOption, ()>, ()>.check(
-            applicativeError: StateT<ForOption, (), Int>.monadError(Option<Any>.monadError()),
+            applicativeError: StateT<ForOption, (), Int>.applicativeError(Option<Any>.monadError()),
             eq: StateTUnitEq(),
             eqEither: StateTEitherEq(),
             gen: { () })


### PR DESCRIPTION
This PR adds several convenience methods to ease the usage of the library, namely:

- Missing `eq` variables in numeric, boolean and String types.
- Missing `semigroup` variables in numeric, boolean and String types.
- Missing `applicativeError` accessor in several compatible types.
- Missing convenience methods to work with `State`. The implementation based on `StateT` forced users to pass `Id` instances in all methods.