### PR TITLE
Add API docs to Syntax group

### DIFF
--- a/Bow.xcodeproj/project.pbxproj
+++ b/Bow.xcodeproj/project.pbxproj
@@ -1119,14 +1119,14 @@
 		11DDCD19217F163400844D9D /* Syntax */ = {
 			isa = PBXGroup;
 			children = (
-				8BA0F48B217E2E9200969984 /* HigherKinds.swift */,
-				8BA0F449217E2E9200969984 /* Typeclass.swift */,
 				8BA0F44A217E2E9200969984 /* BooleanFunctions.swift */,
 				8BA0F43C217E2E9200969984 /* Curry.swift */,
+				8BA0F48B217E2E9200969984 /* HigherKinds.swift */,
 				11DDCD1B217F171900844D9D /* Memoization.swift */,
 				8BA0F45B217E2E9200969984 /* PartialApplication.swift */,
 				8BA0F450217E2E9200969984 /* Predef.swift */,
 				11DDCD22217F1E2B00844D9D /* Reverse.swift */,
+				8BA0F449217E2E9200969984 /* Typeclass.swift */,
 			);
 			path = Syntax;
 			sourceTree = "<group>";

--- a/Sources/Bow/Syntax/BooleanFunctions.swift
+++ b/Sources/Bow/Syntax/BooleanFunctions.swift
@@ -1,61 +1,112 @@
 import Foundation
 
+/**
+ Negates a boolean value.
+ */
 public func not(_ a : Bool) -> Bool {
     return !a
 }
 
+/**
+ Conjunction of two boolean values.
+ 
+ Returns `true` if both inputs are `true`, or `false` otherwise.
+ */
 public func and(_ a : Bool, _ b : Bool) -> Bool {
     return a && b
 }
 
+/**
+ Disjunction of two boolean values.
+ 
+ Returns `false` if both inputs are `false`, or `true` otherwise.
+ */
 public func or(_ a : Bool, _ b : Bool) -> Bool {
     return a || b
 }
 
+/**
+ Exclusive or of two boolean values.
+ 
+ Returns `true` if both inputs have different truth value, or `false` if they are equal.
+ */
 public func xor(_ a : Bool, _ b : Bool) -> Bool {
     return a != b
 }
 
+/**
+ Given a 0-ary function, provides a 0-ary function that returns the complement boolean value.
+ */
 public func complement(_ ff : @escaping () -> Bool) -> () -> Bool {
     return ff >>> not
 }
 
+/**
+ Given a 1-ary function, provides a 1-ary function that returns the complement boolean value.
+ */
 public func complement<A>(_ ff : @escaping (A) -> Bool) -> (A) -> Bool {
     return ff >>> not
 }
 
+/**
+ Given a 2-ary function, provides a 2-ary function that returns the complement boolean value.
+ */
 public func complement<A, B>(_ ff : @escaping (A, B) -> Bool) -> (A, B) -> Bool {
     return { a, b in !ff(a, b) }
 }
 
+/**
+ Given a 3-ary function, provides a 3-ary function that returns the complement boolean value.
+ */
 public func complement<A, B, C>(_ ff : @escaping (A, B, C) -> Bool) -> (A, B, C) -> Bool {
     return { a, b, c in !ff(a, b, c) }
 }
 
+/**
+ Given a 4-ary function, provides a 4-ary function that returns the complement boolean value.
+ */
 public func complement<A, B, C, D>(_ ff : @escaping (A, B, C, D) -> Bool) -> (A, B, C, D) -> Bool {
     return { a, b, c, d in !ff(a, b, c, d) }
 }
 
+/**
+ Given a 5-ary function, provides a 5-ary function that returns the complement boolean value.
+ */
 public func complement<A, B, C, D, E>(_ ff : @escaping (A, B, C, D, E) -> Bool) -> (A, B, C, D, E) -> Bool {
     return { a, b, c, d, e in !ff(a, b, c, d, e) }
 }
 
+/**
+ Given a 6-ary function, provides a 6-ary function that returns the complement boolean value.
+ */
 public func complement<A, B, C, D, E, F>(_ ff : @escaping (A, B, C, D, E, F) -> Bool) -> (A, B, C, D, E, F) -> Bool {
     return { a, b, c, d, e, f in !ff(a, b, c, d, e, f) }
 }
 
+/**
+ Given a 7-ary function, provides a 7-ary function that returns the complement boolean value.
+ */
 public func complement<A, B, C, D, E, F, G>(_ ff : @escaping (A, B, C, D, E, F, G) -> Bool) -> (A, B, C, D, E, F, G) -> Bool {
     return { a, b, c, d, e, f, g in !ff(a, b, c, d, e, f, g) }
 }
 
+/**
+ Given a 8-ary function, provides a 8-ary function that returns the complement boolean value.
+ */
 public func complement<A, B, C, D, E, F, G, H>(_ ff : @escaping (A, B, C, D, E, F, G, H) -> Bool) -> (A, B, C, D, E, F, G, H) -> Bool {
     return { a, b, c, d, e, f, g, h in !ff(a, b, c, d, e, f, g, h) }
 }
 
+/**
+ Given a 9-ary function, provides a 9-ary function that returns the complement boolean value.
+ */
 public func complement<A, B, C, D, E, F, G, H, I>(_ ff : @escaping (A, B, C, D, E, F, G, H, I) -> Bool) -> (A, B, C, D, E, F, G, H, I) -> Bool {
     return { a, b, c, d, e, f, g, h, i in !ff(a, b, c, d, e, f, g, h, i) }
 }
 
+/**
+ Given a 10-ary function, provides a 10-ary function that returns the complement boolean value.
+ */
 public func complement<A, B, C, D, E, F, G, H, I, J>(_ ff : @escaping (A, B, C, D, E, F, G, H, I, J) -> Bool) -> (A, B, C, D, E, F, G, H, I, J) -> Bool {
     return { a, b, c, d, e, f, g, h, i, j in !ff(a, b, c, d, e, f, g, h, i, j) }
 }

--- a/Sources/Bow/Syntax/Curry.swift
+++ b/Sources/Bow/Syntax/Curry.swift
@@ -50,7 +50,7 @@ public func curry<A, B, C, D, E, F>(_ fun : @escaping (A, B, C, D, E) -> F) -> (
 }
 
 /**
- Uncurries a 4-ary function.
+ Uncurries a 5-ary function.
  */
 public func uncurry<A, B, C, D, E, F>(_ fun : @escaping (A) -> (B) -> (C) -> (D) -> (E) -> F) -> (A, B, C, D, E) -> F {
     return { a, b, c, d, e in fun(a)(b)(c)(d)(e) }

--- a/Sources/Bow/Syntax/Curry.swift
+++ b/Sources/Bow/Syntax/Curry.swift
@@ -1,49 +1,85 @@
 import Foundation
 
+/**
+ Curries a 2-ary function.
+ */
 public func curry<A, B, C>(_ fun : @escaping (A, B) -> C) -> (A) -> (B) -> C {
     return { a in { b in fun(a, b) }}
 }
 
+/**
+ Uncurries a 2-ary function.
+ */
 public func uncurry<A, B, C>(_ fun : @escaping (A) -> (B) -> C) -> (A, B) -> C {
     return { a, b in fun(a)(b) }
 }
 
+/**
+ Curries a 3-ary function.
+ */
 public func curry<A, B, C, D>(_ fun : @escaping (A, B, C) -> D) -> (A) -> (B) -> (C) -> D {
     return { a in { b in { c in fun(a,b,c) } } }
 }
 
+/**
+ Uncurries a 3-ary function.
+ */
 public func uncurry<A, B, C, D>(_ fun : @escaping (A) -> (B) -> (C) -> D) -> (A, B, C) -> D {
     return { a, b, c in fun(a)(b)(c) }
 }
 
+/**
+ Curries a 4-ary function.
+ */
 public func curry<A, B, C, D, E>(_ fun : @escaping (A, B, C, D) -> E) -> (A) -> (B) -> (C) -> (D) -> E {
     return { a in { b in { c in { d in fun(a,b,c,d) } } } }
 }
 
+/**
+ Uncurries a 4-ary function.
+ */
 public func uncurry<A, B, C, D, E>(_ fun : @escaping (A) -> (B) -> (C) -> (D) -> E) -> (A, B, C, D) -> E {
     return { a, b, c, d in fun(a)(b)(c)(d) }
 }
 
+/**
+ Curries a 5-ary function.
+ */
 public func curry<A, B, C, D, E, F>(_ fun : @escaping (A, B, C, D, E) -> F) -> (A) -> (B) -> (C) -> (D) -> (E) -> F {
     return { a in { b in { c in { d in { e in fun(a,b,c,d,e) } } } } }
 }
 
+/**
+ Uncurries a 4-ary function.
+ */
 public func uncurry<A, B, C, D, E, F>(_ fun : @escaping (A) -> (B) -> (C) -> (D) -> (E) -> F) -> (A, B, C, D, E) -> F {
     return { a, b, c, d, e in fun(a)(b)(c)(d)(e) }
 }
 
+/**
+ Curries a 6-ary function.
+ */
 public func curry<A, B, C, D, E, F, G>(_ fun : @escaping (A, B, C, D, E, F) -> G) -> (A) -> (B) -> (C) -> (D) -> (E) -> (F) -> G {
     return { a in { b in { c in { d in { e in { f in fun(a,b,c,d,e,f) } } } } } }
 }
 
+/**
+ Uncurries a 6-ary function.
+ */
 public func uncurry<A, B, C, D, E, F, G>(_ fun : @escaping (A) -> (B) -> (C) -> (D) -> (E) -> (F) -> G) -> (A, B, C, D, E, F) -> G {
     return { a, b, c, d, e, f in fun(a)(b)(c)(d)(e)(f) }
 }
 
+/**
+ Curries a 7-ary function.
+ */
 public func curry<A, B, C, D, E, F, G, H>(_ fun : @escaping (A, B, C, D, E, F, G) -> H) -> (A) -> (B) -> (C) -> (D) -> (E) -> (F) -> (G) -> H {
     return { a in { b in { c in { d in { e in { f in { g in fun(a,b,c,d,e,f,g) } } } } } } }
 }
 
+/**
+ Uncurries a 7-ary function.
+ */
 public func uncurry<A, B, C, D, E, F, G, H>(_ fun : @escaping (A) -> (B) -> (C) -> (D) -> (E) -> (F) -> (G) -> H) -> (A, B, C, D, E, F, G) -> H {
     return { a, b, c, d, e, f, g in fun(a)(b)(c)(d)(e)(f)(g) }
 }

--- a/Sources/Bow/Syntax/HigherKinds.swift
+++ b/Sources/Bow/Syntax/HigherKinds.swift
@@ -1,9 +1,48 @@
 import Foundation
 
+/**
+ Simulates a Higher-Kinded Type in Swift with 1 type argument.
+ 
+ This class simulates Higher-Kinded Type support in Swift. `Kind<F, A>` is an alias for `F<A>`, which is not syntactically valid in Swift.
+ Classes that want to have HKT support must extend this class. Type parameter `F` is reserved for a witness to prevent circular references in the inheritance relationship. By convention, witnesses are named like the class they represent, with the prefix `For`. As an example:
+ 
+ ```swift
+ class ForOption {}
+ class Option<A>: Kind<ForOption, A> {}
+ ```
+ */
 open class Kind<F, A> {
     public init() {}
 }
+
+/**
+ Simulates a Higher-Kinded Type in Swift with 2 type arguments.
+ 
+ This class simulates Higher-Kinded Type support in Swift. `Kind2<F, A, B>` is an alias for `F<A, B>`, which is not syntactically valid in Swift.
+ Classes that want to have HKT support must extend this class. Type parameter `F` is reserved for a witness to prevent circular references in the inheritance relationship. By convention, witnesses are named like the class they represent, with the prefix `For`.
+ */
 public typealias Kind2<F, A, B> = Kind<Kind<F, A>, B>
+
+/**
+ Simulates a Higher-Kinded Type in Swift with 3 type arguments.
+ 
+ This class simulates Higher-Kinded Type support in Swift. `Kind3<F, A, B, C>` is an alias for `F<A, B, C>`, which is not syntactically valid in Swift.
+ Classes that want to have HKT support must extend this class. Type parameter `F` is reserved for a witness to prevent circular references in the inheritance relationship. By convention, witnesses are named like the class they represent, with the prefix `For`.
+ */
 public typealias Kind3<F, A, B, C> = Kind<Kind2<F, A, B>, C>
+
+/**
+ Simulates a Higher-Kinded Type in Swift with 4 type arguments.
+ 
+ This class simulates Higher-Kinded Type support in Swift. `Kind4<F, A, B, C, D>` is an alias for `F<A, B, C, D>`, which is not syntactically valid in Swift.
+ Classes that want to have HKT support must extend this class. Type parameter `F` is reserved for a witness to prevent circular references in the inheritance relationship. By convention, witnesses are named like the class they represent, with the prefix `For`.
+ */
 public typealias Kind4<F, A, B, C, D> = Kind<Kind3<F, A, B, C>, D>
+
+/**
+ Simulates a Higher-Kinded Type in Swift with 5 type arguments.
+ 
+ This class simulates Higher-Kinded Type support in Swift. `Kind5<F, A, B, C, D, E>` is an alias for `F<A, B, C, D, E>`, which is not syntactically valid in Swift.
+ Classes that want to have HKT support must extend this class. Type parameter `F` is reserved for a witness to prevent circular references in the inheritance relationship. By convention, witnesses are named like the class they represent, with the prefix `For`.
+ */
 public typealias Kind5<F, A, B, C, D, E> = Kind<Kind4<F, A, B, C, D>, E>

--- a/Sources/Bow/Syntax/Memoization.swift
+++ b/Sources/Bow/Syntax/Memoization.swift
@@ -1,5 +1,13 @@
 import Foundation
 
+/**
+ Memoizes a 1-ary function.
+ 
+ Memoization is a useful technique to cache already computed values, specially in functions with a high computational cost. It requires the input parameter to the function to be `Hashable` in order to be able to save the computed result.
+ This function returns a memoized function that behaves the same as the original one. Given an input, first invokation of the memoized function will compute the result and store it. Subsequent invokations with the same input will not be computed; the stored result will be returned instead.
+ 
+ - parameter f: Function to be memoized. This function must be pure and deterministic in order to have consistent results.
+ */
 public func memoize<A, B>(_ f : @escaping (A) -> B) -> (A) -> B where A : Hashable {
     var cached = Dictionary<A, B>()
     
@@ -13,6 +21,17 @@ public func memoize<A, B>(_ f : @escaping (A) -> B) -> (A) -> B where A : Hashab
     }
 }
 
+/**
+ Memoizes a recursive 1-ary function.
+ 
+ In order to memoize a recursive function, the recursive step must be memoized as well. In order to do so, callers of this function must pass a function that will receive the memoized function and the current input, and use both to provide the output. Input parameters must conform to `Hashable`.
+ As an example, consider this implementation of a memoized factorial:
+ ```swift
+ let memoizedFactorial: (Int) -> Int = memoize { factorial, x in
+    x == 0 ? 1 : x * factorial(x - 1)
+ }
+ ```
+ */
 public func memoize<A, B>(_ f : @escaping ((A) -> B, A) -> B) -> (A) -> B where A : Hashable {
     var cached = Dictionary<A, B>()
     

--- a/Sources/Bow/Syntax/PartialApplication.swift
+++ b/Sources/Bow/Syntax/PartialApplication.swift
@@ -2,34 +2,58 @@ import Foundation
 
 infix operator |> : AdditionPrecedence
 
+/**
+ Applies an argument to a 1-ary function.
+ */
 public func |><A, B>(_ a : A, _ fun : (A) -> B) -> B {
     return fun(a)
 }
 
+/**
+ Applies the first argument to a 2-ary function, returning a 1-ary function with the rest of the arguments of the original function.
+ */
 public func |><A, B, C>(_ a : A, _ fun : @escaping (A, B) -> C) -> (B) -> C {
     return { b in fun(a,b) }
 }
 
+/**
+ Applies the first argument to a 3-ary function, returning a 2-ary function with the rest of the arguments of the original function.
+ */
 public func |><A, B, C, D>(_ a : A, _ fun : @escaping (A, B, C) -> D) -> (B, C) -> D {
     return { b, c in fun(a, b, c) }
 }
 
+/**
+ Applies the first argument to a 4-ary function, returning a 3-ary function with the rest of the arguments of the original function.
+ */
 public func |><A, B, C, D, E>(_ a : A, _ fun : @escaping (A, B, C, D) -> E) -> (B, C, D) -> E {
     return { b, c, d in fun(a, b, c, d) }
 }
 
+/**
+ Applies the first argument to a 5-ary function, returning a 4-ary function with the rest of the arguments of the original function.
+ */
 public func |><A, B, C, D, E, F>(_ a : A, _ fun : @escaping (A, B, C, D, E) -> F) -> (B, C, D, E) -> F {
     return { b, c, d, e in fun(a, b, c, d, e) }
 }
 
+/**
+ Applies the first argument to a 6-ary function, returning a 5-ary function with the rest of the arguments of the original function.
+ */
 public func |><A, B, C, D, E, F, G>(_ a : A, _ fun : @escaping (A, B, C, D, E, F) -> G) -> (B, C, D, E, F) -> G {
     return { b, c, d, e, f in fun(a, b, c, d, e, f) }
 }
 
+/**
+ Applies the first argument to a 7-ary function, returning a 6-ary function with the rest of the arguments of the original function.
+ */
 public func |><A, B, C, D, E, F, G, H>(_ a : A, _ fun : @escaping (A, B, C, D, E, F, G) -> H) -> (B, C, D, E, F, G) -> H {
     return { b, c, d, e, f, g in fun(a, b, c, d, e, f, g) }
 }
 
+/**
+ Applies the first argument to a 8-ary function, returning a 7-ary function with the rest of the arguments of the original function.
+ */
 public func |><A, B, C, D, E, F, G, H, I>(_ a : A, _ fun : @escaping (A, B, C, D, E, F, G, H) -> I) -> (B, C, D, E, F, G, H) -> I {
     return { b, c, d, e, f, g, h in fun(a, b, c, d, e, f, g, h) }
 }

--- a/Sources/Bow/Syntax/Predef.swift
+++ b/Sources/Bow/Syntax/Predef.swift
@@ -3,86 +3,179 @@ import Foundation
 public typealias Unit = ()
 public let unit : Unit = ()
 
+/**
+ Identity function. Returns the input without changing it.
+ */
 public func id<A>(_ a : A) -> A {
     return a
 }
 
+/**
+ Given an input, provides a 0-ary function that always returns such value.
+ */
 public func constant<A>(_ a : A) -> () -> A {
     return { a }
 }
 
+/**
+ Given an input, provides a 1-ary function that always returns such value.
+ */
 public func constant<A, B>(_ a : A) -> (B) -> A {
     return { _ in a }
 }
 
+/**
+ Given an input, provides a 2-ary function that always returns such value.
+ */
 public func constant<A, B, C>(_ a : A) -> (B, C) -> A {
     return { _, _ in a }
 }
 
+/**
+ Given an input, provides a 3-ary function that always returns such value.
+ */
 public func constant<A, B, C, D>(_ a : A) -> (B, C, D) -> A {
     return { _, _, _ in a }
 }
 
+/**
+ Given an input, provides a 4-ary function that always returns such value.
+ */
 public func constant<A, B, C, D, E>(_ a : A) -> (B, C, D, E) -> A {
     return { _, _, _, _ in a }
 }
 
+/**
+ Composes a 0-ary function with a 1-ary function.
+ 
+ Returns a function that is the result of applying `g` to the output of `f`.
+ */
 public func compose<A, B>(_ g : @escaping (A) -> B, _ f : @escaping () -> A) -> () -> B {
     return andThen(f, g)
 }
 
+/**
+ Composes a 0-ary function with a 1-ary function.
+ 
+ Returns a function that is the result of applying `g` to the output of `f`.
+ */
 public func compose<A, B>(_ g : @escaping (A) throws -> B, _ f : @escaping () -> A) -> () throws -> B {
     return andThen(f, g)
 }
 
+/**
+ Composes a 0-ary function with a 1-ary function.
+ 
+ Returns a function that is the result of applying `g` to the output of `f`.
+ */
 public func compose<A, B>(_ g : @escaping (A) -> B, _ f : @escaping () throws -> A) -> () throws -> B {
     return andThen(f, g)
 }
 
+/**
+ Composes a 0-ary function with a 1-ary function.
+ 
+ Returns a function that is the result of applying `g` to the output of `f`.
+ */
 public func compose<A, B>(_ g : @escaping (A) throws -> B, _ f : @escaping () throws -> A) -> () throws -> B {
     return andThen(f, g)
 }
 
+/**
+ Composes a 1-ary function with another 1-ary function.
+ 
+ Returns a function that is the result of applying `g` to the output of `f`.
+ */
 public func compose<A, B, C>(_ g : @escaping (B) -> C, _ f : @escaping (A) -> B) -> (A) -> C {
     return andThen(f, g)
 }
 
+/**
+ Composes a 1-ary function with another 1-ary function.
+ 
+ Returns a function that is the result of applying `g` to the output of `f`.
+ */
 public func compose<A, B, C>(_ g : @escaping (B) throws -> C, _ f : @escaping (A) -> B) -> (A) throws -> C {
     return andThen(f, g)
 }
 
+/**
+ Composes a 1-ary function with another 1-ary function.
+ 
+ Returns a function that is the result of applying `g` to the output of `f`.
+ */
 public func compose<A, B, C>(_ g : @escaping (B) -> C, _ f : @escaping (A) throws -> B) -> (A) throws -> C {
     return andThen(f, g)
 }
 
+/**
+ Composes a 1-ary function with another 1-ary function.
+ 
+ Returns a function that is the result of applying `g` to the output of `f`.
+ */
 public func compose<A, B, C>(_ g : @escaping (B) throws -> C, _ f : @escaping (A) throws -> B) -> (A) throws -> C {
     return andThen(f, g)
 }
 
+/**
+ Composes a 0-ary function with a 1-ary function.
+ 
+ Returns a function that is the result of applying `g` to the output of `f`.
+ */
 public func andThen<A, B>(_ f : @escaping () -> A, _ g : @escaping (A) -> B) -> () -> B {
     return { g(f()) }
 }
 
+/**
+ Composes a 0-ary function with a 1-ary function.
+ 
+ Returns a function that is the result of applying `g` to the output of `f`.
+ */
 public func andThen<A, B>(_ f : @escaping () throws -> A, _ g : @escaping (A) -> B) -> () throws -> B {
     return { g(try f()) }
 }
 
+/**
+ Composes a 0-ary function with a 1-ary function.
+ 
+ Returns a function that is the result of applying `g` to the output of `f`.
+ */
 public func andThen<A, B>(_ f : @escaping () -> A, _ g : @escaping (A) throws -> B) -> () throws -> B {
     return { try g(f()) }
 }
 
+/**
+ Composes a 0-ary function with a 1-ary function.
+ 
+ Returns a function that is the result of applying `g` to the output of `f`.
+ */
 public func andThen<A, B>(_ f : @escaping () throws -> A, _ g : @escaping (A) throws -> B) -> () throws -> B {
     return { try g(try f()) }
 }
 
+/**
+ Composes a 1-ary function with another 1-ary function.
+ 
+ Returns a function that is the result of applying `g` to the output of `f`.
+ */
 public func andThen<A, B, C>(_ f : @escaping (A) -> B, _ g : @escaping (B) -> C) -> (A) -> C {
     return { x in g(f(x)) }
 }
 
+/**
+ Composes a 1-ary function with another 1-ary function.
+ 
+ Returns a function that is the result of applying `g` to the output of `f`.
+ */
 public func andThen<A, B, C>(_ f : @escaping (A) throws -> B, _ g : @escaping (B) -> C) -> (A) throws -> C {
     return { x in g(try f(x)) }
 }
 
+/**
+ Composes a 1-ary function with another 1-ary function.
+ 
+ Returns a function that is the result of applying `g` to the output of `f`.
+ */
 public func andThen<A, B, C>(_ f : @escaping (A) -> B, _ g : @escaping (B) throws -> C) -> (A) throws -> C {
     return { x in try g(f(x)) }
 }
@@ -94,66 +187,146 @@ public func andThen<A, B, C>(_ f : @escaping (A) throws -> B, _ g : @escaping (B
 infix operator >>> : AdditionPrecedence
 infix operator <<< : AdditionPrecedence
 
+/**
+ Composes a 0-ary function with a 1-ary function.
+ 
+ Returns a function that is the result of applying `g` to the output of `f`.
+ */
 public func >>><A, B>(_ f : @escaping () -> A, _ g : @escaping (A) -> B) -> () -> B {
     return andThen(f, g)
 }
 
+/**
+ Composes a 0-ary function with a 1-ary function.
+ 
+ Returns a function that is the result of applying `g` to the output of `f`.
+ */
 public func >>><A, B>(_ f : @escaping () throws -> A, _ g : @escaping (A) -> B) -> () throws -> B {
     return andThen(f, g)
 }
 
+/**
+ Composes a 0-ary function with a 1-ary function.
+ 
+ Returns a function that is the result of applying `g` to the output of `f`.
+ */
 public func >>><A, B>(_ f : @escaping () -> A, _ g : @escaping (A) throws -> B) -> () throws -> B {
     return andThen(f, g)
 }
 
+/**
+ Composes a 0-ary function with a 1-ary function.
+ 
+ Returns a function that is the result of applying `g` to the output of `f`.
+ */
 public func >>><A, B>(_ f : @escaping () throws -> A, _ g : @escaping (A) throws -> B) -> () throws -> B {
     return andThen(f, g)
 }
 
+/**
+ Composes a 1-ary function with another 1-ary function.
+ 
+ Returns a function that is the result of applying `g` to the output of `f`.
+ */
 public func >>><A, B, C>(_ f : @escaping (A) -> B, _ g : @escaping (B) -> C) -> (A) -> C {
     return andThen(f, g)
 }
 
+/**
+ Composes a 1-ary function with another 1-ary function.
+ 
+ Returns a function that is the result of applying `g` to the output of `f`.
+ */
 public func >>><A, B, C>(_ f : @escaping (A) throws -> B, _ g : @escaping (B) -> C) -> (A) throws -> C {
     return andThen(f, g)
 }
 
+/**
+ Composes a 1-ary function with another 1-ary function.
+ 
+ Returns a function that is the result of applying `g` to the output of `f`.
+ */
 public func >>><A, B, C>(_ f : @escaping (A) -> B, _ g : @escaping (B) throws -> C) -> (A) throws -> C {
     return andThen(f, g)
 }
 
+/**
+ Composes a 1-ary function with another 1-ary function.
+ 
+ Returns a function that is the result of applying `g` to the output of `f`.
+ */
 public func >>><A, B, C>(_ f : @escaping (A) throws -> B, _ g : @escaping (B) throws -> C) -> (A) throws -> C {
     return andThen(f, g)
 }
 
+/**
+ Composes a 0-ary function with a 1-ary function.
+ 
+ Returns a function that is the result of applying `g` to the output of `f`.
+ */
 public func <<<<A, B>(_ g : @escaping (A) -> B, _ f : @escaping () -> A) -> () -> B {
     return f >>> g
 }
 
+/**
+ Composes a 0-ary function with a 1-ary function.
+ 
+ Returns a function that is the result of applying `g` to the output of `f`.
+ */
 public func <<<<A, B>(_ g : @escaping (A) throws -> B, _ f : @escaping () -> A) -> () throws -> B {
     return f >>> g
 }
 
+/**
+ Composes a 0-ary function with a 1-ary function.
+ 
+ Returns a function that is the result of applying `g` to the output of `f`.
+ */
 public func <<<<A, B>(_ g : @escaping (A) -> B, _ f : @escaping () throws -> A) -> () throws -> B {
     return f >>> g
 }
 
+/**
+ Composes a 0-ary function with a 1-ary function.
+ 
+ Returns a function that is the result of applying `g` to the output of `f`.
+ */
 public func <<<<A, B>(_ g : @escaping (A) throws -> B, _ f : @escaping () throws -> A) -> () throws -> B {
     return f >>> g
 }
 
+/**
+ Composes a 1-ary function with another 1-ary function.
+ 
+ Returns a function that is the result of applying `g` to the output of `f`.
+ */
 public func <<<<A, B, C>(_ g : @escaping (B) -> C, _ f : @escaping (A) -> B) -> (A) -> C {
     return f >>> g
 }
 
+/**
+ Composes a 1-ary function with another 1-ary function.
+ 
+ Returns a function that is the result of applying `g` to the output of `f`.
+ */
 public func <<<<A, B, C>(_ g : @escaping (B) throws -> C, _ f : @escaping (A) -> B) -> (A) throws -> C {
     return f >>> g
 }
 
+/**
+ Composes a 1-ary function with another 1-ary function.
+ 
+ Returns a function that is the result of applying `g` to the output of `f`.
+ */
 public func <<<<A, B, C>(_ g : @escaping (B) -> C, _ f : @escaping (A) throws -> B) -> (A) throws -> C {
     return f >>> g
 }
 
+/**
+ Composes a 1-ary function with another 1-ary function.
+ 
+ Returns a function that is the result of applying `g` to the output of `f`.
+ */
 public func <<<<A, B, C>(_ g : @escaping (B) throws -> C, _ f : @escaping (A) throws -> B) -> (A) throws -> C {
     return f >>> g
 }

--- a/Sources/Bow/Syntax/Reverse.swift
+++ b/Sources/Bow/Syntax/Reverse.swift
@@ -1,37 +1,64 @@
 import Foundation
 
+/**
+ Given a 2-ary function, returns a 2-ary function where the argument list is reversed.
+ */
 public func reverse<P1, P2, R>(_ f : @escaping (P1, P2) -> R) -> (P2, P1) -> R {
     return { p2, p1 in f(p1, p2) }
 }
 
+/**
+ Given a 3-ary function, returns a 3-ary function where the argument list is reversed.
+ */
 public func reverse<P1, P2, P3, R>(_ f : @escaping (P1, P2, P3) -> R) -> (P3, P2, P1) -> R {
     return { p3, p2, p1 in f(p1, p2, p3) }
 }
 
+/**
+ Given a 4-ary function, returns a 4-ary function where the argument list is reversed.
+ */
 public func reverse<P1, P2, P3, P4, R>(_ f : @escaping (P1, P2, P3, P4) -> R) -> (P4, P3, P2, P1) -> R {
     return { p4, p3, p2, p1 in f(p1, p2, p3, p4) }
 }
 
+/**
+ Given a 5-ary function, returns a 5-ary function where the argument list is reversed.
+ */
 public func reverse<P1, P2, P3, P4, P5, R>(_ f : @escaping (P1, P2, P3, P4, P5) -> R) -> (P5, P4, P3, P2, P1) -> R {
     return { p5, p4, p3, p2, p1 in f(p1, p2, p3, p4, p5) }
 }
 
+/**
+ Given a 6-ary function, returns a 6-ary function where the argument list is reversed.
+ */
 public func reverse<P1, P2, P3, P4, P5, P6, R>(_ f : @escaping (P1, P2, P3, P4, P5, P6) -> R) -> (P6, P5, P4, P3, P2, P1) -> R {
     return { p6, p5, p4, p3, p2, p1 in f(p1, p2, p3, p4, p5, p6) }
 }
 
+/**
+ Given a 7-ary function, returns a 7-ary function where the argument list is reversed.
+ */
 public func reverse<P1, P2, P3, P4, P5, P6, P7, R>(_ f : @escaping (P1, P2, P3, P4, P5, P6, P7) -> R) -> (P7, P6, P5, P4, P3, P2, P1) -> R {
     return { p7, p6, p5, p4, p3, p2, p1 in f(p1, p2, p3, p4, p5, p6, p7) }
 }
 
+/**
+ Given a 8-ary function, returns a 8-ary function where the argument list is reversed.
+ */
 public func reverse<P1, P2, P3, P4, P5, P6, P7, P8, R>(_ f : @escaping (P1, P2, P3, P4, P5, P6, P7, P8) -> R) -> (P8, P7, P6, P5, P4, P3, P2, P1) -> R {
     return { p8, p7, p6, p5, p4, p3, p2, p1 in f(p1, p2, p3, p4, p5, p6, p7, p8) }
 }
 
+/**
+ Given a 9-ary function, returns a 9-ary function where the argument list is reversed.
+ */
 public func reverse<P1, P2, P3, P4, P5, P6, P7, P8, P9, R>(_ f : @escaping (P1, P2, P3, P4, P5, P6, P7, P8, P9) -> R) -> (P9, P8, P7, P6, P5, P4, P3, P2, P1) -> R {
     return { p9, p8, p7, p6, p5, p4, p3, p2, p1 in f(p1, p2, p3, p4, p5, p6, p7, p8, p9) }
 }
 
+/**
+ Given a 10-ary function, returns a 10-ary function where the argument list is reversed.
+ */
 public func reverse<P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, R>(_ f : @escaping (P1, P2, P3, P4, P5, P6, P7, P8, P9, P10) -> R) -> (P10, P9, P8, P7, P6, P5, P4, P3, P2, P1) -> R {
     return { p10, p9, p8, p7, p6, p5, p4, p3, p2, p1 in f(p1, p2, p3, p4, p5, p6, p7, p8, p9, p10) }
 }

--- a/Sources/Bow/Syntax/Typeclass.swift
+++ b/Sources/Bow/Syntax/Typeclass.swift
@@ -1,3 +1,6 @@
 import Foundation
 
+/**
+ Empty protocol to document a protocol is a `Typeclass`.
+ */
 public protocol Typeclass {}


### PR DESCRIPTION
## Related issues

Closes #101.
Closes #102.
Closes #103.
Closes #104.
Closes #106.
Closes #107.
Closes #108.
Closes #109.

## Goal

Adds API documentation to:

- Boolean functions
- Curry
- Memoization
- Reverse
- Predefs
- PartialApplication
- Typeclass
- Higher Kinded Types