### PR TITLE
Read GA id from config

### DIFF
--- a/docs/_includes/_google-tag-manager.html
+++ b/docs/_includes/_google-tag-manager.html
@@ -1,5 +1,5 @@
 <!-- Global site tag (gtag.js) - Google Analytics -->
-<script async src="https://www.googletagmanager.com/gtag/js?id=UA-18433785-19"></script>
+<script async src="https://www.googletagmanager.com/gtag/js?id={{ site.google_analytics }}"></script>
 <script>
   window.dataLayer = window.dataLayer || [];
   function gtag(){dataLayer.push(arguments);}


### PR DESCRIPTION
* Simple fix to set the Google Analytics id parameter to be read from config, as it was incorrectly set as a hardcoded value.
