### PR TITLE
Regroup instances under data types

### DIFF
--- a/Sources/Bow/Data/ArrayK.swift
+++ b/Sources/Bow/Data/ArrayK.swift
@@ -125,6 +125,12 @@ public extension Array {
     }
 }
 
+extension ArrayK : Equatable where A : Equatable {
+    public static func ==(lhs : ArrayK<A>, rhs : ArrayK<A>) -> Bool {
+        return lhs.array == rhs.array
+    }
+}
+
 extension ArrayK : CustomStringConvertible {
     public var description : String {
         let contentsString = self.array.map { x in "\(x)" }.joined(separator: ", ")
@@ -140,205 +146,199 @@ extension ArrayK : CustomDebugStringConvertible where A : CustomDebugStringConve
 }
 
 public extension ArrayK {
-    public static func functor() -> ArrayKFunctor {
-        return ArrayKFunctor()
+    public static func functor() -> FunctorInstance {
+        return FunctorInstance()
     }
     
-    public static func applicative() -> ArrayKApplicative {
-        return ArrayKApplicative()
+    public static func applicative() -> ApplicativeInstance {
+        return ApplicativeInstance()
     }
     
-    public static func monad() -> ArrayKMonad {
-        return ArrayKMonad()
+    public static func monad() -> MonadInstance {
+        return MonadInstance()
     }
     
-    public static func foldable() -> ArrayKFoldable {
-        return ArrayKFoldable()
+    public static func foldable() -> FoldableInstance {
+        return FoldableInstance()
     }
     
-    public static func traverse() -> ArrayKTraverse {
-        return ArrayKTraverse()
+    public static func traverse() -> TraverseInstance {
+        return TraverseInstance()
     }
     
-    public static func semigroup() -> ArrayKSemigroup<A> {
-        return ArrayKSemigroup<A>()
+    public static func semigroup() -> SemigroupInstance<A> {
+        return SemigroupInstance<A>()
     }
     
-    public static func semigroupK() -> ArrayKSemigroupK {
-        return ArrayKSemigroupK()
+    public static func semigroupK() -> SemigroupKInstance {
+        return SemigroupKInstance()
     }
     
-    public static func monoid() -> ArrayKMonoid<A> {
-        return ArrayKMonoid<A>()
+    public static func monoid() -> MonoidInstance<A> {
+        return MonoidInstance<A>()
     }
     
-    public static func monoidK() -> ArrayKMonoidK {
-        return ArrayKMonoidK()
+    public static func monoidK() -> MonoidKInstance {
+        return MonoidKInstance()
     }
     
-    public static func functorFilter() -> ArrayKFunctorFilter {
-        return ArrayKFunctorFilter()
+    public static func functorFilter() -> FunctorFilterInstance {
+        return FunctorFilterInstance()
     }
     
-    public static func monadFilter() -> ArrayKMonadFilter {
-        return ArrayKMonadFilter()
+    public static func monadFilter() -> MonadFilterInstance {
+        return MonadFilterInstance()
     }
     
-    public static func monadCombine() -> ArrayKMonadCombine {
-        return ArrayKMonadCombine()
+    public static func monadCombine() -> MonadCombineInstance {
+        return MonadCombineInstance()
     }
     
-    public static func eq<EqA>(_ eqa : EqA) -> ArrayKEq<A, EqA> {
-        return ArrayKEq<A, EqA>(eqa)
+    public static func eq<EqA>(_ eqa : EqA) -> EqInstance<A, EqA> {
+        return EqInstance<A, EqA>(eqa)
     }
-}
 
-public class ArrayKFunctor : Functor {
-    public typealias F = ForArrayK
-    
-    public func map<A, B>(_ fa: ArrayKOf<A>, _ f: @escaping (A) -> B) -> ArrayKOf<B> {
-        return fa.fix().map(f)
+    public class FunctorInstance : Functor {
+        public typealias F = ForArrayK
+        
+        public func map<A, B>(_ fa: ArrayKOf<A>, _ f: @escaping (A) -> B) -> ArrayKOf<B> {
+            return fa.fix().map(f)
+        }
     }
-}
 
-public class ArrayKApplicative : ArrayKFunctor, Applicative {
-    public func pure<A>(_ a: A) -> ArrayKOf<A> {
-        return ArrayK.pure(a)
+    public class ApplicativeInstance : FunctorInstance, Applicative {
+        public func pure<A>(_ a: A) -> ArrayKOf<A> {
+            return ArrayK<A>.pure(a)
+        }
+        
+        public func ap<A, B>(_ ff: ArrayKOf<(A) -> B>, _ fa: ArrayKOf<A>) -> ArrayKOf<B> {
+            return ff.fix().ap(fa.fix())
+        }
     }
-    
-    public func ap<A, B>(_ ff: ArrayKOf<(A) -> B>, _ fa: ArrayKOf<A>) -> ArrayKOf<B> {
-        return ff.fix().ap(fa.fix())
-    }
-}
 
-public class ArrayKMonad : ArrayKApplicative, Monad {
-    public func flatMap<A, B>(_ fa: ArrayKOf<A>, _ f: @escaping (A) -> ArrayKOf<B>) -> ArrayKOf<B> {
-        return fa.fix().flatMap({ a in f(a).fix() })
+    public class MonadInstance : ApplicativeInstance, Monad {
+        public func flatMap<A, B>(_ fa: ArrayKOf<A>, _ f: @escaping (A) -> ArrayKOf<B>) -> ArrayKOf<B> {
+            return fa.fix().flatMap({ a in f(a).fix() })
+        }
+        
+        public func tailRecM<A, B>(_ a: A, _ f: @escaping (A) -> ArrayKOf<Either<A, B>>) -> ArrayKOf<B> {
+            return ArrayK<A>.tailRecM(a, f)
+        }
     }
-    
-    public func tailRecM<A, B>(_ a: A, _ f: @escaping (A) -> ArrayKOf<Either<A, B>>) -> ArrayKOf<B> {
-        return ArrayK.tailRecM(a, f)
-    }
-}
 
-public class ArrayKFoldable : Foldable {
-    public typealias F = ForArrayK
-    
-    public func foldLeft<A, B>(_ fa: ArrayKOf<A>, _ b: B, _ f: @escaping (B, A) -> B) -> B {
-        return fa.fix().foldLeft(b, f)
+    public class FoldableInstance : Foldable {
+        public typealias F = ForArrayK
+        
+        public func foldLeft<A, B>(_ fa: ArrayKOf<A>, _ b: B, _ f: @escaping (B, A) -> B) -> B {
+            return fa.fix().foldLeft(b, f)
+        }
+        
+        public func foldRight<A, B>(_ fa: ArrayKOf<A>, _ b: Eval<B>, _ f: @escaping (A, Eval<B>) -> Eval<B>) -> Eval<B> {
+            return fa.fix().foldRight(b, f)
+        }
     }
-    
-    public func foldRight<A, B>(_ fa: ArrayKOf<A>, _ b: Eval<B>, _ f: @escaping (A, Eval<B>) -> Eval<B>) -> Eval<B> {
-        return fa.fix().foldRight(b, f)
-    }
-}
 
-public class ArrayKTraverse : ArrayKFoldable, Traverse {
-    public func traverse<G, A, B, Appl>(_ fa: ArrayKOf<A>, _ f: @escaping (A) -> Kind<G, B>, _ applicative: Appl) -> Kind<G, ArrayKOf<B>> where G == Appl.F, Appl : Applicative {
-        return fa.fix().traverse(f, applicative)
+    public class TraverseInstance : FoldableInstance, Traverse {
+        public func traverse<G, A, B, Appl>(_ fa: ArrayKOf<A>, _ f: @escaping (A) -> Kind<G, B>, _ applicative: Appl) -> Kind<G, ArrayKOf<B>> where G == Appl.F, Appl : Applicative {
+            return fa.fix().traverse(f, applicative)
+        }
     }
-}
 
-public class ArrayKSemigroupK : SemigroupK {
-    public typealias F = ForArrayK
-    
-    public func combineK<A>(_ x: ArrayKOf<A>, _ y: ArrayKOf<A>) -> ArrayKOf<A> {
-        return x.fix().combineK(y.fix())
+    public class SemigroupKInstance : SemigroupK {
+        public typealias F = ForArrayK
+        
+        public func combineK<A>(_ x: ArrayKOf<A>, _ y: ArrayKOf<A>) -> ArrayKOf<A> {
+            return x.fix().combineK(y.fix())
+        }
     }
-}
 
-public class ArrayKMonoidK : ArrayKSemigroupK, MonoidK {
-    public func emptyK<A>() -> ArrayKOf<A> {
-        return ArrayK<A>.empty()
+    public class MonoidKInstance : SemigroupKInstance, MonoidK {
+        public func emptyK<A>() -> ArrayKOf<A> {
+            return ArrayK<A>.empty()
+        }
     }
-}
 
-public class ArrayKFunctorFilter : ArrayKFunctor, FunctorFilter {
-    public func mapFilter<A, B>(_ fa: ArrayKOf<A>, _ f: @escaping (A) -> OptionOf<B>) -> ArrayKOf<B> {
-        return fa.fix().mapFilter(f)
+    public class FunctorFilterInstance : FunctorInstance, FunctorFilter {
+        public func mapFilter<A, B>(_ fa: ArrayKOf<A>, _ f: @escaping (A) -> OptionOf<B>) -> ArrayKOf<B> {
+            return fa.fix().mapFilter(f)
+        }
     }
-}
 
-public class ArrayKMonadFilter : ArrayKMonad, MonadFilter {
-    public func empty<A>() -> ArrayKOf<A> {
-        return ArrayK<A>.empty()
+    public class MonadFilterInstance : MonadInstance, MonadFilter {
+        public func empty<A>() -> ArrayKOf<A> {
+            return ArrayK<A>.empty()
+        }
+        
+        public func mapFilter<A, B>(_ fa: ArrayKOf<A>, _ f: @escaping (A) -> OptionOf<B>) -> ArrayKOf<B> {
+            return fa.fix().mapFilter(f)
+        }
     }
-    
-    public func mapFilter<A, B>(_ fa: ArrayKOf<A>, _ f: @escaping (A) -> OptionOf<B>) -> ArrayKOf<B> {
-        return fa.fix().mapFilter(f)
-    }
-}
 
-public class ArrayKMonadCombine : ArrayKMonadFilter, MonadCombine {
-    public func emptyK<A>() -> ArrayKOf<A> {
-        return ArrayK<A>.empty()
+    public class MonadCombineInstance : MonadFilterInstance, MonadCombine {
+        public func emptyK<A>() -> ArrayKOf<A> {
+            return ArrayK<A>.empty()
+        }
+        
+        public func combineK<A>(_ x: ArrayKOf<A>, _ y: ArrayKOf<A>) -> ArrayKOf<A> {
+            return x.fix().combineK(y.fix())
+        }
     }
-    
-    public func combineK<A>(_ x: ArrayKOf<A>, _ y: ArrayKOf<A>) -> ArrayKOf<A> {
-        return x.fix().combineK(y.fix())
-    }
-}
 
-public class ArrayKSemigroup<R> : Semigroup {
-    public typealias A = ArrayKOf<R>
-    
-    public func combine(_ a: ArrayKOf<R>, _ b: ArrayKOf<R>) -> ArrayKOf<R> {
-        return ArrayK.fix(a) + ArrayK.fix(b)
+    public class SemigroupInstance<R> : Semigroup {
+        public typealias A = ArrayKOf<R>
+        
+        public func combine(_ a: ArrayKOf<R>, _ b: ArrayKOf<R>) -> ArrayKOf<R> {
+            return ArrayK<R>.fix(a) + ArrayK<R>.fix(b)
+        }
     }
-}
 
-public class ArrayKMonoid<R> : ArrayKSemigroup<R>, Monoid {
-    public var empty: ArrayKOf<R> {
-        return ArrayK<R>.empty()
+    public class MonoidInstance<R> : SemigroupInstance<R>, Monoid {
+        public var empty: ArrayKOf<R> {
+            return ArrayK<R>.empty()
+        }
     }
-}
 
-public class ArrayKEq<R, EqR> : Eq where EqR : Eq, EqR.A == R {
-    public typealias A = ArrayKOf<R>
-    
-    private let eqr : EqR
-    
-    public init(_ eqr : EqR) {
-        self.eqr = eqr
-    }
-    
-    public func eqv(_ a: ArrayKOf<R>, _ b: ArrayKOf<R>) -> Bool {
-        let a = ArrayK.fix(a)
-        let b = ArrayK.fix(b)
-        if a.array.count != b.array.count {
-            return false
-        } else {
-            return zip(a.array, b.array).map{ aa, bb in eqr.eqv(aa, bb) }.reduce(true, and)
+    public class EqInstance<R, EqR> : Eq where EqR : Eq, EqR.A == R {
+        public typealias A = ArrayKOf<R>
+        
+        private let eqr : EqR
+        
+        public init(_ eqr : EqR) {
+            self.eqr = eqr
+        }
+        
+        public func eqv(_ a: ArrayKOf<R>, _ b: ArrayKOf<R>) -> Bool {
+            let a = ArrayK<R>.fix(a)
+            let b = ArrayK<R>.fix(b)
+            if a.array.count != b.array.count {
+                return false
+            } else {
+                return zip(a.array, b.array).map{ aa, bb in eqr.eqv(aa, bb) }.reduce(true, and)
+            }
         }
     }
 }
 
 public extension Array {
-    public static func eq<EqR>(_ eqr : EqR) -> ArrayEq<Element, EqR> where EqR : Eq, EqR.A == Element {
-        return ArrayEq(eqr)
+    public static func eq<EqR>(_ eqr : EqR) -> EqInstance<Element, EqR> where EqR : Eq, EqR.A == Element {
+        return EqInstance(eqr)
     }
-}
 
-public class ArrayEq<R, EqR> : Eq where EqR : Eq, EqR.A == R {
-    public typealias A = Array<R>
-    
-    private let eqr : EqR
-    
-    public init(_ eqr : EqR) {
-        self.eqr = eqr
-    }
-    
-    public func eqv(_ a: Array<R>, _ b: Array<R>) -> Bool {
-        if a.count != b.count {
-            return false
-        } else {
-            return zip(a, b).map{ aa, bb in eqr.eqv(aa, bb) }.reduce(true, and)
+    public class EqInstance<R, EqR> : Eq where EqR : Eq, EqR.A == R {
+        public typealias A = Array<R>
+        
+        private let eqr : EqR
+        
+        public init(_ eqr : EqR) {
+            self.eqr = eqr
         }
-    }
-}
-
-extension ArrayK : Equatable where A : Equatable {
-    public static func ==(lhs : ArrayK<A>, rhs : ArrayK<A>) -> Bool {
-        return lhs.array == rhs.array
+        
+        public func eqv(_ a: Array<R>, _ b: Array<R>) -> Bool {
+            if a.count != b.count {
+                return false
+            } else {
+                return zip(a, b).map{ aa, bb in eqr.eqv(aa, bb) }.reduce(true, and)
+            }
+        }
     }
 }

--- a/Sources/Bow/Data/Const.swift
+++ b/Sources/Bow/Data/Const.swift
@@ -53,123 +53,123 @@ extension Const : CustomDebugStringConvertible where A : CustomDebugStringConver
 }
 
 public extension Const {
-    public static func functor() -> ConstFunctor<A> {
-        return ConstFunctor<A>()
+    public static func functor() -> FunctorInstance<A> {
+        return FunctorInstance<A>()
     }
     
-    public static func applicative<Mono>(_ monoid : Mono) -> ConstApplicative<A, Mono> {
-        return ConstApplicative<A, Mono>(monoid)
+    public static func applicative<Mono>(_ monoid : Mono) -> ApplicativeInstance<A, Mono> {
+        return ApplicativeInstance<A, Mono>(monoid)
     }
     
-    public static func semigroup<SemiG>(_ semigroup : SemiG) -> ConstSemigroup<A, T, SemiG> {
-        return ConstSemigroup<A, T, SemiG>(semigroup)
+    public static func semigroup<SemiG>(_ semigroup : SemiG) -> SemigroupInstance<A, T, SemiG> {
+        return SemigroupInstance<A, T, SemiG>(semigroup)
     }
     
-    public static func monoid<Mono>(_ monoid : Mono) -> ConstMonoid<A, T, Mono> {
-        return ConstMonoid<A, T, Mono>(monoid)
+    public static func monoid<Mono>(_ monoid : Mono) -> MonoidInstance<A, T, Mono> {
+        return MonoidInstance<A, T, Mono>(monoid)
     }
     
-    public static func foldable() -> ConstFoldable<A> {
-        return ConstFoldable<A>()
+    public static func foldable() -> FoldableInstance<A> {
+        return FoldableInstance<A>()
     }
     
-    public static func traverse() -> ConstTraverse<A> {
-        return ConstTraverse<A>()
+    public static func traverse() -> TraverseInstance<A> {
+        return TraverseInstance<A>()
     }
     
-    public static func traverseFilter() -> ConstTraverseFilter<A> {
-        return ConstTraverseFilter<A>()
+    public static func traverseFilter() -> TraverseFilterInstance<A> {
+        return TraverseFilterInstance<A>()
     }
     
-    public static func eq<EqA>(_ eqa : EqA) -> ConstEq<A, T, EqA> {
-        return ConstEq<A, T, EqA>(eqa)
+    public static func eq<EqA>(_ eqa : EqA) -> EqInstance<A, T, EqA> {
+        return EqInstance<A, T, EqA>(eqa)
     }
-}
 
-public class ConstFunctor<R> : Functor {
-    public typealias F = ConstPartial<R>
-    
-    public func map<A, B>(_ fa: ConstOf<R, A>, _ f: @escaping (A) -> B) -> ConstOf<R, B> {
-        return Const.fix(fa).retag()
+    public class FunctorInstance<R> : Functor {
+        public typealias F = ConstPartial<R>
+        
+        public func map<A, B>(_ fa: ConstOf<R, A>, _ f: @escaping (A) -> B) -> ConstOf<R, B> {
+            return Const<R, A>.fix(fa).retag()
+        }
     }
-}
 
-public class ConstApplicative<R, Mono> : ConstFunctor<R>, Applicative where Mono : Monoid, Mono.A == R {
-    private let monoid : Mono
-    
-    public init(_ monoid : Mono) {
-        self.monoid = monoid
+    public class ApplicativeInstance<R, Mono> : FunctorInstance<R>, Applicative where Mono : Monoid, Mono.A == R {
+        private let monoid : Mono
+        
+        public init(_ monoid : Mono) {
+            self.monoid = monoid
+        }
+        
+        public func pure<A>(_ a: A) -> ConstOf<R, A> {
+            return MonoidInstance(self.monoid).empty
+        }
+        
+        public func ap<A, B>(_ ff: ConstOf<R, (A) -> B>, _ fa: ConstOf<R, A>) -> ConstOf<R, B> {
+            return Const<R, (A) -> B>.fix(ff).ap(Const<R, A>.fix(fa), monoid)
+        }
     }
-    
-    public func pure<A>(_ a: A) -> ConstOf<R, A> {
-        return ConstMonoid(self.monoid).empty
-    }
-    
-    public func ap<A, B>(_ ff: ConstOf<R, (A) -> B>, _ fa: ConstOf<R, A>) -> ConstOf<R, B> {
-        return Const.fix(ff).ap(Const.fix(fa), monoid)
-    }
-}
 
-public class ConstSemigroup<R, S, SemiG> : Semigroup where SemiG : Semigroup, SemiG.A == R {
-    public typealias A = ConstOf<R, S>
-    private let semigroup : SemiG
-    
-    public init(_ semigroup : SemiG) {
-        self.semigroup = semigroup
+    public class SemigroupInstance<R, S, SemiG> : Semigroup where SemiG : Semigroup, SemiG.A == R {
+        public typealias A = ConstOf<R, S>
+        private let semigroup : SemiG
+        
+        public init(_ semigroup : SemiG) {
+            self.semigroup = semigroup
+        }
+        
+        public func combine(_ a: ConstOf<R, S>, _ b: ConstOf<R, S>) -> ConstOf<R, S> {
+            return Const<R, S>.fix(a).combine(Const<R, S>.fix(b), semigroup)
+        }
     }
-    
-    public func combine(_ a: ConstOf<R, S>, _ b: ConstOf<R, S>) -> ConstOf<R, S> {
-        return Const.fix(a).combine(Const.fix(b), semigroup)
-    }
-}
 
-public class ConstMonoid<R, S, Mono> : ConstSemigroup<R, S, Mono>, Monoid where Mono : Monoid, Mono.A == R {
-    private let monoid : Mono
-    
-    override public init(_ monoid : Mono) {
-        self.monoid = monoid
-        super.init(monoid)
+    public class MonoidInstance<R, S, Mono> : SemigroupInstance<R, S, Mono>, Monoid where Mono : Monoid, Mono.A == R {
+        private let monoid : Mono
+        
+        override public init(_ monoid : Mono) {
+            self.monoid = monoid
+            super.init(monoid)
+        }
+        
+        public var empty: ConstOf<R, S> {
+            return Const<R, S>(monoid.empty)
+        }
     }
-    
-    public var empty: ConstOf<R, S> {
-        return Const(monoid.empty)
-    }
-}
 
-public class ConstFoldable<R> : Foldable {
-    public typealias F = ConstPartial<R>
-    
-    public func foldLeft<A, B>(_ fa: ConstOf<R, A>, _ b: B, _ f: @escaping (B, A) -> B) -> B {
-        return b
+    public class FoldableInstance<R> : Foldable {
+        public typealias F = ConstPartial<R>
+        
+        public func foldLeft<A, B>(_ fa: ConstOf<R, A>, _ b: B, _ f: @escaping (B, A) -> B) -> B {
+            return b
+        }
+        
+        public func foldRight<A, B>(_ fa: ConstOf<R, A>, _ b: Eval<B>, _ f: @escaping (A, Eval<B>) -> Eval<B>) -> Eval<B> {
+            return b
+        }
     }
-    
-    public func foldRight<A, B>(_ fa: ConstOf<R, A>, _ b: Eval<B>, _ f: @escaping (A, Eval<B>) -> Eval<B>) -> Eval<B> {
-        return b
-    }
-}
 
-public class ConstTraverse<R> : ConstFoldable<R>, Traverse {
-    public func traverse<G, A, B, Appl>(_ fa: ConstOf<R, A>, _ f: @escaping (A) -> Kind<G, B>, _ applicative: Appl) -> Kind<G, ConstOf<R, B>> where G == Appl.F, Appl : Applicative {
-        return Const.fix(fa).traverse(f, applicative)
+    public class TraverseInstance<R> : FoldableInstance<R>, Traverse {
+        public func traverse<G, A, B, Appl>(_ fa: ConstOf<R, A>, _ f: @escaping (A) -> Kind<G, B>, _ applicative: Appl) -> Kind<G, ConstOf<R, B>> where G == Appl.F, Appl : Applicative {
+            return Const<R, A>.fix(fa).traverse(f, applicative)
+        }
     }
-}
 
-public class ConstTraverseFilter<R> : ConstTraverse<R>, TraverseFilter {
-    public func traverseFilter<A, B, G, Appl>(_ fa: ConstOf<R, A>, _ f: @escaping (A) -> Kind<G, OptionOf<B>>, _ applicative: Appl) -> Kind<G, ConstOf<R, B>> where G == Appl.F, Appl : Applicative {
-        return Const.fix(fa).traverseFilter(f, applicative)
+    public class TraverseFilterInstance<R> : TraverseInstance<R>, TraverseFilter {
+        public func traverseFilter<A, B, G, Appl>(_ fa: ConstOf<R, A>, _ f: @escaping (A) -> Kind<G, OptionOf<B>>, _ applicative: Appl) -> Kind<G, ConstOf<R, B>> where G == Appl.F, Appl : Applicative {
+            return Const<R, A>.fix(fa).traverseFilter(f, applicative)
+        }
     }
-}
 
-public class ConstEq<R, S, EqR> : Eq where EqR : Eq, EqR.A == R {
-    public typealias A = ConstOf<R, S>
-    private let eqr : EqR
-    
-    public init(_ eqr : EqR) {
-        self.eqr = eqr
-    }
-    
-    public func eqv(_ a: ConstOf<R, S>, _ b: ConstOf<R, S>) -> Bool {
-        return eqr.eqv(Const.fix(a).value, Const.fix(b).value)
+    public class EqInstance<R, S, EqR> : Eq where EqR : Eq, EqR.A == R {
+        public typealias A = ConstOf<R, S>
+        private let eqr : EqR
+        
+        public init(_ eqr : EqR) {
+            self.eqr = eqr
+        }
+        
+        public func eqv(_ a: ConstOf<R, S>, _ b: ConstOf<R, S>) -> Bool {
+            return eqr.eqv(Const<R, S>.fix(a).value, Const<R, S>.fix(b).value)
+        }
     }
 }
 

--- a/Sources/Bow/Data/Coproduct.swift
+++ b/Sources/Bow/Data/Coproduct.swift
@@ -53,111 +53,111 @@ public class Coproduct<F, G, A> : CoproductOf<F, G, A> {
 }
 
 public extension Coproduct {
-    public static func functor<FuncF, FuncG>(_ functorF : FuncF, _ functorG : FuncG) -> CoproductFunctor<F, G, FuncF, FuncG> {
-        return CoproductFunctor<F, G, FuncF, FuncG>(functorF, functorG)
+    public static func functor<FuncF, FuncG>(_ functorF : FuncF, _ functorG : FuncG) -> FunctorInstance<F, G, FuncF, FuncG> {
+        return FunctorInstance<F, G, FuncF, FuncG>(functorF, functorG)
     }
     
-    public static func comonad<ComonF, ComonG>(_ comonadF : ComonF, _ comonadG : ComonG) -> CoproductComonad<F, G, ComonF, ComonG> {
-        return CoproductComonad<F, G, ComonF, ComonG>(comonadF, comonadG)
+    public static func comonad<ComonF, ComonG>(_ comonadF : ComonF, _ comonadG : ComonG) -> ComonadInstance<F, G, ComonF, ComonG> {
+        return ComonadInstance<F, G, ComonF, ComonG>(comonadF, comonadG)
     }
     
-    public static func foldable<FoldF, FoldG>(_ foldableF : FoldF, _ foldableG : FoldG) -> CoproductFoldable<F, G, FoldF, FoldG> {
-        return CoproductFoldable<F, G, FoldF, FoldG>(foldableF, foldableG)
+    public static func foldable<FoldF, FoldG>(_ foldableF : FoldF, _ foldableG : FoldG) -> FoldableInstance<F, G, FoldF, FoldG> {
+        return FoldableInstance<F, G, FoldF, FoldG>(foldableF, foldableG)
     }
     
-    public static func traverse<TravF, TravG>(_ traverseF : TravF, _ traverseG : TravG) -> CoproductTraverse<F, G, TravF, TravG>{
-        return CoproductTraverse<F, G, TravF, TravG>(traverseF, traverseG)
+    public static func traverse<TravF, TravG>(_ traverseF : TravF, _ traverseG : TravG) -> TraverseInstance<F, G, TravF, TravG>{
+        return TraverseInstance<F, G, TravF, TravG>(traverseF, traverseG)
     }
     
-    public static func eq<EqA>(_ eq : EqA) -> CoproductEq<F, G, A, EqA> {
-        return CoproductEq<F, G, A, EqA>(eq)
+    public static func eq<EqA>(_ eq : EqA) -> EqInstance<F, G, A, EqA> {
+        return EqInstance<F, G, A, EqA>(eq)
     }
-}
 
-public class CoproductFunctor<G, H, FuncG, FuncH> : Functor where FuncG : Functor, FuncG.F == G, FuncH : Functor, FuncH.F == H {
-    public typealias F = CoproductPartial<G, H>
-    
-    private let functorG : FuncG
-    private let functorH : FuncH
-    
-    public init(_ functorG : FuncG, _ functorH : FuncH) {
-        self.functorG = functorG
-        self.functorH = functorH
+    public class FunctorInstance<G, H, FuncG, FuncH> : Functor where FuncG : Functor, FuncG.F == G, FuncH : Functor, FuncH.F == H {
+        public typealias F = CoproductPartial<G, H>
+        
+        private let functorG : FuncG
+        private let functorH : FuncH
+        
+        public init(_ functorG : FuncG, _ functorH : FuncH) {
+            self.functorG = functorG
+            self.functorH = functorH
+        }
+        
+        public func map<A, B>(_ fa: CoproductOf<G, H, A>, _ f: @escaping (A) -> B) -> CoproductOf<G, H, B> {
+            return Coproduct<G, H, A>.fix(fa).map(functorG, functorH, f)
+        }
     }
-    
-    public func map<A, B>(_ fa: CoproductOf<G, H, A>, _ f: @escaping (A) -> B) -> CoproductOf<G, H, B> {
-        return Coproduct.fix(fa).map(functorG, functorH, f)
-    }
-}
 
-public class CoproductComonad<G, H, ComonG, ComonH> : CoproductFunctor<G, H, ComonG, ComonH>, Comonad where ComonG : Comonad, ComonG.F == G, ComonH : Comonad, ComonH.F == H {
-    
-    private let comonadG : ComonG
-    private let comonadH : ComonH
-    
-    override public init(_ comonadG : ComonG, _ comonadH : ComonH) {
-        self.comonadG = comonadG
-        self.comonadH = comonadH
-        super.init(comonadG, comonadH)
+    public class ComonadInstance<G, H, ComonG, ComonH> : FunctorInstance<G, H, ComonG, ComonH>, Comonad where ComonG : Comonad, ComonG.F == G, ComonH : Comonad, ComonH.F == H {
+        
+        private let comonadG : ComonG
+        private let comonadH : ComonH
+        
+        override public init(_ comonadG : ComonG, _ comonadH : ComonH) {
+            self.comonadG = comonadG
+            self.comonadH = comonadH
+            super.init(comonadG, comonadH)
+        }
+        
+        public func coflatMap<A, B>(_ fa: CoproductOf<G, H, A>, _ f: @escaping (CoproductOf<G, H, A>) -> B) -> CoproductOf<G, H, B> {
+            return Coproduct<G, H, A>.fix(fa).coflatMap(comonadG, comonadH, f)
+        }
+        
+        public func extract<A>(_ fa: CoproductOf<G, H, A>) -> A {
+            return Coproduct<G, H, A>.fix(fa).extract(comonadG, comonadH)
+        }
     }
-    
-    public func coflatMap<A, B>(_ fa: CoproductOf<G, H, A>, _ f: @escaping (CoproductOf<G, H, A>) -> B) -> CoproductOf<G, H, B> {
-        return Coproduct.fix(fa).coflatMap(comonadG, comonadH, f)
-    }
-    
-    public func extract<A>(_ fa: CoproductOf<G, H, A>) -> A {
-        return Coproduct.fix(fa).extract(comonadG, comonadH)
-    }
-}
 
-public class CoproductFoldable<G, H, FoldG, FoldH> : Foldable where FoldG : Foldable, FoldG.F == G, FoldH : Foldable, FoldH.F == H {
-    public typealias F = CoproductPartial<G, H>
-    
-    private let foldableG : FoldG
-    private let foldableH : FoldH
-    
-    public init(_ foldableG : FoldG, _ foldableH : FoldH) {
-        self.foldableG = foldableG
-        self.foldableH = foldableH
+    public class FoldableInstance<G, H, FoldG, FoldH> : Foldable where FoldG : Foldable, FoldG.F == G, FoldH : Foldable, FoldH.F == H {
+        public typealias F = CoproductPartial<G, H>
+        
+        private let foldableG : FoldG
+        private let foldableH : FoldH
+        
+        public init(_ foldableG : FoldG, _ foldableH : FoldH) {
+            self.foldableG = foldableG
+            self.foldableH = foldableH
+        }
+        
+        public func foldLeft<A, B>(_ fa: CoproductOf<G, H, A>, _ b: B, _ f: @escaping (B, A) -> B) -> B {
+            return Coproduct<G, H, A>.fix(fa).foldLeft(b, f, foldableG, foldableH)
+        }
+        
+        public func foldRight<A, B>(_ fa: CoproductOf<G, H, A>, _ b: Eval<B>, _ f: @escaping (A, Eval<B>) -> Eval<B>) -> Eval<B> {
+            return Coproduct<G, H, A>.fix(fa).foldRight(b, f, foldableG, foldableH)
+        }
     }
-    
-    public func foldLeft<A, B>(_ fa: CoproductOf<G, H, A>, _ b: B, _ f: @escaping (B, A) -> B) -> B {
-        return Coproduct.fix(fa).foldLeft(b, f, foldableG, foldableH)
-    }
-    
-    public func foldRight<A, B>(_ fa: CoproductOf<G, H, A>, _ b: Eval<B>, _ f: @escaping (A, Eval<B>) -> Eval<B>) -> Eval<B> {
-        return Coproduct.fix(fa).foldRight(b, f, foldableG, foldableH)
-    }
-}
 
-public class CoproductTraverse<G, H, TravG, TravH> : CoproductFoldable<G, H, TravG, TravH>, Traverse where TravG : Traverse, TravG.F == G, TravH : Traverse, TravH.F == H {
-    
-    private let traverseG : TravG
-    private let traverseH : TravH
-    
-    override public init(_ traverseG : TravG, _ traverseH : TravH) {
-        self.traverseG = traverseG
-        self.traverseH = traverseH
-        super.init(traverseG, traverseH)
+    public class TraverseInstance<G, H, TravG, TravH> : FoldableInstance<G, H, TravG, TravH>, Traverse where TravG : Traverse, TravG.F == G, TravH : Traverse, TravH.F == H {
+        
+        private let traverseG : TravG
+        private let traverseH : TravH
+        
+        override public init(_ traverseG : TravG, _ traverseH : TravH) {
+            self.traverseG = traverseG
+            self.traverseH = traverseH
+            super.init(traverseG, traverseH)
+        }
+        
+        public func traverse<I, A, B, Appl>(_ fa: CoproductOf<G, H, A>, _ f: @escaping (A) -> Kind<I, B>, _ applicative: Appl) -> Kind<I, CoproductOf<G, H, B>> where I == Appl.F, Appl : Applicative {
+            return Coproduct<G, H, A>.fix(fa).traverse(f, applicative, traverseG, traverseH)
+        }
     }
-    
-    public func traverse<I, A, B, Appl>(_ fa: CoproductOf<G, H, A>, _ f: @escaping (A) -> Kind<I, B>, _ applicative: Appl) -> Kind<I, CoproductOf<G, H, B>> where I == Appl.F, Appl : Applicative {
-        return Coproduct.fix(fa).traverse(f, applicative, traverseG, traverseH)
-    }
-}
 
-public class CoproductEq<F, G, B, EqB> : Eq where EqB : Eq, EqB.A == EitherOf<Kind<F, B>, Kind<G, B>>{
-    public typealias A = CoproductOf<F, G, B>
-    
-    private let eq : EqB
-    
-    public init(_ eq : EqB) {
-        self.eq = eq
-    }
-    
-    public func eqv(_ a: CoproductOf<F, G, B>, _ b: CoproductOf<F, G, B>) -> Bool {
-        let a = Coproduct.fix(a)
-        let b = Coproduct.fix(b)
-        return eq.eqv(a.run, b.run)
+    public class EqInstance<F, G, B, EqB> : Eq where EqB : Eq, EqB.A == EitherOf<Kind<F, B>, Kind<G, B>>{
+        public typealias A = CoproductOf<F, G, B>
+        
+        private let eq : EqB
+        
+        public init(_ eq : EqB) {
+            self.eq = eq
+        }
+        
+        public func eqv(_ a: CoproductOf<F, G, B>, _ b: CoproductOf<F, G, B>) -> Bool {
+            let a = Coproduct<F, G, B>.fix(a)
+            let b = Coproduct<F, G, B>.fix(b)
+            return eq.eqv(a.run, b.run)
+        }
     }
 }

--- a/Sources/Bow/Data/Day.swift
+++ b/Sources/Bow/Data/Day.swift
@@ -77,37 +77,37 @@ fileprivate class DefaultDay<F, G, X, Y, A> : Day<F, G, A> {
 }
 
 public extension Day {
-    public static func functor() -> DayFunctor<F, G> {
-        return DayFunctor()
+    public static func functor() -> FunctorInstance<F, G> {
+        return FunctorInstance()
     }
     
-    public static func comonad<ComonF, ComonG>(_ comonadF : ComonF, _ comonadG : ComonG) -> DayComonad<F, G, ComonF, ComonG> {
-        return DayComonad(comonadF, comonadG)
+    public static func comonad<ComonF, ComonG>(_ comonadF : ComonF, _ comonadG : ComonG) -> ComonadInstance<F, G, ComonF, ComonG> {
+        return ComonadInstance(comonadF, comonadG)
     }
-}
 
-public class DayFunctor<G, H> : Functor {
-    public typealias F = DayPartial<G, H>
+    public class FunctorInstance<G, H> : Functor {
+        public typealias F = DayPartial<G, H>
 
-    public func map<A, B>(_ fa: DayOf<G, H, A>, _ f: @escaping (A) -> B) -> DayOf<G, H, B> {
-        return Day<G, H, A>.fix(fa).map(f)
+        public func map<A, B>(_ fa: DayOf<G, H, A>, _ f: @escaping (A) -> B) -> DayOf<G, H, B> {
+            return Day<G, H, A>.fix(fa).map(f)
+        }
     }
-}
 
-public class DayComonad<G, H, ComonG, ComonH> : DayFunctor<G, H>, Comonad where ComonG : Comonad, ComonG.F == G, ComonH : Comonad, ComonH.F == H {
-    private let comonadG : ComonG
-    private let comonadH : ComonH
-    
-    public init(_ comonadG : ComonG, _ comonadH : ComonH) {
-        self.comonadG = comonadG
-        self.comonadH = comonadH
-    }
-    
-    public func coflatMap<A, B>(_ fa: DayOf<G, H, A>, _ f: @escaping (DayOf<G, H, A>) -> B) -> DayOf<G, H, B> {
-        return Day<G, H, A>.fix(fa).coflatMap(comonadG, comonadH, f)
-    }
-    
-    public func extract<A>(_ fa: DayOf<G, H, A>) -> A {
-        return Day<G, H, A>.fix(fa).extract(comonadG, comonadH)
+    public class ComonadInstance<G, H, ComonG, ComonH> : FunctorInstance<G, H>, Comonad where ComonG : Comonad, ComonG.F == G, ComonH : Comonad, ComonH.F == H {
+        private let comonadG : ComonG
+        private let comonadH : ComonH
+        
+        public init(_ comonadG : ComonG, _ comonadH : ComonH) {
+            self.comonadG = comonadG
+            self.comonadH = comonadH
+        }
+        
+        public func coflatMap<A, B>(_ fa: DayOf<G, H, A>, _ f: @escaping (DayOf<G, H, A>) -> B) -> DayOf<G, H, B> {
+            return Day<G, H, A>.fix(fa).coflatMap(comonadG, comonadH, f)
+        }
+        
+        public func extract<A>(_ fa: DayOf<G, H, A>) -> A {
+            return Day<G, H, A>.fix(fa).extract(comonadG, comonadH)
+        }
     }
 }

--- a/Sources/Bow/Data/Either.swift
+++ b/Sources/Bow/Data/Either.swift
@@ -263,179 +263,180 @@ public extension Either {
     /**
      Obtains an instance of the `Functor` typeclass for `Either`.
      */
-    public static func functor() -> EitherApplicative<A> {
-        return EitherApplicative<A>()
+    public static func functor() -> ApplicativeInstance<A> {
+        return ApplicativeInstance<A>()
     }
     
     /**
      Obtains an instance of the `Applicative` typeclass for `Either`.
      */
-    public static func applicative() -> EitherApplicative<A> {
-        return EitherApplicative<A>()
+    public static func applicative() -> ApplicativeInstance<A> {
+        return ApplicativeInstance<A>()
     }
     
     /**
      Obtains an instance of the `Monad` typeclass for `Either`.
      */
-    public static func monad() -> EitherMonad<A> {
-        return EitherMonad<A>()
+    public static func monad() -> MonadInstance<A> {
+        return MonadInstance<A>()
     }
     
     /**
      Obtains an instance of the `ApplicativeError` typeclass for `Either`.
      */
-    public static func applicativeError() -> EitherMonadError<A> {
-        return EitherMonadError<A>()
+    public static func applicativeError() -> MonadErrorInstance<A> {
+        return MonadErrorInstance<A>()
     }
     
     /**
      Obtains an instance of the `MonadError` typeclass for `Either`.
      */
-    public static func monadError() -> EitherMonadError<A> {
-        return EitherMonadError<A>()
+    public static func monadError() -> MonadErrorInstance<A> {
+        return MonadErrorInstance<A>()
     }
     
     /**
      Obtains an instance of the `Foldable` typeclass for `Either`.
      */
-    public static func foldable() -> EitherFoldable<A> {
-        return EitherFoldable<A>()
+    public static func foldable() -> FoldableInstance<A> {
+        return FoldableInstance<A>()
     }
     
     /**
      Obtains an instance of the `Traverse` typeclass for `Either`.
      */
-    public static func traverse() -> EitherTraverse<A> {
-        return EitherTraverse<A>()
+    public static func traverse() -> TraverseInstance<A> {
+        return TraverseInstance<A>()
     }
     
     /**
      Obtains an instance of the `SemigroupK` typeclass for `Either`.
      */
-    public static func semigroupK() -> EitherSemigroupK<A> {
-        return EitherSemigroupK<A>()
+    public static func semigroupK() -> SemigroupKInstance<A> {
+        return SemigroupKInstance<A>()
     }
     
     /**
      Obtains an instance of the `Eq` typeclass for `Either`, given there exists instances of `Eq` for its type arguments.
      */
-    public static func eq<EqL, EqR>(_ eql : EqL, _ eqr : EqR) -> EitherEq<A, B, EqL, EqR> {
-        return EitherEq<A, B, EqL, EqR>(eql, eqr)
+    public static func eq<EqL, EqR>(_ eql : EqL, _ eqr : EqR) -> EqInstance<A, B, EqL, EqR> {
+        return EqInstance<A, B, EqL, EqR>(eql, eqr)
     }
 
     /**
      Obtains an instance of the `Bifunctor` typeclass for `Either`.
      */
-    public static func bifunctor() -> EitherBifunctor<A, B> {
-        return EitherBifunctor<A, B>()
+    public static func bifunctor() -> BifunctorInstance<A, B> {
+        return BifunctorInstance<A, B>()
     }
-}
 
-/**
- An instance of the `Bifunctor` typeclass for the `Either` data type.
- */
-public class EitherBifunctor<A, B>: Bifunctor {
-    public typealias F = ForEither
+    /**
+     An instance of the `Bifunctor` typeclass for the `Either` data type.
+     */
+    public class BifunctorInstance<A, B>: Bifunctor {
+        public typealias F = ForEither
 
-    public func bimap<A, B, C, D>(_ fab: Kind2<ForEither, A, B>, _ f1: @escaping (A) -> C, _ f2: @escaping (B) -> D) -> Kind2<ForEither, C, D> {
-        return Either.fix(fab).bimap(f1, f2)
+        public func bimap<A, B, C, D>(_ fab: EitherOf<A, B>, _ f1: @escaping (A) -> C, _ f2: @escaping (B) -> D) -> EitherOf<C, D> {
+            return Either<A, B>.fix(fab).bimap(f1, f2)
+        }
     }
-}
 
 
-/**
- An instance of the `Applicative` typeclass for the `Either` data type.
- */
-public class EitherApplicative<C> : Applicative {
-    public typealias F = EitherPartial<C>
-    
-    public func pure<A>(_ a: A) -> EitherOf<C, A> {
-        return Either<C, A>.pure(a)
+    /**
+     An instance of the `Applicative` typeclass for the `Either` data type.
+     */
+    public class ApplicativeInstance<C> : Applicative {
+        public typealias F = EitherPartial<C>
+        
+        public func pure<A>(_ a: A) -> EitherOf<C, A> {
+            return Either<C, A>.pure(a)
+        }
+        
+        public func ap<A, B>(_ ff: EitherOf<C, (A) -> B>, _ fa: EitherOf<C, A>) -> EitherOf<C, B> {
+            return Either<C, (A) -> B>.fix(ff).ap(Either<C, A>.fix(fa))
+        }
     }
-    
-    public func ap<A, B>(_ ff: EitherOf<C, (A) -> B>, _ fa: EitherOf<C, A>) -> EitherOf<C, B> {
-        return Either.fix(ff).ap(Either.fix(fa))
-    }
-}
 
-/**
- An instance of the `Monad` typeclass for the `Either` data type.
- */
-public class EitherMonad<C> : EitherApplicative<C>, Monad {
-    public func flatMap<A, B>(_ fa: EitherOf<C, A>, _ f: @escaping (A) -> EitherOf<C, B>) -> EitherOf<C, B> {
-        return Either.fix(fa).flatMap({ eca in Either.fix(f(eca)) })
+    /**
+     An instance of the `Monad` typeclass for the `Either` data type.
+     */
+    public class MonadInstance<C> : ApplicativeInstance<C>, Monad {
+        public func flatMap<A, B>(_ fa: EitherOf<C, A>, _ f: @escaping (A) -> EitherOf<C, B>) -> EitherOf<C, B> {
+            return Either<C, A>.fix(fa).flatMap({ eca in Either<C, B>.fix(f(eca)) })
+        }
+        
+        public func tailRecM<A, B>(_ a: A, _ f: @escaping (A) -> EitherOf<C, Either<A, B>>) -> EitherOf<C, B> {
+            return Either<A, B>.tailRecM(a, f)
+        }
     }
-    
-    public func tailRecM<A, B>(_ a: A, _ f: @escaping (A) -> EitherOf<C, Either<A, B>>) -> EitherOf<C, B> {
-        return Either<A, B>.tailRecM(a, f)
-    }
-}
 
-/**
- An instance of the `MonadError` typeclass for the `Either` data type.
- */
-public class EitherMonadError<C> : EitherMonad<C>, MonadError {
-    public typealias E = C
-    
-    public func raiseError<A>(_ e: C) -> EitherOf<C, A> {
-        return Either<C, A>.left(e)
+    /**
+     An instance of the `MonadError` typeclass for the `Either` data type.
+     */
+    public class MonadErrorInstance<C> : MonadInstance<C>, MonadError {
+        public typealias E = C
+        
+        public func raiseError<A>(_ e: C) -> EitherOf<C, A> {
+            return Either<C, A>.left(e)
+        }
+        
+        public func handleErrorWith<A>(_ fa: EitherOf<C, A>, _ f: @escaping (C) -> EitherOf<C, A>) -> EitherOf<C, A> {
+            return Either<C, A>.fix(fa).fold(f, constant(Either<C, A>.fix(fa)))
+        }
     }
-    
-    public func handleErrorWith<A>(_ fa: EitherOf<C, A>, _ f: @escaping (C) -> EitherOf<C, A>) -> EitherOf<C, A> {
-        return Either.fix(fa).fold(f, constant(Either.fix(fa)))
-    }
-}
 
-/**
- An instance of the `Foldable` typeclass for the `Either` data type.
- */
-public class EitherFoldable<C> : Foldable {
-    public typealias F = EitherPartial<C>
-    
-    public func foldLeft<A, B>(_ fa: EitherOf<C, A>, _ b: B, _ f: @escaping (B, A) -> B) -> B {
-        return Either.fix(fa).foldLeft(b, f)
+    /**
+     An instance of the `Foldable` typeclass for the `Either` data type.
+     */
+    public class FoldableInstance<C> : Foldable {
+        public typealias F = EitherPartial<C>
+        
+        public func foldLeft<A, B>(_ fa: EitherOf<C, A>, _ b: B, _ f: @escaping (B, A) -> B) -> B {
+            return Either<C, A>.fix(fa).foldLeft(b, f)
+        }
+        
+        public func foldRight<A, B>(_ fa: EitherOf<C, A>, _ b: Eval<B>, _ f: @escaping (A, Eval<B>) -> Eval<B>) -> Eval<B> {
+            return Either<C, A>.fix(fa).foldRight(b, f)
+        }
     }
-    
-    public func foldRight<A, B>(_ fa: EitherOf<C, A>, _ b: Eval<B>, _ f: @escaping (A, Eval<B>) -> Eval<B>) -> Eval<B> {
-        return Either.fix(fa).foldRight(b, f)
-    }
-}
 
-/**
- An instance of the `Traverse` typeclass for the `Either` data type.
- */
-public class EitherTraverse<C> : EitherFoldable<C>, Traverse {
-    public func traverse<G, A, B, Appl>(_ fa: EitherOf<C, A>, _ f: @escaping (A) -> Kind<G, B>, _ applicative: Appl) -> Kind<G, EitherOf<C, B>> where G == Appl.F, Appl : Applicative {
-        return Either.fix(fa).traverse(f, applicative)
+    /**
+     An instance of the `Traverse` typeclass for the `Either` data type.
+     */
+    public class TraverseInstance<C> : FoldableInstance<C>, Traverse {
+        public func traverse<G, A, B, Appl>(_ fa: EitherOf<C, A>, _ f: @escaping (A) -> Kind<G, B>, _ applicative: Appl) -> Kind<G, EitherOf<C, B>> where G == Appl.F, Appl : Applicative {
+            return Either<C, A>.fix(fa).traverse(f, applicative)
+        }
     }
-}
 
-/**
- An instance of the `SemigroupK` typeclass for the `Either` data type.
- */
-public class EitherSemigroupK<C> : SemigroupK {
-    public typealias F = EitherPartial<C>
-    
-    public func combineK<A>(_ x: EitherOf<C, A>, _ y: EitherOf<C, A>) -> EitherOf<C, A> {
-        return Either.fix(x).combineK(Either.fix(y))
+    /**
+     An instance of the `SemigroupK` typeclass for the `Either` data type.
+     */
+    public class SemigroupKInstance<C> : SemigroupK {
+        public typealias F = EitherPartial<C>
+        
+        public func combineK<A>(_ x: EitherOf<C, A>, _ y: EitherOf<C, A>) -> EitherOf<C, A> {
+            return Either<C, A>.fix(x).combineK(Either<C, A>.fix(y))
+        }
     }
-}
 
-/**
- An instance of the `Eq` typeclass for the `Either` data type.
- */
-public class EitherEq<L, R, EqL, EqR> : Eq where EqL : Eq, EqL.A == L, EqR : Eq, EqR.A == R {
-    public typealias A = EitherOf<L, R>
-    private let eql : EqL
-    private let eqr : EqR
-    
-    public init(_ eql : EqL, _ eqr : EqR) {
-        self.eql = eql
-        self.eqr = eqr
-    }
-    
-    public func eqv(_ a: EitherOf<L, R>, _ b: EitherOf<L, R>) -> Bool {
-        return Either.fix(a).fold({ aLeft  in Either.fix(b).fold({ bLeft in eql.eqv(aLeft, bLeft) }, constant(false)) },
-                                 { aRight in Either.fix(b).fold(constant(false), { bRight in eqr.eqv(aRight, bRight) }) })
+    /**
+     An instance of the `Eq` typeclass for the `Either` data type.
+     */
+    public class EqInstance<L, R, EqL, EqR> : Eq where EqL : Eq, EqL.A == L, EqR : Eq, EqR.A == R {
+        public typealias A = EitherOf<L, R>
+        private let eql : EqL
+        private let eqr : EqR
+        
+        public init(_ eql : EqL, _ eqr : EqR) {
+            self.eql = eql
+            self.eqr = eqr
+        }
+        
+        public func eqv(_ a: EitherOf<L, R>, _ b: EitherOf<L, R>) -> Bool {
+            return Either<L, R>.fix(a).fold(
+                { aLeft in Either<L, R>.fix(b).fold({ bLeft in eql.eqv(aLeft, bLeft) }, constant(false)) },
+                { aRight in Either<L, R>.fix(b).fold(constant(false), { bRight in eqr.eqv(aRight, bRight) }) })
+        }
     }
 }

--- a/Sources/Bow/Data/Eval.swift
+++ b/Sources/Bow/Data/Eval.swift
@@ -301,41 +301,41 @@ public extension Kind where F == ForEval {
 }
 
 public extension Eval {
-    public static func functor() -> EvalApplicative {
-        return EvalApplicative()
+    public static func functor() -> ApplicativeInstance {
+        return ApplicativeInstance()
     }
     
-    public static func applicative() -> EvalApplicative {
-        return EvalApplicative()
+    public static func applicative() -> ApplicativeInstance {
+        return ApplicativeInstance()
     }
     
-    public static func eq<EqA>(_ eq : EqA) -> EvalEq<A, EqA> {
-        return EvalEq<A, EqA>(eq)
+    public static func eq<EqA>(_ eq : EqA) -> EqInstance<A, EqA> {
+        return EqInstance<A, EqA>(eq)
     }
-}
 
-public class EvalApplicative : Applicative {
-    public typealias F = ForEval
-    
-    public func pure<A>(_ a: A) -> Kind<F, A> {
-        return Eval<A>.pure(a)
+    public class ApplicativeInstance : Applicative {
+        public typealias F = ForEval
+        
+        public func pure<A>(_ a: A) -> Kind<F, A> {
+            return Eval<A>.pure(a)
+        }
+        
+        public func ap<A, B>(_ ff: Kind<F, (A) -> B>, _ fa: Kind<F, A>) -> Kind<F, B> {
+            return ff.fix().ap(fa.fix())
+        }
     }
-    
-    public func ap<A, B>(_ ff: Kind<F, (A) -> B>, _ fa: Kind<F, A>) -> Kind<F, B> {
-        return ff.fix().ap(fa.fix())
-    }
-}
 
-public class EvalEq<B, EqB> : Eq where EqB : Eq, EqB.A == B {
-    public typealias A = EvalOf<B>
-    
-    private let eq : EqB
-    
-    public init(_ eq : EqB) {
-        self.eq = eq
-    }
-    
-    public func eqv(_ a: EvalOf<B>, _ b: EvalOf<B>) -> Bool {
-        return eq.eqv(a.fix().value(), b.fix().value())
+    public class EqInstance<B, EqB> : Eq where EqB : Eq, EqB.A == B {
+        public typealias A = EvalOf<B>
+        
+        private let eq : EqB
+        
+        public init(_ eq : EqB) {
+            self.eq = eq
+        }
+        
+        public func eqv(_ a: EvalOf<B>, _ b: EvalOf<B>) -> Bool {
+            return eq.eqv(a.fix().value(), b.fix().value())
+        }
     }
 }

--- a/Sources/Bow/Data/Id.swift
+++ b/Sources/Bow/Data/Id.swift
@@ -149,147 +149,147 @@ extension Id {
     /**
      Obtains an instance of the `Functor` typeclass for `Id`.
      */
-    public static func functor() -> IdFunctor {
-        return IdFunctor()
+    public static func functor() -> FunctorInstance {
+        return FunctorInstance()
     }
     
     /**
      Obtains an instance of the `Applicative` typeclass for `Id`.
      */
-    public static func applicative() -> IdApplicative {
-        return IdApplicative()
+    public static func applicative() -> ApplicativeInstance {
+        return ApplicativeInstance()
     }
     
     /**
      Obtains an instance of the `Monad` typeclass for `Id`.
      */
-    public static func monad() -> IdMonad {
-        return IdMonad()
+    public static func monad() -> MonadInstance {
+        return MonadInstance()
     }
     
     /**
      Obtains an instance of the `Comonad` typeclass for `Id`.
      */
-    public static func comonad() -> IdBimonad {
-        return IdBimonad()
+    public static func comonad() -> BimonadInstance {
+        return BimonadInstance()
     }
     
     /**
      Obtains an instance of the `Bimonad` typeclass for `Id`.
      */
-    public static func bimonad() -> IdBimonad {
-        return IdBimonad()
+    public static func bimonad() -> BimonadInstance {
+        return BimonadInstance()
     }
     
     /**
      Obtains an instance of the `Foldable` typeclass for `Id`.
      */
-    public static func foldable() -> IdFoldable {
-        return IdFoldable()
+    public static func foldable() -> FoldableInstance {
+        return FoldableInstance()
     }
     
     /**
      Obtains an instance of the `Traverse` typeclass for `Id`.
      */
-    public static func traverse() -> IdTraverse {
-        return IdTraverse()
+    public static func traverse() -> TraverseInstance {
+        return TraverseInstance()
     }
 
     /**
      Obtains an instance of the `Eq` typeclass for `Id`.
      */
-    public static func eq<EqA>(_ eqa : EqA) -> IdEq<A, EqA> {
-        return IdEq<A, EqA>(eqa)
+    public static func eq<EqA>(_ eqa : EqA) -> EqInstance<A, EqA> {
+        return EqInstance<A, EqA>(eqa)
     }
-}
 
-/**
- An instance of the `Functor` typeclass for the `Id` data type.
- */
-public class IdFunctor : Functor {
-    public typealias F = ForId
-    
-    public func map<A, B>(_ fa: IdOf<A>, _ f: @escaping (A) -> B) -> IdOf<B> {
-        return fa.fix().map(f)
+    /**
+     An instance of the `Functor` typeclass for the `Id` data type.
+     */
+    public class FunctorInstance : Functor {
+        public typealias F = ForId
+        
+        public func map<A, B>(_ fa: IdOf<A>, _ f: @escaping (A) -> B) -> IdOf<B> {
+            return fa.fix().map(f)
+        }
     }
-}
 
-/**
- An instance of the `Applicative` typeclass for the `Id` data type.
- */
-public class IdApplicative : IdFunctor, Applicative {
-    public func pure<A>(_ a: A) -> IdOf<A> {
-        return Id.pure(a)
+    /**
+     An instance of the `Applicative` typeclass for the `Id` data type.
+     */
+    public class ApplicativeInstance : FunctorInstance, Applicative {
+        public func pure<A>(_ a: A) -> IdOf<A> {
+            return Id<A>.pure(a)
+        }
+        
+        public func ap<A, B>(_ ff: IdOf<(A) -> B>, _ fa: IdOf<A>) -> IdOf<B> {
+            return ff.fix().ap(fa.fix())
+        }
     }
-    
-    public func ap<A, B>(_ ff: IdOf<(A) -> B>, _ fa: IdOf<A>) -> IdOf<B> {
-        return ff.fix().ap(fa.fix())
-    }
-}
 
-/**
- An instance of the `Monad` typeclass for the `Id` data type.
- */
-public class IdMonad : IdApplicative, Monad {
-    public func flatMap<A, B>(_ fa: IdOf<A>, _ f: @escaping (A) -> IdOf<B>) -> IdOf<B> {
-        return fa.fix().flatMap({ a in f(a).fix() })
+    /**
+     An instance of the `Monad` typeclass for the `Id` data type.
+     */
+    public class MonadInstance : ApplicativeInstance, Monad {
+        public func flatMap<A, B>(_ fa: IdOf<A>, _ f: @escaping (A) -> IdOf<B>) -> IdOf<B> {
+            return fa.fix().flatMap({ a in f(a).fix() })
+        }
+        
+        public func tailRecM<A, B>(_ a: A, _ f: @escaping (A) -> IdOf<Either<A, B>>) -> IdOf<B> {
+            return Id<A>.tailRecM(a, f)
+        }
     }
-    
-    public func tailRecM<A, B>(_ a: A, _ f: @escaping (A) -> IdOf<Either<A, B>>) -> IdOf<B> {
-        return Id.tailRecM(a, f)
-    }
-}
 
-/**
- An instance of the `Bimonad` typeclass for the `Id` data type.
- */
-public class IdBimonad : IdMonad, Bimonad {
-    public func coflatMap<A, B>(_ fa: IdOf<A>, _ f: @escaping (IdOf<A>) -> B) -> IdOf<B> {
-        return fa.fix().coflatMap(f as (Id<A>) -> B)
+    /**
+     An instance of the `Bimonad` typeclass for the `Id` data type.
+     */
+    public class BimonadInstance : MonadInstance, Bimonad {
+        public func coflatMap<A, B>(_ fa: IdOf<A>, _ f: @escaping (IdOf<A>) -> B) -> IdOf<B> {
+            return fa.fix().coflatMap(f as (Id<A>) -> B)
+        }
+        
+        public func extract<A>(_ fa: IdOf<A>) -> A {
+            return fa.fix().extract()
+        }
     }
-    
-    public func extract<A>(_ fa: IdOf<A>) -> A {
-        return fa.fix().extract()
-    }
-}
 
-/**
- An instance of the `Foldable` typeclass for the `Id` data type.
- */
-public class IdFoldable : Foldable {
-    public typealias F = ForId
-    
-    public func foldLeft<A, B>(_ fa: IdOf<A>, _ b: B, _ f: @escaping (B, A) -> B) -> B {
-        return fa.fix().foldLeft(b, f)
+    /**
+     An instance of the `Foldable` typeclass for the `Id` data type.
+     */
+    public class FoldableInstance : Foldable {
+        public typealias F = ForId
+        
+        public func foldLeft<A, B>(_ fa: IdOf<A>, _ b: B, _ f: @escaping (B, A) -> B) -> B {
+            return fa.fix().foldLeft(b, f)
+        }
+        
+        public func foldRight<A, B>(_ fa: IdOf<A>, _ b: Eval<B>, _ f: @escaping (A, Eval<B>) -> Eval<B>) -> Eval<B> {
+            return fa.fix().foldRight(b, f)
+        }
     }
-    
-    public func foldRight<A, B>(_ fa: IdOf<A>, _ b: Eval<B>, _ f: @escaping (A, Eval<B>) -> Eval<B>) -> Eval<B> {
-        return fa.fix().foldRight(b, f)
-    }
-}
 
-/**
- An instance of the `Traverse` typeclass for the `Id` data type.
- */
-public class IdTraverse : IdFoldable, Traverse {
-    public func traverse<G, A, B, Appl>(_ fa: IdOf<A>, _ f: @escaping (A) -> Kind<G, B>, _ applicative: Appl) -> Kind<G, IdOf<B>> where G == Appl.F, Appl : Applicative {
-        return fa.fix().traverse(f, applicative)
+    /**
+     An instance of the `Traverse` typeclass for the `Id` data type.
+     */
+    public class TraverseInstance : FoldableInstance, Traverse {
+        public func traverse<G, A, B, Appl>(_ fa: IdOf<A>, _ f: @escaping (A) -> Kind<G, B>, _ applicative: Appl) -> Kind<G, IdOf<B>> where G == Appl.F, Appl : Applicative {
+            return fa.fix().traverse(f, applicative)
+        }
     }
-}
 
-/**
- An instance of the `Eq` typeclass for the `Id` data type.
- */
-public class IdEq<B, EqB> : Eq where EqB : Eq, EqB.A == B {
-    public typealias A = IdOf<B>
-    
-    private let eqb : EqB
-    
-    public init(_ eqb : EqB) {
-        self.eqb = eqb
-    }
-    
-    public func eqv(_ a: IdOf<B>, _ b: IdOf<B>) -> Bool {
-        return eqb.eqv(Id.fix(a).value, Id.fix(b).value)
+    /**
+     An instance of the `Eq` typeclass for the `Id` data type.
+     */
+    public class EqInstance<B, EqB> : Eq where EqB : Eq, EqB.A == B {
+        public typealias A = IdOf<B>
+        
+        private let eqb : EqB
+        
+        public init(_ eqb : EqB) {
+            self.eqb = eqb
+        }
+        
+        public func eqv(_ a: IdOf<B>, _ b: IdOf<B>) -> Bool {
+            return eqb.eqv(Id<B>.fix(a).value, Id<B>.fix(b).value)
+        }
     }
 }

--- a/Sources/Bow/Data/Moore.swift
+++ b/Sources/Bow/Data/Moore.swift
@@ -33,29 +33,29 @@ public class Moore<E, V> : MooreOf<E, V> {
 }
 
 public extension Moore {
-    public static func functor() -> MooreFunctor<E> {
-        return MooreFunctor<E>()
+    public static func functor() -> FunctorInstance<E> {
+        return FunctorInstance<E>()
     }
     
-    public static func comonad() -> MooreComonad<E> {
-        return MooreComonad<E>()
+    public static func comonad() -> ComonadInstance<E> {
+        return ComonadInstance<E>()
     }
-}
 
-public class MooreFunctor<E> : Functor {
-    public typealias F = MoorePartial<E>
-    
-    public func map<A, B>(_ fa: MooreOf<E, A>, _ f: @escaping (A) -> B) -> MooreOf<E, B> {
-        return Moore<E, A>.fix(fa).map(f)
+    public class FunctorInstance<E> : Functor {
+        public typealias F = MoorePartial<E>
+        
+        public func map<A, B>(_ fa: MooreOf<E, A>, _ f: @escaping (A) -> B) -> MooreOf<E, B> {
+            return Moore<E, A>.fix(fa).map(f)
+        }
     }
-}
 
-public class MooreComonad<E> : MooreFunctor<E>, Comonad {
-    public func coflatMap<A, B>(_ fa: Kind<Kind<ForMoore, E>, A>, _ f: @escaping (Kind<Kind<ForMoore, E>, A>) -> B) -> Kind<Kind<ForMoore, E>, B> {
-        return Moore<E, A>.fix(fa).coflatMap(f)
-    }
-    
-    public func extract<A>(_ fa: Kind<Kind<ForMoore, E>, A>) -> A {
-        return Moore<E, A>.fix(fa).extract()
+    public class ComonadInstance<E> : FunctorInstance<E>, Comonad {
+        public func coflatMap<A, B>(_ fa: Kind<Kind<ForMoore, E>, A>, _ f: @escaping (Kind<Kind<ForMoore, E>, A>) -> B) -> Kind<Kind<ForMoore, E>, B> {
+            return Moore<E, A>.fix(fa).coflatMap(f)
+        }
+        
+        public func extract<A>(_ fa: Kind<Kind<ForMoore, E>, A>) -> A {
+            return Moore<E, A>.fix(fa).extract()
+        }
     }
 }

--- a/Sources/Bow/Data/Option.swift
+++ b/Sources/Bow/Data/Option.swift
@@ -315,22 +315,22 @@ public extension Option {
     /**
      Obtains an instance of the `Functor` typeclass for `Option`.
      */
-    public static func functor() -> OptionFunctor {
-        return OptionFunctor()
+    public static func functor() -> FunctorInstance {
+        return FunctorInstance()
     }
     
     /**
      Obtains an instance of the `Applicative` typeclass for `Option`.
      */
-    public static func applicative() -> OptionApplicative {
-        return OptionApplicative()
+    public static func applicative() -> ApplicativeInstance {
+        return ApplicativeInstance()
     }
     
     /**
      Obtains an instance of the `Monad` typeclass for `Option`.
      */
-    public static func monad() -> OptionMonad {
-        return OptionMonad()
+    public static func monad() -> MonadInstance {
+        return MonadInstance()
     }
     
     /**
@@ -338,8 +338,8 @@ public extension Option {
      
      - semigroup: An instance of a `Semigroup` for the wrapped type.
      */
-    public static func semigroup<SemiG>(_ semigroup : SemiG) -> OptionSemigroup<A, SemiG> {
-        return OptionSemigroup<A, SemiG>(semigroup)
+    public static func semigroup<SemiG>(_ semigroup : SemiG) -> SemigroupInstance<A, SemiG> {
+        return SemigroupInstance<A, SemiG>(semigroup)
     }
     
     /**
@@ -347,221 +347,220 @@ public extension Option {
      
      - semigroup: An instance of a `Semigroup` for the wrapped type.
      */
-    public static func monoid<SemiG>(_ semigroup : SemiG) -> OptionMonoid<A, SemiG> {
-        return OptionMonoid<A, SemiG>(semigroup)
+    public static func monoid<SemiG>(_ semigroup : SemiG) -> MonoidInstance<A, SemiG> {
+        return MonoidInstance<A, SemiG>(semigroup)
     }
     
     /**
      Obtains an instance of the `ApplicativeError` typeclass for `Option`.
      */
-    public static func applicativeError() -> OptionMonadError {
-        return OptionMonadError()
+    public static func applicativeError() -> MonadErrorInstance {
+        return MonadErrorInstance()
     }
     
     /**
      Obtains an instance of the `MonadError` typeclass for `Option`.
      */
-    public static func monadError() -> OptionMonadError {
-        return OptionMonadError()
+    public static func monadError() -> MonadErrorInstance {
+        return MonadErrorInstance()
     }
     
     /**
      Obtains an instance of the `Eq` typeclass for `Option`.
      */
-    public static func eq<EqA>(_ eqa : EqA) -> OptionEq<A, EqA> {
-        return OptionEq<A, EqA>(eqa)
+    public static func eq<EqA>(_ eqa : EqA) -> EqInstance<A, EqA> {
+        return EqInstance<A, EqA>(eqa)
     }
     
     /**
      Obtains an instance of the `FunctorFilter` typeclass for `Option`.
      */
-    public static func functorFilter() -> OptionFunctorFilter {
-        return OptionFunctorFilter()
+    public static func functorFilter() -> FunctorFilterInstance {
+        return FunctorFilterInstance()
     }
     
     /**
      Obtains an instance of the `MonadFilter` typeclass for `Option`.
      */
-    public static func monadFilter() -> OptionMonadFilter {
-        return OptionMonadFilter()
+    public static func monadFilter() -> MonadFilterInstance {
+        return MonadFilterInstance()
     }
     
     /**
      Obtains an instance of the `Foldable` typeclass for `Option`.
      */
-    public static func foldable() -> OptionFoldable {
-        return OptionFoldable()
+    public static func foldable() -> FoldableInstance {
+        return FoldableInstance()
     }
     
     /**
      Obtains an instance of the `Traverse` typeclass for `Option`.
      */
-    public static func traverse() -> OptionTraverse {
-        return OptionTraverse()
+    public static func traverse() -> TraverseInstance {
+        return TraverseInstance()
     }
     
     /**
      Obtains an instance of the `TraverseFilter` typeclass for `Option`.
      */
-    public static func traverseFilter() -> OptionTraverseFilter {
-        return OptionTraverseFilter()
+    public static func traverseFilter() -> TraverseFilterInstance {
+        return TraverseFilterInstance()
+    }
+
+    /**
+     An instance of the `Functor` typeclass for the `Option` data type.
+     */
+    public class FunctorInstance : Functor {
+        public typealias F = ForOption
+        
+        public func map<A, B>(_ fa: OptionOf<A>, _ f: @escaping (A) -> B) -> OptionOf<B> {
+            return fa.fix().map(f)
+        }
+    }
+
+    /**
+     An instance of the `Applicative` typeclass for the `Option` data type.
+     */
+    public class ApplicativeInstance : FunctorInstance, Applicative {
+        public func pure<A>(_ a: A) -> OptionOf<A> {
+            return Option<A>.pure(a)
+        }
+        
+        public func ap<A, B>(_ ff: OptionOf<(A) -> B>, _ fa: OptionOf<A>) -> OptionOf<B> {
+            return ff.fix().ap(fa.fix())
+        }
+    }
+
+    /**
+     An instance of the `Monad` typeclass for the `Option` data type.
+     */
+    public class MonadInstance : ApplicativeInstance, Monad {
+        public func flatMap<A, B>(_ fa: OptionOf<A>, _ f: @escaping (A) -> OptionOf<B>) -> OptionOf<B> {
+            return fa.fix().flatMap({ a in f(a).fix() })
+        }
+        
+        public func tailRecM<A, B>(_ a: A, _ f: @escaping (A) -> OptionOf<Either<A, B>>) -> OptionOf<B> {
+            return Option<A>.tailRecM(a, { a in f(a).fix() })
+        }
+    }
+
+    /**
+     An instance of the `Semigroup` typeclass for the `Option` data type.
+     */
+    public class SemigroupInstance<R, SemiG> : Semigroup where SemiG : Semigroup, SemiG.A == R {
+        public typealias A = OptionOf<R>
+        private let semigroup : SemiG
+        
+        public init(_ semigroup : SemiG) {
+            self.semigroup = semigroup
+        }
+        
+        public func combine(_ a: OptionOf<R>, _ b: OptionOf<R>) -> OptionOf<R> {
+            let a = Option<R>.fix(a)
+            let b = Option<R>.fix(b)
+            return a.fold(constant(b),
+                          { aSome in b.fold(constant(a),
+                                            { bSome in Option<R>.some(semigroup.combine(aSome, bSome)) })
+                          })
+        }
+    }
+
+    /**
+     An instance of the `Monoid` typeclass for the `Option` data type.
+     */
+    public class MonoidInstance<R, SemiG> : SemigroupInstance<R, SemiG>, Monoid where SemiG : Semigroup, SemiG.A == R {
+        public var empty : OptionOf<R>{
+            return Option<R>.none()
+        }
+    }
+
+    /**
+     An instance of the `MonadError` typeclass for the `Option` data type.
+     */
+    public class MonadErrorInstance : MonadInstance, MonadError {
+        public typealias E = Unit
+        
+        public func raiseError<A>(_ e: Unit) -> OptionOf<A> {
+            return Option<A>.none()
+        }
+        
+        public func handleErrorWith<A>(_ fa: OptionOf<A>, _ f: @escaping (Unit) -> OptionOf<A>) -> OptionOf<A> {
+            return fa.fix().orElse(f(unit).fix())
+        }
+    }
+
+    /**
+     An instance of the `Eq` typeclass for the `Option` data type.
+     */
+    public class EqInstance<R, EqR> : Eq where EqR : Eq, EqR.A == R {
+        public typealias A = OptionOf<R>
+        
+        private let eqr : EqR
+        
+        public init(_ eqr : EqR) {
+            self.eqr = eqr
+        }
+        
+        public func eqv(_ a: OptionOf<R>, _ b: OptionOf<R>) -> Bool {
+            let a = Option<R>.fix(a)
+            let b = Option<R>.fix(b)
+            return a.fold({ b.fold(constant(true), constant(false)) },
+                          { aSome in b.fold(constant(false), { bSome in eqr.eqv(aSome, bSome) })})
+        }
+    }
+
+    /**
+     An instance of the `FunctorFilter` typeclass for the `Option` data type.
+     */
+    public class FunctorFilterInstance : FunctorInstance, FunctorFilter {
+        public func mapFilter<A, B>(_ fa: OptionOf<A>, _ f: @escaping (A) -> OptionOf<B>) -> OptionOf<B> {
+            return fa.fix().mapFilter(f)
+        }
+    }
+
+    /**
+     An instance of the `MonadFilter` typeclass for the `Option` data type.
+     */
+    public class MonadFilterInstance : MonadInstance, MonadFilter {
+        public func empty<A>() -> OptionOf<A> {
+            return Option<A>.empty()
+        }
+        
+        public func mapFilter<A, B>(_ fa: Kind<ForOption, A>, _ f: @escaping (A) -> Kind<ForOption, B>) -> Kind<ForOption, B> {
+            return fa.fix().mapFilter(f)
+        }
+    }
+
+    /**
+     An instance of the `Foldable` typeclass for the `Option` data type.
+     */
+    public class FoldableInstance : Foldable {
+        public typealias F = ForOption
+        
+        public func foldLeft<A, B>(_ fa: Kind<ForOption, A>, _ b: B, _ f: @escaping (B, A) -> B) -> B {
+            return fa.fix().foldLeft(b, f)
+        }
+        
+        public func foldRight<A, B>(_ fa: Kind<ForOption, A>, _ b: Eval<B>, _ f: @escaping (A, Eval<B>) -> Eval<B>) -> Eval<B> {
+            return fa.fix().foldRight(b, f)
+        }
+    }
+
+    /**
+     An instance of the `Traverse` typeclass for the `Option` data type.
+     */
+    public class TraverseInstance : FoldableInstance, Traverse {
+        public func traverse<G, A, B, Appl>(_ fa: Kind<ForOption, A>, _ f: @escaping (A) -> Kind<G, B>, _ applicative: Appl) -> Kind<G, Kind<ForOption, B>> where G == Appl.F, Appl : Applicative {
+            return fa.fix().traverse(f, applicative)
+        }
+    }
+
+    /**
+     An instance of the `TraverseFilter` typeclass for the `Option` data type.
+     */
+    public class TraverseFilterInstance : TraverseInstance, TraverseFilter {
+        public func traverseFilter<A, B, G, Appl>(_ fa: Kind<ForOption, A>, _ f: @escaping (A) -> Kind<G, OptionOf<B>>, _ applicative: Appl) -> Kind<G, Kind<ForOption, B>> where G == Appl.F, Appl : Applicative {
+            return fa.fix().traverseFilter(f, applicative)
+        }
     }
 }
-
-/**
- An instance of the `Functor` typeclass for the `Option` data type.
- */
-public class OptionFunctor : Functor {
-    public typealias F = ForOption
-    
-    public func map<A, B>(_ fa: OptionOf<A>, _ f: @escaping (A) -> B) -> OptionOf<B> {
-        return fa.fix().map(f)
-    }
-}
-
-/**
- An instance of the `Applicative` typeclass for the `Option` data type.
- */
-public class OptionApplicative : OptionFunctor, Applicative {
-    public func pure<A>(_ a: A) -> OptionOf<A> {
-        return Option.pure(a)
-    }
-    
-    public func ap<A, B>(_ ff: OptionOf<(A) -> B>, _ fa: OptionOf<A>) -> OptionOf<B> {
-        return ff.fix().ap(fa.fix())
-    }
-}
-
-/**
- An instance of the `Monad` typeclass for the `Option` data type.
- */
-public class OptionMonad : OptionApplicative, Monad {
-    public func flatMap<A, B>(_ fa: OptionOf<A>, _ f: @escaping (A) -> OptionOf<B>) -> OptionOf<B> {
-        return fa.fix().flatMap({ a in f(a).fix() })
-    }
-    
-    public func tailRecM<A, B>(_ a: A, _ f: @escaping (A) -> OptionOf<Either<A, B>>) -> OptionOf<B> {
-        return Option<A>.tailRecM(a, { a in f(a).fix() })
-    }
-}
-
-/**
- An instance of the `Semigroup` typeclass for the `Option` data type.
- */
-public class OptionSemigroup<R, SemiG> : Semigroup where SemiG : Semigroup, SemiG.A == R {
-    public typealias A = OptionOf<R>
-    private let semigroup : SemiG
-    
-    public init(_ semigroup : SemiG) {
-        self.semigroup = semigroup
-    }
-    
-    public func combine(_ a: OptionOf<R>, _ b: OptionOf<R>) -> OptionOf<R> {
-        let a = Option.fix(a)
-        let b = Option.fix(b)
-        return a.fold(constant(b),
-                      { aSome in b.fold(constant(a),
-                                        { bSome in Option.some(semigroup.combine(aSome, bSome)) })
-                      })
-    }
-}
-
-/**
- An instance of the `Monoid` typeclass for the `Option` data type.
- */
-public class OptionMonoid<R, SemiG> : OptionSemigroup<R, SemiG>, Monoid where SemiG : Semigroup, SemiG.A == R {
-    public var empty : OptionOf<R>{
-        return Option<R>.none()
-    }
-}
-
-/**
- An instance of the `MonadError` typeclass for the `Option` data type.
- */
-public class OptionMonadError : OptionMonad, MonadError {
-    public typealias E = Unit
-    
-    public func raiseError<A>(_ e: Unit) -> OptionOf<A> {
-        return Option<A>.none()
-    }
-    
-    public func handleErrorWith<A>(_ fa: OptionOf<A>, _ f: @escaping (Unit) -> OptionOf<A>) -> OptionOf<A> {
-        return fa.fix().orElse(f(unit).fix())
-    }
-}
-
-/**
- An instance of the `Eq` typeclass for the `Option` data type.
- */
-public class OptionEq<R, EqR> : Eq where EqR : Eq, EqR.A == R {
-    public typealias A = OptionOf<R>
-    
-    private let eqr : EqR
-    
-    public init(_ eqr : EqR) {
-        self.eqr = eqr
-    }
-    
-    public func eqv(_ a: OptionOf<R>, _ b: OptionOf<R>) -> Bool {
-        let a = Option.fix(a)
-        let b = Option.fix(b)
-        return a.fold({ b.fold(constant(true), constant(false)) },
-                      { aSome in b.fold(constant(false), { bSome in eqr.eqv(aSome, bSome) })})
-    }
-}
-
-/**
- An instance of the `FunctorFilter` typeclass for the `Option` data type.
- */
-public class OptionFunctorFilter : OptionFunctor, FunctorFilter {
-    public func mapFilter<A, B>(_ fa: OptionOf<A>, _ f: @escaping (A) -> OptionOf<B>) -> OptionOf<B> {
-        return fa.fix().mapFilter(f)
-    }
-}
-
-/**
- An instance of the `MonadFilter` typeclass for the `Option` data type.
- */
-public class OptionMonadFilter : OptionMonad, MonadFilter {
-    public func empty<A>() -> OptionOf<A> {
-        return Option.empty()
-    }
-    
-    public func mapFilter<A, B>(_ fa: Kind<ForOption, A>, _ f: @escaping (A) -> Kind<ForOption, B>) -> Kind<ForOption, B> {
-        return fa.fix().mapFilter(f)
-    }
-}
-
-/**
- An instance of the `Foldable` typeclass for the `Option` data type.
- */
-public class OptionFoldable : Foldable {
-    public typealias F = ForOption
-    
-    public func foldLeft<A, B>(_ fa: Kind<ForOption, A>, _ b: B, _ f: @escaping (B, A) -> B) -> B {
-        return fa.fix().foldLeft(b, f)
-    }
-    
-    public func foldRight<A, B>(_ fa: Kind<ForOption, A>, _ b: Eval<B>, _ f: @escaping (A, Eval<B>) -> Eval<B>) -> Eval<B> {
-        return fa.fix().foldRight(b, f)
-    }
-}
-
-/**
- An instance of the `Traverse` typeclass for the `Option` data type.
- */
-public class OptionTraverse : OptionFoldable, Traverse {
-    public func traverse<G, A, B, Appl>(_ fa: Kind<ForOption, A>, _ f: @escaping (A) -> Kind<G, B>, _ applicative: Appl) -> Kind<G, Kind<ForOption, B>> where G == Appl.F, Appl : Applicative {
-        return fa.fix().traverse(f, applicative)
-    }
-}
-
-/**
- An instance of the `TraverseFilter` typeclass for the `Option` data type.
- */
-public class OptionTraverseFilter : OptionTraverse, TraverseFilter {
-    public func traverseFilter<A, B, G, Appl>(_ fa: Kind<ForOption, A>, _ f: @escaping (A) -> Kind<G, OptionOf<B>>, _ applicative: Appl) -> Kind<G, Kind<ForOption, B>> where G == Appl.F, Appl : Applicative {
-        return fa.fix().traverseFilter(f, applicative)
-    }
-}
-

--- a/Sources/Bow/Data/SetK.swift
+++ b/Sources/Bow/Data/SetK.swift
@@ -68,53 +68,51 @@ public extension Set {
 
 public extension SetK {
 
-	public static func semigroup() -> SetKSemigroup<A> {
-		return SetKSemigroup()
+	public static func semigroup() -> SemigroupInstance<A> {
+		return SemigroupInstance()
 	}
 
-	public static func monoid() -> SetKMonoid<A> {
-		return SetKMonoid()
+	public static func monoid() -> MonoidInstance<A> {
+		return MonoidInstance()
 	}
 
-	public static func eq<EqA>(_ eqa : EqA) -> SetKEq<A, EqA> {
-		return SetKEq<A, EqA>(eqa)
+	public static func eq<EqA>(_ eqa : EqA) -> EqInstance<A, EqA> {
+		return EqInstance<A, EqA>(eqa)
 	}
+
+    public class SemigroupInstance<R: Hashable>: Semigroup {
+        public typealias A = SetKOf<R>
+
+        public func combine(_ a : SetKOf<R>, _ b : SetKOf<R>) -> SetKOf<R>  {
+            return a.fix().combineK(b.fix())
+        }
+    }
+
+    public class MonoidInstance<R: Hashable>: SemigroupInstance<R>, Monoid {
+        public typealias A = SetKOf<R>
+
+        public var empty: SetKOf<R> {
+            return SetK<R>.empty()
+        }
+    }
+
+    public class EqInstance<R, EqR> : Eq where EqR : Eq, EqR.A == R, EqR.A : Hashable {
+        public typealias A = SetKOf<R>
+
+        private let eqr : EqR
+
+        public init(_ eqr : EqR) {
+            self.eqr = eqr
+        }
+
+        public func eqv(_ setA: SetKOf<R>, _ setB: SetKOf<R>) -> Bool {
+            let a = setA.fix()
+            let b = setB.fix()
+            if a.set.count != b.set.count {
+                return false
+            } else {
+                return a.set.map { aa in b.set.contains{ bb in self.eqr.eqv(aa, bb) }}.reduce(true, and)
+            }
+        }
+    }
 }
-
-public class SetKSemigroup<R: Hashable>: Semigroup {
-	public typealias A = SetKOf<R>
-
-	public func combine(_ a : SetKOf<R>, _ b : SetKOf<R>) -> SetKOf<R>  {
-		return a.fix().combineK(b.fix())
-	}
-}
-
-public class SetKMonoid<R: Hashable>: SetKSemigroup<R>, Monoid {
-	public typealias A = SetKOf<R>
-
-	public var empty: SetKOf<R> {
-		return SetK<R>.empty()
-	}
-}
-
-public class SetKEq<R, EqR> : Eq where EqR : Eq, EqR.A == R, EqR.A : Hashable {
-	public typealias A = SetKOf<R>
-
-	private let eqr : EqR
-
-	public init(_ eqr : EqR) {
-		self.eqr = eqr
-	}
-
-	public func eqv(_ setA: SetKOf<R>, _ setB: SetKOf<R>) -> Bool {
-		let a = setA.fix()
-		let b = setB.fix()
-		if a.set.count != b.set.count {
-			return false
-		} else {
-			return a.set.map { aa in b.set.contains{ bb in self.eqr.eqv(aa, bb) }}.reduce(true, and)
-		}
-	}
-}
-
-

--- a/Sources/Bow/Data/State.swift
+++ b/Sources/Bow/Data/State.swift
@@ -14,19 +14,19 @@ public class State<S, A> : StateOf<S, A> {
 }
 
 public extension State {
-    public static func functor() -> StateTFunctor<ForId, S, IdFunctor> {
+    public static func functor() -> StateTFunctor<ForId, S, Id<A>.FunctorInstance> {
         return StateT<ForId, S, A>.functor(Id<A>.functor())
     }
     
-    public static func applicative() -> StateTApplicative<ForId, S, IdMonad> {
+    public static func applicative() -> StateTApplicative<ForId, S, Id<A>.MonadInstance> {
         return StateT<ForId, S, A>.applicative(Id<A>.monad())
     }
     
-    public static func monad() -> StateTMonad<ForId, S, IdMonad> {
+    public static func monad() -> StateTMonad<ForId, S, Id<A>.MonadInstance> {
         return StateT<ForId, S, A>.monad(Id<A>.monad())
     }
     
-    public static func monadState() -> StateTMonadState<ForId, S, IdMonad> {
+    public static func monadState() -> StateTMonadState<ForId, S, Id<A>.MonadInstance> {
         return StateT<ForId, S, A>.monadState(Id<A>.monad())
     }
 }

--- a/Sources/Bow/Data/Store.swift
+++ b/Sources/Bow/Data/Store.swift
@@ -41,29 +41,29 @@ public class Store<S, V> : StoreOf<S, V> {
 }
 
 public extension Store {
-    public static func functor() -> StoreFunctor<S> {
-        return StoreFunctor<S>()
+    public static func functor() -> FunctorInstance<S> {
+        return FunctorInstance<S>()
     }
     
-    public static func comonad() -> StoreComonad<S> {
-        return StoreComonad<S>()
+    public static func comonad() -> ComonadInstance<S> {
+        return ComonadInstance<S>()
     }
-}
 
-public class StoreFunctor<S> : Functor {
-    public typealias F = StorePartial<S>
-    
-    public func map<A, B>(_ fa: StoreOf<S, A>, _ f: @escaping (A) -> B) -> StoreOf<S, B> {
-        return Store<S, A>.fix(fa).map(f)
+    public class FunctorInstance<S> : Functor {
+        public typealias F = StorePartial<S>
+        
+        public func map<A, B>(_ fa: StoreOf<S, A>, _ f: @escaping (A) -> B) -> StoreOf<S, B> {
+            return Store<S, A>.fix(fa).map(f)
+        }
     }
-}
 
-public class StoreComonad<S> : StoreFunctor<S>, Comonad {
-    public func coflatMap<A, B>(_ fa: StoreOf<S, A>, _ f: @escaping (StoreOf<S, A>) -> B) -> StoreOf<S, B> {
-        return Store<S, A>.fix(fa).coflatMap(f)
-    }
-    
-    public func extract<A>(_ fa: StoreOf<S, A>) -> A {
-        return Store<S, A>.fix(fa).extract()
+    public class ComonadInstance<S> : FunctorInstance<S>, Comonad {
+        public func coflatMap<A, B>(_ fa: StoreOf<S, A>, _ f: @escaping (StoreOf<S, A>) -> B) -> StoreOf<S, B> {
+            return Store<S, A>.fix(fa).coflatMap(f)
+        }
+        
+        public func extract<A>(_ fa: StoreOf<S, A>) -> A {
+            return Store<S, A>.fix(fa).extract()
+        }
     }
 }

--- a/Sources/Bow/Data/Sum.swift
+++ b/Sources/Bow/Data/Sum.swift
@@ -57,49 +57,47 @@ public class Sum<F, G, V> : SumOf<F, G, V> {
 }
 
 public extension Sum {
-    public static func functor<FuncF, FuncG>(_ functorF : FuncF, _ functorG : FuncG) -> SumFunctor<F, G, FuncF, FuncG> {
-        return SumFunctor(functorF, functorG)
+    public static func functor<FuncF, FuncG>(_ functorF : FuncF, _ functorG : FuncG) -> FunctorInstance<F, G, FuncF, FuncG> {
+        return FunctorInstance(functorF, functorG)
     }
     
-    public static func comonad<ComonF, ComonG>(_ comonadF : ComonF, _ comonadG : ComonG) -> SumComonad<F, G, ComonF, ComonG> {
-        return SumComonad(comonadF, comonadG)
+    public static func comonad<ComonF, ComonG>(_ comonadF : ComonF, _ comonadG : ComonG) -> ComonadInstance<F, G, ComonF, ComonG> {
+        return ComonadInstance(comonadF, comonadG)
     }
-}
 
-public class SumFunctor<G, H, FuncG, FuncH> : Functor where FuncG : Functor, FuncG.F == G, FuncH : Functor, FuncH.F == H {
-    public typealias F = SumPartial<G, H>
-    
-    private let functorG : FuncG
-    private let functorH : FuncH
-    
-    public init(_ functorG : FuncG, _ functorH : FuncH) {
-        self.functorG = functorG
-        self.functorH = functorH
+    public class FunctorInstance<G, H, FuncG, FuncH> : Functor where FuncG : Functor, FuncG.F == G, FuncH : Functor, FuncH.F == H {
+        public typealias F = SumPartial<G, H>
+        
+        private let functorG : FuncG
+        private let functorH : FuncH
+        
+        public init(_ functorG : FuncG, _ functorH : FuncH) {
+            self.functorG = functorG
+            self.functorH = functorH
+        }
+        
+        public func map<A, B>(_ fa: SumOf<G, H, A>, _ f: @escaping (A) -> B) -> SumOf<G, H, B> {
+            return Sum<G, H, A>.fix(fa).map(functorG, functorH, f)
+        }
     }
-    
-    public func map<A, B>(_ fa: SumOf<G, H, A>, _ f: @escaping (A) -> B) -> SumOf<G, H, B> {
-        return Sum<G, H, A>.fix(fa).map(functorG, functorH, f)
-    }
-}
 
-public class SumComonad<G, H, ComonG, ComonH> : SumFunctor<G, H, ComonG, ComonH>, Comonad where ComonG : Comonad, ComonG.F == G, ComonH : Comonad, ComonH.F == H {
-    
-    private let comonadG : ComonG
-    private let comonadH : ComonH
-    
-    override public init(_ comonadG : ComonG, _ comonadH : ComonH) {
-        self.comonadG = comonadG
-        self.comonadH = comonadH
-        super.init(comonadG, comonadH)
+    public class ComonadInstance<G, H, ComonG, ComonH> : FunctorInstance<G, H, ComonG, ComonH>, Comonad where ComonG : Comonad, ComonG.F == G, ComonH : Comonad, ComonH.F == H {
+        
+        private let comonadG : ComonG
+        private let comonadH : ComonH
+        
+        override public init(_ comonadG : ComonG, _ comonadH : ComonH) {
+            self.comonadG = comonadG
+            self.comonadH = comonadH
+            super.init(comonadG, comonadH)
+        }
+        
+        public func coflatMap<A, B>(_ fa: SumOf<G, H, A>, _ f: @escaping (SumOf<G, H, A>) -> B) -> SumOf<G, H, B> {
+            return Sum<G, H, A>.fix(fa).coflatMap(comonadG, comonadH, f)
+        }
+        
+        public func extract<A>(_ fa: SumOf<G, H, A>) -> A {
+            return Sum<G, H, A>.fix(fa).extract(comonadG, comonadH)
+        }
     }
-    
-    public func coflatMap<A, B>(_ fa: SumOf<G, H, A>, _ f: @escaping (SumOf<G, H, A>) -> B) -> SumOf<G, H, B> {
-        return Sum<G, H, A>.fix(fa).coflatMap(comonadG, comonadH, f)
-    }
-    
-    public func extract<A>(_ fa: SumOf<G, H, A>) -> A {
-        return Sum<G, H, A>.fix(fa).extract(comonadG, comonadH)
-    }
-    
-    
 }

--- a/Sources/Bow/Data/Tuple.swift
+++ b/Sources/Bow/Data/Tuple.swift
@@ -1,23 +1,23 @@
 import Foundation
 
 public class Tuple<A, B> {
-    public static func eq<EqA, EqB>(_ eqa : EqA, _ eqb : EqB) -> TupleEq<A, B, EqA, EqB> {
-        return TupleEq<A, B, EqA, EqB>(eqa, eqb)
-    }
-}
-
-public class TupleEq<M, N, EqM, EqN> : Eq where EqM : Eq, EqM.A == M, EqN : Eq, EqN.A == N {
-    public typealias A = (M, N)
-    
-    private let eqm : EqM
-    private let eqn : EqN
-    
-    public init(_ eqm : EqM, _ eqn : EqN) {
-        self.eqm = eqm
-        self.eqn = eqn
+    public static func eq<EqA, EqB>(_ eqa : EqA, _ eqb : EqB) -> EqInstance<A, B, EqA, EqB> {
+        return EqInstance<A, B, EqA, EqB>(eqa, eqb)
     }
     
-    public func eqv(_ a: (M, N), _ b: (M, N)) -> Bool {
-        return eqm.eqv(a.0, b.0) && eqn.eqv(a.1, b.1)
+    public class EqInstance<M, N, EqM, EqN> : Eq where EqM : Eq, EqM.A == M, EqN : Eq, EqN.A == N {
+        public typealias A = (M, N)
+        
+        private let eqm : EqM
+        private let eqn : EqN
+        
+        public init(_ eqm : EqM, _ eqn : EqN) {
+            self.eqm = eqm
+            self.eqn = eqn
+        }
+        
+        public func eqv(_ a: (M, N), _ b: (M, N)) -> Bool {
+            return eqm.eqv(a.0, b.0) && eqn.eqv(a.1, b.1)
+        }
     }
 }

--- a/Sources/Bow/Instances/BoolInstances.swift
+++ b/Sources/Bow/Instances/BoolInstances.swift
@@ -1,58 +1,57 @@
 import Foundation
 
-/**
- Instance of `Semigroup` for `Bool`. Uses conjunction as combination of elements.
- */
-public class AndSemigroup : Semigroup {
-    public typealias A = Bool
-    
-    public func combine(_ a: Bool, _ b: Bool) -> Bool {
-        return a && b
-    }
-}
-
-/**
- Instance of `Monoid` for `Bool`. Uses conjunction as combination of elements.
- */
-public class AndMonoid : AndSemigroup, Monoid {
-    public var empty : Bool {
-        return true
-    }
-}
-
-/**
- Instance of `Semigroup` for `Bool`. Uses disjunction as combination of elements.
- */
-public class OrSemigroup : Semigroup {
-    public typealias A = Bool
-    
-    public func combine(_ a: Bool, _ b: Bool) -> Bool {
-        return a || b
-    }
-}
-
-/**
- Instance of `Monoid` for `Bool`. Uses disjunction as combination of elements.
- */
-public class OrMonoid : OrSemigroup, Monoid {
-    public var empty : Bool {
-        return false
-    }
-}
-
-/**
- Instance of `Eq` for `Bool`.
- */
-public class BoolEq : Eq {
-    public typealias A = Bool
-    
-    public func eqv(_ a: Bool, _ b: Bool) -> Bool {
-        return a == b
-    }
-}
-
-// MARK: Typeclass instances
 public extension Bool {
+    /**
+     Instance of `Semigroup` for `Bool`. Uses conjunction as combination of elements.
+     */
+    public class AndSemigroup : Semigroup {
+        public typealias A = Bool
+        
+        public func combine(_ a: Bool, _ b: Bool) -> Bool {
+            return a && b
+        }
+    }
+
+    /**
+     Instance of `Monoid` for `Bool`. Uses conjunction as combination of elements.
+     */
+    public class AndMonoid : AndSemigroup, Monoid {
+        public var empty : Bool {
+            return true
+        }
+    }
+
+    /**
+     Instance of `Semigroup` for `Bool`. Uses disjunction as combination of elements.
+     */
+    public class OrSemigroup : Semigroup {
+        public typealias A = Bool
+        
+        public func combine(_ a: Bool, _ b: Bool) -> Bool {
+            return a || b
+        }
+    }
+
+    /**
+     Instance of `Monoid` for `Bool`. Uses disjunction as combination of elements.
+     */
+    public class OrMonoid : OrSemigroup, Monoid {
+        public var empty : Bool {
+            return false
+        }
+    }
+
+    /**
+     Instance of `Eq` for `Bool`.
+     */
+    public class BoolEq : Eq {
+        public typealias A = Bool
+        
+        public func eqv(_ a: Bool, _ b: Bool) -> Bool {
+            return a == b
+        }
+    }
+
     /**
      Provides an instance of `Semigroup` for `Bool`, using conjunction.
      */

--- a/Sources/Bow/Instances/NumberInstances.swift
+++ b/Sources/Bow/Instances/NumberInstances.swift
@@ -374,96 +374,95 @@ public extension Int32 {
 }
 
 // MARK: Int64 instances
-
-/**
- Instance of `Semigroup` for the `Int64` primitive type, with sum as combination method.
- */
-public class Int64SumSemigroup : Semigroup {
-    public typealias A = Int64
-    
-    public func combine(_ a : Int64, _ b : Int64) -> Int64 {
-        return a.addingReportingOverflow(b).partialValue
-    }
-}
-
-/**
- Instance of `Monoid` for the `Int64` primitive type, with sum as combination method.
- */
-public class Int64SumMonoid : Int64SumSemigroup, Monoid {
-    public var empty : Int64 {
-        return 0
-    }
-}
-
-/**
- Instance of `Semigroup` for the `Int64` primitive type, with product as combination method.
- */
-public class Int64ProductSemigroup : Semigroup {
-    public typealias A = Int64
-    
-    public func combine(_ a : Int64, _ b : Int64) -> Int64 {
-        return a.multipliedReportingOverflow(by: b).partialValue
-    }
-}
-
-/**
- Instance of `Monoid` for the `Int64` primitive type, with product as combination method.
- */
-public class Int64ProductMonoid : Int64ProductSemigroup, Monoid {
-    public var empty : Int64 {
-        return 1
-    }
-}
-
-/**
- Instance of `Eq` for the `Int64` primitive type.
- */
-public class Int64Eq : Eq {
-    public typealias A = Int64
-    
-    public func eqv(_ a: Int64, _ b: Int64) -> Bool {
-        return a == b
-    }
-}
-
-/**
- Instance of `Order` for the `Int64` primitive type.
- */
-public class Int64Order : Int64Eq, Order {
-    public func compare(_ a: Int64, _ b: Int64) -> Int {
-        return Int(a) - Int(b)
-    }
-}
-
 public extension Int64 {
+    /**
+     Instance of `Semigroup` for the `Int64` primitive type, with sum as combination method.
+     */
+    public class SumSemigroupInstance : Semigroup {
+        public typealias A = Int64
+        
+        public func combine(_ a : Int64, _ b : Int64) -> Int64 {
+            return a.addingReportingOverflow(b).partialValue
+        }
+    }
+
+    /**
+     Instance of `Monoid` for the `Int64` primitive type, with sum as combination method.
+     */
+    public class SumMonoidInstance : SumSemigroupInstance, Monoid {
+        public var empty : Int64 {
+            return 0
+        }
+    }
+
+    /**
+     Instance of `Semigroup` for the `Int64` primitive type, with product as combination method.
+     */
+    public class ProductSemigroupInstance : Semigroup {
+        public typealias A = Int64
+        
+        public func combine(_ a : Int64, _ b : Int64) -> Int64 {
+            return a.multipliedReportingOverflow(by: b).partialValue
+        }
+    }
+
+    /**
+     Instance of `Monoid` for the `Int64` primitive type, with product as combination method.
+     */
+    public class ProductMonoidInstance : ProductSemigroupInstance, Monoid {
+        public var empty : Int64 {
+            return 1
+        }
+    }
+
+    /**
+     Instance of `Eq` for the `Int64` primitive type.
+     */
+    public class EqInstance : Eq {
+        public typealias A = Int64
+        
+        public func eqv(_ a: Int64, _ b: Int64) -> Bool {
+            return a == b
+        }
+    }
+
+    /**
+     Instance of `Order` for the `Int64` primitive type.
+     */
+    public class OrderInstance : EqInstance, Order {
+        public func compare(_ a: Int64, _ b: Int64) -> Int {
+            return Int(a) - Int(b)
+        }
+    }
+
     /// Provides an instance of `Semigroup`, with sum as combination method.
-    public static var sumSemigroup : Int64SumSemigroup {
-        return Int64SumSemigroup()
+    public static var sumSemigroup : SumSemigroupInstance {
+        return SumSemigroupInstance()
     }
     
     /// Provides an instance of `Monoid`, with sum as combination method.
-    public static var sumMonoid : Int64SumMonoid {
-        return Int64SumMonoid()
+    public static var sumMonoid : SumMonoidInstance {
+        return SumMonoidInstance()
     }
     
     /// Provides an instance of `Semigroup`, with product as combination method.
-    public static var productSemigroup : Int64ProductSemigroup {
-        return Int64ProductSemigroup()
+    public static var productSemigroup : ProductSemigroupInstance {
+        return ProductSemigroupInstance()
     }
     
     /// Provides an instance of `Monoid`, with product as combination method.
-    public static var productMonoid : Int64ProductMonoid {
-        return Int64ProductMonoid()
+    public static var productMonoid : ProductMonoidInstance {
+        return ProductMonoidInstance()
     }
     
     /// Provides an instance of `Eq`.
-    public static var eq : Int64Eq {
-        return Int64Eq()
+    public static var eq : EqInstance {
+        return EqInstance()
     }
     
     /// Provides an instance of `Order`.
-    public static var order : Int64Order {
-        return Int64Order()
+    public static var order : OrderInstance {
+        return OrderInstance()
     }
 }
 

--- a/Sources/Bow/Instances/NumberInstances.swift
+++ b/Sources/Bow/Instances/NumberInstances.swift
@@ -663,101 +663,100 @@ public extension UInt8 {
 }
 
 // MARK: UInt16 instances
-
-/**
- Instance of `Semigroup` for the `UInt16` primitive type, with sum as combination method.
- */
-public class UInt16SumSemigroup : Semigroup {
-    public typealias A = UInt16
-    
-    public func combine(_ a : UInt16, _ b : UInt16) -> UInt16 {
-        return a.addingReportingOverflow(b).partialValue
+public extension UInt16 {
+    /**
+     Instance of `Semigroup` for the `UInt16` primitive type, with sum as combination method.
+     */
+    public class SumSemigroupInstance : Semigroup {
+        public typealias A = UInt16
+        
+        public func combine(_ a : UInt16, _ b : UInt16) -> UInt16 {
+            return a.addingReportingOverflow(b).partialValue
+        }
     }
-}
 
-/**
- Instance of `Monoid` for the `UInt16` primitive type, with sum as combination method.
- */
-public class UInt16SumMonoid : UInt16SumSemigroup, Monoid {
-    public var empty : UInt16 {
-        return 0
+    /**
+     Instance of `Monoid` for the `UInt16` primitive type, with sum as combination method.
+     */
+    public class SumMonoidInstance : SumSemigroupInstance, Monoid {
+        public var empty : UInt16 {
+            return 0
+        }
     }
-}
 
-/**
- Instance of `Semigroup` for the `UInt16` primitive type, with product as combination method.
- */
-public class UInt16ProductSemigroup : Semigroup {
-    public typealias A = UInt16
-    
-    public func combine(_ a : UInt16, _ b : UInt16) -> UInt16 {
-        return a.multipliedReportingOverflow(by: b).partialValue
+    /**
+     Instance of `Semigroup` for the `UInt16` primitive type, with product as combination method.
+     */
+    public class ProductSemigroupInstance : Semigroup {
+        public typealias A = UInt16
+        
+        public func combine(_ a : UInt16, _ b : UInt16) -> UInt16 {
+            return a.multipliedReportingOverflow(by: b).partialValue
+        }
     }
-}
 
-/**
- Instance of `Monoid` for the `UInt16` primitive type, with product as combination method.
- */
-public class UInt16ProductMonoid : UInt16ProductSemigroup, Monoid {
-    public var empty : UInt16 {
-        return 1
-    }
-}
-
-/**
- Instance of `Eq` for the `UInt16` primitive type.
- */
-public class UInt16Eq : Eq {
-    public typealias A = UInt16
-    
-    public func eqv(_ a: UInt16, _ b: UInt16) -> Bool {
-        return a == b
-    }
-}
-
-/**
- Instance of `Order` for the `UInt16` primitive type.
- */
-public class UInt16Order : UInt16Eq, Order {
-    public func compare(_ a: UInt16, _ b: UInt16) -> Int {
-        if a < b {
-            return -1
-        } else if a > b {
+    /**
+     Instance of `Monoid` for the `UInt16` primitive type, with product as combination method.
+     */
+    public class ProductMonoidInstance : ProductSemigroupInstance, Monoid {
+        public var empty : UInt16 {
             return 1
         }
-        return 0
     }
-}
 
-public extension UInt16 {
+    /**
+     Instance of `Eq` for the `UInt16` primitive type.
+     */
+    public class EqInstance : Eq {
+        public typealias A = UInt16
+        
+        public func eqv(_ a: UInt16, _ b: UInt16) -> Bool {
+            return a == b
+        }
+    }
+
+    /**
+     Instance of `Order` for the `UInt16` primitive type.
+     */
+    public class OrderInstance : EqInstance, Order {
+        public func compare(_ a: UInt16, _ b: UInt16) -> Int {
+            if a < b {
+                return -1
+            } else if a > b {
+                return 1
+            }
+            return 0
+        }
+    }
+
     /// Provides an instance of `Semigroup`, with sum as combination method.
-    public static var sumSemigroup : UInt16SumSemigroup {
-        return UInt16SumSemigroup()
+    public static var sumSemigroup : SumSemigroupInstance {
+        return SumSemigroupInstance()
     }
     
     /// Provides an instance of `Monoid`, with sum as combination method.
-    public static var sumMonoid : UInt16SumMonoid {
-        return UInt16SumMonoid()
+    public static var sumMonoid : SumMonoidInstance {
+        return SumMonoidInstance()
     }
     
     /// Provides an instance of `Semigroup`, with product as combination method.
-    public static var productSemigroup : UInt16ProductSemigroup {
-        return UInt16ProductSemigroup()
+    public static var productSemigroup : ProductSemigroupInstance {
+        return ProductSemigroupInstance()
     }
     
     /// Provides an instance of `Monoid`, with product as combination method.
-    public static var productMonoid : UInt16ProductMonoid {
-        return UInt16ProductMonoid()
+    public static var productMonoid : ProductMonoidInstance {
+        return ProductMonoidInstance()
     }
     
     /// Provides an instance of `Eq`.
-    public static var eq : UInt16Eq {
-        return UInt16Eq()
+    public static var eq : EqInstance {
+        return EqInstance()
     }
     
     /// Provides an instance of `Order`.
-    public static var order : UInt16Order {
-        return UInt16Order()
+    public static var order : OrderInstance {
+        return OrderInstance()
     }
 }
 

--- a/Sources/Bow/Instances/NumberInstances.swift
+++ b/Sources/Bow/Instances/NumberInstances.swift
@@ -761,101 +761,100 @@ public extension UInt16 {
 }
 
 // MARK: UInt32 instances
-
-/**
- Instance of `Semigroup` for the `UInt32` primitive type, with sum as combination method.
- */
-public class UInt32SumSemigroup : Semigroup {
-    public typealias A = UInt32
-    
-    public func combine(_ a : UInt32, _ b : UInt32) -> UInt32 {
-        return a.addingReportingOverflow(b).partialValue
+public extension UInt32 {
+    /**
+     Instance of `Semigroup` for the `UInt32` primitive type, with sum as combination method.
+     */
+    public class SumSemigroupInstance : Semigroup {
+        public typealias A = UInt32
+        
+        public func combine(_ a : UInt32, _ b : UInt32) -> UInt32 {
+            return a.addingReportingOverflow(b).partialValue
+        }
     }
-}
 
-/**
- Instance of `Monoid` for the `UInt32` primitive type, with sum as combination method.
- */
-public class UInt32SumMonoid : UInt32SumSemigroup, Monoid {
-    public var empty : UInt32 {
-        return 0
+    /**
+     Instance of `Monoid` for the `UInt32` primitive type, with sum as combination method.
+     */
+    public class SumMonoidInstance : SumSemigroupInstance, Monoid {
+        public var empty : UInt32 {
+            return 0
+        }
     }
-}
 
-/**
- Instance of `Semigroup` for the `UInt32` primitive type, with product as combination method.
- */
-public class UInt32ProductSemigroup : Semigroup {
-    public typealias A = UInt32
-    
-    public func combine(_ a : UInt32, _ b : UInt32) -> UInt32 {
-        return a.multipliedReportingOverflow(by: b).partialValue
+    /**
+     Instance of `Semigroup` for the `UInt32` primitive type, with product as combination method.
+     */
+    public class ProductSemigroupInstance : Semigroup {
+        public typealias A = UInt32
+        
+        public func combine(_ a : UInt32, _ b : UInt32) -> UInt32 {
+            return a.multipliedReportingOverflow(by: b).partialValue
+        }
     }
-}
 
-/**
- Instance of `Monoid` for the `UInt32` primitive type, with product as combination method.
- */
-public class UInt32ProductMonoid : UInt32ProductSemigroup, Monoid {
-    public var empty : UInt32 {
-        return 1
-    }
-}
-
-/**
- Instance of `Eq` for the `UInt32` primitive type.
- */
-public class UInt32Eq : Eq {
-    public typealias A = UInt32
-    
-    public func eqv(_ a: UInt32, _ b: UInt32) -> Bool {
-        return a == b
-    }
-}
-
-/**
- Instance of `Order` for the `UInt32` primitive type.
- */
-public class UInt32Order : UInt32Eq, Order {
-    public func compare(_ a: UInt32, _ b: UInt32) -> Int {
-        if a < b {
-            return -1
-        } else if a > b {
+    /**
+     Instance of `Monoid` for the `UInt32` primitive type, with product as combination method.
+     */
+    public class ProductMonoidInstance : ProductSemigroupInstance, Monoid {
+        public var empty : UInt32 {
             return 1
         }
-        return 0
     }
-}
 
-public extension UInt32 {
+    /**
+     Instance of `Eq` for the `UInt32` primitive type.
+     */
+    public class EqInstance : Eq {
+        public typealias A = UInt32
+        
+        public func eqv(_ a: UInt32, _ b: UInt32) -> Bool {
+            return a == b
+        }
+    }
+
+    /**
+     Instance of `Order` for the `UInt32` primitive type.
+     */
+    public class OrderInstance : EqInstance, Order {
+        public func compare(_ a: UInt32, _ b: UInt32) -> Int {
+            if a < b {
+                return -1
+            } else if a > b {
+                return 1
+            }
+            return 0
+        }
+    }
+
     /// Provides an instance of `Semigroup`, with sum as combination method.
-    public static var sumSemigroup : UInt32SumSemigroup {
-        return UInt32SumSemigroup()
+    public static var sumSemigroup : SumSemigroupInstance {
+        return SumSemigroupInstance()
     }
     
     /// Provides an instance of `Monoid`, with sum as combination method.
-    public static var sumMonoid : UInt32SumMonoid {
-        return UInt32SumMonoid()
+    public static var sumMonoid : SumMonoidInstance {
+        return SumMonoidInstance()
     }
     
     /// Provides an instance of `Semigroup`, with product as combination method.
-    public static var productSemigroup : UInt32ProductSemigroup {
-        return UInt32ProductSemigroup()
+    public static var productSemigroup : ProductSemigroupInstance {
+        return ProductSemigroupInstance()
     }
     
     /// Provides an instance of `Monoid`, with product as combination method.
-    public static var productMonoid : UInt32ProductMonoid {
-        return UInt32ProductMonoid()
+    public static var productMonoid : ProductMonoidInstance {
+        return ProductMonoidInstance()
     }
     
     /// Provides an instance of `Eq`.
-    public static var eq : UInt32Eq {
-        return UInt32Eq()
+    public static var eq : EqInstance {
+        return EqInstance()
     }
     
     /// Provides an instance of `Order`.
-    public static var order : UInt32Order {
-        return UInt32Order()
+    public static var order : OrderInstance {
+        return OrderInstance()
     }
 }
 

--- a/Sources/Bow/Instances/NumberInstances.swift
+++ b/Sources/Bow/Instances/NumberInstances.swift
@@ -467,101 +467,100 @@ public extension Int64 {
 }
 
 // MARK: UInt instances
-
-/**
- Instance of `Semigroup` for the `UInt` primitive type, with sum as combination method.
- */
-public class UIntSumSemigroup : Semigroup {
-    public typealias A = UInt
-    
-    public func combine(_ a : UInt, _ b : UInt) -> UInt {
-        return a + b
+public extension UInt {
+    /**
+     Instance of `Semigroup` for the `UInt` primitive type, with sum as combination method.
+     */
+    public class SumSemigroupInstance : Semigroup {
+        public typealias A = UInt
+        
+        public func combine(_ a : UInt, _ b : UInt) -> UInt {
+            return a + b
+        }
     }
-}
 
-/**
- Instance of `Monoid` for the `UInt` primitive type, with sum as combination method.
- */
-public class UIntSumMonoid : UIntSumSemigroup, Monoid {
-    public var empty : UInt {
-        return 0
+    /**
+     Instance of `Monoid` for the `UInt` primitive type, with sum as combination method.
+     */
+    public class SumMonoidInstance : SumSemigroupInstance, Monoid {
+        public var empty : UInt {
+            return 0
+        }
     }
-}
 
-/**
- Instance of `Semigroup` for the `UInt` primitive type, with product as combination method.
- */
-public class UIntProductSemigroup : Semigroup {
-    public typealias A = UInt
-    
-    public func combine(_ a : UInt, _ b : UInt) -> UInt {
-        return a * b
+    /**
+     Instance of `Semigroup` for the `UInt` primitive type, with product as combination method.
+     */
+    public class ProductSemigroupInstance : Semigroup {
+        public typealias A = UInt
+        
+        public func combine(_ a : UInt, _ b : UInt) -> UInt {
+            return a * b
+        }
     }
-}
 
-/**
- Instance of `Monoid` for the `UInt` primitive type, with product as combination method.
- */
-public class UIntProductMonoid : UIntProductSemigroup, Monoid {
-    public var empty : UInt {
-        return 1
-    }
-}
-
-/**
- Instance of `Eq` for the `UInt` primitive type.
- */
-public class UIntEq : Eq {
-    public typealias A = UInt
-    
-    public func eqv(_ a: UInt, _ b: UInt) -> Bool {
-        return a == b
-    }
-}
-
-/**
- Instance of `Order` for the `UInt` primitive type.
- */
-public class UIntOrder : UIntEq, Order {
-    public func compare(_ a: UInt, _ b: UInt) -> Int {
-        if a < b {
-            return -1
-        } else if a > b {
+    /**
+     Instance of `Monoid` for the `UInt` primitive type, with product as combination method.
+     */
+    public class ProductMonoidInstance : ProductSemigroupInstance, Monoid {
+        public var empty : UInt {
             return 1
         }
-        return 0
     }
-}
 
-public extension UInt {
+    /**
+     Instance of `Eq` for the `UInt` primitive type.
+     */
+    public class EqInstance : Eq {
+        public typealias A = UInt
+        
+        public func eqv(_ a: UInt, _ b: UInt) -> Bool {
+            return a == b
+        }
+    }
+
+    /**
+     Instance of `Order` for the `UInt` primitive type.
+     */
+    public class OrderInstance : EqInstance, Order {
+        public func compare(_ a: UInt, _ b: UInt) -> Int {
+            if a < b {
+                return -1
+            } else if a > b {
+                return 1
+            }
+            return 0
+        }
+    }
+
     /// Provides an instance of `Semigroup`, with sum as combination method.
-    public static var sumSemigroup : UIntSumSemigroup {
-        return UIntSumSemigroup()
+    public static var sumSemigroup : SumSemigroupInstance {
+        return SumSemigroupInstance()
     }
     
     /// Provides an instance of `Monoid`, with sum as combination method.
-    public static var sumMonoid : UIntSumMonoid {
-        return UIntSumMonoid()
+    public static var sumMonoid : SumMonoidInstance {
+        return SumMonoidInstance()
     }
     
     /// Provides an instance of `Semigroup`, with product as combination method.
-    public static var productSemigroup : UIntProductSemigroup {
-        return UIntProductSemigroup()
+    public static var productSemigroup : ProductSemigroupInstance {
+        return ProductSemigroupInstance()
     }
     
     /// Provides an instance of `Monoid`, with product as combination method.
-    public static var productMonoid : UIntProductMonoid {
-        return UIntProductMonoid()
+    public static var productMonoid : ProductMonoidInstance {
+        return ProductMonoidInstance()
     }
     
     /// Provides an instance of `Eq`.
-    public static var eq : UIntEq {
-        return UIntEq()
+    public static var eq : EqInstance {
+        return EqInstance()
     }
     
     /// Provides an instance of `Order`.
-    public static var order : UIntOrder {
-        return UIntOrder()
+    public static var order : OrderInstance {
+        return OrderInstance()
     }
 }
 
@@ -644,8 +643,8 @@ public extension UInt8 {
     }
     
     /// Provides an instance of `Semigroup`, with product as combination method.
-    public static var productSemigroup : UIntProductSemigroup {
-        return UIntProductSemigroup()
+    public static var productSemigroup : UInt8ProductSemigroup {
+        return UInt8ProductSemigroup()
     }
     
     /// Provides an instance of `Monoid`, with product as combination method.

--- a/Sources/Bow/Instances/NumberInstances.swift
+++ b/Sources/Bow/Instances/NumberInstances.swift
@@ -565,101 +565,100 @@ public extension UInt {
 }
 
 // MARK: UInt8 instances
-
-/**
- Instance of `Semigroup` for the `UInt8` primitive type, with sum as combination method.
- */
-public class UInt8SumSemigroup : Semigroup {
-    public typealias A = UInt8
-    
-    public func combine(_ a : UInt8, _ b : UInt8) -> UInt8 {
-        return a.addingReportingOverflow(b).partialValue
+public extension UInt8 {
+    /**
+     Instance of `Semigroup` for the `UInt8` primitive type, with sum as combination method.
+     */
+    public class SumSemigroupInstance : Semigroup {
+        public typealias A = UInt8
+        
+        public func combine(_ a : UInt8, _ b : UInt8) -> UInt8 {
+            return a.addingReportingOverflow(b).partialValue
+        }
     }
-}
 
-/**
- Instance of `Monoid` for the `UInt8` primitive type, with sum as combination method.
- */
-public class UInt8SumMonoid : UInt8SumSemigroup, Monoid {
-    public var empty : UInt8 {
-        return 0
+    /**
+     Instance of `Monoid` for the `UInt8` primitive type, with sum as combination method.
+     */
+    public class SumMonoidInstance : SumSemigroupInstance, Monoid {
+        public var empty : UInt8 {
+            return 0
+        }
     }
-}
 
-/**
- Instance of `Semigroup` for the `UInt8` primitive type, with product as combination method.
- */
-public class UInt8ProductSemigroup : Semigroup {
-    public typealias A = UInt8
-    
-    public func combine(_ a : UInt8, _ b : UInt8) -> UInt8 {
-        return a.multipliedReportingOverflow(by: b).partialValue
+    /**
+     Instance of `Semigroup` for the `UInt8` primitive type, with product as combination method.
+     */
+    public class ProductSemigroupInstance : Semigroup {
+        public typealias A = UInt8
+        
+        public func combine(_ a : UInt8, _ b : UInt8) -> UInt8 {
+            return a.multipliedReportingOverflow(by: b).partialValue
+        }
     }
-}
 
-/**
- Instance of `Monoid` for the `UInt8` primitive type, with product as combination method.
- */
-public class UInt8ProductMonoid : UInt8ProductSemigroup, Monoid {
-    public var empty : UInt8 {
-        return 1
-    }
-}
-
-/**
- Instance of `Eq` for the `UInt8` primitive type.
- */
-public class UInt8Eq : Eq {
-    public typealias A = UInt8
-    
-    public func eqv(_ a: UInt8, _ b: UInt8) -> Bool {
-        return a == b
-    }
-}
-
-/**
- Instance of `Order` for the `UInt8` primitive type.
- */
-public class UInt8Order : UInt8Eq, Order {
-    public func compare(_ a: UInt8, _ b: UInt8) -> Int {
-        if a < b {
-            return -1
-        } else if a > b {
+    /**
+     Instance of `Monoid` for the `UInt8` primitive type, with product as combination method.
+     */
+    public class ProductMonoidInstance : ProductSemigroupInstance, Monoid {
+        public var empty : UInt8 {
             return 1
         }
-        return 0
     }
-}
 
-public extension UInt8 {
+    /**
+     Instance of `Eq` for the `UInt8` primitive type.
+     */
+    public class EqInstance : Eq {
+        public typealias A = UInt8
+        
+        public func eqv(_ a: UInt8, _ b: UInt8) -> Bool {
+            return a == b
+        }
+    }
+
+    /**
+     Instance of `Order` for the `UInt8` primitive type.
+     */
+    public class OrderInstance : EqInstance, Order {
+        public func compare(_ a: UInt8, _ b: UInt8) -> Int {
+            if a < b {
+                return -1
+            } else if a > b {
+                return 1
+            }
+            return 0
+        }
+    }
+
     /// Provides an instance of `Semigroup`, with sum as combination method.
-    public static var sumSemigroup : UInt8SumSemigroup {
-        return UInt8SumSemigroup()
+    public static var sumSemigroup : SumSemigroupInstance {
+        return SumSemigroupInstance()
     }
     
     /// Provides an instance of `Monoid`, with sum as combination method.
-    public static var sumMonoid : UInt8SumMonoid {
-        return UInt8SumMonoid()
+    public static var sumMonoid : SumMonoidInstance {
+        return SumMonoidInstance()
     }
     
     /// Provides an instance of `Semigroup`, with product as combination method.
-    public static var productSemigroup : UInt8ProductSemigroup {
-        return UInt8ProductSemigroup()
+    public static var productSemigroup : ProductSemigroupInstance {
+        return ProductSemigroupInstance()
     }
     
     /// Provides an instance of `Monoid`, with product as combination method.
-    public static var productMonoid : UInt8ProductMonoid {
-        return UInt8ProductMonoid()
+    public static var productMonoid : ProductMonoidInstance {
+        return ProductMonoidInstance()
     }
     
     /// Provides an instance of `Eq`.
-    public static var eq : UInt8Eq {
-        return UInt8Eq()
+    public static var eq : EqInstance {
+        return EqInstance()
     }
     
     /// Provides an instance of `Order`.
-    public static var order : UInt8Order {
-        return UInt8Order()
+    public static var order : OrderInstance {
+        return OrderInstance()
     }
 }
 

--- a/Sources/Bow/Instances/NumberInstances.swift
+++ b/Sources/Bow/Instances/NumberInstances.swift
@@ -1055,100 +1055,99 @@ public extension Float {
 }
 
 // MARK: Double instances
-
-/**
- Instance of `Semigroup` for the `Double` primitive type, with sum as combination method.
- */
-public class DoubleSumSemigroup : Semigroup {
-    public typealias A = Double
-    
-    public func combine(_ a : Double, _ b : Double) -> Double {
-        return a + b
+public extension Double {
+    /**
+     Instance of `Semigroup` for the `Double` primitive type, with sum as combination method.
+     */
+    public class SumSemigroupInstance : Semigroup {
+        public typealias A = Double
+        
+        public func combine(_ a : Double, _ b : Double) -> Double {
+            return a + b
+        }
     }
-}
 
-/**
- Instance of `Monoid` for the `Double` primitive type, with sum as combination method.
- */
-public class DoubleSumMonoid : DoubleSumSemigroup, Monoid {
-    public var empty : Double {
-        return 0
+    /**
+     Instance of `Monoid` for the `Double` primitive type, with sum as combination method.
+     */
+    public class SumMonoidInstance : SumSemigroupInstance, Monoid {
+        public var empty : Double {
+            return 0
+        }
     }
-}
 
-/**
- Instance of `Semigroup` for the `Double` primitive type, with product as combination method.
- */
-public class DoubleProductSemigroup : Semigroup {
-    public typealias A = Double
-    
-    public func combine(_ a : Double, _ b : Double) -> Double {
-        return a * b
+    /**
+     Instance of `Semigroup` for the `Double` primitive type, with product as combination method.
+     */
+    public class ProductSemigroupInstance : Semigroup {
+        public typealias A = Double
+        
+        public func combine(_ a : Double, _ b : Double) -> Double {
+            return a * b
+        }
     }
-}
 
-/**
- Instance of `Monoid` for the `Double` primitive type, with product as combination method.
- */
-public class DoubleProductMonoid : DoubleProductSemigroup, Monoid {
-    public var empty : Double {
-        return 1
-    }
-}
-
-/**
- Instance of `Eq` for the `Double` primitive type.
- */
-public class DoubleEq : Eq {
-    public typealias A = Double
-    
-    public func eqv(_ a: Double, _ b: Double) -> Bool {
-        return a.isEqual(to: b)
-    }
-}
-
-/**
- Instance of `Order` for the `Double` primitive type.
- */
-public class DoubleOrder : DoubleEq, Order {
-    public func compare(_ a: Double, _ b: Double) -> Int {
-        if a < b {
-            return -1
-        } else if a > b {
+    /**
+     Instance of `Monoid` for the `Double` primitive type, with product as combination method.
+     */
+    public class ProductMonoidInstance : ProductSemigroupInstance, Monoid {
+        public var empty : Double {
             return 1
         }
-        return 0
     }
-}
 
-public extension Double {
+    /**
+     Instance of `Eq` for the `Double` primitive type.
+     */
+    public class EqInstance : Eq {
+        public typealias A = Double
+        
+        public func eqv(_ a: Double, _ b: Double) -> Bool {
+            return a.isEqual(to: b)
+        }
+    }
+
+    /**
+     Instance of `Order` for the `Double` primitive type.
+     */
+    public class OrderInstance : EqInstance, Order {
+        public func compare(_ a: Double, _ b: Double) -> Int {
+            if a < b {
+                return -1
+            } else if a > b {
+                return 1
+            }
+            return 0
+        }
+    }
+
     /// Provides an instance of `Semigroup`, with sum as combination method.
-    public static var sumSemigroup : DoubleSumSemigroup {
-        return DoubleSumSemigroup()
+    public static var sumSemigroup : SumSemigroupInstance {
+        return SumSemigroupInstance()
     }
     
     /// Provides an instance of `Monoid`, with sum as combination method.
-    public static var sumMonoid : DoubleSumMonoid {
-        return DoubleSumMonoid()
+    public static var sumMonoid : SumMonoidInstance {
+        return SumMonoidInstance()
     }
     
     /// Provides an instance of `Semigroup`, with product as combination method.
-    public static var productSemigroup : DoubleProductSemigroup {
-        return DoubleProductSemigroup()
+    public static var productSemigroup : ProductSemigroupInstance {
+        return ProductSemigroupInstance()
     }
     
     /// Provides an instance of `Monoid`, with product as combination method.
-    public static var productMonoid : DoubleProductMonoid {
-        return DoubleProductMonoid()
+    public static var productMonoid : ProductMonoidInstance {
+        return ProductMonoidInstance()
     }
     
     /// Provides an instance of `Eq`.
-    public static var eq : DoubleEq {
-        return DoubleEq()
+    public static var eq : EqInstance {
+        return EqInstance()
     }
     
     /// Provides an instance of `Order`.
-    public static var order : DoubleOrder {
-        return DoubleOrder()
+    public static var order : OrderInstance {
+        return OrderInstance()
     }
 }

--- a/Sources/Bow/Instances/NumberInstances.swift
+++ b/Sources/Bow/Instances/NumberInstances.swift
@@ -859,101 +859,100 @@ public extension UInt32 {
 }
 
 // MARK: UInt64 instances
-
-/**
- Instance of `Semigroup` for the `UInt64` primitive type, with sum as combination method.
- */
-public class UInt64SumSemigroup : Semigroup {
-    public typealias A = UInt64
-    
-    public func combine(_ a : UInt64, _ b : UInt64) -> UInt64 {
-        return a.addingReportingOverflow(b).partialValue
+public extension UInt64 {
+    /**
+     Instance of `Semigroup` for the `UInt64` primitive type, with sum as combination method.
+     */
+    public class SumSemigroupInstance : Semigroup {
+        public typealias A = UInt64
+        
+        public func combine(_ a : UInt64, _ b : UInt64) -> UInt64 {
+            return a.addingReportingOverflow(b).partialValue
+        }
     }
-}
 
-/**
- Instance of `Monoid` for the `UInt64` primitive type, with sum as combination method.
- */
-public class UInt64SumMonoid : UInt64SumSemigroup, Monoid {
-    public var empty : UInt64 {
-        return 0
+    /**
+     Instance of `Monoid` for the `UInt64` primitive type, with sum as combination method.
+     */
+    public class SumMonoidInstance : SumSemigroupInstance, Monoid {
+        public var empty : UInt64 {
+            return 0
+        }
     }
-}
 
-/**
- Instance of `Semigroup` for the `UInt64` primitive type, with product as combination method.
- */
-public class UInt64ProductSemigroup : Semigroup {
-    public typealias A = UInt64
-    
-    public func combine(_ a : UInt64, _ b : UInt64) -> UInt64 {
-        return a.multipliedReportingOverflow(by: b).partialValue
+    /**
+     Instance of `Semigroup` for the `UInt64` primitive type, with product as combination method.
+     */
+    public class ProductSemigroupInstance : Semigroup {
+        public typealias A = UInt64
+        
+        public func combine(_ a : UInt64, _ b : UInt64) -> UInt64 {
+            return a.multipliedReportingOverflow(by: b).partialValue
+        }
     }
-}
 
-/**
- Instance of `Monoid` for the `UInt64` primitive type, with product as combination method.
- */
-public class UInt64ProductMonoid : UInt64ProductSemigroup, Monoid {
-    public var empty : UInt64 {
-        return 1
-    }
-}
-
-/**
- Instance of `Eq` for the `UInt64` primitive type.
- */
-public class UInt64Eq : Eq {
-    public typealias A = UInt64
-    
-    public func eqv(_ a: UInt64, _ b: UInt64) -> Bool {
-        return a == b
-    }
-}
-
-/**
- Instance of `Order` for the `UInt64` primitive type.
- */
-public class UInt64Order : UInt64Eq, Order {
-    public func compare(_ a: UInt64, _ b: UInt64) -> Int {
-        if a < b {
-            return -1
-        } else if a > b {
+    /**
+     Instance of `Monoid` for the `UInt64` primitive type, with product as combination method.
+     */
+    public class ProductMonoidInstance : ProductSemigroupInstance, Monoid {
+        public var empty : UInt64 {
             return 1
         }
-        return 0
     }
-}
 
-public extension UInt64 {
+    /**
+     Instance of `Eq` for the `UInt64` primitive type.
+     */
+    public class EqInstance : Eq {
+        public typealias A = UInt64
+        
+        public func eqv(_ a: UInt64, _ b: UInt64) -> Bool {
+            return a == b
+        }
+    }
+
+    /**
+     Instance of `Order` for the `UInt64` primitive type.
+     */
+    public class OrderInstance : EqInstance, Order {
+        public func compare(_ a: UInt64, _ b: UInt64) -> Int {
+            if a < b {
+                return -1
+            } else if a > b {
+                return 1
+            }
+            return 0
+        }
+    }
+
     /// Provides an instance of `Semigroup`, with sum as combination method.
-    public static var sumSemigroup : UInt64SumSemigroup {
-        return UInt64SumSemigroup()
+    public static var sumSemigroup : SumSemigroupInstance {
+        return SumSemigroupInstance()
     }
     
     /// Provides an instance of `Monoid`, with sum as combination method.
-    public static var sumMonoid : UInt64SumMonoid {
-        return UInt64SumMonoid()
+    public static var sumMonoid : SumMonoidInstance {
+        return SumMonoidInstance()
     }
     
     /// Provides an instance of `Semigroup`, with product as combination method.
-    public static var productSemigroup : UInt64ProductSemigroup {
-        return UInt64ProductSemigroup()
+    public static var productSemigroup : ProductSemigroupInstance {
+        return ProductSemigroupInstance()
     }
     
     /// Provides an instance of `Monoid`, with product as combination method.
-    public static var productMonoid : UInt64ProductMonoid {
-        return UInt64ProductMonoid()
+    public static var productMonoid : ProductMonoidInstance {
+        return ProductMonoidInstance()
     }
     
     /// Provides an instance of `Eq`.
-    public static var eq : UInt64Eq {
-        return UInt64Eq()
+    public static var eq : EqInstance {
+        return EqInstance()
     }
     
     /// Provides an instance of `Order`.
-    public static var order : UInt64Order {
-        return UInt64Order()
+    public static var order : OrderInstance {
+        return OrderInstance()
     }
 }
 

--- a/Sources/Bow/Instances/NumberInstances.swift
+++ b/Sources/Bow/Instances/NumberInstances.swift
@@ -2,97 +2,95 @@ import Foundation
 
 // MARK: Int instances
 
-/**
- Instance of `Semigroup` for the `Int` primitive type, with sum as combination method.
- */
-public class IntSumSemigroup : Semigroup {
-    public typealias A = Int
-    
-    public func combine(_ a : Int, _ b : Int) -> Int {
-        return a + b
-    }
-}
-
-/**
- Instance of `Monoid` for the `Int` primitive type, with sum as combination method.
- */
-public class IntSumMonoid : IntSumSemigroup, Monoid {
-    public var empty : Int {
-        return 0
-    }
-}
-
-/**
- Instance of `Semigroup` for the `Int` primitive type, with product as combination method.
- */
-public class IntProductSemigroup : Semigroup {
-    public typealias A = Int
-    
-    public func combine(_ a : Int, _ b : Int) -> Int {
-        return a * b
-    }
-}
-
-/**
- Instance of `Monoid` for the `Int` primitive type, with product as combination method.
- */
-public class IntProductMonoid : IntProductSemigroup, Monoid {
-    public var empty : Int {
-        return 1
-    }
-}
-
-/**
- Instance of `Eq` for the `Int` primitive type.
- */
-public class IntEq : Eq {
-    public typealias A = Int
-    
-    public func eqv(_ a: Int, _ b: Int) -> Bool {
-        return a == b
-    }
-}
-
-
-/**
- Instance of `Order` for the `Int` primitive type.
- */
-public class IntOrder : IntEq, Order {
-    public func compare(_ a: Int, _ b: Int) -> Int {
-        return a - b
-    }
-}
-
 public extension Int {
+    /**
+     Instance of `Semigroup` for the `Int` primitive type, with sum as combination method.
+     */
+    public class SumSemigroupInstance : Semigroup {
+        public typealias A = Int
+        
+        public func combine(_ a : Int, _ b : Int) -> Int {
+            return a + b
+        }
+    }
+
+    /**
+     Instance of `Monoid` for the `Int` primitive type, with sum as combination method.
+     */
+    public class SumMonoidInstance : SumSemigroupInstance, Monoid {
+        public var empty : Int {
+            return 0
+        }
+    }
+
+    /**
+     Instance of `Semigroup` for the `Int` primitive type, with product as combination method.
+     */
+    public class ProductSemigroupInstance : Semigroup {
+        public typealias A = Int
+        
+        public func combine(_ a : Int, _ b : Int) -> Int {
+            return a * b
+        }
+    }
+
+    /**
+     Instance of `Monoid` for the `Int` primitive type, with product as combination method.
+     */
+    public class ProductMonoidInstance : ProductSemigroupInstance, Monoid {
+        public var empty : Int {
+            return 1
+        }
+    }
+
+    /**
+     Instance of `Eq` for the `Int` primitive type.
+     */
+    public class EqInstance : Eq {
+        public typealias A = Int
+        
+        public func eqv(_ a: Int, _ b: Int) -> Bool {
+            return a == b
+        }
+    }
+
+    /**
+     Instance of `Order` for the `Int` primitive type.
+     */
+    public class OrderInstance : EqInstance, Order {
+        public func compare(_ a: Int, _ b: Int) -> Int {
+            return a - b
+        }
+    }
     
     /// Provides an instance of `Semigroup`, with sum as combination method.
-    public static var sumSemigroup : IntSumSemigroup {
-        return IntSumSemigroup()
+    public static var sumSemigroup : SumSemigroupInstance {
+        return SumSemigroupInstance()
     }
     
     /// Provides an instance of `Monoid`, with sum as combination method.
-    public static var sumMonoid : IntSumMonoid {
-        return IntSumMonoid()
+    public static var sumMonoid : SumMonoidInstance {
+        return SumMonoidInstance()
     }
     
     /// Provides an instance of `Semigroup`, with product as combination method.
-    public static var productSemigroup : IntProductSemigroup {
-        return IntProductSemigroup()
+    public static var productSemigroup : ProductSemigroupInstance {
+        return ProductSemigroupInstance()
     }
     
     /// Provides an instance of `Monoid`, with product as combination method.
-    public static var productMonoid : IntProductMonoid {
-        return IntProductMonoid()
+    public static var productMonoid : ProductMonoidInstance {
+        return ProductMonoidInstance()
     }
     
     /// Provides an instance of `Eq`.
-    public static var eq : IntEq {
-        return IntEq()
+    public static var eq : EqInstance {
+        return EqInstance()
     }
     
     /// Provides an instance of `Order`.
-    public static var order : IntOrder {
-        return IntOrder()
+    public static var order : OrderInstance {
+        return OrderInstance()
     }
 }
 

--- a/Sources/Bow/Instances/NumberInstances.swift
+++ b/Sources/Bow/Instances/NumberInstances.swift
@@ -281,96 +281,95 @@ public extension Int16 {
 }
 
 // MARK: Int32 instances
-
-/**
- Instance of `Semigroup` for the `Int32` primitive type, with sum as combination method.
- */
-public class Int32SumSemigroup : Semigroup {
-    public typealias A = Int32
-    
-    public func combine(_ a : Int32, _ b : Int32) -> Int32 {
-        return a.addingReportingOverflow(b).partialValue
-    }
-}
-
-/**
- Instance of `Monoid` for the `Int32` primitive type, with sum as combination method.
- */
-public class Int32SumMonoid : Int32SumSemigroup, Monoid {
-    public var empty : Int32 {
-        return 0
-    }
-}
-
-/**
- Instance of `Semigroup` for the `Int32` primitive type, with product as combination method.
- */
-public class Int32ProductSemigroup : Semigroup {
-    public typealias A = Int32
-    
-    public func combine(_ a : Int32, _ b : Int32) -> Int32 {
-        return a.multipliedReportingOverflow(by: b).partialValue
-    }
-}
-
-/**
- Instance of `Monoid` for the `Int32` primitive type, with product as combination method.
- */
-public class Int32ProductMonoid : Int32ProductSemigroup, Monoid {
-    public var empty : Int32 {
-        return 1
-    }
-}
-
-/**
- Instance of `Eq` for the `Int32` primitive type.
- */
-public class Int32Eq : Eq {
-    public typealias A = Int32
-    
-    public func eqv(_ a: Int32, _ b: Int32) -> Bool {
-        return a == b
-    }
-}
-
-/**
- Instance of `Order` for the `Int32` primitive type.
- */
-public class Int32Order : Int32Eq, Order {
-    public func compare(_ a: Int32, _ b: Int32) -> Int {
-        return Int(a) - Int(b)
-    }
-}
-
 public extension Int32 {
+    /**
+     Instance of `Semigroup` for the `Int32` primitive type, with sum as combination method.
+     */
+    public class SumSemigroupInstance : Semigroup {
+        public typealias A = Int32
+        
+        public func combine(_ a : Int32, _ b : Int32) -> Int32 {
+            return a.addingReportingOverflow(b).partialValue
+        }
+    }
+
+    /**
+     Instance of `Monoid` for the `Int32` primitive type, with sum as combination method.
+     */
+    public class SumMonoidInstance : SumSemigroupInstance, Monoid {
+        public var empty : Int32 {
+            return 0
+        }
+    }
+
+    /**
+     Instance of `Semigroup` for the `Int32` primitive type, with product as combination method.
+     */
+    public class ProductSemigroupInstance : Semigroup {
+        public typealias A = Int32
+        
+        public func combine(_ a : Int32, _ b : Int32) -> Int32 {
+            return a.multipliedReportingOverflow(by: b).partialValue
+        }
+    }
+
+    /**
+     Instance of `Monoid` for the `Int32` primitive type, with product as combination method.
+     */
+    public class ProductMonoidInstance : ProductSemigroupInstance, Monoid {
+        public var empty : Int32 {
+            return 1
+        }
+    }
+
+    /**
+     Instance of `Eq` for the `Int32` primitive type.
+     */
+    public class EqInstance : Eq {
+        public typealias A = Int32
+        
+        public func eqv(_ a: Int32, _ b: Int32) -> Bool {
+            return a == b
+        }
+    }
+
+    /**
+     Instance of `Order` for the `Int32` primitive type.
+     */
+    public class OrderInstance : EqInstance, Order {
+        public func compare(_ a: Int32, _ b: Int32) -> Int {
+            return Int(a) - Int(b)
+        }
+    }
+
     /// Provides an instance of `Semigroup`, with sum as combination method.
-    public static var sumSemigroup : Int32SumSemigroup {
-        return Int32SumSemigroup()
+    public static var sumSemigroup : SumSemigroupInstance {
+        return SumSemigroupInstance()
     }
     
     /// Provides an instance of `Monoid`, with sum as combination method.
-    public static var sumMonoid : Int32SumMonoid {
-        return Int32SumMonoid()
+    public static var sumMonoid : SumMonoidInstance {
+        return SumMonoidInstance()
     }
 
     /// Provides an instance of `Semigroup`, with product as combination method.
-    public static var productSemigroup : Int32ProductSemigroup {
-        return Int32ProductSemigroup()
+    public static var productSemigroup : ProductSemigroupInstance {
+        return ProductSemigroupInstance()
     }
     
     /// Provides an instance of `Monoid`, with product as combination method.
-    public static var productMonoid : Int32ProductMonoid {
-        return Int32ProductMonoid()
+    public static var productMonoid : ProductMonoidInstance {
+        return ProductMonoidInstance()
     }
     
     /// Provides an instance of `Eq`.
-    public static var eq : Int32Eq {
-        return Int32Eq()
+    public static var eq : EqInstance {
+        return EqInstance()
     }
     
     /// Provides an instance of `Order`.
-    public static var order : Int32Order {
-        return Int32Order()
+    public static var order : OrderInstance {
+        return OrderInstance()
     }
 }
 

--- a/Sources/Bow/Instances/NumberInstances.swift
+++ b/Sources/Bow/Instances/NumberInstances.swift
@@ -95,96 +95,95 @@ public extension Int {
 }
 
 // MARK: Int8 instances
-
-/**
- Instance of `Semigroup` for the `Int8` primitive type, with sum as combination method.
- */
-public class Int8SumSemigroup : Semigroup {
-    public typealias A = Int8
-    
-    public func combine(_ a : Int8, _ b : Int8) -> Int8 {
-        return a.addingReportingOverflow(b).partialValue
-    }
-}
-
-/**
- Instance of `Monoid` for the `Int8` primitive type, with sum as combination method.
- */
-public class Int8SumMonoid : Int8SumSemigroup, Monoid {
-    public var empty : Int8 {
-        return 0
-    }
-}
-
-/**
- Instance of `Semigroup` for the `Int8` primitive type, with product as combination method.
- */
-public class Int8ProductSemigroup : Semigroup {
-    public typealias A = Int8
-    
-    public func combine(_ a : Int8, _ b : Int8) -> Int8 {
-        return a.multipliedReportingOverflow(by: b).partialValue
-    }
-}
-
-/**
- Instance of `Monoid` for the `Int8` primitive type, with product as combination method.
- */
-public class Int8ProductMonoid : Int8ProductSemigroup, Monoid {
-    public var empty : Int8 {
-        return 1
-    }
-}
-
-/**
- Instance of `Eq` for the `Int8` primitive type.
- */
-public class Int8Eq : Eq {
-    public typealias A = Int8
-    
-    public func eqv(_ a: Int8, _ b: Int8) -> Bool {
-        return a == b
-    }
-}
-
-/**
- Instance of `Order` for the `Int8` primitive type.
- */
-public class Int8Order : Int8Eq, Order {
-    public func compare(_ a: Int8, _ b: Int8) -> Int {
-        return Int(a) - Int(b)
-    }
-}
-
 public extension Int8 {
+    /**
+     Instance of `Semigroup` for the `Int8` primitive type, with sum as combination method.
+     */
+    public class SumSemigroupInstance : Semigroup {
+        public typealias A = Int8
+        
+        public func combine(_ a : Int8, _ b : Int8) -> Int8 {
+            return a.addingReportingOverflow(b).partialValue
+        }
+    }
+
+    /**
+     Instance of `Monoid` for the `Int8` primitive type, with sum as combination method.
+     */
+    public class SumMonoidInstance : SumSemigroupInstance, Monoid {
+        public var empty : Int8 {
+            return 0
+        }
+    }
+
+    /**
+     Instance of `Semigroup` for the `Int8` primitive type, with product as combination method.
+     */
+    public class ProductSemigroupInstance : Semigroup {
+        public typealias A = Int8
+        
+        public func combine(_ a : Int8, _ b : Int8) -> Int8 {
+            return a.multipliedReportingOverflow(by: b).partialValue
+        }
+    }
+
+    /**
+     Instance of `Monoid` for the `Int8` primitive type, with product as combination method.
+     */
+    public class ProductMonoidInstance : ProductSemigroupInstance, Monoid {
+        public var empty : Int8 {
+            return 1
+        }
+    }
+
+    /**
+     Instance of `Eq` for the `Int8` primitive type.
+     */
+    public class EqInstance : Eq {
+        public typealias A = Int8
+        
+        public func eqv(_ a: Int8, _ b: Int8) -> Bool {
+            return a == b
+        }
+    }
+
+    /**
+     Instance of `Order` for the `Int8` primitive type.
+     */
+    public class OrderInstance : EqInstance, Order {
+        public func compare(_ a: Int8, _ b: Int8) -> Int {
+            return Int(a) - Int(b)
+        }
+    }
+
     /// Provides an instance of `Semigroup`, with sum as combination method.
-    public static var sumSemigroup : Int8SumSemigroup {
-        return Int8SumSemigroup()
+    public static var sumSemigroup : SumSemigroupInstance {
+        return SumSemigroupInstance()
     }
     
     /// Provides an instance of `Monoid`, with sum as combination method.
-    public static var sumMonoid : Int8SumMonoid {
-        return Int8SumMonoid()
+    public static var sumMonoid : SumMonoidInstance {
+        return SumMonoidInstance()
     }
     
     /// Provides an instance of `Semigroup`, with product as combination method.
-    public static var productSemigroup : Int8ProductSemigroup {
-        return Int8ProductSemigroup()
+    public static var productSemigroup : ProductSemigroupInstance {
+        return ProductSemigroupInstance()
     }
     
     /// Provides an instance of `Monoid`, with product as combination method.
-    public static var productMonoid : Int8ProductMonoid {
-        return Int8ProductMonoid()
+    public static var productMonoid : ProductMonoidInstance {
+        return ProductMonoidInstance()
     }
     
     /// Provides an instance of `Eq`.
-    public static var eq : Int8Eq {
-        return Int8Eq()
+    public static var eq : EqInstance {
+        return EqInstance()
     }
     
     /// Provides an instance of `Order`.
-    public static var order : Int8Order {
-        return Int8Order()
+    public static var order : OrderInstance {
+        return OrderInstance()
     }
 }
 

--- a/Sources/Bow/Instances/NumberInstances.swift
+++ b/Sources/Bow/Instances/NumberInstances.swift
@@ -188,96 +188,95 @@ public extension Int8 {
 }
 
 // MARK: Int16 instances
-
-/**
- Instance of `Semigroup` for the `Int16` primitive type, with sum as combination method.
- */
-public class Int16SumSemigroup : Semigroup {
-    public typealias A = Int16
-    
-    public func combine(_ a : Int16, _ b : Int16) -> Int16 {
-        return a.addingReportingOverflow(b).partialValue
-    }
-}
-
-/**
- Instance of `Monoid` for the `Int16` primitive type, with sum as combination method.
- */
-public class Int16SumMonoid : Int16SumSemigroup, Monoid {
-    public var empty : Int16 {
-        return 0
-    }
-}
-
-/**
- Instance of `Semigroup` for the `Int16` primitive type, with product as combination method.
- */
-public class Int16ProductSemigroup : Semigroup {
-    public typealias A = Int16
-    
-    public func combine(_ a : Int16, _ b : Int16) -> Int16 {
-        return a.multipliedReportingOverflow(by: b).partialValue
-    }
-}
-
-/**
- Instance of `Monoid` for the `Int16` primitive type, with product as combination method.
- */
-public class Int16ProductMonoid : Int16ProductSemigroup, Monoid {
-    public var empty : Int16 {
-        return 1
-    }
-}
-
-/**
- Instance of `Eq` for the `Int16` primitive type.
- */
-public class Int16Eq : Eq {
-    public typealias A = Int16
-    
-    public func eqv(_ a: Int16, _ b: Int16) -> Bool {
-        return a == b
-    }
-}
-
-/**
- Instance of `Order` for the `Int16` primitive type.
- */
-public class Int16Order : Int16Eq, Order {
-    public func compare(_ a: Int16, _ b: Int16) -> Int {
-        return Int(a) - Int(b)
-    }
-}
-
 public extension Int16 {
+    /**
+     Instance of `Semigroup` for the `Int16` primitive type, with sum as combination method.
+     */
+    public class SumSemigroupInstance : Semigroup {
+        public typealias A = Int16
+        
+        public func combine(_ a : Int16, _ b : Int16) -> Int16 {
+            return a.addingReportingOverflow(b).partialValue
+        }
+    }
+
+    /**
+     Instance of `Monoid` for the `Int16` primitive type, with sum as combination method.
+     */
+    public class SumMonoidInstance : SumSemigroupInstance, Monoid {
+        public var empty : Int16 {
+            return 0
+        }
+    }
+
+    /**
+     Instance of `Semigroup` for the `Int16` primitive type, with product as combination method.
+     */
+    public class ProductSemigroupInstance : Semigroup {
+        public typealias A = Int16
+        
+        public func combine(_ a : Int16, _ b : Int16) -> Int16 {
+            return a.multipliedReportingOverflow(by: b).partialValue
+        }
+    }
+
+    /**
+     Instance of `Monoid` for the `Int16` primitive type, with product as combination method.
+     */
+    public class ProductMonoidInstance : ProductSemigroupInstance, Monoid {
+        public var empty : Int16 {
+            return 1
+        }
+    }
+
+    /**
+     Instance of `Eq` for the `Int16` primitive type.
+     */
+    public class EqInstance : Eq {
+        public typealias A = Int16
+        
+        public func eqv(_ a: Int16, _ b: Int16) -> Bool {
+            return a == b
+        }
+    }
+
+    /**
+     Instance of `Order` for the `Int16` primitive type.
+     */
+    public class OrderInstance : EqInstance, Order {
+        public func compare(_ a: Int16, _ b: Int16) -> Int {
+            return Int(a) - Int(b)
+        }
+    }
+
     /// Provides an instance of `Semigroup`, with sum as combination method.
-    public static var sumSemigroup : Int16SumSemigroup {
-        return Int16SumSemigroup()
+    public static var sumSemigroup : SumSemigroupInstance {
+        return SumSemigroupInstance()
     }
     
     /// Provides an instance of `Monoid`, with sum as combination method.
-    public static var sumMonoid : Int16SumMonoid {
-        return Int16SumMonoid()
+    public static var sumMonoid : SumMonoidInstance {
+        return SumMonoidInstance()
     }
     
     /// Provides an instance of `Semigroup`, with product as combination method.
-    public static var productSemigroup : Int16ProductSemigroup {
-        return Int16ProductSemigroup()
+    public static var productSemigroup : ProductSemigroupInstance {
+        return ProductSemigroupInstance()
     }
     
     /// Provides an instance of `Monoid`, with product as combination method.
-    public static var productMonoid : Int16ProductMonoid {
-        return Int16ProductMonoid()
+    public static var productMonoid : ProductMonoidInstance {
+        return ProductMonoidInstance()
     }
     
     /// Provides an instance of `Eq`.
-    public static var eq : Int16Eq {
-        return Int16Eq()
+    public static var eq : EqInstance {
+        return EqInstance()
     }
     
     /// Provides an instance of `Order`.
-    public static var order : Int16Order {
-        return Int16Order()
+    public static var order : OrderInstance {
+        return OrderInstance()
     }
 }
 

--- a/Sources/Bow/Instances/NumberInstances.swift
+++ b/Sources/Bow/Instances/NumberInstances.swift
@@ -957,101 +957,100 @@ public extension UInt64 {
 }
 
 // MARK: Float instances
-
-/**
- Instance of `Semigroup` for the `Float` primitive type, with sum as combination method.
- */
-public class FloatSumSemigroup : Semigroup {
-    public typealias A = Float
-    
-    public func combine(_ a : Float, _ b : Float) -> Float {
-        return a + b
+public extension Float {
+    /**
+     Instance of `Semigroup` for the `Float` primitive type, with sum as combination method.
+     */
+    public class SumSemigroupInstance : Semigroup {
+        public typealias A = Float
+        
+        public func combine(_ a : Float, _ b : Float) -> Float {
+            return a + b
+        }
     }
-}
 
-/**
- Instance of `Monoid` for the `Float` primitive type, with sum as combination method.
- */
-public class FloatSumMonoid : FloatSumSemigroup, Monoid {
-    public var empty : Float {
-        return 0
+    /**
+     Instance of `Monoid` for the `Float` primitive type, with sum as combination method.
+     */
+    public class SumMonoidInstance : SumSemigroupInstance, Monoid {
+        public var empty : Float {
+            return 0
+        }
     }
-}
 
-/**
- Instance of `Semigroup` for the `Float` primitive type, with product as combination method.
- */
-public class FloatProductSemigroup : Semigroup {
-    public typealias A = Float
-    
-    public func combine(_ a : Float, _ b : Float) -> Float {
-        return a * b
+    /**
+     Instance of `Semigroup` for the `Float` primitive type, with product as combination method.
+     */
+    public class ProductSemigroupInstance : Semigroup {
+        public typealias A = Float
+        
+        public func combine(_ a : Float, _ b : Float) -> Float {
+            return a * b
+        }
     }
-}
 
-/**
- Instance of `Monoid` for the `Float` primitive type, with product as combination method.
- */
-public class FloatProductMonoid : FloatProductSemigroup, Monoid {
-    public var empty : Float {
-        return 1
-    }
-}
-
-/**
- Instance of `Eq` for the `Float` primitive type.
- */
-public class FloatEq : Eq {
-    public typealias A = Float
-    
-    public func eqv(_ a: Float, _ b: Float) -> Bool {
-        return a.isEqual(to: b)
-    }
-}
-
-/**
- Instance of `Order` for the `Float` primitive type.
- */
-public class FloatOrder : FloatEq, Order {
-    public func compare(_ a: Float, _ b: Float) -> Int {
-        if a < b {
-            return -1
-        } else if a > b {
+    /**
+     Instance of `Monoid` for the `Float` primitive type, with product as combination method.
+     */
+    public class ProductMonoidInstance : ProductSemigroupInstance, Monoid {
+        public var empty : Float {
             return 1
         }
-        return 0
     }
-}
 
-public extension Float {
+    /**
+     Instance of `Eq` for the `Float` primitive type.
+     */
+    public class EqInstance : Eq {
+        public typealias A = Float
+        
+        public func eqv(_ a: Float, _ b: Float) -> Bool {
+            return a.isEqual(to: b)
+        }
+    }
+
+    /**
+     Instance of `Order` for the `Float` primitive type.
+     */
+    public class OrderInstance : EqInstance, Order {
+        public func compare(_ a: Float, _ b: Float) -> Int {
+            if a < b {
+                return -1
+            } else if a > b {
+                return 1
+            }
+            return 0
+        }
+    }
+
     /// Provides an instance of `Semigroup`, with sum as combination method.
-    public static var sumSemigroup : FloatSumSemigroup {
-        return FloatSumSemigroup()
+    public static var sumSemigroup : SumSemigroupInstance {
+        return SumSemigroupInstance()
     }
     
     /// Provides an instance of `Monoid`, with sum as combination method.
-    public static var sumMonoid : FloatSumMonoid {
-        return FloatSumMonoid()
+    public static var sumMonoid : SumMonoidInstance {
+        return SumMonoidInstance()
     }
     
     /// Provides an instance of `Semigroup`, with product as combination method.
-    public static var productSemigroup : FloatProductSemigroup {
-        return FloatProductSemigroup()
+    public static var productSemigroup : ProductSemigroupInstance {
+        return ProductSemigroupInstance()
     }
     
     /// Provides an instance of `Monoid`, with product as combination method.
-    public static var productMonoid : FloatProductMonoid {
-        return FloatProductMonoid()
+    public static var productMonoid : ProductMonoidInstance {
+        return ProductMonoidInstance()
     }
     
     /// Provides an instance of `Eq`.
-    public static var eq : FloatEq {
-        return FloatEq()
+    public static var eq : EqInstance {
+        return EqInstance()
     }
     
     /// Provides an instance of `Order`.
-    public static var order : FloatOrder {
-        return FloatOrder()
+    public static var order : OrderInstance {
+        return OrderInstance()
     }
 }
 

--- a/Sources/Bow/Instances/StringInstances.swift
+++ b/Sources/Bow/Instances/StringInstances.swift
@@ -1,67 +1,67 @@
 import Foundation
 
-/**
- Instance of `Semigroup` for `String`, using concatenation as combination method.
- */
-public class StringConcatSemigroup : Semigroup {
-    public typealias A = String
-    
-    public func combine(_ a : String, _ b : String) -> String {
-        return a + b
-    }
-}
-
-/**
- Instance of `Monoid` for `String`, using concatenation as combination method.
- */
-public class StringConcatMonoid : StringConcatSemigroup, Monoid {
-    public var empty : String {
-        return ""
-    }
-}
-
-/**
- Instance of `Eq` for `String`.
- */
-public class StringEq : Eq {
-    public typealias A = String
-    
-    public func eqv(_ a: String, _ b: String) -> Bool {
-        return a == b
-    }
-}
-
-/**
- Instance of `Order` for `String`.
- */
-public class StringOrder : StringEq, Order {
-    public func compare(_ a: String, _ b: String) -> Int {
-        switch a.compare(b) {
-        case .orderedAscending: return -1
-        case .orderedDescending: return 1
-        case .orderedSame: return 0
+public extension String {
+    /**
+     Instance of `Semigroup` for `String`, using concatenation as combination method.
+     */
+    public class ConcatSemigroupInstance : Semigroup {
+        public typealias A = String
+        
+        public func combine(_ a : String, _ b : String) -> String {
+            return a + b
         }
     }
-}
 
-public extension String {
+    /**
+     Instance of `Monoid` for `String`, using concatenation as combination method.
+     */
+    public class ConcatMonoidInstance : ConcatSemigroupInstance, Monoid {
+        public var empty : String {
+            return ""
+        }
+    }
+
+    /**
+     Instance of `Eq` for `String`.
+     */
+    public class EqInstance : Eq {
+        public typealias A = String
+        
+        public func eqv(_ a: String, _ b: String) -> Bool {
+            return a == b
+        }
+    }
+
+    /**
+     Instance of `Order` for `String`.
+     */
+    public class OrderInstance : EqInstance, Order {
+        public func compare(_ a: String, _ b: String) -> Int {
+            switch a.compare(b) {
+            case .orderedAscending: return -1
+            case .orderedDescending: return 1
+            case .orderedSame: return 0
+            }
+        }
+    }
+
     /// Provides an instance of `Semigroup`.
-    public static var concatSemigroup : StringConcatSemigroup {
-        return StringConcatSemigroup()
+    public static var concatSemigroup : ConcatSemigroupInstance {
+        return ConcatSemigroupInstance()
     }
     
     /// Provides an instance of `Monoid`.
-    public static var concatMonoid : StringConcatMonoid {
-        return StringConcatMonoid()
+    public static var concatMonoid : ConcatMonoidInstance {
+        return ConcatMonoidInstance()
     }
     
     /// Provides an instance of `Eq`.
-    public static var eq : StringEq {
-        return StringEq()
+    public static var eq : EqInstance {
+        return EqInstance()
     }
     
     /// Provides an instance of `Order`.
-    public static var order : StringOrder {
-        return StringOrder()
+    public static var order : OrderInstance {
+        return OrderInstance()
     }
 }

--- a/Sources/Bow/Typeclasses/Foldable.swift
+++ b/Sources/Bow/Typeclasses/Foldable.swift
@@ -91,7 +91,7 @@ public extension Foldable {
     public func get<A>(_ fa : Kind<F, A>, _ index : Int64) -> Option<A> {
         return (foldM(fa, Int64(0), { i, a in
             (i == index) ? Either<A, Int64>.left(a) : Either<A, Int64>.right(i + 1)
-        }, Either<A, Int64>.monad() as EitherMonad<A>) as! Either<A, Int64>)
+        }, Either<A, Int64>.monad() as Either.MonadInstance<A>) as! Either<A, Int64>)
             .fold(Option<A>.some, constant(Option<A>.none()))
     }
     

--- a/Tests/BowTests/Data/SetKTest.swift
+++ b/Tests/BowTests/Data/SetKTest.swift
@@ -9,7 +9,7 @@ class SetKTest: XCTestCase {
 		return { a in SetK<Int>.pure(a) }
 	}
 
-	let eq = SetK.eq(IntEq())
+	let eq = SetK.eq(Int.EqInstance())
 
 	func testEqLaws() {
 		EqLaws.check(eq: self.eq, generator: self.generator)

--- a/Tests/BowTests/Transformers/WriterTTest.swift
+++ b/Tests/BowTests/Transformers/WriterTTest.swift
@@ -80,6 +80,6 @@ class WriterTTest: XCTestCase {
             monoid: Int.sumMonoid,
             eq: self.eq,
             eqUnit: WriterT.eq(Id.eq(Tuple.eq(Int.order, UnitEq()))),
-            eqTuple: WriterT.eq(Id.eq(Tuple.eq(Int.order, TupleEq(Int.order, Int.order)))))
+            eqTuple: WriterT.eq(Id.eq(Tuple.eq(Int.order, Tuple<Int, Int>.EqInstance(Int.order, Int.order)))))
     }
 }


### PR DESCRIPTION
## Goal

- Improve modularity of instances of typeclasses for data types.
- Improve readability of generated documentation

## Implementation details

Instances of typeclasses for data types are now defined inside its class implementation; for instance, previous class `ArrayKApplicative` was defined in a global scope. Now, it is defined in the `ArrayK` scope and renamed to `ApplicativeInstance`; therefore, it's full name is `ArrayK<A>.ApplicativeInstance`.
