### PR TITLE
Fix broken dependencies

### DIFF
--- a/BowRx.podspec
+++ b/BowRx.podspec
@@ -24,8 +24,8 @@ Pod::Spec.new do |s|
   s.watchos.deployment_target = "3.0"
   s.source   = { :git => "https://github.com/bow-swift/bow.git", :tag => "#{s.version}" }
   s.source_files = "Sources/BowRx/**/*.swift"
-  s.dependency "RxSwift", "~> 4.0.0"
-  s.dependency "RxCocoa", "~> 4.0.0"
+  s.dependency "RxSwift", "~> 4.4.0"
+  s.dependency "RxCocoa", "~> 4.4.0"
   s.dependency "Bow", "~> 0.2.0"
   s.dependency "BowEffects", "~> 0.2.0"
 end

--- a/Cartfile
+++ b/Cartfile
@@ -1,0 +1,3 @@
+github "ReactiveX/RxSwift" ~> 4.4.0
+github "Thomvis/BrightFutures" ~> 7.0.0
+github "antitypical/Result" ~> 4.0.0

--- a/Cartfile.private
+++ b/Cartfile.private
@@ -1,5 +1,2 @@
 github "typelift/SwiftCheck" ~> 0.9.1
 github "Quick/Nimble" ~> 7.0.2
-github "ReactiveX/RxSwift" ~> 4.0
-github "Thomvis/BrightFutures" ~> 7.0.0
-github "antitypical/Result" ~> 4.0.0


### PR DESCRIPTION
Carthage is not able to resolve transitive dependencies because they were in the private file. Also, Rx dependencies need to be in version 4.4 in order to work with Swift 4.2.