### PR TITLE
Add MARK to docs section

### DIFF
--- a/Sources/Bow/Syntax/HigherKinds.swift
+++ b/Sources/Bow/Syntax/HigherKinds.swift
@@ -8,6 +8,7 @@ import Foundation
 ///     class ForOption {}
 ///     class Option<A>: Kind<ForOption, A> {}
 open class Kind<F, A> {
+    /// Default initializer
     public init() {}
 }
 

--- a/Sources/Bow/Typeclasses/Monad.swift
+++ b/Sources/Bow/Typeclasses/Monad.swift
@@ -38,7 +38,7 @@ public extension Monad {
         return flatMap(fa, { a in a ? ifTrue() : ifFalse() })
     }
     
-    // Binding
+    // MARK: Monad comprehensions
     
     public static func binding<B, C>(_ f: () -> Kind<Self, B>,
                               _ fb: @escaping (B) -> Kind<Self, C>) -> Kind<Self, C> {
@@ -214,6 +214,7 @@ public extension Kind where F: Monad {
         return F.mproduct(self, f)
     }
 
+    // MARK: Syntax for Monad Comprehensions
     public static func binding<B, C>(_ f: () -> Kind<F, B>,
                                      _ fb: @escaping (B) -> Kind<F, C>) -> Kind<F, C> {
         return F.binding(f, fb)

--- a/Sources/BowEffects/Typeclasses/Async.swift
+++ b/Sources/BowEffects/Typeclasses/Async.swift
@@ -22,6 +22,7 @@ public func runAsyncUnsafe<F: Async, A>(_ f: @escaping () -> Either<F.E, A>) -> 
     return F.runAsync { callback in callback(f()) }
 }
 
+// MARK: Syntax for Async
 public extension Kind where F: Async {
     public static func runAsync(_ fa: @escaping Proc<F.E, A>) -> Kind<F, A> {
         return F.runAsync(fa)

--- a/Sources/BowEffects/Typeclasses/ConcurrentEffect.swift
+++ b/Sources/BowEffects/Typeclasses/ConcurrentEffect.swift
@@ -7,6 +7,7 @@ public protocol ConcurrentEffect: Effect {
     static func runAsyncCancellable<A>(_ fa: Kind<Self, A>, _ callback: @escaping (Either<E, A>) -> Kind<Self, ()>) -> Kind<Self, Disposable>
 }
 
+// MARK: Syntax for ConcurrentEffect
 public extension Kind where F: ConcurrentEffect {
     func runAsyncCancellable(_ callback: @escaping (Either<F.E, A>) -> Kind<F, ()>) -> Kind<F, Disposable> {
         return F.runAsyncCancellable(self, callback)

--- a/Sources/BowEffects/Typeclasses/Effect.swift
+++ b/Sources/BowEffects/Typeclasses/Effect.swift
@@ -5,6 +5,7 @@ public protocol Effect: Async {
     static func runAsync<A>(_ fa: Kind<Self, A>, _ callback: @escaping (Either<E, A>) -> Kind<Self, ()>) -> Kind<Self, ()>
 }
 
+// MARK: Syntax for Effect
 public extension Kind where F: Effect {
     public func runAsync(_ callback: @escaping (Either<F.E, A>) -> Kind<F, ()>) -> Kind<F, ()> {
         return F.runAsync(self, callback)

--- a/Sources/BowEffects/Typeclasses/MonadDefer.swift
+++ b/Sources/BowEffects/Typeclasses/MonadDefer.swift
@@ -26,6 +26,8 @@ public extension MonadDefer {
     }
 }
 
+// MARK: Syntax for MonadDefer
+
 public extension Kind where F: MonadDefer {
     public static func suspend(_ fa: @escaping () -> Kind<F, A>) -> Kind<F, A> {
         return F.suspend(fa)

--- a/Sources/BowRecursionSchemes/Typeclasses/Corecursive.swift
+++ b/Sources/BowRecursionSchemes/Typeclasses/Corecursive.swift
@@ -15,6 +15,8 @@ public extension Corecursive {
     }
 }
 
+// MARK: Syntax for Corecursive
+
 public extension Kind where F: Corecursive, A: Functor {
     public static func embedT(_ tf: Kind<A, Eval<Kind<F, A>>>) -> Eval<Kind<F, A>> {
         return F.embedT(tf)

--- a/Sources/BowRecursionSchemes/Typeclasses/Recursive.swift
+++ b/Sources/BowRecursionSchemes/Typeclasses/Recursive.swift
@@ -15,6 +15,8 @@ public extension Recursive {
     }
 }
 
+// MARK: Syntax for Recursive
+
 public extension Kind where F: Recursive, A: Functor {
     public func projectT() -> Kind<A, Kind<F, A>> {
         return F.projectT(self)


### PR DESCRIPTION
## Goal

Jazzy uses `// MARK:` as delimiters for sections in the docs. This PR adds some missing ones in order to have better sectioned docs for `Kind`.