### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ pod "BowBrightFutures", "~> 0.2.0"
 
 ### Carthage
 
-Carthage with download the whole Bow project, but it will compile individual frameworks for each module that you can use separately. Add this line to your Cartfile:
+Carthage will download the whole Bow project, but it will compile individual frameworks for each module that you can use separately. Add this line to your Cartfile:
 
 ```
 github "bow-swift/Bow" ~> 0.2.0

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Bow
 
-[![Build Status](https://travis-ci.org/arrow-kt/bow.svg?branch=master)](https://travis-ci.org/arrow-kt/bow)
-[![codecov](https://codecov.io/gh/arrow-kt/bow/branch/master/graph/badge.svg)](https://codecov.io/gh/arrow-kt/bow)
+[![Build Status](https://travis-ci.org/bow-swift/bow.svg?branch=master)](https://travis-ci.org/bow-swift/bow)
+[![codecov](https://codecov.io/gh/bow-swift/bow/branch/master/graph/badge.svg)](https://codecov.io/gh/bow-swift/bow)
 [![Gitter](https://badges.gitter.im/arrow-kt/bow.svg)](https://gitter.im/arrow-kt/bow?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
 Bow is a library for Typed Functional Programming in Swift.
@@ -20,7 +20,31 @@ Bow is split in multiple modules that can be consumed independently. These modul
 - `BowBrightFutures`: module to provide an integration with BrightFutures.
 - `BowRx`: module to provide an integration with RxSwift.
 
-Bow is available using Cocoapods, Carthage and Swift Package Manager.
+Bow is available using CocoaPods and Carthage.
+
+### CocoaPods
+
+You can consume each Bow module as a separate pod. You can add these lines to your Podfile at your convenience:
+
+```ruby
+pod "Bow", "~> 0.2.0"
+pod "BowOptics", "~> 0.2.0"
+pod "BowRecursionSchemes", "~> 0.2.0"
+pod "BowFree", "~> 0.2.0"
+pod "BowGeneric", "~> 0.2.0"
+pod "BowResult", "~> 0.2.0"
+pod "BowEffects", "~> 0.2.0"
+pod "BowRx", "~> 0.2.0"
+pod "BowBrightFutures", "~> 0.2.0"
+```
+
+### Carthage
+
+Carthage with download the whole Bow project, but it will compile individual frameworks for each module that you can use separately. Add this line to your Cartfile:
+
+```
+github "bow-swift/Bow" ~> 0.2.0
+```
 
 ## Contributing
 

--- a/Sources/Bow/Data/State.swift
+++ b/Sources/Bow/Data/State.swift
@@ -11,34 +11,6 @@ public class State<S, A> : StateOf<S, A> {
     public init(_ run : @escaping (S) -> (S, A)) {
         super.init(Id.pure({ s in Id.pure(run(s)) }))
     }
-    
-    public func run(_ initial : S) -> (S, A) {
-        return self.runM(initial, Id<S>.monad()).fix().extract()
-    }
-    
-    public func runA(_ s : S) -> A {
-        return run(s).1
-    }
-    
-    public func runS(_ s : S) -> S {
-        return run(s).0
-    }
-    
-    public func map<B>(_ f : @escaping (A) -> B) -> StateOf<S, B> {
-        return self.map(f, Id<A>.functor())
-    }
-    
-    public func ap<B>(_ ff : StateOf<S, (A) -> B>) -> StateOf<S, B> {
-        return self.ap(ff, Id<A>.monad())
-    }
-    
-    public func flatMap<B>(_ f : @escaping (A) -> StateOf<S, B>) -> StateOf<S, B> {
-        return self.flatMap(f, Id<A>.monad())
-    }
-    
-    public func product<B>(_ sb : State<S, B>) -> StateOf<S, (A, B)> {
-        return self.product(sb, Id<A>.monad())
-    }
 }
 
 public extension State {

--- a/Sources/Bow/Transformers/StateT.swift
+++ b/Sources/Bow/Transformers/StateT.swift
@@ -120,6 +120,36 @@ public class StateT<F, S, A> : StateTOf<F, S, A> {
     }
 }
 
+public extension StateT where F == ForId {
+    public func run(_ initialState : S) -> (S, A) {
+        return self.runM(initialState, Id<A>.monad()).fix().value
+    }
+    
+    public func runA(_ s : S) -> A {
+        return run(s).1
+    }
+    
+    public func runS(_ s : S) -> S {
+        return run(s).0
+    }
+    
+    public func map<B>(_ f : @escaping (A) -> B) -> StateOf<S, B> {
+        return self.map(f, Id<A>.functor())
+    }
+    
+    public func ap<B>(_ ff : StateOf<S, (A) -> B>) -> StateOf<S, B> {
+        return self.ap(ff, Id<A>.monad())
+    }
+    
+    public func flatMap<B>(_ f : @escaping (A) -> StateOf<S, B>) -> StateOf<S, B> {
+        return self.flatMap(f, Id<A>.monad())
+    }
+    
+    public func product<B>(_ sb : State<S, B>) -> StateOf<S, (A, B)> {
+        return self.product(sb, Id<A>.monad())
+    }
+}
+
 public extension StateT {
     public static func functor<FuncF>(_ functor : FuncF) -> StateTFunctor<F, S, FuncF> {
         return StateTFunctor<F, S, FuncF>(functor)


### PR DESCRIPTION
This PR updates the README to point the badges to the right URLs (they were outdated after the migration to the new organization) and adds information to consume the library from CocoaPods and Carthage.

It also moves some methods from State to a constrained extension of StateT in order to make them more accessible without castings.