### PR TITLE
Remove public visibility of initializers in typeclass instances

### DIFF
--- a/Sources/Bow/Arrow/Function0.swift
+++ b/Sources/Bow/Arrow/Function0.swift
@@ -126,7 +126,7 @@ public extension Function0 {
         
         private let eq : EqB
         
-        public init(_ eq : EqB) {
+        init(_ eq : EqB) {
             self.eq = eq
         }
         

--- a/Sources/Bow/Arrow/Kleisli.swift
+++ b/Sources/Bow/Arrow/Kleisli.swift
@@ -105,7 +105,7 @@ public extension Kleisli {
         
         private let functor : FuncG
         
-        public init(_ functor : FuncG) {
+        init(_ functor : FuncG) {
             self.functor = functor
         }
         
@@ -118,7 +118,7 @@ public extension Kleisli {
         
         private let applicative : ApplG
         
-        override public init(_ applicative : ApplG) {
+        override init(_ applicative : ApplG) {
             self.applicative = applicative
             super.init(applicative)
         }
@@ -136,7 +136,7 @@ public extension Kleisli {
         
         fileprivate let monad : MonG
         
-        override public init(_ monad : MonG) {
+        override init(_ monad : MonG) {
             self.monad = monad
             super.init(monad)
         }
@@ -167,7 +167,7 @@ public extension Kleisli {
         
         private let monadError : MonErrG
         
-        override public init(_ monadError : MonErrG) {
+        override init(_ monadError : MonErrG) {
             self.monadError = monadError
             super.init(monadError)
         }

--- a/Sources/Bow/Data/ArrayK.swift
+++ b/Sources/Bow/Data/ArrayK.swift
@@ -303,7 +303,7 @@ public extension ArrayK {
         
         private let eqr : EqR
         
-        public init(_ eqr : EqR) {
+        init(_ eqr : EqR) {
             self.eqr = eqr
         }
         
@@ -329,7 +329,7 @@ public extension Array {
         
         private let eqr : EqR
         
-        public init(_ eqr : EqR) {
+        init(_ eqr : EqR) {
             self.eqr = eqr
         }
         

--- a/Sources/Bow/Data/Const.swift
+++ b/Sources/Bow/Data/Const.swift
@@ -52,6 +52,12 @@ extension Const : CustomDebugStringConvertible where A : CustomDebugStringConver
     }
 }
 
+extension Const : Equatable where A : Equatable {
+    public static func ==(lhs : Const<A, T>, rhs : Const<A, T>) -> Bool {
+        return lhs.value == rhs.value
+    }
+}
+
 public extension Const {
     public static func functor() -> FunctorInstance<A> {
         return FunctorInstance<A>()
@@ -96,7 +102,7 @@ public extension Const {
     public class ApplicativeInstance<R, Mono> : FunctorInstance<R>, Applicative where Mono : Monoid, Mono.A == R {
         private let monoid : Mono
         
-        public init(_ monoid : Mono) {
+        init(_ monoid : Mono) {
             self.monoid = monoid
         }
         
@@ -113,7 +119,7 @@ public extension Const {
         public typealias A = ConstOf<R, S>
         private let semigroup : SemiG
         
-        public init(_ semigroup : SemiG) {
+        init(_ semigroup : SemiG) {
             self.semigroup = semigroup
         }
         
@@ -125,7 +131,7 @@ public extension Const {
     public class MonoidInstance<R, S, Mono> : SemigroupInstance<R, S, Mono>, Monoid where Mono : Monoid, Mono.A == R {
         private let monoid : Mono
         
-        override public init(_ monoid : Mono) {
+        override init(_ monoid : Mono) {
             self.monoid = monoid
             super.init(monoid)
         }
@@ -163,18 +169,12 @@ public extension Const {
         public typealias A = ConstOf<R, S>
         private let eqr : EqR
         
-        public init(_ eqr : EqR) {
+        init(_ eqr : EqR) {
             self.eqr = eqr
         }
         
         public func eqv(_ a: ConstOf<R, S>, _ b: ConstOf<R, S>) -> Bool {
             return eqr.eqv(Const<R, S>.fix(a).value, Const<R, S>.fix(b).value)
         }
-    }
-}
-
-extension Const : Equatable where A : Equatable {
-    public static func ==(lhs : Const<A, T>, rhs : Const<A, T>) -> Bool {
-        return lhs.value == rhs.value
     }
 }

--- a/Sources/Bow/Data/Coproduct.swift
+++ b/Sources/Bow/Data/Coproduct.swift
@@ -79,7 +79,7 @@ public extension Coproduct {
         private let functorG : FuncG
         private let functorH : FuncH
         
-        public init(_ functorG : FuncG, _ functorH : FuncH) {
+        init(_ functorG : FuncG, _ functorH : FuncH) {
             self.functorG = functorG
             self.functorH = functorH
         }
@@ -94,7 +94,7 @@ public extension Coproduct {
         private let comonadG : ComonG
         private let comonadH : ComonH
         
-        override public init(_ comonadG : ComonG, _ comonadH : ComonH) {
+        override init(_ comonadG : ComonG, _ comonadH : ComonH) {
             self.comonadG = comonadG
             self.comonadH = comonadH
             super.init(comonadG, comonadH)
@@ -115,7 +115,7 @@ public extension Coproduct {
         private let foldableG : FoldG
         private let foldableH : FoldH
         
-        public init(_ foldableG : FoldG, _ foldableH : FoldH) {
+        init(_ foldableG : FoldG, _ foldableH : FoldH) {
             self.foldableG = foldableG
             self.foldableH = foldableH
         }
@@ -134,7 +134,7 @@ public extension Coproduct {
         private let traverseG : TravG
         private let traverseH : TravH
         
-        override public init(_ traverseG : TravG, _ traverseH : TravH) {
+        override init(_ traverseG : TravG, _ traverseH : TravH) {
             self.traverseG = traverseG
             self.traverseH = traverseH
             super.init(traverseG, traverseH)
@@ -150,7 +150,7 @@ public extension Coproduct {
         
         private let eq : EqB
         
-        public init(_ eq : EqB) {
+        init(_ eq : EqB) {
             self.eq = eq
         }
         

--- a/Sources/Bow/Data/Day.swift
+++ b/Sources/Bow/Data/Day.swift
@@ -97,7 +97,7 @@ public extension Day {
         private let comonadG : ComonG
         private let comonadH : ComonH
         
-        public init(_ comonadG : ComonG, _ comonadH : ComonH) {
+        init(_ comonadG : ComonG, _ comonadH : ComonH) {
             self.comonadG = comonadG
             self.comonadH = comonadH
         }

--- a/Sources/Bow/Data/Either.swift
+++ b/Sources/Bow/Data/Either.swift
@@ -428,7 +428,7 @@ public extension Either {
         private let eql : EqL
         private let eqr : EqR
         
-        public init(_ eql : EqL, _ eqr : EqR) {
+        init(_ eql : EqL, _ eqr : EqR) {
             self.eql = eql
             self.eqr = eqr
         }

--- a/Sources/Bow/Data/Eval.swift
+++ b/Sources/Bow/Data/Eval.swift
@@ -330,7 +330,7 @@ public extension Eval {
         
         private let eq : EqB
         
-        public init(_ eq : EqB) {
+        init(_ eq : EqB) {
             self.eq = eq
         }
         

--- a/Sources/Bow/Data/Id.swift
+++ b/Sources/Bow/Data/Id.swift
@@ -284,7 +284,7 @@ extension Id {
         
         private let eqb : EqB
         
-        public init(_ eqb : EqB) {
+        init(_ eqb : EqB) {
             self.eqb = eqb
         }
         

--- a/Sources/Bow/Data/Ior.swift
+++ b/Sources/Bow/Data/Ior.swift
@@ -249,7 +249,7 @@ public extension Ior {
     public class ApplicativeInstance<L, SemiG> : FunctorInstance<L>, Applicative where SemiG : Semigroup, SemiG.A == L {
         fileprivate let semigroup : SemiG
         
-        public init(_ semigroup : SemiG) {
+        init(_ semigroup : SemiG) {
             self.semigroup = semigroup
         }
         
@@ -297,7 +297,7 @@ public extension Ior {
         private let eql : EqL
         private let eqr : EqR
         
-        public init(_ eql : EqL, _ eqr : EqR) {
+        init(_ eql : EqL, _ eqr : EqR) {
             self.eql = eql
             self.eqr = eqr
         }

--- a/Sources/Bow/Data/NonEmptyArray.swift
+++ b/Sources/Bow/Data/NonEmptyArray.swift
@@ -285,7 +285,7 @@ public extension NonEmptyArray {
         
         private let eqr : EqR
         
-        public init(_ eqr : EqR) {
+        init(_ eqr : EqR) {
             self.eqr = eqr
         }
         

--- a/Sources/Bow/Data/Option.swift
+++ b/Sources/Bow/Data/Option.swift
@@ -451,7 +451,7 @@ public extension Option {
         public typealias A = OptionOf<R>
         private let semigroup : SemiG
         
-        public init(_ semigroup : SemiG) {
+        init(_ semigroup : SemiG) {
             self.semigroup = semigroup
         }
         

--- a/Sources/Bow/Data/SetK.swift
+++ b/Sources/Bow/Data/SetK.swift
@@ -101,7 +101,7 @@ public extension SetK {
 
         private let eqr : EqR
 
-        public init(_ eqr : EqR) {
+        init(_ eqr : EqR) {
             self.eqr = eqr
         }
 

--- a/Sources/Bow/Data/Sum.swift
+++ b/Sources/Bow/Data/Sum.swift
@@ -71,7 +71,7 @@ public extension Sum {
         private let functorG : FuncG
         private let functorH : FuncH
         
-        public init(_ functorG : FuncG, _ functorH : FuncH) {
+        init(_ functorG : FuncG, _ functorH : FuncH) {
             self.functorG = functorG
             self.functorH = functorH
         }
@@ -86,7 +86,7 @@ public extension Sum {
         private let comonadG : ComonG
         private let comonadH : ComonH
         
-        override public init(_ comonadG : ComonG, _ comonadH : ComonH) {
+        override init(_ comonadG : ComonG, _ comonadH : ComonH) {
             self.comonadG = comonadG
             self.comonadH = comonadH
             super.init(comonadG, comonadH)

--- a/Sources/Bow/Data/Try.swift
+++ b/Sources/Bow/Data/Try.swift
@@ -239,7 +239,7 @@ public extension Try {
         public typealias A = TryOf<R>
         private let eqr : EqR
         
-        public init(_ eqr : EqR) {
+        init(_ eqr : EqR) {
             self.eqr = eqr
         }
         

--- a/Sources/Bow/Data/Tuple.swift
+++ b/Sources/Bow/Data/Tuple.swift
@@ -11,7 +11,7 @@ public class Tuple<A, B> {
         private let eqm : EqM
         private let eqn : EqN
         
-        public init(_ eqm : EqM, _ eqn : EqN) {
+        init(_ eqm : EqM, _ eqn : EqN) {
             self.eqm = eqm
             self.eqn = eqn
         }

--- a/Sources/Bow/Data/Validated.swift
+++ b/Sources/Bow/Data/Validated.swift
@@ -215,7 +215,7 @@ public extension Validated {
     public class ValidatedApplicative<R, SemiG> : ValidatedFunctor<R>, Applicative where SemiG : Semigroup, SemiG.A == R {
         private let semigroup : SemiG
         
-        public init(_ semigroup : SemiG) {
+        init(_ semigroup : SemiG) {
             self.semigroup = semigroup
         }
         
@@ -263,7 +263,7 @@ public extension Validated {
         
         private let semigroup : SemiG
         
-        public init(_ semigroup : SemiG) {
+        init(_ semigroup : SemiG) {
             self.semigroup = semigroup
         }
         
@@ -277,7 +277,7 @@ public extension Validated {
         private let eql : EqL
         private let eqr : EqR
         
-        public init(_ eql : EqL, _ eqr : EqR) {
+        init(_ eql : EqL, _ eqr : EqR) {
             self.eql = eql
             self.eqr = eqr
         }

--- a/Sources/Bow/Transformers/EitherT.swift
+++ b/Sources/Bow/Transformers/EitherT.swift
@@ -135,7 +135,7 @@ public extension EitherT {
         
         private let functor : Func
         
-        public init(_ functor : Func) {
+        init(_ functor : Func) {
             self.functor = functor
         }
         
@@ -148,7 +148,7 @@ public extension EitherT {
         
         fileprivate let monad : Mon
         
-        override public init(_ monad : Mon) {
+        override init(_ monad : Mon) {
             self.monad = monad
             super.init(monad)
         }
@@ -194,7 +194,7 @@ public extension EitherT {
         
         private let monad : Mon
         
-        public init(_ monad : Mon) {
+        init(_ monad : Mon) {
             self.monad = monad
         }
         
@@ -209,7 +209,7 @@ public extension EitherT {
         private let eq : EqA
         private let functor : Func
         
-        public init(_ eq : EqA, _ functor : Func) {
+        init(_ eq : EqA, _ functor : Func) {
             self.eq = eq
             self.functor = functor
         }

--- a/Sources/Bow/Transformers/OptionT.swift
+++ b/Sources/Bow/Transformers/OptionT.swift
@@ -150,7 +150,7 @@ public extension OptionT {
         
         fileprivate let functor : FuncG
         
-        public init(_ functor : FuncG) {
+        init(_ functor : FuncG) {
             self.functor = functor
         }
         
@@ -170,7 +170,7 @@ public extension OptionT {
         
         fileprivate let monad : MonG
         
-        override public init(_ monad : MonG) {
+        override init(_ monad : MonG) {
             self.monad = monad
             super.init(monad)
         }
@@ -200,7 +200,7 @@ public extension OptionT {
         
         fileprivate let monad : MonG
         
-        public init(_ monad : MonG) {
+        init(_ monad : MonG) {
             self.monad = monad
         }
         
@@ -221,7 +221,7 @@ public extension OptionT {
         private let eq : EqF
         private let functor : Func
         
-        public init(_ eq : EqF, _ functor : Func) {
+        init(_ eq : EqF, _ functor : Func) {
             self.eq = eq
             self.functor = functor
         }

--- a/Sources/Bow/Transformers/StateT.swift
+++ b/Sources/Bow/Transformers/StateT.swift
@@ -188,7 +188,7 @@ public extension StateT {
         
         private let functor : FuncG
         
-        public init(_ functor : FuncG) {
+        init(_ functor : FuncG) {
             self.functor = functor
         }
         
@@ -200,7 +200,7 @@ public extension StateT {
     public class ApplicativeInstance<G, S, MonG> : FunctorInstance<G, S, MonG>, Applicative where MonG : Monad, MonG.F == G {
         fileprivate let monad : MonG
         
-        override public init(_ monad : MonG) {
+        override init(_ monad : MonG) {
             self.monad = monad
             super.init(monad)
         }
@@ -243,7 +243,7 @@ public extension StateT {
         private let monad : MonG
         private let semigroupK : SemiKG
         
-        public init(_ monad : MonG, _ semigroupK : SemiKG) {
+        init(_ monad : MonG, _ semigroupK : SemiKG) {
             self.monad = monad
             self.semigroupK = semigroupK
         }
@@ -256,7 +256,7 @@ public extension StateT {
     public class MonadCombineInstance<G, S, MonComG> : MonadInstance<G, S, MonComG>, MonadCombine where MonComG : MonadCombine, MonComG.F == G {
         private let monadCombine : MonComG
         
-        override public init(_ monadCombine : MonComG) {
+        override init(_ monadCombine : MonComG) {
             self.monadCombine = monadCombine
             super.init(monadCombine)
         }
@@ -283,7 +283,7 @@ public extension StateT {
         
         private let monadError : MonErrG
         
-        override public init(_ monadError : MonErrG) {
+        override init(_ monadError : MonErrG) {
             self.monadError = monadError
             super.init(monadError)
         }

--- a/Sources/Bow/Transformers/WriterT.swift
+++ b/Sources/Bow/Transformers/WriterT.swift
@@ -175,7 +175,7 @@ public extension WriterT {
         
         private let functor : FuncG
         
-        public init(_ functor : FuncG) {
+        init(_ functor : FuncG) {
             self.functor = functor
         }
         
@@ -189,7 +189,7 @@ public extension WriterT {
         fileprivate let monad : MonG
         fileprivate let monoid : MonoW
         
-        public init(_ monad : MonG, _ monoid : MonoW) {
+        init(_ monad : MonG, _ monoid : MonoW) {
             self.monad = monad
             self.monoid = monoid
             super.init(monad)
@@ -219,7 +219,7 @@ public extension WriterT {
 
         private let monadFilter : MonFilG
         
-        override public init(_ monadFilter : MonFilG, _ monoid : MonoW) {
+        override init(_ monadFilter : MonFilG, _ monoid : MonoW) {
             self.monadFilter = monadFilter
             super.init(monadFilter, monoid)
         }
@@ -234,7 +234,7 @@ public extension WriterT {
         
         private let semigroupK : SemiKG
         
-        public init(_ semigroupK : SemiKG) {
+        init(_ semigroupK : SemiKG) {
             self.semigroupK = semigroupK
         }
         
@@ -247,7 +247,7 @@ public extension WriterT {
         
         private let monoidK : MonoKG
         
-        override public init(_ monoidK : MonoKG) {
+        override init(_ monoidK : MonoKG) {
             self.monoidK = monoidK
             super.init(monoidK)
         }
@@ -282,7 +282,7 @@ public extension WriterT {
         
         private let eq : EqF
         
-        public init(_ eq : EqF) {
+        init(_ eq : EqF) {
             self.eq = eq
         }
         

--- a/Sources/BowEffects/IO.swift
+++ b/Sources/BowEffects/IO.swift
@@ -357,7 +357,7 @@ public extension IO {
 
     public class AsyncInstance<Err> : MonadErrorInstance<Err>, Async where Err : Error {
         public func suspend<A>(_ fa: @escaping () -> Kind<ForIO, A>) -> Kind<ForIO, A> {
-            fatalError("Not implemented yet")
+            return IO<A>.suspend { fa().fix() }
         }
         
         public typealias F = ForIO
@@ -384,7 +384,7 @@ public extension IO {
         
         private let semigroup : SemiG
         
-        public init(_ semigroup : SemiG) {
+        init(_ semigroup : SemiG) {
             self.semigroup = semigroup
         }
         
@@ -396,7 +396,7 @@ public extension IO {
     public class MonoidInstance<B, Mono> : SemigroupInstance<B, Mono>, Monoid where Mono : Monoid, Mono.A == B {
         private let monoid : Mono
         
-        override public init(_ monoid : Mono) {
+        override init(_ monoid : Mono) {
             self.monoid = monoid
             super.init(monoid)
         }
@@ -412,7 +412,7 @@ public extension IO {
         private let eq : EqB
         private let eqError : EqError
         
-        public init(_ eq : EqB, _ eqError : EqError) {
+        init(_ eq : EqB, _ eqError : EqError) {
             self.eq = eq
             self.eqError = eqError
         }

--- a/Sources/BowFree/Cofree.swift
+++ b/Sources/BowFree/Cofree.swift
@@ -100,7 +100,7 @@ public extension Cofree {
         
         fileprivate let functor : Func
         
-        public init(_ functor : Func) {
+        init(_ functor : Func) {
             self.functor = functor
         }
         

--- a/Sources/BowFree/Coyoneda.swift
+++ b/Sources/BowFree/Coyoneda.swift
@@ -50,7 +50,7 @@ public class Coyoneda<F, P, A> : CoyonedaOf<F, P, A> {
 fileprivate class YonedaFromCoyoneda<F, A, Func> : Yoneda<F, A> where Func : Functor, Func.F == F {
     private let functor : Func
     
-    public init(_ functor : Func) {
+    init(_ functor : Func) {
         self.functor = functor
     }
     

--- a/Sources/BowFree/Free.swift
+++ b/Sources/BowFree/Free.swift
@@ -214,7 +214,7 @@ public extension Free {
         private let monad : MonG
         private let eq : EqGB
         
-        public init(_ functionK : FuncKFG, _ monad : MonG, _ eq : EqGB) {
+        init(_ functionK : FuncKFG, _ monad : MonG, _ eq : EqGB) {
             self.functionK = functionK
             self.monad = monad
             self.eq = eq

--- a/Sources/BowFree/Yoneda.swift
+++ b/Sources/BowFree/Yoneda.swift
@@ -69,7 +69,7 @@ public extension Yoneda {
         
         private let functor : Func
         
-        public init(_ functor : Func) {
+        init(_ functor : Func) {
             self.functor = functor
         }
         


### PR DESCRIPTION
## Goal

To have a single way to construct and demand for instances for a given typeclass instance for a data type.

## Implementation details

This PR removes the `public` visibility modifier from the `init` methods in some instances of typeclasses for data types that allowed users to build instances directly, instead of using the designated `static` methods in the corresponding data types. Since this was only possible in a few cases, the decision is to remove the accessibility to such initializers and force the usage of `static` methods to retrieve instances. An example: consider that an instance of `Eq` is needed for `Option<Int>`. Instead of initializing it manually:

```swift
let eq = Option<Int>.EqInstance(Int.EqInstance())
```

The correct way is:

```swift
let eq = Option<Int>.eq(Int.eq)
```