### PR TITLE
Rename toOption/fromOption

### DIFF
--- a/Sources/Bow/Data/Option.swift
+++ b/Sources/Bow/Data/Option.swift
@@ -20,7 +20,7 @@ public class Option<A> : OptionOf<A> {
         return None()
     }
     
-    public static func fromOption(_ a : A?) -> Option<A> {
+    public static func fromOptional(_ a : A?) -> Option<A> {
         if let a = a { return some(a) }
         return none()
     }
@@ -127,7 +127,7 @@ public class Option<A> : OptionOf<A> {
         return fold(defaultValue, Option.some)
     }
     
-    public func toOption() -> A? {
+    public func toOptional() -> A? {
         return fold(constant(nil), id)
     }
     
@@ -345,5 +345,11 @@ extension Option : Equatable where A : Equatable {
     public static func ==(lhs : Option<A>, rhs : Option<A>) -> Bool {
         return lhs.fold({ rhs.fold(constant(true), constant(false)) },
                         { a in rhs.fold(constant(false), { b in a == b })})
+    }
+}
+
+extension Optional {
+    func toOption() -> Option<Wrapped> {
+        return Option<Wrapped>.fromOptional(self)
     }
 }

--- a/Sources/BowOptics/STD/Maybe+Optics.swift
+++ b/Sources/BowOptics/STD/Maybe+Optics.swift
@@ -4,8 +4,8 @@ import Bow
 public extension Option {
     public static func toPOption<B>() -> PIso<Option<A>, Option<B>, A?, B?> {
         return PIso<Option<A>, Option<B>, A?, B?>(
-            get: { x in x.toOption() },
-            reverseGet: Option<B>.fromOption)
+            get: { x in x.toOptional() },
+            reverseGet: Option<B>.fromOptional)
     }
     
     public static func toOption() -> Iso<Option<A>, A?> {

--- a/Tests/BowOpticsTests/FoldTest.swift
+++ b/Tests/BowOpticsTests/FoldTest.swift
@@ -37,7 +37,7 @@ class FoldTest : XCTestCase {
         
         property("Find first element matching predicate") <- forAll { (array : ArrayOf<Int>) in
             return Option.eq(Int.order).eqv(self.intFold.find(array.getArray.k(), { x in x > 10 }),
-                                           Option.fromOption(array.getArray.filter{ x in x > 10 }.first))
+                                           Option.fromOptional(array.getArray.filter{ x in x > 10 }.first))
         }
         
         property("Checking existence of a target") <- forAll(self.nonEmptyListGen, Bool.arbitrary) { (array : ArrayOf<Int>, predicate : Bool) in

--- a/Tests/BowOpticsTests/OptionalTest.swift
+++ b/Tests/BowOpticsTests/OptionalTest.swift
@@ -19,37 +19,37 @@ class OptionalTest: XCTestCase {
     
     func testOptionalAsFold() {
         property("Optional as Fold: size") <- forAll { (ints : ArrayOf<Int>) in
-            return optionalHead.asFold().size(ints.getArray) == Option.fromOption(ints.getArray.first).map(constant(1)).getOrElse(0)
+            return optionalHead.asFold().size(ints.getArray) == Option.fromOptional(ints.getArray.first).map(constant(1)).getOrElse(0)
         }
         
         property("Optional as Fold: nonEmpty") <- forAll { (ints : ArrayOf<Int>) in
-            return optionalHead.asFold().nonEmpty(ints.getArray) == Option.fromOption(ints.getArray.first).isDefined
+            return optionalHead.asFold().nonEmpty(ints.getArray) == Option.fromOptional(ints.getArray.first).isDefined
         }
         
         property("Optional as Fold: isEmpty") <- forAll { (ints : ArrayOf<Int>) in
-            return optionalHead.asFold().isEmpty(ints.getArray) == Option.fromOption(ints.getArray.first).isEmpty
+            return optionalHead.asFold().isEmpty(ints.getArray) == Option.fromOptional(ints.getArray.first).isEmpty
         }
         
         property("Optional as Fold: getAll") <- forAll { (ints : ArrayOf<Int>) in
-            return ListK.eq(Int.order).eqv(optionalHead.asFold().getAll(ints.getArray), Option.fromOption(ints.getArray.first).toList().k())
+            return ListK.eq(Int.order).eqv(optionalHead.asFold().getAll(ints.getArray), Option.fromOptional(ints.getArray.first).toList().k())
         }
         
         property("Optional as Fold: combineAll") <- forAll { (ints : ArrayOf<Int>) in
-            return optionalHead.asFold().combineAll(Int.sumMonoid, ints.getArray) == Option.fromOption(ints.getArray.first).fold(constant(Int.sumMonoid.empty), id)
+            return optionalHead.asFold().combineAll(Int.sumMonoid, ints.getArray) == Option.fromOptional(ints.getArray.first).fold(constant(Int.sumMonoid.empty), id)
         }
         
         property("Optional as Fold: fold") <- forAll { (ints : ArrayOf<Int>) in
-            return optionalHead.asFold().fold(Int.sumMonoid, ints.getArray) == Option.fromOption(ints.getArray.first).fold(constant(Int.sumMonoid.empty), id)
+            return optionalHead.asFold().fold(Int.sumMonoid, ints.getArray) == Option.fromOptional(ints.getArray.first).fold(constant(Int.sumMonoid.empty), id)
         }
         
         property("Optional as Fold: headOption") <- forAll { (ints : ArrayOf<Int>) in
             return Option.eq(Int.order).eqv(optionalHead.asFold().headOption(ints.getArray),
-                                           Option.fromOption(ints.getArray.first))
+                                           Option.fromOptional(ints.getArray.first))
         }
         
         property("Optional as Fold: lastOption") <- forAll { (ints : ArrayOf<Int>) in
             return Option.eq(Int.order).eqv(optionalHead.asFold().lastOption(ints.getArray),
-                                           Option.fromOption(ints.getArray.first))
+                                           Option.fromOptional(ints.getArray.first))
         }
     }
     

--- a/Tests/BowOpticsTests/TestDomain.swift
+++ b/Tests/BowOpticsTests/TestDomain.swift
@@ -104,6 +104,6 @@ let sumPrism = Prism<SumType, String>(getOrModify: { sum in
 
 let optionalHead = BowOptics.Optional<Array<Int>, Int>(
     set: { array, value in [value] + ((array.count > 1) ? Array(array.dropFirst()) : [])},
-    getOrModify: { array in Option.fromOption(array.first).fold(constant(Either.left(array)), Either.right) })
+    getOrModify: { array in Option.fromOptional(array.first).fold(constant(Either.left(array)), Either.right) })
 
 let defaultHead = BowOptics.Optional<Int, Int>(set: { a, _ in a }, getOrModify: Either.right)

--- a/Tests/BowOpticsTests/TraversalTest.swift
+++ b/Tests/BowOpticsTests/TraversalTest.swift
@@ -49,13 +49,13 @@ class TraversalTest: XCTestCase {
         property("Traversal as Fold: headOption") <- forAll { (array : ArrayOf<Int>) in
             return Option.eq(Int.order).eqv(
                 self.listKTraversal.asFold().headOption(array.getArray.k()),
-                Option.fromOption(array.getArray.first))
+                Option.fromOptional(array.getArray.first))
         }
         
         property("Traversal as Fold: lastOption") <- forAll { (array : ArrayOf<Int>) in
             return Option.eq(Int.order).eqv(
                 self.listKTraversal.asFold().lastOption(array.getArray.k()),
-                Option.fromOption(array.getArray.last))
+                Option.fromOptional(array.getArray.last))
         }
     }
     
@@ -78,7 +78,7 @@ class TraversalTest: XCTestCase {
         property("Find a target in a traversal") <- forAll { (array : ArrayOf<Int>) in
             return Option.eq(Int.order).eqv(
                 self.listKTraversal.find(array.getArray.k(), { x in x > 10 }),
-                Option.fromOption(array.getArray.filter { x in x > 10 }.first))
+                Option.fromOptional(array.getArray.filter { x in x > 10 }.first))
         }
         
         property("Size of a traversal") <- forAll { (array : ArrayOf<Int>) in

--- a/Tests/BowRxTests/MaybeKTest.swift
+++ b/Tests/BowRxTests/MaybeKTest.swift
@@ -29,8 +29,8 @@ class MaybeKTest : XCTestCase {
         typealias A = Kind<ForMaybeK, EitherOf<CategoryError, Int>>
         
         func eqv(_ a: Kind<ForMaybeK, EitherOf<CategoryError, Int>>, _ b: Kind<ForMaybeK, EitherOf<CategoryError, Int>>) -> Bool {
-            let x = Option.fromOption(a.fix().value.blockingGet())
-            let y = Option.fromOption(b.fix().value.blockingGet())
+            let x = Option.fromOptional(a.fix().value.blockingGet())
+            let y = Option.fromOptional(b.fix().value.blockingGet())
             
             return Option.eq(Either.eq(CategoryError.eq, Int.order)).eqv(x, y)
         }

--- a/Tests/BowRxTests/ObservableKTest.swift
+++ b/Tests/BowRxTests/ObservableKTest.swift
@@ -29,8 +29,8 @@ class ObservableKTest : XCTestCase {
         typealias A = ObservableKOf<EitherOf<CategoryError, Int>>
         
         func eqv(_ a: ObservableKOf<EitherOf<CategoryError, Int>>, _ b: ObservableKOf<EitherOf<CategoryError, Int>>) -> Bool {
-            let x = Option.fromOption(a.fix().value.blockingGet())
-            let y = Option.fromOption(b.fix().value.blockingGet())
+            let x = Option.fromOptional(a.fix().value.blockingGet())
+            let y = Option.fromOptional(b.fix().value.blockingGet())
             return Option.eq(Either.eq(CategoryError.eq, Int.order)).eqv(x, y)
         }
     }

--- a/Tests/BowRxTests/SingleKTest.swift
+++ b/Tests/BowRxTests/SingleKTest.swift
@@ -28,8 +28,8 @@ class SingleKTest : XCTestCase {
         typealias A = Kind<ForSingleK, EitherOf<CategoryError, Int>>
         
         func eqv(_ a: Kind<ForSingleK, EitherOf<CategoryError, Int>>, _ b: Kind<ForSingleK, EitherOf<CategoryError, Int>>) -> Bool {
-            let x = Option.fromOption(a.fix().value.blockingGet())
-            let y = Option.fromOption(b.fix().value.blockingGet())
+            let x = Option.fromOptional(a.fix().value.blockingGet())
+            let y = Option.fromOptional(b.fix().value.blockingGet())
             return Option.eq(Either.eq(CategoryError.eq, Int.order)).eqv(x, y)
         }
     }

--- a/Tests/BowTests/Data/OptionTest.swift
+++ b/Tests/BowTests/Data/OptionTest.swift
@@ -91,21 +91,21 @@ class OptionTest: XCTestCase {
     func testFromToOption() {
         property("fromOption - toOption isomorphism") <- forAll { (x : Int?, y : Int) in
             let option = y % 2 == 0 ? Option<Int>.none() : Option<Int>.some(y)
-            return Option.fromOption(x).toOption() == x &&
-                Option.eq(Int.order).eqv(Option.fromOption(option.toOption()), option)
+            return Option.fromOptional(x).toOptional() == x &&
+                Option.eq(Int.order).eqv(Option.fromOptional(option.toOptional()), option)
         }
     }
     
     func testDefinedOrEmpty() {
         property("Option cannot be simultaneously empty and defined") <- forAll { (x : Int?) in
-            let option = Option.fromOption(x)
+            let option = Option.fromOptional(x)
             return xor(option.isEmpty, option.isDefined)
         }
     }
     
     func testGetOrElse() {
         property("getOrElse consistent with orElse") <- forAll { (x : Int?, y : Int) in
-            let option = Option.fromOption(x)
+            let option = Option.fromOptional(x)
             return Option.eq(Int.order).eqv(Option<Int>.pure(option.getOrElse(y)),
                                            option.orElse(Option.pure(y)))
         }
@@ -113,7 +113,7 @@ class OptionTest: XCTestCase {
     
     func testFilter() {
         property("filter is opposite of filterNot") <- forAll { (x : Int?, predicate : ArrowOf<Int, Bool>) in
-            let option = Option.fromOption(x)
+            let option = Option.fromOptional(x)
             let eq = Option.eq(Int.order)
             let none = Option<Int>.none()
             return xor(eq.eqv(option.filter(predicate.getArrow), none), eq.eqv(option.filterNot(predicate.getArrow), none))
@@ -122,7 +122,7 @@ class OptionTest: XCTestCase {
     
     func testExistForAll() {
         property("exists and forall are equivalent") <- forAll { (x : Int?, predicate : ArrowOf<Int, Bool>) in
-            let option = Option.fromOption(x)
+            let option = Option.fromOptional(x)
             return option.exists(predicate.getArrow) == option.forall(predicate.getArrow)
         }
     }

--- a/Tests/BowTests/Data/ValidatedTest.swift
+++ b/Tests/BowTests/Data/ValidatedTest.swift
@@ -68,7 +68,7 @@ class ValidatedTest: XCTestCase {
     
     func testConversionConsistency() {
         property("Consistency fromOption - toOption") <- forAll { (x : Int?, none : String) in
-            let option = Option<Int>.fromOption(x)
+            let option = Option<Int>.fromOptional(x)
             let validated = Validated.fromOption(option, ifNone: constant(none))
             return Option<Int>.eq(Int.order).eqv(validated.toOption(), option)
         }


### PR DESCRIPTION
Current methods to convert from/to native Swift `Optional<A>` (namely `A?`) are not named properly. This PR changes:

- `toOption()` becomes `toOptional()`
- `fromOption()` becomes `fromOptional()`