### PR TITLE
Deprecate operators

### DIFF
--- a/Sources/Bow/Arrow/KleisliOperator.swift
+++ b/Sources/Bow/Arrow/KleisliOperator.swift
@@ -2,46 +2,57 @@ import Foundation
 
 infix operator >=> : AdditionPrecedence
 
+@available(*, deprecated, message: "Use Kleisli composition instead.")
 public func >=><A, B, C>(_ f : @escaping (A) -> Function0<B>, _ g : @escaping (B) -> Function0<C>) -> (A) -> Function0<C> {
     return { a in f(a) >>= g }
 }
 
+@available(*, deprecated, message: "Use Kleisli composition instead.")
 public func >=><A, B, C, D>(_ f : @escaping (A) -> Function1<D, B>, _ g : @escaping (B) -> Function1<D, C>) -> (A) -> Function1<D, C> {
     return { a in f(a) >>= g }
 }
 
+@available(*, deprecated, message: "Use Kleisli composition instead.")
 public func >=><A, B, C, D>(_ f : @escaping (A) -> Either<D, B>, _ g : @escaping (B) -> Either<D, C>) -> (A) -> Either<D, C> {
     return { a in f(a) >>= g }
 }
 
+@available(*, deprecated, message: "Use Kleisli composition instead.")
 public func >=><A, B, C>(_ f : @escaping (A) -> Eval<B>, _ g : @escaping (B) -> Eval<C>) -> (A) -> Eval<C> {
     return { a in f(a) >>= g }
 }
 
+@available(*, deprecated, message: "Use Kleisli composition instead.")
 public func >=><A, B, C>(_ f : @escaping (A) -> Id<B>, _ g : @escaping (B) -> Id<C>) -> (A) -> Id<C> {
     return { a in f(a) >>= g }
 }
 
+@available(*, deprecated, message: "Use Kleisli composition instead.")
 public func >=><A, B, C>(_ f : @escaping (A) -> ListK<B>, _ g : @escaping (B) -> ListK<C>) -> (A) -> ListK<C> {
     return { a in f(a) >>= g }
 }
 
+@available(*, deprecated, message: "Use Kleisli composition instead.")
 public func >=><A, B, C, D>(_ f : @escaping (A) -> MapK<D, B>, _ g : @escaping (B) -> MapK<D, C>) -> (A) -> MapK<D, C> {
     return { a in f(a) >>= g }
 }
 
+@available(*, deprecated, message: "Use Kleisli composition instead.")
 public func >=><A, B, C>(_ f : @escaping (A) -> Option<B>, _ g : @escaping (B) -> Option<C>) -> (A) -> Option<C> {
     return { a in f(a) >>= g }
 }
 
+@available(*, deprecated, message: "Use Kleisli composition instead.")
 public func >=><A, B, C>(_ f : @escaping (A) -> NonEmptyList<B>, _ g : @escaping (B) -> NonEmptyList<C>) -> (A) -> NonEmptyList<C> {
     return { a in f(a) >>= g }
 }
 
+@available(*, deprecated, message: "Use Kleisli composition instead.")
 public func >=><A, B, C, D>(_ f : @escaping (A) -> Reader<D, B>, _ g : @escaping (B) -> Reader<D, C>) -> (A) -> Reader<D, C> {
     return { a in f(a) >>= g }
 }
 
+@available(*, deprecated, message: "Use Kleisli composition instead.")
 public func >=><A, B, C>(_ f : @escaping (A) -> Try<B>, _ g : @escaping (B) -> Try<C>) -> (A) -> Try<C> {
     return { a in f(a) >>= g }
 }

--- a/Sources/Bow/Data/FlatmapOperator.swift
+++ b/Sources/Bow/Data/FlatmapOperator.swift
@@ -2,46 +2,57 @@ import Foundation
 
 infix operator >>= : AdditionPrecedence
 
+@available(*, deprecated, message: "Use flatMap instead.")
 public func >>=<A, B>(_ fa : Function0<A>, _ f : @escaping (A) -> Function0<B>) -> Function0<B> {
     return fa.flatMap(f)
 }
 
+@available(*, deprecated, message: "Use flatMap instead.")
 public func >>=<A, B, C>(_ fa : Function1<A, B>, _ f : @escaping (B) -> Function1<A, C>) -> Function1<A, C> {
     return fa.flatMap(f)
 }
 
+@available(*, deprecated, message: "Use flatMap instead.")
 public func >>=<A, B, C>(_ fa : Either<A, B>, _ f : @escaping (B) -> Either<A, C>) -> Either<A, C> {
     return fa.flatMap(f)
 }
 
+@available(*, deprecated, message: "Use flatMap instead.")
 public func >>=<A, B>(_ fa : Eval<A>, _ f : @escaping (A) -> Eval<B>) -> Eval<B> {
     return fa.flatMap(f)
 }
 
+@available(*, deprecated, message: "Use flatMap instead.")
 public func >>=<A, B>(_ fa : Id<A>, _ f : @escaping (A) -> Id<B>) -> Id<B> {
     return fa.flatMap(f)
 }
 
+@available(*, deprecated, message: "Use flatMap instead.")
 public func >>=<A, B>(_ fa : ListK<A>, _ f : @escaping (A) -> ListK<B>) -> ListK<B> {
     return fa.flatMap(f)
 }
 
+@available(*, deprecated, message: "Use flatMap instead.")
 public func >>=<K, A, B>(_ fa : MapK<K, A>, _ f : @escaping (A) -> MapK<K, B>) -> MapK<K, B> {
     return fa.flatMap(f)
 }
 
+@available(*, deprecated, message: "Use flatMap instead.")
 public func >>=<A, B>(_ fa : Option<A>, _ f : @escaping (A) -> Option<B>) -> Option<B> {
     return fa.flatMap(f)
 }
 
+@available(*, deprecated, message: "Use flatMap instead.")
 public func >>=<A, B>(_ fa : NonEmptyList<A>, _ f : @escaping (A) -> NonEmptyList<B>) -> NonEmptyList<B> {
     return fa.flatMap(f)
 }
 
+@available(*, deprecated, message: "Use flatMap instead.")
 public func >>=<A, B, C>(_ fa : Reader<A, B>, _ f : @escaping (B) -> Reader<A, C>) -> Reader<A, C> {
     return fa.flatMap(f)
 }
 
+@available(*, deprecated, message: "Use flatMap instead.")
 public func >>=<A, B>(_ fa : Try<A>, _ f : @escaping (A) -> Try<B>) -> Try<B> {
     return fa.flatMap(f)
 }

--- a/Tests/BowLaws/FunctorFilterLaws.swift
+++ b/Tests/BowLaws/FunctorFilterLaws.swift
@@ -15,7 +15,7 @@ class FunctorFilterLaws<F> {
             let f : (Int) -> Option<Int> = arc4random_uniform(2) == 0 ? { _ in Option.pure(b) } : { _ in Option<Int>.none() }
             let g : (Int) -> Option<Int> = arc4random_uniform(2) == 0 ? { _ in Option.pure(c) } : { _ in Option<Int>.none() }
             return eq.eqv(functorFilter.mapFilter(functorFilter.mapFilter(fa, f), g),
-                          functorFilter.mapFilter(fa, f >=> g ))
+                          functorFilter.mapFilter(fa, { x in f(x).flatMap(g) } ))
         }
     }
     


### PR DESCRIPTION
Operators >>= (flatMap) and >=> (Kleisli composition) are not generic enough, and often controversial. For the sake of readability and ease of understanding of the code, these operators are being deprecated.