### PR TITLE
Refactor ap method in Applicative

### DIFF
--- a/Sources/Bow/Arrow/Function0.swift
+++ b/Sources/Bow/Arrow/Function0.swift
@@ -43,8 +43,8 @@ public class Function0<A> : Function0Of<A> {
         return Function0<B>({ f(self) })
     }
     
-    public func ap<B>(_ ff : Function0<(A) -> B>) -> Function0<B> {
-        return Function0<B>(f >>> ff.f())
+    public func ap<AA, B>(_ ff : Function0<AA>) -> Function0<B> where A == (AA) -> B {
+        return Function0<B>(ff.f >>> f())
     }
     
     public func extract() -> A {
@@ -98,7 +98,7 @@ public class Function0Applicative : Function0Functor, Applicative {
     }
     
     public func ap<A, B>(_ fa: Kind<Function0Applicative.F, A>, _ ff: Kind<Function0Applicative.F, (A) -> B>) -> Kind<Function0Applicative.F, B> {
-        return Function0.fix(fa).ap(Function0.fix(ff))
+        return Function0.fix(ff).ap(Function0.fix(fa))
     }
 }
 

--- a/Sources/Bow/Arrow/Function0.swift
+++ b/Sources/Bow/Arrow/Function0.swift
@@ -97,7 +97,7 @@ public class Function0Applicative : Function0Functor, Applicative {
         return Function0.pure(a)
     }
     
-    public func ap<A, B>(_ fa: Kind<Function0Applicative.F, A>, _ ff: Kind<Function0Applicative.F, (A) -> B>) -> Kind<Function0Applicative.F, B> {
+    public func ap<A, B>(_ ff: Kind<Function0Applicative.F, (A) -> B>, _ fa: Kind<Function0Applicative.F, A>) -> Kind<Function0Applicative.F, B> {
         return Function0.fix(ff).ap(Function0.fix(fa))
     }
 }

--- a/Sources/Bow/Arrow/Function0.swift
+++ b/Sources/Bow/Arrow/Function0.swift
@@ -43,8 +43,8 @@ public class Function0<A> : Function0Of<A> {
         return Function0<B>({ f(self) })
     }
     
-    public func ap<AA, B>(_ ff : Function0<AA>) -> Function0<B> where A == (AA) -> B {
-        return Function0<B>(ff.f >>> f())
+    public func ap<AA, B>(_ fa : Function0<AA>) -> Function0<B> where A == (AA) -> B {
+        return Function0<B>(fa.f >>> f())
     }
     
     public func extract() -> A {

--- a/Sources/Bow/Arrow/Function1.swift
+++ b/Sources/Bow/Arrow/Function1.swift
@@ -40,8 +40,8 @@ public class Function1<I, O> : Function1Of<I, O> {
         return Function1<I, B>(h)
     }
     
-    public func ap<B>(_ ff : Function1<I, (O) -> B>) -> Function1<I, B> {
-        return Function1<I, B>({ i in ff.f(i)(self.f(i)) })
+    public func ap<AA, B>(_ ff : Function1<I, AA>) -> Function1<I, B> where O == (AA) -> B {
+        return Function1<I, B>({ i in self.f(i)(ff.f(i)) })
     }
     
     public func local(_ g : @escaping (I) -> I) -> Function1<I, O> {
@@ -85,7 +85,7 @@ public class Function1Applicative<I> : Function1Functor<I>, Applicative {
     }
     
     public func ap<A, B>(_ fa: Function1Of<I, A>, _ ff: Function1Of<I, (A) -> B>) -> Function1Of<I, B> {
-        return Function1.fix(fa).ap(Function1.fix(ff))
+        return Function1.fix(ff).ap(Function1.fix(fa))
     }
 }
 

--- a/Sources/Bow/Arrow/Function1.swift
+++ b/Sources/Bow/Arrow/Function1.swift
@@ -40,8 +40,8 @@ public class Function1<I, O> : Function1Of<I, O> {
         return Function1<I, B>(h)
     }
     
-    public func ap<AA, B>(_ ff : Function1<I, AA>) -> Function1<I, B> where O == (AA) -> B {
-        return Function1<I, B>({ i in self.f(i)(ff.f(i)) })
+    public func ap<AA, B>(_ fa : Function1<I, AA>) -> Function1<I, B> where O == (AA) -> B {
+        return Function1<I, B>({ i in self.f(i)(fa.f(i)) })
     }
     
     public func local(_ g : @escaping (I) -> I) -> Function1<I, O> {

--- a/Sources/Bow/Arrow/Function1.swift
+++ b/Sources/Bow/Arrow/Function1.swift
@@ -84,7 +84,7 @@ public class Function1Applicative<I> : Function1Functor<I>, Applicative {
         return Function1<I, A>.pure(a)
     }
     
-    public func ap<A, B>(_ fa: Function1Of<I, A>, _ ff: Function1Of<I, (A) -> B>) -> Function1Of<I, B> {
+    public func ap<A, B>(_ ff: Function1Of<I, (A) -> B>, _ fa: Function1Of<I, A>) -> Function1Of<I, B> {
         return Function1.fix(ff).ap(Function1.fix(fa))
     }
 }

--- a/Sources/Bow/Arrow/Kleisli.swift
+++ b/Sources/Bow/Arrow/Kleisli.swift
@@ -17,7 +17,7 @@ public class Kleisli<F, D, A> : KleisliOf<F, D, A> {
     }
     
     public func ap<AA, B, Appl>(_ ff : Kleisli<F, D, AA>, _ applicative : Appl) -> Kleisli<F, D, B> where Appl : Applicative, Appl.F == F, A == (AA) -> B {
-        return Kleisli<F, D, B>({ d in applicative.ap(ff.run(d), self.run(d)) })
+        return Kleisli<F, D, B>({ d in applicative.ap(self.run(d), ff.run(d)) })
     }
     
     public func map<B, Func>(_ f : @escaping (A) -> B, _ functor : Func) -> Kleisli<F, D, B> where Func : Functor, Func.F == F {
@@ -128,7 +128,7 @@ public class KleisliApplicative<G, D, ApplG> : KleisliFunctor<G, D, ApplG>, Appl
         return Kleisli.pure(a, applicative)
     }
     
-    public func ap<A, B>(_ fa: KleisliOf<G, D, A>, _ ff: KleisliOf<G, D, (A) -> B>) -> KleisliOf<G, D, B> {
+    public func ap<A, B>(_ ff: KleisliOf<G, D, (A) -> B>, _ fa: KleisliOf<G, D, A>) -> KleisliOf<G, D, B> {
         return Kleisli.fix(ff).ap(Kleisli.fix(fa), applicative)
     }
 }

--- a/Sources/Bow/Arrow/Kleisli.swift
+++ b/Sources/Bow/Arrow/Kleisli.swift
@@ -16,8 +16,8 @@ public class Kleisli<F, D, A> : KleisliOf<F, D, A> {
         self.run = run
     }
     
-    public func ap<B, Appl>(_ ff : Kleisli<F, D, (A) -> B>, _ applicative : Appl) -> Kleisli<F, D, B> where Appl : Applicative, Appl.F == F {
-        return Kleisli<F, D, B>({ d in applicative.ap(self.run(d), ff.run(d)) })
+    public func ap<AA, B, Appl>(_ ff : Kleisli<F, D, AA>, _ applicative : Appl) -> Kleisli<F, D, B> where Appl : Applicative, Appl.F == F, A == (AA) -> B {
+        return Kleisli<F, D, B>({ d in applicative.ap(ff.run(d), self.run(d)) })
     }
     
     public func map<B, Func>(_ f : @escaping (A) -> B, _ functor : Func) -> Kleisli<F, D, B> where Func : Functor, Func.F == F {
@@ -129,7 +129,7 @@ public class KleisliApplicative<G, D, ApplG> : KleisliFunctor<G, D, ApplG>, Appl
     }
     
     public func ap<A, B>(_ fa: KleisliOf<G, D, A>, _ ff: KleisliOf<G, D, (A) -> B>) -> KleisliOf<G, D, B> {
-        return Kleisli.fix(fa).ap(Kleisli.fix(ff), applicative)
+        return Kleisli.fix(ff).ap(Kleisli.fix(fa), applicative)
     }
 }
 

--- a/Sources/Bow/Arrow/Kleisli.swift
+++ b/Sources/Bow/Arrow/Kleisli.swift
@@ -16,8 +16,8 @@ public class Kleisli<F, D, A> : KleisliOf<F, D, A> {
         self.run = run
     }
     
-    public func ap<AA, B, Appl>(_ ff : Kleisli<F, D, AA>, _ applicative : Appl) -> Kleisli<F, D, B> where Appl : Applicative, Appl.F == F, A == (AA) -> B {
-        return Kleisli<F, D, B>({ d in applicative.ap(self.run(d), ff.run(d)) })
+    public func ap<AA, B, Appl>(_ fa : Kleisli<F, D, AA>, _ applicative : Appl) -> Kleisli<F, D, B> where Appl : Applicative, Appl.F == F, A == (AA) -> B {
+        return Kleisli<F, D, B>({ d in applicative.ap(self.run(d), fa.run(d)) })
     }
     
     public func map<B, Func>(_ f : @escaping (A) -> B, _ functor : Func) -> Kleisli<F, D, B> where Func : Functor, Func.F == F {

--- a/Sources/Bow/Data/Const.swift
+++ b/Sources/Bow/Data/Const.swift
@@ -105,7 +105,7 @@ public class ConstApplicative<R, Mono> : ConstFunctor<R>, Applicative where Mono
         return ConstMonoid(self.monoid).empty
     }
     
-    public func ap<A, B>(_ fa: ConstOf<R, A>, _ ff: ConstOf<R, (A) -> B>) -> ConstOf<R, B> {
+    public func ap<A, B>(_ ff: ConstOf<R, (A) -> B>, _ fa: ConstOf<R, A>) -> ConstOf<R, B> {
         return Const.fix(ff).ap(Const.fix(fa), monoid)
     }
 }

--- a/Sources/Bow/Data/Const.swift
+++ b/Sources/Bow/Data/Const.swift
@@ -35,8 +35,8 @@ public class Const<A, T> : ConstOf<A, T> {
         return Const<A, T>(semigroup.combine(self.value, other.value))
     }
     
-    public func ap<AA, U, SemiG>(_ ff : Const<A, AA>, _ semigroup : SemiG) -> Const<A, U> where SemiG : Semigroup, SemiG.A == A, T == (AA) -> U {
-        return self.retag().combine(ff.retag(), semigroup)
+    public func ap<AA, U, SemiG>(_ fa : Const<A, AA>, _ semigroup : SemiG) -> Const<A, U> where SemiG : Semigroup, SemiG.A == A, T == (AA) -> U {
+        return self.retag().combine(fa.retag(), semigroup)
     }
 }
 

--- a/Sources/Bow/Data/Const.swift
+++ b/Sources/Bow/Data/Const.swift
@@ -35,8 +35,8 @@ public class Const<A, T> : ConstOf<A, T> {
         return Const<A, T>(semigroup.combine(self.value, other.value))
     }
     
-    public func ap<U, SemiG>(_ ff : Const<A, (T) -> U>, _ semigroup : SemiG) -> Const<A, U> where SemiG : Semigroup, SemiG.A == A {
-        return ff.retag().combine(self.retag(), semigroup)
+    public func ap<AA, U, SemiG>(_ ff : Const<A, AA>, _ semigroup : SemiG) -> Const<A, U> where SemiG : Semigroup, SemiG.A == A, T == (AA) -> U {
+        return self.retag().combine(ff.retag(), semigroup)
     }
 }
 
@@ -106,7 +106,7 @@ public class ConstApplicative<R, Mono> : ConstFunctor<R>, Applicative where Mono
     }
     
     public func ap<A, B>(_ fa: ConstOf<R, A>, _ ff: ConstOf<R, (A) -> B>) -> ConstOf<R, B> {
-        return Const.fix(fa).ap(Const.fix(ff), monoid)
+        return Const.fix(ff).ap(Const.fix(fa), monoid)
     }
 }
 

--- a/Sources/Bow/Data/Either.swift
+++ b/Sources/Bow/Data/Either.swift
@@ -202,7 +202,7 @@ public class EitherApplicative<C> : Applicative {
         return Either<C, A>.pure(a)
     }
     
-    public func ap<A, B>(_ fa: EitherOf<C, A>, _ ff: EitherOf<C, (A) -> B>) -> EitherOf<C, B> {
+    public func ap<A, B>(_ ff: EitherOf<C, (A) -> B>, _ fa: EitherOf<C, A>) -> EitherOf<C, B> {
         return Either.fix(ff).ap(Either.fix(fa))
     }
 }

--- a/Sources/Bow/Data/Either.swift
+++ b/Sources/Bow/Data/Either.swift
@@ -79,7 +79,7 @@ public class Either<A, B> : EitherOf<A, B> {
     }
     
     public func ap<BB, C>(_ fb : Either<A, BB>) -> Either<A, C> where B == (BB) -> C {
-        return self.flatMap(fb.map)
+        return flatMap(fb.map)
     }
     
     public func flatMap<C>(_ f : (B) -> Either<A, C>) -> Either<A, C> {

--- a/Sources/Bow/Data/Either.swift
+++ b/Sources/Bow/Data/Either.swift
@@ -78,8 +78,8 @@ public class Either<A, B> : EitherOf<A, B> {
                     { b in Either<C, D>.right(fb(b)) })
     }
     
-    public func ap<BB, C>(_ ff : Either<A, BB>) -> Either<A, C> where B == (BB) -> C {
-        return self.flatMap(ff.map)
+    public func ap<BB, C>(_ fb : Either<A, BB>) -> Either<A, C> where B == (BB) -> C {
+        return self.flatMap(fb.map)
     }
     
     public func flatMap<C>(_ f : (B) -> Either<A, C>) -> Either<A, C> {

--- a/Sources/Bow/Data/Either.swift
+++ b/Sources/Bow/Data/Either.swift
@@ -78,8 +78,8 @@ public class Either<A, B> : EitherOf<A, B> {
                     { b in Either<C, D>.right(fb(b)) })
     }
     
-    public func ap<C>(_ ff : Either<A, (B) -> C>) -> Either<A, C> {
-        return ff.flatMap{ f in self.map(f) }
+    public func ap<BB, C>(_ ff : Either<A, BB>) -> Either<A, C> where B == (BB) -> C {
+        return self.flatMap(ff.map)
     }
     
     public func flatMap<C>(_ f : (B) -> Either<A, C>) -> Either<A, C> {
@@ -203,7 +203,7 @@ public class EitherApplicative<C> : Applicative {
     }
     
     public func ap<A, B>(_ fa: EitherOf<C, A>, _ ff: EitherOf<C, (A) -> B>) -> EitherOf<C, B> {
-        return Either.fix(fa).ap(Either.fix(ff))
+        return Either.fix(ff).ap(Either.fix(fa))
     }
 }
 

--- a/Sources/Bow/Data/Eval.swift
+++ b/Sources/Bow/Data/Eval.swift
@@ -68,8 +68,8 @@ public class Eval<A> : EvalOf<A> {
         return flatMap{ a in Eval<B>.now(f(a)) }
     }
     
-    public func ap<AA, B>(_ ff : Eval<AA>) -> Eval<B> where A == (AA) -> B {
-        return flatMap(ff.map)
+    public func ap<AA, B>(_ fa : Eval<AA>) -> Eval<B> where A == (AA) -> B {
+        return flatMap(fa.map)
     }
     
     public func flatMap<B>(_ f : @escaping (A) -> Eval<B>) -> Eval<B> {

--- a/Sources/Bow/Data/Eval.swift
+++ b/Sources/Bow/Data/Eval.swift
@@ -321,7 +321,7 @@ public class EvalApplicative : Applicative {
         return Eval<A>.pure(a)
     }
     
-    public func ap<A, B>(_ fa: Kind<F, A>, _ ff: Kind<F, (A) -> B>) -> Kind<F, B> {
+    public func ap<A, B>(_ ff: Kind<F, (A) -> B>, _ fa: Kind<F, A>) -> Kind<F, B> {
         return ff.fix().ap(fa.fix())
     }
 }

--- a/Sources/Bow/Data/Eval.swift
+++ b/Sources/Bow/Data/Eval.swift
@@ -68,8 +68,8 @@ public class Eval<A> : EvalOf<A> {
         return flatMap{ a in Eval<B>.now(f(a)) }
     }
     
-    public func ap<B>(_ ff : Eval<(A) -> B>) -> Eval<B> {
-        return ff.flatMap(map)
+    public func ap<AA, B>(_ ff : Eval<AA>) -> Eval<B> where A == (AA) -> B {
+        return flatMap(ff.map)
     }
     
     public func flatMap<B>(_ f : @escaping (A) -> Eval<B>) -> Eval<B> {
@@ -322,7 +322,7 @@ public class EvalApplicative : Applicative {
     }
     
     public func ap<A, B>(_ fa: Kind<F, A>, _ ff: Kind<F, (A) -> B>) -> Kind<F, B> {
-        return fa.fix().ap(ff.fix())
+        return ff.fix().ap(fa.fix())
     }
 }
 

--- a/Sources/Bow/Data/Id.swift
+++ b/Sources/Bow/Data/Id.swift
@@ -28,8 +28,8 @@ public class Id<A> : IdOf<A> {
         return Id<B>(f(value))
     }
     
-    public func ap<AA, B>(_ ff : Id<AA>) -> Id<B> where A == (AA) -> B{
-        return flatMap(ff.map)
+    public func ap<AA, B>(_ fa : Id<AA>) -> Id<B> where A == (AA) -> B{
+        return flatMap(fa.map)
     }
     
     public func flatMap<B>(_ f : (A) -> Id<B>) -> Id<B> {

--- a/Sources/Bow/Data/Id.swift
+++ b/Sources/Bow/Data/Id.swift
@@ -122,7 +122,7 @@ public class IdApplicative : IdFunctor, Applicative {
         return Id.pure(a)
     }
     
-    public func ap<A, B>(_ fa: IdOf<A>, _ ff: IdOf<(A) -> B>) -> IdOf<B> {
+    public func ap<A, B>(_ ff: IdOf<(A) -> B>, _ fa: IdOf<A>) -> IdOf<B> {
         return ff.fix().ap(fa.fix())
     }
 }

--- a/Sources/Bow/Data/Id.swift
+++ b/Sources/Bow/Data/Id.swift
@@ -28,8 +28,8 @@ public class Id<A> : IdOf<A> {
         return Id<B>(f(value))
     }
     
-    public func ap<B>(_ ff : Id<(A) -> B>) -> Id<B> {
-        return ff.flatMap(map)
+    public func ap<AA, B>(_ ff : Id<AA>) -> Id<B> where A == (AA) -> B{
+        return flatMap(ff.map)
     }
     
     public func flatMap<B>(_ f : (A) -> Id<B>) -> Id<B> {
@@ -123,7 +123,7 @@ public class IdApplicative : IdFunctor, Applicative {
     }
     
     public func ap<A, B>(_ fa: IdOf<A>, _ ff: IdOf<(A) -> B>) -> IdOf<B> {
-        return fa.fix().ap(ff.fix())
+        return ff.fix().ap(fa.fix())
     }
 }
 

--- a/Sources/Bow/Data/Ior.swift
+++ b/Sources/Bow/Data/Ior.swift
@@ -122,8 +122,8 @@ public class Ior<A, B> : IorOf<A, B> {
                     })
     }
     
-    public func ap<BB, C, SemiG>(_ ff : Ior<A, BB>, _ semigroup : SemiG) -> Ior<A, C> where SemiG : Semigroup, SemiG.A == A, B == (BB) -> C {
-        return flatMap(ff.map, semigroup)
+    public func ap<BB, C, SemiG>(_ fa : Ior<A, BB>, _ semigroup : SemiG) -> Ior<A, C> where SemiG : Semigroup, SemiG.A == A, B == (BB) -> C {
+        return flatMap(fa.map, semigroup)
     }
     
     public func swap() -> Ior<B, A> {

--- a/Sources/Bow/Data/Ior.swift
+++ b/Sources/Bow/Data/Ior.swift
@@ -122,8 +122,8 @@ public class Ior<A, B> : IorOf<A, B> {
                     })
     }
     
-    public func ap<C, SemiG>(_ ff : Ior<A, (B) -> C>, _ semigroup : SemiG) -> Ior<A, C> where SemiG : Semigroup, SemiG.A == A {
-        return ff.flatMap(self.map, semigroup)
+    public func ap<BB, C, SemiG>(_ ff : Ior<A, BB>, _ semigroup : SemiG) -> Ior<A, C> where SemiG : Semigroup, SemiG.A == A, B == (BB) -> C {
+        return flatMap(ff.map, semigroup)
     }
     
     public func swap() -> Ior<B, A> {
@@ -251,7 +251,7 @@ public class IorApplicative<L, SemiG> : IorFunctor<L>, Applicative where SemiG :
     }
     
     public func ap<A, B>(_ fa: IorOf<L, A>, _ ff: IorOf<L, (A) -> B>) -> IorOf<L, B> {
-        return Ior.fix(fa).ap(Ior.fix(ff), semigroup)
+        return Ior.fix(ff).ap(Ior.fix(fa), semigroup)
     }
 }
 

--- a/Sources/Bow/Data/Ior.swift
+++ b/Sources/Bow/Data/Ior.swift
@@ -250,7 +250,7 @@ public class IorApplicative<L, SemiG> : IorFunctor<L>, Applicative where SemiG :
         return Ior<L, A>.right(a)
     }
     
-    public func ap<A, B>(_ fa: IorOf<L, A>, _ ff: IorOf<L, (A) -> B>) -> IorOf<L, B> {
+    public func ap<A, B>(_ ff: IorOf<L, (A) -> B>, _ fa: IorOf<L, A>) -> IorOf<L, B> {
         return Ior.fix(ff).ap(Ior.fix(fa), semigroup)
     }
 }

--- a/Sources/Bow/Data/ListK.swift
+++ b/Sources/Bow/Data/ListK.swift
@@ -54,8 +54,8 @@ public class ListK<A> : ListKOf<A> {
         return ListK<B>(self.list.map(f))
     }
     
-    public func ap<AA, B>(_ ff : ListK<AA>) -> ListK<B> where A == (AA) -> B {
-        return flatMap(ff.map)
+    public func ap<AA, B>(_ fa : ListK<AA>) -> ListK<B> where A == (AA) -> B {
+        return flatMap(fa.map)
     }
     
     public func flatMap<B>(_ f : (A) -> ListK<B>) -> ListK<B> {

--- a/Sources/Bow/Data/ListK.swift
+++ b/Sources/Bow/Data/ListK.swift
@@ -206,7 +206,7 @@ public class ListKApplicative : ListKFunctor, Applicative {
         return ListK.pure(a)
     }
     
-    public func ap<A, B>(_ fa: ListKOf<A>, _ ff: ListKOf<(A) -> B>) -> ListKOf<B> {
+    public func ap<A, B>(_ ff: ListKOf<(A) -> B>, _ fa: ListKOf<A>) -> ListKOf<B> {
         return ff.fix().ap(fa.fix())
     }
 }

--- a/Sources/Bow/Data/ListK.swift
+++ b/Sources/Bow/Data/ListK.swift
@@ -54,8 +54,8 @@ public class ListK<A> : ListKOf<A> {
         return ListK<B>(self.list.map(f))
     }
     
-    public func ap<B>(_ ff : ListK<(A) -> B>) -> ListK<B> {
-        return ff.flatMap(map)
+    public func ap<AA, B>(_ ff : ListK<AA>) -> ListK<B> where A == (AA) -> B {
+        return flatMap(ff.map)
     }
     
     public func flatMap<B>(_ f : (A) -> ListK<B>) -> ListK<B> {
@@ -207,7 +207,7 @@ public class ListKApplicative : ListKFunctor, Applicative {
     }
     
     public func ap<A, B>(_ fa: ListKOf<A>, _ ff: ListKOf<(A) -> B>) -> ListKOf<B> {
-        return fa.fix().ap(ff.fix())
+        return ff.fix().ap(fa.fix())
     }
 }
 

--- a/Sources/Bow/Data/MapK.swift
+++ b/Sources/Bow/Data/MapK.swift
@@ -40,8 +40,8 @@ public class MapK<K : Hashable, A> : MapKOf<K, A> {
         return fb.map{ b in self.map2(b, f) }
     }
     
-    public func ap<AA, B>(_ ff : MapK<K, AA>) -> MapK<K, B> where A == (AA) -> B {
-        return flatMap(ff.map)
+    public func ap<AA, B>(_ fa : MapK<K, AA>) -> MapK<K, B> where A == (AA) -> B {
+        return flatMap(fa.map)
     }
     
     public func flatMap<B>(_ f : (A) -> MapK<K, B>) -> MapK<K, B> {

--- a/Sources/Bow/Data/MapK.swift
+++ b/Sources/Bow/Data/MapK.swift
@@ -40,8 +40,8 @@ public class MapK<K : Hashable, A> : MapKOf<K, A> {
         return fb.map{ b in self.map2(b, f) }
     }
     
-    public func ap<B>(_ ff : MapK<K, (A) -> B>) -> MapK<K, B> {
-        return ff.flatMap(map)
+    public func ap<AA, B>(_ ff : MapK<K, AA>) -> MapK<K, B> where A == (AA) -> B {
+        return flatMap(ff.map)
     }
     
     public func flatMap<B>(_ f : (A) -> MapK<K, B>) -> MapK<K, B> {

--- a/Sources/Bow/Data/NonEmptyList.swift
+++ b/Sources/Bow/Data/NonEmptyList.swift
@@ -215,7 +215,7 @@ public class NonEmptyListApplicative : NonEmptyListFunctor, Applicative {
         return NonEmptyList.pure(a)
     }
     
-    public func ap<A, B>(_ fa: NonEmptyListOf<A>, _ ff: NonEmptyListOf<(A) -> B>) -> NonEmptyListOf<B> {
+    public func ap<A, B>(_ ff: NonEmptyListOf<(A) -> B>, _ fa: NonEmptyListOf<A>) -> NonEmptyListOf<B> {
         return ff.fix().ap(fa.fix())
     }
 }

--- a/Sources/Bow/Data/NonEmptyList.swift
+++ b/Sources/Bow/Data/NonEmptyList.swift
@@ -83,8 +83,8 @@ public class NonEmptyList<A> : NonEmptyListOf<A> {
         return f(head) + tail.flatMap{ a in f(a).all() }
     }
     
-    public func ap<B>(_ ff : NonEmptyList<(A) -> B>) -> NonEmptyList<B> {
-        return ff.flatMap(map)
+    public func ap<AA, B>(_ ff : NonEmptyList<AA>) -> NonEmptyList<B> where A == (AA) -> B {
+        return flatMap(ff.map)
     }
     
     public func foldL<B>(_ b : B, _ f : (B, A) -> B) -> B {
@@ -216,7 +216,7 @@ public class NonEmptyListApplicative : NonEmptyListFunctor, Applicative {
     }
     
     public func ap<A, B>(_ fa: NonEmptyListOf<A>, _ ff: NonEmptyListOf<(A) -> B>) -> NonEmptyListOf<B> {
-        return fa.fix().ap(ff.fix())
+        return ff.fix().ap(fa.fix())
     }
 }
 

--- a/Sources/Bow/Data/NonEmptyList.swift
+++ b/Sources/Bow/Data/NonEmptyList.swift
@@ -83,8 +83,8 @@ public class NonEmptyList<A> : NonEmptyListOf<A> {
         return f(head) + tail.flatMap{ a in f(a).all() }
     }
     
-    public func ap<AA, B>(_ ff : NonEmptyList<AA>) -> NonEmptyList<B> where A == (AA) -> B {
-        return flatMap(ff.map)
+    public func ap<AA, B>(_ fa : NonEmptyList<AA>) -> NonEmptyList<B> where A == (AA) -> B {
+        return flatMap(fa.map)
     }
     
     public func foldL<B>(_ b : B, _ f : (B, A) -> B) -> B {

--- a/Sources/Bow/Data/Option.swift
+++ b/Sources/Bow/Data/Option.swift
@@ -233,7 +233,7 @@ public class OptionApplicative : OptionFunctor, Applicative {
         return Option.pure(a)
     }
     
-    public func ap<A, B>(_ fa: OptionOf<A>, _ ff: OptionOf<(A) -> B>) -> OptionOf<B> {
+    public func ap<A, B>(_ ff: OptionOf<(A) -> B>, _ fa: OptionOf<A>) -> OptionOf<B> {
         return ff.fix().ap(fa.fix())
     }
 }

--- a/Sources/Bow/Data/Option.swift
+++ b/Sources/Bow/Data/Option.swift
@@ -63,8 +63,8 @@ public class Option<A> : OptionOf<A> {
                     { a in Option<B>.some(f(a)) })
     }
     
-    public func ap<B>(_ ff : Option<(A) -> B>) -> Option<B> {
-        return ff.flatMap(map)
+    public func ap<AA, B>(_ ff : Option<AA>) -> Option<B> where A == (AA) -> B{
+        return flatMap(ff.map)
     }
     
     public func flatMap<B>(_ f : (A) -> Option<B>) -> Option<B> {
@@ -234,7 +234,7 @@ public class OptionApplicative : OptionFunctor, Applicative {
     }
     
     public func ap<A, B>(_ fa: OptionOf<A>, _ ff: OptionOf<(A) -> B>) -> OptionOf<B> {
-        return fa.fix().ap(ff.fix())
+        return ff.fix().ap(fa.fix())
     }
 }
 

--- a/Sources/Bow/Data/Option.swift
+++ b/Sources/Bow/Data/Option.swift
@@ -63,8 +63,8 @@ public class Option<A> : OptionOf<A> {
                     { a in Option<B>.some(f(a)) })
     }
     
-    public func ap<AA, B>(_ ff : Option<AA>) -> Option<B> where A == (AA) -> B{
-        return flatMap(ff.map)
+    public func ap<AA, B>(_ fa : Option<AA>) -> Option<B> where A == (AA) -> B{
+        return flatMap(fa.map)
     }
     
     public func flatMap<B>(_ f : (A) -> Option<B>) -> Option<B> {

--- a/Sources/Bow/Data/Reader.swift
+++ b/Sources/Bow/Data/Reader.swift
@@ -18,7 +18,7 @@ public class Reader<D, A> : ReaderT<ForId, D, A> {
     }
     
     public func ap<B>(_ ff : Reader<D, (A) -> B>) -> Reader<D, B> {
-        return toReader(self.ap(ff, Id<A>.applicative()))
+        return toReader(ff.ap(self, Id<A>.applicative()))
     }
     
     public func flatMap<B>(_ f : @escaping (A) -> Reader<D, B>) -> Reader<D, B> {

--- a/Sources/Bow/Data/Reader.swift
+++ b/Sources/Bow/Data/Reader.swift
@@ -17,8 +17,8 @@ public class Reader<D, A> : ReaderT<ForId, D, A> {
         return toReader(self.map(f, Id<A>.functor()))
     }
     
-    public func ap<AA, B>(_ ff : Reader<D, AA>) -> Reader<D, B> where A == (AA) -> B {
-        return toReader(self.ap(ff, Id<A>.applicative()))
+    public func ap<AA, B>(_ fa : Reader<D, AA>) -> Reader<D, B> where A == (AA) -> B {
+        return toReader(self.ap(fa, Id<A>.applicative()))
     }
     
     public func flatMap<B>(_ f : @escaping (A) -> Reader<D, B>) -> Reader<D, B> {

--- a/Sources/Bow/Data/Reader.swift
+++ b/Sources/Bow/Data/Reader.swift
@@ -17,8 +17,8 @@ public class Reader<D, A> : ReaderT<ForId, D, A> {
         return toReader(self.map(f, Id<A>.functor()))
     }
     
-    public func ap<B>(_ ff : Reader<D, (A) -> B>) -> Reader<D, B> {
-        return toReader(ff.ap(self, Id<A>.applicative()))
+    public func ap<AA, B>(_ ff : Reader<D, AA>) -> Reader<D, B> where A == (AA) -> B {
+        return toReader(self.ap(ff, Id<A>.applicative()))
     }
     
     public func flatMap<B>(_ f : @escaping (A) -> Reader<D, B>) -> Reader<D, B> {

--- a/Sources/Bow/Data/Try.swift
+++ b/Sources/Bow/Data/Try.swift
@@ -85,8 +85,8 @@ public class Try<A> : TryOf<A> {
         return fold(Try<B>.raise, f)
     }
     
-    public func ap<B>(_ ff : Try<(A) -> B>) -> Try<B> {
-        return ff.flatMap(map)
+    public func ap<AA, B>(_ ff : Try<AA>) -> Try<B> where A == (AA) -> B {
+        return flatMap(ff.map)
     }
     
     public func filter(_ predicate : (A) -> Bool) -> Try<A> {
@@ -203,7 +203,7 @@ public class TryApplicative : TryFunctor, Applicative {
     }
     
     public func ap<A, B>(_ fa: TryOf<A>, _ ff: TryOf<(A) -> B>) -> TryOf<B> {
-        return fa.fix().ap(ff.fix())
+        return ff.fix().ap(fa.fix())
     }
 }
 

--- a/Sources/Bow/Data/Try.swift
+++ b/Sources/Bow/Data/Try.swift
@@ -202,7 +202,7 @@ public class TryApplicative : TryFunctor, Applicative {
         return Try<A>.pure(a)
     }
     
-    public func ap<A, B>(_ fa: TryOf<A>, _ ff: TryOf<(A) -> B>) -> TryOf<B> {
+    public func ap<A, B>(_ ff: TryOf<(A) -> B>, _ fa: TryOf<A>) -> TryOf<B> {
         return ff.fix().ap(fa.fix())
     }
 }

--- a/Sources/Bow/Data/Try.swift
+++ b/Sources/Bow/Data/Try.swift
@@ -85,8 +85,8 @@ public class Try<A> : TryOf<A> {
         return fold(Try<B>.raise, f)
     }
     
-    public func ap<AA, B>(_ ff : Try<AA>) -> Try<B> where A == (AA) -> B {
-        return flatMap(ff.map)
+    public func ap<AA, B>(_ fa : Try<AA>) -> Try<B> where A == (AA) -> B {
+        return flatMap(fa.map)
     }
     
     public func filter(_ predicate : (A) -> Bool) -> Try<A> {

--- a/Sources/Bow/Data/Validated.swift
+++ b/Sources/Bow/Data/Validated.swift
@@ -217,7 +217,7 @@ public class ValidatedApplicative<R, SemiG> : ValidatedFunctor<R>, Applicative w
         return Validated<R, A>.valid(a)
     }
     
-    public func ap<A, B>(_ fa: ValidatedOf<R, A>, _ ff: ValidatedOf<R, (A) -> B>) -> ValidatedOf<R, B> {
+    public func ap<A, B>(_ ff: ValidatedOf<R, (A) -> B>, _ fa: ValidatedOf<R, A>) -> ValidatedOf<R, B> {
         return Validated.fix(ff).ap(Validated.fix(fa), semigroup)
     }
 }

--- a/Sources/Bow/Data/Validated.swift
+++ b/Sources/Bow/Data/Validated.swift
@@ -85,11 +85,11 @@ public class Validated<E, A> : ValidatedOf<E, A> {
         return bimap(f, id)
     }
     
-    public func ap<B, SemiG>(_ ff : Validated<E, (A) -> B>, _ semigroup : SemiG) -> Validated<E, B> where SemiG : Semigroup, SemiG.A == E {
-        return fold({ e in ff.fold({ ee in Validated<E, B>.invalid(semigroup.combine(e, ee)) },
-                                   { _ in Validated<E, B>.invalid(e) }) },
-                    { a in ff.fold({ ee in Validated<E, B>.invalid(ee) },
-                                   { f in Validated<E, B>.valid(f(a)) }) })
+    public func ap<AA, B, SemiG>(_ ff : Validated<E, AA>, _ semigroup : SemiG) -> Validated<E, B> where SemiG : Semigroup, SemiG.A == E, A == (AA) -> B {
+        return ff.fold({ e in self.fold({ ee in Validated<E, B>.invalid(semigroup.combine(e, ee)) },
+                                        { _ in Validated<E, B>.invalid(e) }) },
+                       { a in self.fold({ ee in Validated<E, B>.invalid(ee) },
+                                        { f in Validated<E, B>.valid(f(a)) }) })
     }
     
     public func foldL<B>(_ b : B, _ f : (B, A) -> B) -> B {
@@ -218,7 +218,7 @@ public class ValidatedApplicative<R, SemiG> : ValidatedFunctor<R>, Applicative w
     }
     
     public func ap<A, B>(_ fa: ValidatedOf<R, A>, _ ff: ValidatedOf<R, (A) -> B>) -> ValidatedOf<R, B> {
-        return Validated.fix(fa).ap(Validated.fix(ff), semigroup)
+        return Validated.fix(ff).ap(Validated.fix(fa), semigroup)
     }
 }
 

--- a/Sources/Bow/Data/Validated.swift
+++ b/Sources/Bow/Data/Validated.swift
@@ -85,8 +85,8 @@ public class Validated<E, A> : ValidatedOf<E, A> {
         return bimap(f, id)
     }
     
-    public func ap<AA, B, SemiG>(_ ff : Validated<E, AA>, _ semigroup : SemiG) -> Validated<E, B> where SemiG : Semigroup, SemiG.A == E, A == (AA) -> B {
-        return ff.fold({ e in self.fold({ ee in Validated<E, B>.invalid(semigroup.combine(e, ee)) },
+    public func ap<AA, B, SemiG>(_ fa : Validated<E, AA>, _ semigroup : SemiG) -> Validated<E, B> where SemiG : Semigroup, SemiG.A == E, A == (AA) -> B {
+        return fa.fold({ e in self.fold({ ee in Validated<E, B>.invalid(semigroup.combine(e, ee)) },
                                         { _ in Validated<E, B>.invalid(e) }) },
                        { a in self.fold({ ee in Validated<E, B>.invalid(ee) },
                                         { f in Validated<E, B>.valid(f(a)) }) })

--- a/Sources/Bow/Transformers/EitherT.swift
+++ b/Sources/Bow/Transformers/EitherT.swift
@@ -55,8 +55,8 @@ public class EitherT<F, A, B> : EitherTOf<F, A, B> {
         return EitherT<F, A, C>(functor.map(fc, Either<A, C>.right))
     }
     
-    public func ap<BB, C, Mon>(_ ff : EitherT<F, A, BB>, _ monad : Mon) -> EitherT<F, A, C> where Mon : Monad, Mon.F == F, B == (BB) -> C {
-        return self.flatMap({ f in ff.map(f, monad) }, monad)
+    public func ap<BB, C, Mon>(_ fa : EitherT<F, A, BB>, _ monad : Mon) -> EitherT<F, A, C> where Mon : Monad, Mon.F == F, B == (BB) -> C {
+        return self.flatMap({ f in fa.map(f, monad) }, monad)
     }
     
     public func flatMap<C, Mon>(_ f : @escaping (B) -> EitherT<F, A, C>, _ monad : Mon) -> EitherT<F, A, C> where Mon : Monad, Mon.F == F {

--- a/Sources/Bow/Transformers/EitherT.swift
+++ b/Sources/Bow/Transformers/EitherT.swift
@@ -56,7 +56,7 @@ public class EitherT<F, A, B> : EitherTOf<F, A, B> {
     }
     
     public func ap<BB, C, Mon>(_ fa : EitherT<F, A, BB>, _ monad : Mon) -> EitherT<F, A, C> where Mon : Monad, Mon.F == F, B == (BB) -> C {
-        return self.flatMap({ f in fa.map(f, monad) }, monad)
+        return flatMap({ f in fa.map(f, monad) }, monad)
     }
     
     public func flatMap<C, Mon>(_ f : @escaping (B) -> EitherT<F, A, C>, _ monad : Mon) -> EitherT<F, A, C> where Mon : Monad, Mon.F == F {

--- a/Sources/Bow/Transformers/EitherT.swift
+++ b/Sources/Bow/Transformers/EitherT.swift
@@ -55,8 +55,8 @@ public class EitherT<F, A, B> : EitherTOf<F, A, B> {
         return EitherT<F, A, C>(functor.map(fc, Either<A, C>.right))
     }
     
-    public func ap<C, Mon>(_ ff : EitherT<F, A, (B) -> C>, _ monad : Mon) -> EitherT<F, A, C> where Mon : Monad, Mon.F == F {
-        return ff.flatMap({ f in self.map(f, monad) }, monad)
+    public func ap<BB, C, Mon>(_ ff : EitherT<F, A, BB>, _ monad : Mon) -> EitherT<F, A, C> where Mon : Monad, Mon.F == F, B == (BB) -> C {
+        return self.flatMap({ f in ff.map(f, monad) }, monad)
     }
     
     public func flatMap<C, Mon>(_ f : @escaping (B) -> EitherT<F, A, C>, _ monad : Mon) -> EitherT<F, A, C> where Mon : Monad, Mon.F == F {
@@ -159,7 +159,7 @@ public class EitherTApplicative<G, M, Mon> : EitherTFunctor<G, M, Mon>, Applicat
     }
     
     public func ap<A, B>(_ fa: EitherTOf<G, M, A>, _ ff: EitherTOf<G, M, (A) -> B>) -> EitherTOf<G, M, B> {
-        return EitherT.fix(fa).ap(EitherT.fix(ff), monad)
+        return EitherT.fix(ff).ap(EitherT.fix(fa), monad)
     }
 }
 

--- a/Sources/Bow/Transformers/EitherT.swift
+++ b/Sources/Bow/Transformers/EitherT.swift
@@ -158,7 +158,7 @@ public class EitherTApplicative<G, M, Mon> : EitherTFunctor<G, M, Mon>, Applicat
         return EitherT<G, M, A>.pure(a, monad)
     }
     
-    public func ap<A, B>(_ fa: EitherTOf<G, M, A>, _ ff: EitherTOf<G, M, (A) -> B>) -> EitherTOf<G, M, B> {
+    public func ap<A, B>(_ ff: EitherTOf<G, M, (A) -> B>, _ fa: EitherTOf<G, M, A>) -> EitherTOf<G, M, B> {
         return EitherT.fix(ff).ap(EitherT.fix(fa), monad)
     }
 }

--- a/Sources/Bow/Transformers/OptionT.swift
+++ b/Sources/Bow/Transformers/OptionT.swift
@@ -180,7 +180,7 @@ public class OptionTApplicative<G, MonG> : OptionTFunctor<G, MonG>, Applicative 
         return OptionT.pure(a, monad)
     }
     
-    public func ap<A, B>(_ fa: OptionTOf<G, A>, _ ff: OptionTOf<G, (A) -> B>) -> OptionTOf<G, B> {
+    public func ap<A, B>(_ ff: OptionTOf<G, (A) -> B>, _ fa: OptionTOf<G, A>) -> OptionTOf<G, B> {
         return OptionT.fix(ff).ap(OptionT.fix(fa), monad)
     }
 }

--- a/Sources/Bow/Transformers/OptionT.swift
+++ b/Sources/Bow/Transformers/OptionT.swift
@@ -49,8 +49,8 @@ public class OptionT<F, A> : OptionTOf<F, A> {
         return OptionT<F, B>(functor.map(value, { option in option.map(f) } ))
     }
     
-    public func ap<AA, B, Mon>(_ ff : OptionT<F, AA>, _ monad : Mon) -> OptionT<F, B> where Mon : Monad, Mon.F == F, A == (AA) -> B {
-        return flatMap({ f in ff.map(f, monad) }, monad)
+    public func ap<AA, B, Mon>(_ fa : OptionT<F, AA>, _ monad : Mon) -> OptionT<F, B> where Mon : Monad, Mon.F == F, A == (AA) -> B {
+        return flatMap({ f in fa.map(f, monad) }, monad)
     }
     
     public func flatMap<B, Mon>(_ f : @escaping (A) -> OptionT<F, B>, _ monad : Mon) -> OptionT<F, B> where Mon : Monad, Mon.F == F {

--- a/Sources/Bow/Transformers/OptionT.swift
+++ b/Sources/Bow/Transformers/OptionT.swift
@@ -49,8 +49,8 @@ public class OptionT<F, A> : OptionTOf<F, A> {
         return OptionT<F, B>(functor.map(value, { option in option.map(f) } ))
     }
     
-    public func ap<B, Mon>(_ ff : OptionT<F, (A) -> B>, _ monad : Mon) -> OptionT<F, B> where Mon : Monad, Mon.F == F {
-        return ff.flatMap({ f in self.map(f, monad) }, monad)
+    public func ap<AA, B, Mon>(_ ff : OptionT<F, AA>, _ monad : Mon) -> OptionT<F, B> where Mon : Monad, Mon.F == F, A == (AA) -> B {
+        return flatMap({ f in ff.map(f, monad) }, monad)
     }
     
     public func flatMap<B, Mon>(_ f : @escaping (A) -> OptionT<F, B>, _ monad : Mon) -> OptionT<F, B> where Mon : Monad, Mon.F == F {
@@ -181,7 +181,7 @@ public class OptionTApplicative<G, MonG> : OptionTFunctor<G, MonG>, Applicative 
     }
     
     public func ap<A, B>(_ fa: OptionTOf<G, A>, _ ff: OptionTOf<G, (A) -> B>) -> OptionTOf<G, B> {
-        return OptionT.fix(fa).ap(OptionT.fix(ff), monad)
+        return OptionT.fix(ff).ap(OptionT.fix(fa), monad)
     }
 }
 

--- a/Sources/Bow/Transformers/StateT.swift
+++ b/Sources/Bow/Transformers/StateT.swift
@@ -69,8 +69,8 @@ public class StateT<F, S, A> : StateTOf<F, S, A> {
         }.map{ ssz in StateT<F, S, Z>(ssz) }
     }
     
-    public func ap<AA, B, Mon>(_ ff : StateT<F, S, AA>, _ monad : Mon) -> StateT<F, S, B> where Mon : Monad, Mon.F == F, A == (AA) -> B {
-        return self.map2(ff, { f, a in f(a) }, monad)
+    public func ap<AA, B, Mon>(_ fa : StateT<F, S, AA>, _ monad : Mon) -> StateT<F, S, B> where Mon : Monad, Mon.F == F, A == (AA) -> B {
+        return self.map2(fa, { f, a in f(a) }, monad)
     }
     
     public func product<B, Mon>(_ sb : StateT<F, S, B>, _ monad : Mon) -> StateT<F, S, (A, B)> where Mon : Monad, Mon.F == F {

--- a/Sources/Bow/Transformers/StateT.swift
+++ b/Sources/Bow/Transformers/StateT.swift
@@ -69,8 +69,8 @@ public class StateT<F, S, A> : StateTOf<F, S, A> {
         }.map{ ssz in StateT<F, S, Z>(ssz) }
     }
     
-    public func ap<B, Mon>(_ ff : StateT<F, S, (A) -> B>, _ monad : Mon) -> StateT<F, S, B> where Mon : Monad, Mon.F == F {
-        return ff.map2(self, { f, a in f(a) }, monad)
+    public func ap<AA, B, Mon>(_ ff : StateT<F, S, AA>, _ monad : Mon) -> StateT<F, S, B> where Mon : Monad, Mon.F == F, A == (AA) -> B {
+        return self.map2(ff, { f, a in f(a) }, monad)
     }
     
     public func product<B, Mon>(_ sb : StateT<F, S, B>, _ monad : Mon) -> StateT<F, S, (A, B)> where Mon : Monad, Mon.F == F {
@@ -137,7 +137,7 @@ public extension StateT where F == ForId {
         return self.map(f, Id<A>.functor())
     }
     
-    public func ap<B>(_ ff : StateOf<S, (A) -> B>) -> StateOf<S, B> {
+    public func ap<AA, B>(_ ff : StateOf<S, AA>) -> StateOf<S, B> where A == (AA) -> B {
         return self.ap(ff, Id<A>.monad())
     }
     
@@ -211,7 +211,7 @@ public class StateTApplicative<G, S, MonG> : StateTFunctor<G, S, MonG>, Applicat
     }
     
     public func ap<A, B>(_ fa: StateTOf<G, S, A>, _ ff: StateTOf<G, S, (A) -> B>) -> StateTOf<G, S, B> {
-        return StateT.fix(fa).ap(StateT.fix(ff), monad)
+        return StateT.fix(ff).ap(StateT.fix(fa), monad)
     }
 }
 

--- a/Sources/Bow/Transformers/StateT.swift
+++ b/Sources/Bow/Transformers/StateT.swift
@@ -70,7 +70,7 @@ public class StateT<F, S, A> : StateTOf<F, S, A> {
     }
     
     public func ap<AA, B, Mon>(_ fa : StateT<F, S, AA>, _ monad : Mon) -> StateT<F, S, B> where Mon : Monad, Mon.F == F, A == (AA) -> B {
-        return self.map2(fa, { f, a in f(a) }, monad)
+        return map2(fa, { f, a in f(a) }, monad)
     }
     
     public func product<B, Mon>(_ sb : StateT<F, S, B>, _ monad : Mon) -> StateT<F, S, (A, B)> where Mon : Monad, Mon.F == F {

--- a/Sources/Bow/Transformers/StateT.swift
+++ b/Sources/Bow/Transformers/StateT.swift
@@ -210,7 +210,7 @@ public class StateTApplicative<G, S, MonG> : StateTFunctor<G, S, MonG>, Applicat
         return StateT(monad.pure({ s in self.monad.pure((s, a))}))
     }
     
-    public func ap<A, B>(_ fa: StateTOf<G, S, A>, _ ff: StateTOf<G, S, (A) -> B>) -> StateTOf<G, S, B> {
+    public func ap<A, B>(_ ff: StateTOf<G, S, (A) -> B>, _ fa: StateTOf<G, S, A>) -> StateTOf<G, S, B> {
         return StateT.fix(ff).ap(StateT.fix(fa), monad)
     }
 }

--- a/Sources/Bow/Transformers/WriterT.swift
+++ b/Sources/Bow/Transformers/WriterT.swift
@@ -200,7 +200,7 @@ public class WriterTApplicative<G, W, MonG, MonoW> : WriterTFunctor<G, W, MonG>,
         return WriterT(monad.pure((monoid.empty, a)))
     }
     
-    public func ap<A, B>(_ fa: WriterTOf<G, W, A>, _ ff: WriterTOf<G, W, (A) -> B>) -> WriterTOf<G, W, B> {
+    public func ap<A, B>(_ ff: WriterTOf<G, W, (A) -> B>, _ fa: WriterTOf<G, W, A>) -> WriterTOf<G, W, B> {
         return WriterT.fix(ff).ap(WriterT.fix(fa), monoid, monad)
     }
 }

--- a/Sources/Bow/Transformers/WriterT.swift
+++ b/Sources/Bow/Transformers/WriterT.swift
@@ -88,8 +88,8 @@ public class WriterT<F, W, A> : WriterTOf<F, W, A> {
         return WriterT<F, W, B>(applicative.map2(fb, value, { x, y in (y.0, x) }))
     }
     
-    public func ap<B, SemiG, Mon>(_ ff : WriterT<F, W, (A) -> B>, _ semigroup : SemiG, _ monad : Mon) -> WriterT<F, W, B> where SemiG : Semigroup, SemiG.A == W, Mon : Monad, Mon.F == F {
-        return ff.flatMap({ pair in self.map(pair, monad)}, semigroup, monad)
+    public func ap<AA, B, SemiG, Mon>(_ ff : WriterT<F, W, AA>, _ semigroup : SemiG, _ monad : Mon) -> WriterT<F, W, B> where SemiG : Semigroup, SemiG.A == W, Mon : Monad, Mon.F == F, A == (AA) -> B {
+        return flatMap({ pair in ff.map(pair, monad)}, semigroup, monad)
     }
     
     public func flatMap<B, SemiG, Mon>(_ f : @escaping (A) -> WriterT<F, W, B>, _ semigroup : SemiG, _ monad : Mon) -> WriterT<F, W, B> where SemiG : Semigroup, SemiG.A == W, Mon : Monad, Mon.F == F {
@@ -201,7 +201,7 @@ public class WriterTApplicative<G, W, MonG, MonoW> : WriterTFunctor<G, W, MonG>,
     }
     
     public func ap<A, B>(_ fa: WriterTOf<G, W, A>, _ ff: WriterTOf<G, W, (A) -> B>) -> WriterTOf<G, W, B> {
-        return WriterT.fix(fa).ap(WriterT.fix(ff), monoid, monad)
+        return WriterT.fix(ff).ap(WriterT.fix(fa), monoid, monad)
     }
 }
 

--- a/Sources/Bow/Transformers/WriterT.swift
+++ b/Sources/Bow/Transformers/WriterT.swift
@@ -88,8 +88,8 @@ public class WriterT<F, W, A> : WriterTOf<F, W, A> {
         return WriterT<F, W, B>(applicative.map2(fb, value, { x, y in (y.0, x) }))
     }
     
-    public func ap<AA, B, SemiG, Mon>(_ ff : WriterT<F, W, AA>, _ semigroup : SemiG, _ monad : Mon) -> WriterT<F, W, B> where SemiG : Semigroup, SemiG.A == W, Mon : Monad, Mon.F == F, A == (AA) -> B {
-        return flatMap({ pair in ff.map(pair, monad)}, semigroup, monad)
+    public func ap<AA, B, SemiG, Mon>(_ fa : WriterT<F, W, AA>, _ semigroup : SemiG, _ monad : Mon) -> WriterT<F, W, B> where SemiG : Semigroup, SemiG.A == W, Mon : Monad, Mon.F == F, A == (AA) -> B {
+        return flatMap({ pair in fa.map(pair, monad)}, semigroup, monad)
     }
     
     public func flatMap<B, SemiG, Mon>(_ f : @escaping (A) -> WriterT<F, W, B>, _ semigroup : SemiG, _ monad : Mon) -> WriterT<F, W, B> where SemiG : Semigroup, SemiG.A == W, Mon : Monad, Mon.F == F {

--- a/Sources/Bow/Typeclasses/Applicative.swift
+++ b/Sources/Bow/Typeclasses/Applicative.swift
@@ -11,7 +11,7 @@ public extension Applicative {
     }
     
     public func product<A, B>(_ fa : Kind<F, A>, _ fb : Kind<F, B>) -> Kind<F, (A, B)> {
-        return self.ap(self.map(fa, { (a : A) in { (b : B) in (a, b) }}), fb)
+        return ap(self.map(fa, { (a : A) in { (b : B) in (a, b) }}), fb)
     }
     
     public func product<A, B, Z>(_ fa : Kind<F, (A, B)>, _ fz : Kind<F, Z>) -> Kind<F, (A, B, Z)> {

--- a/Sources/Bow/Typeclasses/Applicative.swift
+++ b/Sources/Bow/Typeclasses/Applicative.swift
@@ -2,16 +2,16 @@ import Foundation
 
 public protocol Applicative : Functor {
     func pure<A>(_ a : A) -> Kind<F, A>
-    func ap<A, B>(_ fa : Kind<F, A>, _ ff : Kind<F, (A) -> B>) -> Kind<F, B>
+    func ap<A, B>(_ ff : Kind<F, (A) -> B>, _ fa : Kind<F, A>) -> Kind<F, B>
 }
 
 public extension Applicative {
     public func map<A, B>(_ fa: Kind<F, A>, _ f: @escaping (A) -> B) -> Kind<F, B> {
-        return ap(fa, pure(f))
+        return ap(pure(f), fa)
     }
     
     public func product<A, B>(_ fa : Kind<F, A>, _ fb : Kind<F, B>) -> Kind<F, (A, B)> {
-        return self.ap(fb, self.map(fa, { (a : A) in { (b : B) in (a, b) }}))
+        return self.ap(self.map(fa, { (a : A) in { (b : B) in (a, b) }}), fb)
     }
     
     public func product<A, B, Z>(_ fa : Kind<F, (A, B)>, _ fz : Kind<F, Z>) -> Kind<F, (A, B, Z)> {

--- a/Sources/BowBrightFutures/FutureK.swift
+++ b/Sources/BowBrightFutures/FutureK.swift
@@ -73,8 +73,8 @@ public class FutureK<E, A> : FutureKOf<E, A> where E : Error {
         return value.map(f).k()
     }
     
-    public func ap<B>(_ fa : FutureKOf<E, (A) -> B>) -> FutureK<E, B> {
-        return flatMap { a in FutureK<E, (A) -> B>.fix(fa).map { ff in ff(a) } }
+    public func ap<AA, B>(_ fa : FutureKOf<E, AA>) -> FutureK<E, B> where A == (AA) -> B {
+        return FutureK<E, AA>.fix(fa).flatMap { a in self.map { ff in ff(a) } }
     }
     
     public func flatMap<B>(_ f : @escaping (A) -> FutureKOf<E, B>) -> FutureK<E, B> {
@@ -139,7 +139,7 @@ public class FutureKApplicative<E> : FutureKFunctor<E>, Applicative where E : Er
     }
     
     public func ap<A, B>(_ fa: FutureKOf<E, A>, _ ff: FutureKOf<E, (A) -> B>) -> FutureKOf<E, B> {
-        return FutureK<E, A>.fix(fa).ap(ff)
+        return FutureK<E, (A) -> B>.fix(ff).ap(fa)
     }
 }
 

--- a/Sources/BowBrightFutures/FutureK.swift
+++ b/Sources/BowBrightFutures/FutureK.swift
@@ -138,8 +138,8 @@ public class FutureKApplicative<E> : FutureKFunctor<E>, Applicative where E : Er
         return FutureK<E, A>.pure(a)
     }
     
-    public func ap<A, B>(_ fa: FutureKOf<E, A>, _ ff: FutureKOf<E, (A) -> B>) -> FutureKOf<E, B> {
-        return FutureK<E, (A) -> B>.fix(ff).ap(fa)
+    public func ap<A, B>(_ ff: FutureKOf<E, (A) -> B>, _ fa: FutureKOf<E, A>) -> FutureKOf<E, B> {
+        return FutureK.fix(ff).ap(fa)
     }
 }
 

--- a/Sources/BowEffects/IO.swift
+++ b/Sources/BowEffects/IO.swift
@@ -341,7 +341,7 @@ public class IOApplicative : IOFunctor, Applicative {
         return IO.pure(a)
     }
     
-    public func ap<A, B>(_ fa: IOOf<A>, _ ff: IOOf<(A) -> B>) -> IOOf<B> {
+    public func ap<A, B>(_ ff: IOOf<(A) -> B>, _ fa: IOOf<A>) -> IOOf<B> {
         return ff.fix().ap(fa.fix())
     }
 }

--- a/Sources/BowEffects/IO.swift
+++ b/Sources/BowEffects/IO.swift
@@ -161,8 +161,8 @@ public class IO<A> : IOOf<A> {
         return FMap(f, self)
     }
     
-    public func ap<AA, B>(_ ff : IO<AA>) -> IO<B> where A == (AA) -> B {
-        return flatMap(ff.map)
+    public func ap<AA, B>(_ fa : IO<AA>) -> IO<B> where A == (AA) -> B {
+        return flatMap(fa.map)
     }
     
     public func flatMap<B>(_ f : @escaping (A) throws -> IO<B>) -> IO<B> {

--- a/Sources/BowEffects/IO.swift
+++ b/Sources/BowEffects/IO.swift
@@ -161,8 +161,8 @@ public class IO<A> : IOOf<A> {
         return FMap(f, self)
     }
     
-    public func ap<B>(_ ff : IO<(A) -> B>) -> IO<B> {
-        return ff.flatMap(self.map)
+    public func ap<AA, B>(_ ff : IO<AA>) -> IO<B> where A == (AA) -> B {
+        return flatMap(ff.map)
     }
     
     public func flatMap<B>(_ f : @escaping (A) throws -> IO<B>) -> IO<B> {
@@ -342,7 +342,7 @@ public class IOApplicative : IOFunctor, Applicative {
     }
     
     public func ap<A, B>(_ fa: IOOf<A>, _ ff: IOOf<(A) -> B>) -> IOOf<B> {
-        return fa.fix().ap(ff.fix())
+        return ff.fix().ap(fa.fix())
     }
 }
 

--- a/Sources/BowFree/Free.swift
+++ b/Sources/BowFree/Free.swift
@@ -154,8 +154,8 @@ internal class ApplicativeFreePartial<S, Appl> : Applicative where Appl : Applic
         return Free.pure(a)
     }
 
-    func ap<A, B>(_ fa: FreeOf<S, A>, _ ff: FreeOf<S, (A) -> B>) -> FreeOf<S, B> {
-        return applicative.ap(fa, ff)
+    func ap<A, B>(_ ff: FreeOf<S, (A) -> B>, _ fa: FreeOf<S, A>) -> FreeOf<S, B> {
+        return applicative.ap(ff, fa)
     }
 }
 
@@ -190,7 +190,7 @@ public class FreeApplicativeInstance<S> : FreeFunctor<S>, Applicative {
         return Free.pure(a)
     }
     
-    public func ap<A, B>(_ fa: FreeOf<S, A>, _ ff: FreeOf<S, (A) -> B>) -> FreeOf<S, B> {
+    public func ap<A, B>(_ ff: FreeOf<S, (A) -> B>, _ fa: FreeOf<S, A>) -> FreeOf<S, B> {
         return Free.fix(ff).ap(Free.fix(fa))
     }
 }

--- a/Sources/BowFree/Free.swift
+++ b/Sources/BowFree/Free.swift
@@ -39,8 +39,8 @@ public class Free<S, A> : FreeOf<S, A> {
         return flatMap { a in Free<S, B>.pure(f(a)) }
     }
     
-    public func ap<B>(_ ff : Free<S, (A) -> B>) -> Free<S, B> {
-        return ff.flatMap(map)
+    public func ap<AA, B>(_ ff : Free<S, AA>) -> Free<S, B> where A == (AA) -> B {
+        return flatMap(ff.map)
     }
     
     public func flatMap<B>(_ f : @escaping (A) -> Free<S, B>) -> Free<S, B> {
@@ -191,7 +191,7 @@ public class FreeApplicativeInstance<S> : FreeFunctor<S>, Applicative {
     }
     
     public func ap<A, B>(_ fa: FreeOf<S, A>, _ ff: FreeOf<S, (A) -> B>) -> FreeOf<S, B> {
-        return Free.fix(fa).ap(Free.fix(ff))
+        return Free.fix(ff).ap(Free.fix(fa))
     }
 }
 

--- a/Sources/BowFree/Free.swift
+++ b/Sources/BowFree/Free.swift
@@ -39,7 +39,7 @@ public class Free<S, A> : FreeOf<S, A> {
         return flatMap { a in Free<S, B>.pure(f(a)) }
     }
     
-    public func ap<AA, B>(_ ff : Free<S, AA>) -> Free<S, B> where A == (AA) -> B {
+    public func ap<AA, B>(_ fa : Free<S, AA>) -> Free<S, B> where A == (AA) -> B {
         return flatMap(ff.map)
     }
     

--- a/Sources/BowFree/Free.swift
+++ b/Sources/BowFree/Free.swift
@@ -40,7 +40,7 @@ public class Free<S, A> : FreeOf<S, A> {
     }
     
     public func ap<AA, B>(_ fa : Free<S, AA>) -> Free<S, B> where A == (AA) -> B {
-        return flatMap(ff.map)
+        return flatMap(fa.map)
     }
     
     public func flatMap<B>(_ f : @escaping (A) -> Free<S, B>) -> Free<S, B> {

--- a/Sources/BowRx/MaybeK.swift
+++ b/Sources/BowRx/MaybeK.swift
@@ -168,7 +168,7 @@ public class MaybeKApplicative : MaybeKFunctor, Applicative {
         return MaybeK.pure(a)
     }
     
-    public func ap<A, B>(_ fa: MaybeKOf<A>, _ ff: MaybeKOf<(A) -> B>) -> MaybeKOf<B> {
+    public func ap<A, B>(_ ff: MaybeKOf<(A) -> B>, _ fa: MaybeKOf<A>) -> MaybeKOf<B> {
         return ff.fix().ap(fa)
     }
 }

--- a/Sources/BowRx/MaybeK.swift
+++ b/Sources/BowRx/MaybeK.swift
@@ -61,8 +61,8 @@ public class MaybeK<A> : MaybeKOf<A> {
         return value.map(f).k()
     }
     
-    public func ap<B>(_ fa : MaybeKOf<(A) -> B>) -> MaybeK<B> {
-        return flatMap { a in fa.fix().map{ ff in ff(a) } }
+    public func ap<AA, B>(_ fa : MaybeKOf<AA>) -> MaybeK<B> where A == (AA) -> B {
+        return fa.fix().flatMap { a in self.map{ ff in ff(a) } }
     }
     
     public func flatMap<B>(_ f : @escaping (A) -> MaybeK<B>) -> MaybeK<B> {
@@ -169,7 +169,7 @@ public class MaybeKApplicative : MaybeKFunctor, Applicative {
     }
     
     public func ap<A, B>(_ fa: MaybeKOf<A>, _ ff: MaybeKOf<(A) -> B>) -> MaybeKOf<B> {
-        return fa.fix().ap(ff)
+        return ff.fix().ap(fa)
     }
 }
 

--- a/Sources/BowRx/ObservableK.swift
+++ b/Sources/BowRx/ObservableK.swift
@@ -80,8 +80,8 @@ public class ObservableK<A> : ObservableKOf<A> {
         return value.map(f).k()
     }
     
-    public func ap<B>(_ fa : ObservableKOf<(A) -> B>) -> ObservableK<B> {
-        return flatMap { a in fa.fix().map { ff in ff(a) } }
+    public func ap<AA, B>(_ fa : ObservableKOf<AA>) -> ObservableK<B> where A == (AA) -> B {
+        return fa.fix().flatMap { a in self.map { ff in ff(a) } }
     }
     
     public func flatMap<B>(_ f : @escaping (A) -> ObservableKOf<B>) -> ObservableK<B> {
@@ -200,7 +200,7 @@ public class ObservableKApplicative : ObservableKFunctor, Applicative {
     }
     
     public func ap<A, B>(_ fa: ObservableKOf<A>, _ ff: ObservableKOf<(A) -> B>) -> ObservableKOf<B> {
-        return fa.fix().ap(ff)
+        return ff.fix().ap(fa)
     }
 }
 

--- a/Sources/BowRx/ObservableK.swift
+++ b/Sources/BowRx/ObservableK.swift
@@ -199,7 +199,7 @@ public class ObservableKApplicative : ObservableKFunctor, Applicative {
         return ObservableK.pure(a)
     }
     
-    public func ap<A, B>(_ fa: ObservableKOf<A>, _ ff: ObservableKOf<(A) -> B>) -> ObservableKOf<B> {
+    public func ap<A, B>(_ ff: ObservableKOf<(A) -> B>, _ fa: ObservableKOf<A>) -> ObservableKOf<B> {
         return ff.fix().ap(fa)
     }
 }

--- a/Sources/BowRx/SingleK.swift
+++ b/Sources/BowRx/SingleK.swift
@@ -83,8 +83,8 @@ public class SingleK<A> : SingleKOf<A> {
         return value.map(f).k()
     }
     
-    public func ap<B>(_ fa : SingleKOf<(A) -> B>) -> SingleK<B> {
-        return flatMap { a in fa.fix().map { ff in ff(a) } }
+    public func ap<AA, B>(_ fa : SingleKOf<AA>) -> SingleK<B> where A == (AA) -> B {
+        return fa.fix().flatMap { a in self.map { ff in ff(a) } }
     }
     
     public func flatMap<B>(_ f : @escaping (A) -> SingleKOf<B>) -> SingleK<B> {
@@ -165,7 +165,7 @@ public class SingleKApplicative : SingleKFunctor, Applicative {
     }
     
     public func ap<A, B>(_ fa: SingleKOf<A>, _ ff: SingleKOf<(A) -> B>) -> SingleKOf<B> {
-        return fa.fix().ap(ff)
+        return ff.fix().ap(fa)
     }
 }
 

--- a/Sources/BowRx/SingleK.swift
+++ b/Sources/BowRx/SingleK.swift
@@ -164,7 +164,7 @@ public class SingleKApplicative : SingleKFunctor, Applicative {
         return SingleK.pure(a)
     }
     
-    public func ap<A, B>(_ fa: SingleKOf<A>, _ ff: SingleKOf<(A) -> B>) -> SingleKOf<B> {
+    public func ap<A, B>(_ ff: SingleKOf<(A) -> B>, _ fa: SingleKOf<A>) -> SingleKOf<B> {
         return ff.fix().ap(fa)
     }
 }

--- a/Tests/BowLaws/AlternativeLaws.swift
+++ b/Tests/BowLaws/AlternativeLaws.swift
@@ -27,13 +27,13 @@ class AlternativeLaws<F> {
     
     private static func rightDistributivity<Alt, EqA>(_ alternative : Alt, _ eq : EqA) where Alt : Alternative, Alt.F == F, EqA : Eq, EqA.A == Kind<F, Int> {
         property("Left distributivity") <- forAll { (x : Int, f : ArrowOf<Int, Int>, g : ArrowOf<Int, Int>) in
-            return eq.eqv(alternative.ap(alternative.pure(x),
-                                         alternative.combineK(alternative.pure(f.getArrow),
-                                                              alternative.pure(g.getArrow))),
-                          alternative.combineK(alternative.ap(alternative.pure(x),
-                                                              alternative.pure(f.getArrow)),
-                                               alternative.ap(alternative.pure(x),
-                                                              alternative.pure(g.getArrow))))
+            return eq.eqv(alternative.ap(alternative.combineK(alternative.pure(f.getArrow),
+                                                              alternative.pure(g.getArrow)),
+                                         alternative.pure(x)),
+                          alternative.combineK(alternative.ap(alternative.pure(f.getArrow),
+                                                              alternative.pure(x)),
+                                               alternative.ap(alternative.pure(g.getArrow),
+                                                              alternative.pure(x))))
         }
     }
 }

--- a/Tests/BowLaws/ApplicativeLaws.swift
+++ b/Tests/BowLaws/ApplicativeLaws.swift
@@ -16,14 +16,14 @@ class ApplicativeLaws<F> {
     
     private static func apIdentity<Appl, EqA>(applicative : Appl, eq : EqA) where Appl : Applicative, Appl.F == F, EqA : Eq, EqA.A == Kind<F, Int> {
         property("ap identity") <- forAll() { (a : Int) in
-            return eq.eqv(applicative.ap(applicative.pure(a), applicative.pure(id)),
+            return eq.eqv(applicative.ap(applicative.pure(id), applicative.pure(a)),
                           applicative.pure(a))
         }
     }
     
     private static func homomorphism<Appl, EqA>(applicative : Appl, eq : EqA) where Appl : Applicative, Appl.F == F, EqA : Eq, EqA.A == Kind<F, Int> {
         property("homomorphism") <- forAll() { (a : Int, f : ArrowOf<Int, Int>) in
-            return eq.eqv(applicative.ap(applicative.pure(a), applicative.pure(f.getArrow)),
+            return eq.eqv(applicative.ap(applicative.pure(f.getArrow), applicative.pure(a)),
                           applicative.pure(f.getArrow(a)))
         }
     }
@@ -31,8 +31,8 @@ class ApplicativeLaws<F> {
     private static func interchange<Appl, EqA>(applicative : Appl, eq : EqA) where Appl : Applicative, Appl.F == F, EqA : Eq, EqA.A == Kind<F, Int> {
         property("interchange") <- forAll() { (a : Int, b : Int) in
             let fa = applicative.pure(constant(a) as (Int) -> Int)
-            return eq.eqv(applicative.ap(applicative.pure(b), fa),
-                          applicative.ap(fa, applicative.pure({ (x : (Int) -> Int) in x(a) } )))
+            return eq.eqv(applicative.ap(fa, applicative.pure(b)),
+                          applicative.ap(applicative.pure({ (x : (Int) -> Int) in x(a) } ), fa))
         }
     }
     
@@ -40,7 +40,7 @@ class ApplicativeLaws<F> {
         property("mad derived") <- forAll() { (a : Int, f : ArrowOf<Int, Int>) in
             let fa = applicative.pure(a)
             return eq.eqv(applicative.map(fa, f.getArrow),
-                          applicative.ap(fa, applicative.pure(f.getArrow)))
+                          applicative.ap(applicative.pure(f.getArrow), fa))
             
         }
     }


### PR DESCRIPTION
As suggested in #77, for a nicer usage of `ap`, the wrapped function should be on the left hand side of `ap`, allowing for a better syntax call. This PR provides this change in every data type supporting `ap`, in the `Applicative` typeclass (swapping arguments for a better curried version) and in all instances of such typeclass.