### PR TITLE
Rename foldL and foldR

### DIFF
--- a/Sources/Bow/Data/Const.swift
+++ b/Sources/Bow/Data/Const.swift
@@ -143,7 +143,7 @@ public class ConstFoldable<R> : Foldable {
         return b
     }
     
-    public func foldR<A, B>(_ fa: ConstOf<R, A>, _ b: Eval<B>, _ f: @escaping (A, Eval<B>) -> Eval<B>) -> Eval<B> {
+    public func foldRight<A, B>(_ fa: ConstOf<R, A>, _ b: Eval<B>, _ f: @escaping (A, Eval<B>) -> Eval<B>) -> Eval<B> {
         return b
     }
 }

--- a/Sources/Bow/Data/Const.swift
+++ b/Sources/Bow/Data/Const.swift
@@ -139,7 +139,7 @@ public class ConstMonoid<R, S, Mono> : ConstSemigroup<R, S, Mono>, Monoid where 
 public class ConstFoldable<R> : Foldable {
     public typealias F = ConstPartial<R>
     
-    public func foldL<A, B>(_ fa: ConstOf<R, A>, _ b: B, _ f: @escaping (B, A) -> B) -> B {
+    public func foldLeft<A, B>(_ fa: ConstOf<R, A>, _ b: B, _ f: @escaping (B, A) -> B) -> B {
         return b
     }
     

--- a/Sources/Bow/Data/Coproduct.swift
+++ b/Sources/Bow/Data/Coproduct.swift
@@ -35,9 +35,9 @@ public class Coproduct<F, G, A> : CoproductOf<F, G, A> {
         return run.fold({ fa in f.invoke(fa) }, { ga in g.invoke(ga) })
     }
     
-    public func foldL<B, FoldF, FoldG>(_ b : B, _ f : @escaping (B, A) -> B, _ foldableF : FoldF, _ foldableG : FoldG) -> B where FoldF : Foldable, FoldF.F == F, FoldG : Foldable, FoldG.F == G {
-        return run.fold({ fa in foldableF.foldL(fa, b, f) },
-                        { ga in foldableG.foldL(ga, b, f) })
+    public func foldLeft<B, FoldF, FoldG>(_ b : B, _ f : @escaping (B, A) -> B, _ foldableF : FoldF, _ foldableG : FoldG) -> B where FoldF : Foldable, FoldF.F == F, FoldG : Foldable, FoldG.F == G {
+        return run.fold({ fa in foldableF.foldLeft(fa, b, f) },
+                        { ga in foldableG.foldLeft(ga, b, f) })
     }
     
     public func foldR<B, FoldF, FoldG>(_ b : Eval<B>, _ f : @escaping (A, Eval<B>) -> Eval<B>, _ foldableF : FoldF, _ foldableG : FoldG) -> Eval<B> where FoldF : Foldable, FoldF.F == F, FoldG : Foldable, FoldG.F == G {
@@ -121,8 +121,8 @@ public class CoproductFoldable<G, H, FoldG, FoldH> : Foldable where FoldG : Fold
         self.foldableH = foldableH
     }
     
-    public func foldL<A, B>(_ fa: CoproductOf<G, H, A>, _ b: B, _ f: @escaping (B, A) -> B) -> B {
-        return Coproduct.fix(fa).foldL(b, f, foldableG, foldableH)
+    public func foldLeft<A, B>(_ fa: CoproductOf<G, H, A>, _ b: B, _ f: @escaping (B, A) -> B) -> B {
+        return Coproduct.fix(fa).foldLeft(b, f, foldableG, foldableH)
     }
     
     public func foldR<A, B>(_ fa: CoproductOf<G, H, A>, _ b: Eval<B>, _ f: @escaping (A, Eval<B>) -> Eval<B>) -> Eval<B> {

--- a/Sources/Bow/Data/Coproduct.swift
+++ b/Sources/Bow/Data/Coproduct.swift
@@ -40,9 +40,9 @@ public class Coproduct<F, G, A> : CoproductOf<F, G, A> {
                         { ga in foldableG.foldLeft(ga, b, f) })
     }
     
-    public func foldR<B, FoldF, FoldG>(_ b : Eval<B>, _ f : @escaping (A, Eval<B>) -> Eval<B>, _ foldableF : FoldF, _ foldableG : FoldG) -> Eval<B> where FoldF : Foldable, FoldF.F == F, FoldG : Foldable, FoldG.F == G {
-        return run.fold({ fa in foldableF.foldR(fa, b, f) },
-                        { ga in foldableG.foldR(ga, b, f) })
+    public func foldRight<B, FoldF, FoldG>(_ b : Eval<B>, _ f : @escaping (A, Eval<B>) -> Eval<B>, _ foldableF : FoldF, _ foldableG : FoldG) -> Eval<B> where FoldF : Foldable, FoldF.F == F, FoldG : Foldable, FoldG.F == G {
+        return run.fold({ fa in foldableF.foldRight(fa, b, f) },
+                        { ga in foldableG.foldRight(ga, b, f) })
     }
     
     public func traverse<B, H, Appl, TravF, TravG>(_ f : @escaping (A) -> Kind<H, B>, _ applicative : Appl, _ traverseF : TravF, _ traverseG : TravG) -> Kind<H, CoproductOf<F, G, B>> where Appl : Applicative, Appl.F == H, TravF : Traverse, TravF.F == F, TravG : Traverse, TravG.F == G {
@@ -125,8 +125,8 @@ public class CoproductFoldable<G, H, FoldG, FoldH> : Foldable where FoldG : Fold
         return Coproduct.fix(fa).foldLeft(b, f, foldableG, foldableH)
     }
     
-    public func foldR<A, B>(_ fa: CoproductOf<G, H, A>, _ b: Eval<B>, _ f: @escaping (A, Eval<B>) -> Eval<B>) -> Eval<B> {
-        return Coproduct.fix(fa).foldR(b, f, foldableG, foldableH)
+    public func foldRight<A, B>(_ fa: CoproductOf<G, H, A>, _ b: Eval<B>, _ f: @escaping (A, Eval<B>) -> Eval<B>) -> Eval<B> {
+        return Coproduct.fix(fa).foldRight(b, f, foldableG, foldableH)
     }
 }
 

--- a/Sources/Bow/Data/Either.swift
+++ b/Sources/Bow/Data/Either.swift
@@ -60,7 +60,7 @@ public class Either<A, B> : EitherOf<A, B> {
         return fold(constant(c), { b in f(c, b) })
     }
     
-    public func foldR<C>(_ c : Eval<C>, _ f : (B, Eval<C>) -> Eval<C>) -> Eval<C> {
+    public func foldRight<C>(_ c : Eval<C>, _ f : (B, Eval<C>) -> Eval<C>) -> Eval<C> {
         return fold(constant(c), { b in f(b, c) })
     }
     
@@ -236,8 +236,8 @@ public class EitherFoldable<C> : Foldable {
         return Either.fix(fa).foldLeft(b, f)
     }
     
-    public func foldR<A, B>(_ fa: EitherOf<C, A>, _ b: Eval<B>, _ f: @escaping (A, Eval<B>) -> Eval<B>) -> Eval<B> {
-        return Either.fix(fa).foldR(b, f)
+    public func foldRight<A, B>(_ fa: EitherOf<C, A>, _ b: Eval<B>, _ f: @escaping (A, Eval<B>) -> Eval<B>) -> Eval<B> {
+        return Either.fix(fa).foldRight(b, f)
     }
 }
 

--- a/Sources/Bow/Data/Either.swift
+++ b/Sources/Bow/Data/Either.swift
@@ -56,7 +56,7 @@ public class Either<A, B> : EitherOf<A, B> {
         return fold({ _ in fatalError("Attempted to obtain rightValue on a left instance") }, id)
     }
     
-    public func foldL<C>(_ c : C, _ f : (C, B) -> C) -> C {
+    public func foldLeft<C>(_ c : C, _ f : (C, B) -> C) -> C {
         return fold(constant(c), { b in f(c, b) })
     }
     
@@ -232,8 +232,8 @@ public class EitherMonadError<C> : EitherMonad<C>, MonadError {
 public class EitherFoldable<C> : Foldable {
     public typealias F = EitherPartial<C>
     
-    public func foldL<A, B>(_ fa: EitherOf<C, A>, _ b: B, _ f: @escaping (B, A) -> B) -> B {
-        return Either.fix(fa).foldL(b, f)
+    public func foldLeft<A, B>(_ fa: EitherOf<C, A>, _ b: B, _ f: @escaping (B, A) -> B) -> B {
+        return Either.fix(fa).foldLeft(b, f)
     }
     
     public func foldR<A, B>(_ fa: EitherOf<C, A>, _ b: Eval<B>, _ f: @escaping (A, Eval<B>) -> Eval<B>) -> Eval<B> {

--- a/Sources/Bow/Data/Id.swift
+++ b/Sources/Bow/Data/Id.swift
@@ -36,7 +36,7 @@ public class Id<A> : IdOf<A> {
         return f(value)
     }
     
-    public func foldL<B>(_ b : B, _ f : (B, A) -> B) -> B {
+    public func foldLeft<B>(_ b : B, _ f : (B, A) -> B) -> B {
         return f(b, value)
     }
     
@@ -150,8 +150,8 @@ public class IdBimonad : IdMonad, Bimonad {
 public class IdFoldable : Foldable {
     public typealias F = ForId
     
-    public func foldL<A, B>(_ fa: IdOf<A>, _ b: B, _ f: @escaping (B, A) -> B) -> B {
-        return fa.fix().foldL(b, f)
+    public func foldLeft<A, B>(_ fa: IdOf<A>, _ b: B, _ f: @escaping (B, A) -> B) -> B {
+        return fa.fix().foldLeft(b, f)
     }
     
     public func foldR<A, B>(_ fa: IdOf<A>, _ b: Eval<B>, _ f: @escaping (A, Eval<B>) -> Eval<B>) -> Eval<B> {

--- a/Sources/Bow/Data/Id.swift
+++ b/Sources/Bow/Data/Id.swift
@@ -40,7 +40,7 @@ public class Id<A> : IdOf<A> {
         return f(b, value)
     }
     
-    public func foldR<B>(_ b : Eval<B>, _ f : (A, Eval<B>) -> Eval<B>) -> Eval<B> {
+    public func foldRight<B>(_ b : Eval<B>, _ f : (A, Eval<B>) -> Eval<B>) -> Eval<B> {
         return f(value, b)
     }
     
@@ -154,8 +154,8 @@ public class IdFoldable : Foldable {
         return fa.fix().foldLeft(b, f)
     }
     
-    public func foldR<A, B>(_ fa: IdOf<A>, _ b: Eval<B>, _ f: @escaping (A, Eval<B>) -> Eval<B>) -> Eval<B> {
-        return fa.fix().foldR(b, f)
+    public func foldRight<A, B>(_ fa: IdOf<A>, _ b: Eval<B>, _ f: @escaping (A, Eval<B>) -> Eval<B>) -> Eval<B> {
+        return fa.fix().foldRight(b, f)
     }
 }
 

--- a/Sources/Bow/Data/Ior.swift
+++ b/Sources/Bow/Data/Ior.swift
@@ -83,7 +83,7 @@ public class Ior<A, B> : IorOf<A, B> {
                     { _, b in f(c, b) })
     }
     
-    public func foldR<C>(_ c : Eval<C>, _ f : (B, Eval<C>) -> Eval<C>) -> Eval<C> {
+    public func foldRight<C>(_ c : Eval<C>, _ f : (B, Eval<C>) -> Eval<C>) -> Eval<C> {
         return fold(constant(c),
                     { b in f(b, c) },
                     { _, b in f(b, c) })
@@ -273,8 +273,8 @@ public class IorFoldable<L> : Foldable {
         return Ior.fix(fa).foldLeft(b, f)
     }
     
-    public func foldR<A, B>(_ fa: IorOf<L, A>, _ b: Eval<B>, _ f: @escaping (A, Eval<B>) -> Eval<B>) -> Eval<B> {
-        return Ior.fix(fa).foldR(b, f)
+    public func foldRight<A, B>(_ fa: IorOf<L, A>, _ b: Eval<B>, _ f: @escaping (A, Eval<B>) -> Eval<B>) -> Eval<B> {
+        return Ior.fix(fa).foldRight(b, f)
     }
 }
 

--- a/Sources/Bow/Data/Ior.swift
+++ b/Sources/Bow/Data/Ior.swift
@@ -77,7 +77,7 @@ public class Ior<A, B> : IorOf<A, B> {
         return fold(constant(false), constant(false), constant(true))
     }
     
-    public func foldL<C>(_ c : C, _ f : (C, B) -> C) -> C {
+    public func foldLeft<C>(_ c : C, _ f : (C, B) -> C) -> C {
         return fold(constant(c),
                     { b in f(c, b) },
                     { _, b in f(c, b) })
@@ -269,8 +269,8 @@ public class IorMonad<L, SemiG> : IorApplicative<L, SemiG>, Monad where SemiG : 
 public class IorFoldable<L> : Foldable {
     public typealias F = IorPartial<L>
     
-    public func foldL<A, B>(_ fa: IorOf<L, A>, _ b: B, _ f: @escaping (B, A) -> B) -> B {
-        return Ior.fix(fa).foldL(b, f)
+    public func foldLeft<A, B>(_ fa: IorOf<L, A>, _ b: B, _ f: @escaping (B, A) -> B) -> B {
+        return Ior.fix(fa).foldLeft(b, f)
     }
     
     public func foldR<A, B>(_ fa: IorOf<L, A>, _ b: Eval<B>, _ f: @escaping (A, Eval<B>) -> Eval<B>) -> Eval<B> {

--- a/Sources/Bow/Data/ListK.swift
+++ b/Sources/Bow/Data/ListK.swift
@@ -62,7 +62,7 @@ public class ListK<A> : ListKOf<A> {
         return ListK<B>(list.flatMap({ a in f(a).list }))
     }
     
-    public func foldL<B>(_ b : B, _ f : (B, A) -> B) -> B {
+    public func foldLeft<B>(_ b : B, _ f : (B, A) -> B) -> B {
         return list.reduce(b, f)
     }
     
@@ -224,8 +224,8 @@ public class ListKMonad : ListKApplicative, Monad {
 public class ListKFoldable : Foldable {
     public typealias F = ForListK
     
-    public func foldL<A, B>(_ fa: ListKOf<A>, _ b: B, _ f: @escaping (B, A) -> B) -> B {
-        return fa.fix().foldL(b, f)
+    public func foldLeft<A, B>(_ fa: ListKOf<A>, _ b: B, _ f: @escaping (B, A) -> B) -> B {
+        return fa.fix().foldLeft(b, f)
     }
     
     public func foldR<A, B>(_ fa: ListKOf<A>, _ b: Eval<B>, _ f: @escaping (A, Eval<B>) -> Eval<B>) -> Eval<B> {

--- a/Sources/Bow/Data/ListK.swift
+++ b/Sources/Bow/Data/ListK.swift
@@ -66,7 +66,7 @@ public class ListK<A> : ListKOf<A> {
         return list.reduce(b, f)
     }
     
-    public func foldR<B>(_ b : Eval<B>, _ f : @escaping (A, Eval<B>) -> Eval<B>) -> Eval<B> {
+    public func foldRight<B>(_ b : Eval<B>, _ f : @escaping (A, Eval<B>) -> Eval<B>) -> Eval<B> {
         func loop(_ lkw : ListK<A>) -> Eval<B> {
             if lkw.list.isEmpty {
                 return b
@@ -78,7 +78,7 @@ public class ListK<A> : ListKOf<A> {
     }
     
     public func traverse<G, B, Appl>(_ f : @escaping (A) -> Kind<G, B>, _ applicative : Appl) -> Kind<G, ListKOf<B>> where Appl : Applicative, Appl.F == G {
-        let x = foldR(Eval.always({ applicative.pure(ListK<B>([])) }),
+        let x = foldRight(Eval.always({ applicative.pure(ListK<B>([])) }),
                      { a, eval in applicative.map2Eval(f(a), eval, { x, y in ListK<B>([x]) + y }) }).value()
         return applicative.map(x, { a in a as ListKOf<B> })
     }
@@ -228,8 +228,8 @@ public class ListKFoldable : Foldable {
         return fa.fix().foldLeft(b, f)
     }
     
-    public func foldR<A, B>(_ fa: ListKOf<A>, _ b: Eval<B>, _ f: @escaping (A, Eval<B>) -> Eval<B>) -> Eval<B> {
-        return fa.fix().foldR(b, f)
+    public func foldRight<A, B>(_ fa: ListKOf<A>, _ b: Eval<B>, _ f: @escaping (A, Eval<B>) -> Eval<B>) -> Eval<B> {
+        return fa.fix().foldRight(b, f)
     }
 }
 

--- a/Sources/Bow/Data/MapK.swift
+++ b/Sources/Bow/Data/MapK.swift
@@ -54,7 +54,7 @@ public class MapK<K : Hashable, A> : MapKOf<K, A> {
         return self.dictionary.values.reduce(b, f)
     }
     
-    public func foldR<B>(_ b : Eval<B>, _ f : (A, Eval<B>) -> Eval<B>) -> Eval<B> {
+    public func foldRight<B>(_ b : Eval<B>, _ f : (A, Eval<B>) -> Eval<B>) -> Eval<B> {
         return self.dictionary.values.reversed().reduce(b, { b, a in f(a, b) })
     }
     

--- a/Sources/Bow/Data/MapK.swift
+++ b/Sources/Bow/Data/MapK.swift
@@ -50,7 +50,7 @@ public class MapK<K : Hashable, A> : MapKOf<K, A> {
         }).k()
     }
     
-    public func foldL<B>(_ b : B, _ f : (B, A) -> B) -> B {
+    public func foldLeft<B>(_ b : B, _ f : (B, A) -> B) -> B {
         return self.dictionary.values.reduce(b, f)
     }
     

--- a/Sources/Bow/Data/NonEmptyList.swift
+++ b/Sources/Bow/Data/NonEmptyList.swift
@@ -91,8 +91,8 @@ public class NonEmptyList<A> : NonEmptyListOf<A> {
         return tail.reduce(f(b, head), f)
     }
     
-    public func foldR<B>(_ b : Eval<B>, _ f : @escaping (A, Eval<B>) -> Eval<B>) -> Eval<B> {
-        return ListK<A>.foldable().foldR(self.all().k(), b, f)
+    public func foldRight<B>(_ b : Eval<B>, _ f : @escaping (A, Eval<B>) -> Eval<B>) -> Eval<B> {
+        return ListK<A>.foldable().foldRight(self.all().k(), b, f)
     }
     
     public func traverse<G, B, Appl>(_ f : @escaping (A) -> Kind<G, B>, _ applicative : Appl) -> Kind<G, NonEmptyListOf<B>> where Appl : Applicative, Appl.F == G {
@@ -248,8 +248,8 @@ public class NonEmptyListFoldable : Foldable {
         return fa.fix().foldLeft(b, f)
     }
     
-    public func foldR<A, B>(_ fa: NonEmptyListOf<A>, _ b: Eval<B>, _ f: @escaping (A, Eval<B>) -> Eval<B>) -> Eval<B> {
-        return fa.fix().foldR(b, f)
+    public func foldRight<A, B>(_ fa: NonEmptyListOf<A>, _ b: Eval<B>, _ f: @escaping (A, Eval<B>) -> Eval<B>) -> Eval<B> {
+        return fa.fix().foldRight(b, f)
     }
 }
 

--- a/Sources/Bow/Data/NonEmptyList.swift
+++ b/Sources/Bow/Data/NonEmptyList.swift
@@ -87,7 +87,7 @@ public class NonEmptyList<A> : NonEmptyListOf<A> {
         return flatMap(fa.map)
     }
     
-    public func foldL<B>(_ b : B, _ f : (B, A) -> B) -> B {
+    public func foldLeft<B>(_ b : B, _ f : (B, A) -> B) -> B {
         return tail.reduce(f(b, head), f)
     }
     
@@ -244,8 +244,8 @@ public class NonEmptyListBimonad : NonEmptyListMonad, Bimonad {
 public class NonEmptyListFoldable : Foldable {
     public typealias F = ForNonEmptyList
     
-    public func foldL<A, B>(_ fa: NonEmptyListOf<A>, _ b: B, _ f: @escaping (B, A) -> B) -> B {
-        return fa.fix().foldL(b, f)
+    public func foldLeft<A, B>(_ fa: NonEmptyListOf<A>, _ b: B, _ f: @escaping (B, A) -> B) -> B {
+        return fa.fix().foldLeft(b, f)
     }
     
     public func foldR<A, B>(_ fa: NonEmptyListOf<A>, _ b: Eval<B>, _ f: @escaping (A, Eval<B>) -> Eval<B>) -> Eval<B> {

--- a/Sources/Bow/Data/Option.swift
+++ b/Sources/Bow/Data/Option.swift
@@ -71,7 +71,7 @@ public class Option<A> : OptionOf<A> {
         return fold(Option<B>.none, f)
     }
     
-    public func foldL<B>(_ b : B, _ f : (B, A) -> B) -> B {
+    public func foldLeft<B>(_ b : B, _ f : (B, A) -> B) -> B {
         return fold({ b },
                     { a in f(b, a) })
     }
@@ -320,8 +320,8 @@ public class OptionMonadFilter : OptionMonad, MonadFilter {
 public class OptionFoldable : Foldable {
     public typealias F = ForOption
     
-    public func foldL<A, B>(_ fa: Kind<ForOption, A>, _ b: B, _ f: @escaping (B, A) -> B) -> B {
-        return fa.fix().foldL(b, f)
+    public func foldLeft<A, B>(_ fa: Kind<ForOption, A>, _ b: B, _ f: @escaping (B, A) -> B) -> B {
+        return fa.fix().foldLeft(b, f)
     }
     
     public func foldR<A, B>(_ fa: Kind<ForOption, A>, _ b: Eval<B>, _ f: @escaping (A, Eval<B>) -> Eval<B>) -> Eval<B> {

--- a/Sources/Bow/Data/Option.swift
+++ b/Sources/Bow/Data/Option.swift
@@ -76,7 +76,7 @@ public class Option<A> : OptionOf<A> {
                     { a in f(b, a) })
     }
     
-    public func foldR<B>(_ b : Eval<B>, _ f : (A, Eval<B>) -> Eval<B>) -> Eval<B> {
+    public func foldRight<B>(_ b : Eval<B>, _ f : (A, Eval<B>) -> Eval<B>) -> Eval<B> {
         return self.fold(constant(b),
                          { a in f(a, b) })
     }
@@ -324,8 +324,8 @@ public class OptionFoldable : Foldable {
         return fa.fix().foldLeft(b, f)
     }
     
-    public func foldR<A, B>(_ fa: Kind<ForOption, A>, _ b: Eval<B>, _ f: @escaping (A, Eval<B>) -> Eval<B>) -> Eval<B> {
-        return fa.fix().foldR(b, f)
+    public func foldRight<A, B>(_ fa: Kind<ForOption, A>, _ b: Eval<B>, _ f: @escaping (A, Eval<B>) -> Eval<B>) -> Eval<B> {
+        return fa.fix().foldRight(b, f)
     }
 }
 

--- a/Sources/Bow/Data/SetK.swift
+++ b/Sources/Bow/Data/SetK.swift
@@ -34,7 +34,7 @@ public class SetK<A: Hashable> : SetKOf<A> {
 		return set.isEmpty
 	}
 
-	public func foldL<B>(_ b : B, _ f : (B, A) -> B) -> B {
+	public func foldLeft<B>(_ b : B, _ f : (B, A) -> B) -> B {
 		return set.reduce(b, f)
 	}
 

--- a/Sources/Bow/Data/SetK.swift
+++ b/Sources/Bow/Data/SetK.swift
@@ -38,7 +38,7 @@ public class SetK<A: Hashable> : SetKOf<A> {
 		return set.reduce(b, f)
 	}
 
-	public func foldR<B>(_ b : Eval<B>, _ f : @escaping (A, Eval<B>) -> Eval<B>) -> Eval<B> {
+	public func foldRight<B>(_ b : Eval<B>, _ f : @escaping (A, Eval<B>) -> Eval<B>) -> Eval<B> {
 		func loop(_ skw : SetK<A>) -> Eval<B> {
 			if skw.set.isEmpty {
 				return b

--- a/Sources/Bow/Data/Try.swift
+++ b/Sources/Bow/Data/Try.swift
@@ -62,7 +62,7 @@ public class Try<A> : TryOf<A> {
         }
     }
     
-    public func foldL<B>(_ b : B, _ f : (B, A) -> B) -> B {
+    public func foldLeft<B>(_ b : B, _ f : (B, A) -> B) -> B {
         return fold(constant(b),
                     { a in f(b, a) })
     }
@@ -248,8 +248,8 @@ public class TryEq<R, EqR> : Eq where EqR : Eq, EqR.A == R {
 public class TryFoldable : Foldable {
     public typealias F = ForTry
     
-    public func foldL<A, B>(_ fa: Kind<ForTry, A>, _ b: B, _ f: @escaping (B, A) -> B) -> B {
-        return fa.fix().foldL(b, f)
+    public func foldLeft<A, B>(_ fa: Kind<ForTry, A>, _ b: B, _ f: @escaping (B, A) -> B) -> B {
+        return fa.fix().foldLeft(b, f)
     }
     
     public func foldR<A, B>(_ fa: Kind<ForTry, A>, _ b: Eval<B>, _ f: @escaping (A, Eval<B>) -> Eval<B>) -> Eval<B> {

--- a/Sources/Bow/Data/Try.swift
+++ b/Sources/Bow/Data/Try.swift
@@ -67,7 +67,7 @@ public class Try<A> : TryOf<A> {
                     { a in f(b, a) })
     }
     
-    public func foldR<B>(_ lb : Eval<B>, _ f : (A, Eval<B>) -> Eval<B>) -> Eval<B> {
+    public func foldRight<B>(_ lb : Eval<B>, _ f : (A, Eval<B>) -> Eval<B>) -> Eval<B> {
         return fold(constant(lb),
                     { a in f(a, lb) })
     }
@@ -252,8 +252,8 @@ public class TryFoldable : Foldable {
         return fa.fix().foldLeft(b, f)
     }
     
-    public func foldR<A, B>(_ fa: Kind<ForTry, A>, _ b: Eval<B>, _ f: @escaping (A, Eval<B>) -> Eval<B>) -> Eval<B> {
-        return fa.fix().foldR(b, f)
+    public func foldRight<A, B>(_ fa: Kind<ForTry, A>, _ b: Eval<B>, _ f: @escaping (A, Eval<B>) -> Eval<B>) -> Eval<B> {
+        return fa.fix().foldRight(b, f)
     }
 }
 

--- a/Sources/Bow/Data/Validated.swift
+++ b/Sources/Bow/Data/Validated.swift
@@ -96,7 +96,7 @@ public class Validated<E, A> : ValidatedOf<E, A> {
         return fold(constant(b), { a in f(b, a) })
     }
     
-    public func foldR<B>(_ b : Eval<B>, _ f : (A, Eval<B>) -> Eval<B>) -> Eval<B>{
+    public func foldRight<B>(_ b : Eval<B>, _ f : (A, Eval<B>) -> Eval<B>) -> Eval<B>{
         return fold(constant(b), { a in f(a, b) })
     }
     
@@ -241,8 +241,8 @@ public class ValidatedFoldable<R> : Foldable {
         return Validated.fix(fa).foldLeft(b, f)
     }
     
-    public func foldR<A, B>(_ fa: ValidatedOf<R, A>, _ b: Eval<B>, _ f: @escaping (A, Eval<B>) -> Eval<B>) -> Eval<B> {
-        return Validated.fix(fa).foldR(b, f)
+    public func foldRight<A, B>(_ fa: ValidatedOf<R, A>, _ b: Eval<B>, _ f: @escaping (A, Eval<B>) -> Eval<B>) -> Eval<B> {
+        return Validated.fix(fa).foldRight(b, f)
     }
 }
 

--- a/Sources/Bow/Data/Validated.swift
+++ b/Sources/Bow/Data/Validated.swift
@@ -92,7 +92,7 @@ public class Validated<E, A> : ValidatedOf<E, A> {
                                         { f in Validated<E, B>.valid(f(a)) }) })
     }
     
-    public func foldL<B>(_ b : B, _ f : (B, A) -> B) -> B {
+    public func foldLeft<B>(_ b : B, _ f : (B, A) -> B) -> B {
         return fold(constant(b), { a in f(b, a) })
     }
     
@@ -237,8 +237,8 @@ public class ValidatedApplicativeError<R, SemiG> : ValidatedApplicative<R, SemiG
 public class ValidatedFoldable<R> : Foldable {
     public typealias F = ValidatedPartial<R>
     
-    public func foldL<A, B>(_ fa: ValidatedOf<R, A>, _ b: B, _ f: @escaping (B, A) -> B) -> B {
-        return Validated.fix(fa).foldL(b, f)
+    public func foldLeft<A, B>(_ fa: ValidatedOf<R, A>, _ b: B, _ f: @escaping (B, A) -> B) -> B {
+        return Validated.fix(fa).foldLeft(b, f)
     }
     
     public func foldR<A, B>(_ fa: ValidatedOf<R, A>, _ b: Eval<B>, _ f: @escaping (A, Eval<B>) -> Eval<B>) -> Eval<B> {

--- a/Sources/Bow/Typeclasses/Composed/ComposedFoldable.swift
+++ b/Sources/Bow/Typeclasses/Composed/ComposedFoldable.swift
@@ -19,8 +19,8 @@ public extension ComposedFoldable {
         return foldableG.foldLeft(unnest(fa), b, { bb, aa in self.foldableH.foldLeft(aa, bb, f) })
     }
     
-    public func foldR<A, B>(_ fa: Kind<Nested<G, H>, A>, _ b: Eval<B>, _ f: @escaping (A, Eval<B>) -> Eval<B>) -> Eval<B> {
-        return foldableG.foldR(unnest(fa), b, { aa, bb in self.foldableH.foldR(aa, bb, f) })
+    public func foldRight<A, B>(_ fa: Kind<Nested<G, H>, A>, _ b: Eval<B>, _ f: @escaping (A, Eval<B>) -> Eval<B>) -> Eval<B> {
+        return foldableG.foldRight(unnest(fa), b, { aa, bb in self.foldableH.foldRight(aa, bb, f) })
     }
     
     public func foldLC<A, B>(_ fa : Kind<G, Kind<H, A>>, _ b : B, _ f : @escaping (B, A) -> B) -> B {
@@ -28,7 +28,7 @@ public extension ComposedFoldable {
     }
     
     public func foldRC<A, B>(_ fa : Kind<G, Kind<H, A>>, _ b : Eval<B>, _ f : @escaping (A, Eval<B>) -> Eval<B>) -> Eval<B> {
-        return foldR(nest(fa), b, f)
+        return foldRight(nest(fa), b, f)
     }
 }
 

--- a/Sources/Bow/Typeclasses/Composed/ComposedFoldable.swift
+++ b/Sources/Bow/Typeclasses/Composed/ComposedFoldable.swift
@@ -15,8 +15,8 @@ public extension ComposedFoldable {
         return BaseComposedFoldable<G, H, FoldG, FoldH>(foldableG, foldableH)
     }
     
-    public func foldL<A, B>(_ fa: Kind<Nested<G, H>, A>, _ b: B, _ f: @escaping (B, A) -> B) -> B {
-        return foldableG.foldL(unnest(fa), b, { bb, aa in self.foldableH.foldL(aa, bb, f) })
+    public func foldLeft<A, B>(_ fa: Kind<Nested<G, H>, A>, _ b: B, _ f: @escaping (B, A) -> B) -> B {
+        return foldableG.foldLeft(unnest(fa), b, { bb, aa in self.foldableH.foldLeft(aa, bb, f) })
     }
     
     public func foldR<A, B>(_ fa: Kind<Nested<G, H>, A>, _ b: Eval<B>, _ f: @escaping (A, Eval<B>) -> Eval<B>) -> Eval<B> {
@@ -24,7 +24,7 @@ public extension ComposedFoldable {
     }
     
     public func foldLC<A, B>(_ fa : Kind<G, Kind<H, A>>, _ b : B, _ f : @escaping (B, A) -> B) -> B {
-        return foldL(nest(fa), b, f)
+        return foldLeft(nest(fa), b, f)
     }
     
     public func foldRC<A, B>(_ fa : Kind<G, Kind<H, A>>, _ b : Eval<B>, _ f : @escaping (A, Eval<B>) -> Eval<B>) -> Eval<B> {

--- a/Sources/Bow/Typeclasses/Foldable.swift
+++ b/Sources/Bow/Typeclasses/Foldable.swift
@@ -3,17 +3,17 @@ import Foundation
 public protocol Foldable : Typeclass {
     associatedtype F
     
-    func foldL<A, B>(_ fa : Kind<F, A>, _ b : B, _ f : @escaping (B, A) -> B) -> B
+    func foldLeft<A, B>(_ fa : Kind<F, A>, _ b : B, _ f : @escaping (B, A) -> B) -> B
     func foldR<A, B>(_ fa : Kind<F, A>, _ b : Eval<B>, _ f : @escaping (A, Eval<B>) -> Eval<B>) -> Eval<B>
 }
 
 public extension Foldable {
     public func fold<A, Mono>(_ monoid : Mono, _ fa : Kind<F, A>) -> A where Mono : Monoid, Mono.A == A {
-        return foldL(fa, monoid.empty, { acc, a in monoid.combine(acc, a) })
+        return foldLeft(fa, monoid.empty, { acc, a in monoid.combine(acc, a) })
     }
     
     public func reduceLeftToOption<A, B>(_ fa : Kind<F, A>, _ f : @escaping (A) -> B, _ g : @escaping(B, A) -> B) -> Option<B> {
-        return foldL(fa, Option.empty(), { option, a in
+        return foldLeft(fa, Option.empty(), { option, a in
             option.fold(constant(Option<B>.some(f(a))),
                         { b in Option<B>.some(g(b, a)) })
         })
@@ -41,7 +41,7 @@ public extension Foldable {
     }
     
     public func foldMap<A, B, Mono>(_ monoid : Mono, _ fa : Kind<F, A>, _ f : @escaping (A) -> B) -> B where Mono : Monoid, Mono.A == B {
-        return foldL(fa, monoid.empty, { b, a in monoid.combine(b, f(a)) })
+        return foldLeft(fa, monoid.empty, { b, a in monoid.combine(b, f(a)) })
     }
     
     public func traverse_<G, A, B, Appl>(_ applicative : Appl, _ fa : Kind<F, A>, _ f : @escaping (A) -> Kind<G, B>) -> Kind<G, Unit> where Appl : Applicative, Appl.F == G {
@@ -81,7 +81,7 @@ public extension Foldable {
     }
     
     public func foldM<G, A, B, Mon>(_ fa : Kind<F, A>, _ b : B, _ f : @escaping (B, A) -> Kind<G, B>, _ monad : Mon) -> Kind<G, B> where Mon : Monad, Mon.F == G {
-        return foldL(fa, monad.pure(b), { gb, a in monad.flatMap(gb, { b in f(b, a) }) })
+        return foldLeft(fa, monad.pure(b), { gb, a in monad.flatMap(gb, { b in f(b, a) }) })
     }
     
     public func foldMapM<G, A, B, Mon, Mono>(_ fa : Kind<F, A>, _ f : @escaping (A) -> Kind<G, B>, _ monad : Mon, _ monoid : Mono) -> Kind<G, B> where Mon : Monad, Mon.F == G, Mono : Monoid, Mono.A == B {

--- a/Sources/Bow/Typeclasses/MonadCombine.swift
+++ b/Sources/Bow/Typeclasses/MonadCombine.swift
@@ -4,7 +4,7 @@ public protocol MonadCombine : MonadFilter, Alternative {}
 
 public extension MonadCombine {
     public func unite<G, A, Fold>(_ fga : Kind<F, Kind<G, A>>, _ foldable : Fold) -> Kind<F, A> where Fold : Foldable, Fold.F == G {
-        return flatMap(fga, { ga in foldable.foldL(ga, self.empty(), { acc, a in self.combineK(acc, self.pure(a)) })})
+        return flatMap(fga, { ga in foldable.foldLeft(ga, self.empty(), { acc, a in self.combineK(acc, self.pure(a)) })})
     }
     
     public func separate<G, A, B, Bifold>(_ fgab : Kind<F, Kind2<G, A, B>>, _ bifoldable : Bifold) -> (Kind<F, A>, Kind<F, B>) where Bifold : Bifoldable, Bifold.F == G {

--- a/Sources/Bow/Typeclasses/NonEmptyReducible.swift
+++ b/Sources/Bow/Typeclasses/NonEmptyReducible.swift
@@ -14,8 +14,8 @@ public extension NonEmptyReducible {
         return foldable().foldLeft(ga, f(b, a), f)
     }
     
-    public func foldR<A, B>(_ fa: Kind<F, A>, _ b: Eval<B>, _ f: @escaping (A, Eval<B>) -> Eval<B>) -> Eval<B> {
-        return Eval<(A, Kind<G, A>)>.always({ self.split(fa) }).flatMap{ (a, ga) in f(a, self.foldable().foldR(ga, b, f)) }
+    public func foldRight<A, B>(_ fa: Kind<F, A>, _ b: Eval<B>, _ f: @escaping (A, Eval<B>) -> Eval<B>) -> Eval<B> {
+        return Eval<(A, Kind<G, A>)>.always({ self.split(fa) }).flatMap{ (a, ga) in f(a, self.foldable().foldRight(ga, b, f)) }
     }
     
     public func reduceLeftTo<A, B>(_ fa: Kind<F, A>, _ f: (A) -> B, _ g: @escaping (B, A) -> B) -> B {

--- a/Sources/Bow/Typeclasses/NonEmptyReducible.swift
+++ b/Sources/Bow/Typeclasses/NonEmptyReducible.swift
@@ -9,9 +9,9 @@ public protocol NonEmptyReducible : Reducible {
 }
 
 public extension NonEmptyReducible {
-    public func foldL<A, B>(_ fa: Kind<F, A>, _ b: B, _ f: @escaping (B, A) -> B) -> B {
+    public func foldLeft<A, B>(_ fa: Kind<F, A>, _ b: B, _ f: @escaping (B, A) -> B) -> B {
         let (a, ga) = split(fa)
-        return foldable().foldL(ga, f(b, a), f)
+        return foldable().foldLeft(ga, f(b, a), f)
     }
     
     public func foldR<A, B>(_ fa: Kind<F, A>, _ b: Eval<B>, _ f: @escaping (A, Eval<B>) -> Eval<B>) -> Eval<B> {
@@ -20,7 +20,7 @@ public extension NonEmptyReducible {
     
     public func reduceLeftTo<A, B>(_ fa: Kind<F, A>, _ f: (A) -> B, _ g: @escaping (B, A) -> B) -> B {
         let (a, ga) = split(fa)
-        return foldable().foldL(ga, f(a), { b, a in g(b, a) })
+        return foldable().foldLeft(ga, f(a), { b, a in g(b, a) })
     }
     
     public func reduceRightTo<A, B>(_ fa: Kind<F, A>, _ f: @escaping (A) -> B, _ g: @escaping (A, Eval<B>) -> Eval<B>) -> Eval<B> {

--- a/Sources/BowRx/MaybeK.swift
+++ b/Sources/BowRx/MaybeK.swift
@@ -186,7 +186,7 @@ public class MaybeKMonad : MaybeKApplicative, Monad {
 public class MaybeKFoldable : Foldable {
     public typealias F = ForMaybeK
     
-    public func foldL<A, B>(_ fa: MaybeKOf<A>, _ b: B, _ f: @escaping (B, A) -> B) -> B {
+    public func foldLeft<A, B>(_ fa: MaybeKOf<A>, _ b: B, _ f: @escaping (B, A) -> B) -> B {
         return fa.fix().foldLeft(b, f)
     }
     

--- a/Sources/BowRx/MaybeK.swift
+++ b/Sources/BowRx/MaybeK.swift
@@ -190,7 +190,7 @@ public class MaybeKFoldable : Foldable {
         return fa.fix().foldLeft(b, f)
     }
     
-    public func foldR<A, B>(_ fa: MaybeKOf<A>, _ b: Eval<B>, _ f: @escaping (A, Eval<B>) -> Eval<B>) -> Eval<B> {
+    public func foldRight<A, B>(_ fa: MaybeKOf<A>, _ b: Eval<B>, _ f: @escaping (A, Eval<B>) -> Eval<B>) -> Eval<B> {
         return fa.fix().foldRight(b, f)
     }
 }

--- a/Sources/BowRx/ObservableK.swift
+++ b/Sources/BowRx/ObservableK.swift
@@ -217,7 +217,7 @@ public class ObservableKMonad : ObservableKApplicative, Monad {
 public class ObservableKFoldable : Foldable {
     public typealias F = ForObservableK
     
-    public func foldL<A, B>(_ fa: ObservableKOf<A>, _ b: B, _ f: @escaping (B, A) -> B) -> B {
+    public func foldLeft<A, B>(_ fa: ObservableKOf<A>, _ b: B, _ f: @escaping (B, A) -> B) -> B {
         return fa.fix().foldLeft(b, f)
     }
     

--- a/Sources/BowRx/ObservableK.swift
+++ b/Sources/BowRx/ObservableK.swift
@@ -221,7 +221,7 @@ public class ObservableKFoldable : Foldable {
         return fa.fix().foldLeft(b, f)
     }
     
-    public func foldR<A, B>(_ fa: ObservableKOf<A>, _ b: Eval<B>, _ f: @escaping (A, Eval<B>) -> Eval<B>) -> Eval<B> {
+    public func foldRight<A, B>(_ fa: ObservableKOf<A>, _ b: Eval<B>, _ f: @escaping (A, Eval<B>) -> Eval<B>) -> Eval<B> {
         return fa.fix().foldRight(b, f)
     }
 }

--- a/Tests/BowLaws/FoldableLaws.swift
+++ b/Tests/BowLaws/FoldableLaws.swift
@@ -15,7 +15,7 @@ class FoldableLaws<F> {
             let input = generator(x)
             
             return foldable.foldMap(Int.sumMonoid, input, f.getArrow) ==
-                foldable.foldL(input, Int.sumMonoid.empty, { b, a in Int.sumMonoid.combine(b, f.getArrow(a)) })
+                foldable.foldLeft(input, Int.sumMonoid.empty, { b, a in Int.sumMonoid.combine(b, f.getArrow(a)) })
         }
     }
     
@@ -53,7 +53,7 @@ class FoldableLaws<F> {
         property("Exists consistent with find") <- forAll { (x : Int, f : ArrowOf<Int, Int>) in
             let input = generator(x)
             
-            let foldL = foldable.foldL(input, Int.sumMonoid.empty, { b, a in Int.sumMonoid.combine(b, f.getArrow(a)) })
+            let foldL = foldable.foldLeft(input, Int.sumMonoid.empty, { b, a in Int.sumMonoid.combine(b, f.getArrow(a)) })
             let foldM = foldable.foldM(input, Int.sumMonoid.empty, { b, a in Id(Int.sumMonoid.combine(b, f.getArrow(a))) }, Id<Int>.monad()).fix().value
             return foldL == foldM
         }


### PR DESCRIPTION
`foldL` and `foldR` are replaced by better names `foldLeft` and `foldRight`.