### PR TITLE
Update podspecs to have the proper dependencies listed

### DIFF
--- a/BowBrightFutures.podspec
+++ b/BowBrightFutures.podspec
@@ -24,5 +24,7 @@ Pod::Spec.new do |s|
   s.watchos.deployment_target = "2.0"
   s.source   = { :git => "https://github.com/bow-swift/bow.git", :tag => "#{s.version}" }
   s.source_files = "Sources/BowBrightFutures/**/*.swift"
+  s.dependency "Bow", "~> 0.2.0"
+  s.dependency "BowResult", "~> 0.2.0"
   s.dependency "BrightFutures", "~> 7.0.0"
 end

--- a/BowEffects.podspec
+++ b/BowEffects.podspec
@@ -24,4 +24,5 @@ Pod::Spec.new do |s|
   s.watchos.deployment_target = "2.0"
   s.source   = { :git => "https://github.com/bow-swift/bow.git", :tag => "#{s.version}" }
   s.source_files = "Sources/BowEffects/**/*.swift"
+  s.dependency "Bow", "~> 0.2.0"
 end

--- a/BowFree.podspec
+++ b/BowFree.podspec
@@ -24,4 +24,5 @@ Pod::Spec.new do |s|
   s.watchos.deployment_target = "2.0"
   s.source   = { :git => "https://github.com/bow-swift/bow.git", :tag => "#{s.version}" }
   s.source_files = "Sources/BowFree/**/*.swift"
+  s.dependency "Bow", "~> 0.2.0"
 end

--- a/BowGeneric.podspec
+++ b/BowGeneric.podspec
@@ -24,4 +24,5 @@ Pod::Spec.new do |s|
   s.watchos.deployment_target = "2.0"
   s.source   = { :git => "https://github.com/bow-swift/bow.git", :tag => "#{s.version}" }
   s.source_files = "Sources/BowGeneric/**/*.swift"
+  s.dependency "Bow", "~> 0.2.0"
 end

--- a/BowOptics.podspec
+++ b/BowOptics.podspec
@@ -24,4 +24,5 @@ Pod::Spec.new do |s|
   s.watchos.deployment_target = "2.0"
   s.source   = { :git => "https://github.com/bow-swift/bow.git", :tag => "#{s.version}" }
   s.source_files = "Sources/BowOptics/**/*.swift"
+  s.dependency "Bow", "~> 0.2.0"
 end

--- a/BowRecursionSchemes.podspec
+++ b/BowRecursionSchemes.podspec
@@ -24,4 +24,5 @@ Pod::Spec.new do |s|
   s.watchos.deployment_target = "2.0"
   s.source   = { :git => "https://github.com/bow-swift/bow.git", :tag => "#{s.version}" }
   s.source_files = "Sources/BowRecursionSchemes/**/*.swift"
+  s.dependency "Bow", "~> 0.2.0"
 end

--- a/BowResult.podspec
+++ b/BowResult.podspec
@@ -25,4 +25,5 @@ Pod::Spec.new do |s|
   s.source   = { :git => "https://github.com/bow-swift/bow.git", :tag => "#{s.version}" }
   s.source_files = "Sources/BowResult/**/*.swift"
   s.dependency "Result", "~> 4.0.0"
+  s.dependency "Bow", "~> 0.2.0"
 end

--- a/BowRx.podspec
+++ b/BowRx.podspec
@@ -26,4 +26,5 @@ Pod::Spec.new do |s|
   s.source_files = "Sources/BowRx/**/*.swift"
   s.dependency "RxSwift", "~> 4.0.0"
   s.dependency "RxCocoa", "~> 4.0.0"
+  s.dependency "Bow", "~> 0.2.0"
 end


### PR DESCRIPTION
Podspecs were missing internal dependencies, mainly to the core Bow module. This PR adds them and prepares release 0.2.0.

These podspecs need to be linted with Cocoapods 1.6.0-beta2 since there is a bug in previous versions which was throwing a false negative error when building the library for macOS. Probably this version needs to be used for release as well.