### PR TITLE
Reformat Option docs

### DIFF
--- a/Sources/Bow/Data/Option.swift
+++ b/Sources/Bow/Data/Option.swift
@@ -1,18 +1,12 @@
 import Foundation
 
-/**
- Witness for the `Option<A>` data type. To be used in simulated Higher Kinded Types.
- */
+/// Witness for the `Option<A>` data type. To be used in simulated Higher Kinded Types.
 public final class ForOption {}
 
-/**
- Higher Kinded Type alias to improve readability of `Kind<ForOption, A>`.
- */
+/// Higher Kinded Type alias to improve readability of `Kind<ForOption, A>`.
 public typealias OptionOf<A> = Kind<ForOption, A>
 
-/**
- Represents optional values. Instances of this type may represent the presence of a value (`some`) or absence of it (`none`). This type is isomorphic to native Swift `Optional<A>` (usually written `A?`), with the addition of behaving as a Higher Kinded Type.
- */
+/// Represents optional values. Instances of this type may represent the presence of a value (`some`) or absence of it (`none`). This type is isomorphic to native Swift `Optional<A>` (usually written `A?`), with the addition of behaving as a Higher Kinded Type.
 public final class Option<A>: OptionOf<A> {
     private let value: A?
     /**
@@ -22,24 +16,30 @@ public final class Option<A>: OptionOf<A> {
      
      - parameter a: Value to be wrapped in an `Option<A>`.
      */
+
+    /// Constructs an instance of `Option` with presence of a value of the type parameter.
+    ///
+    /// It is an alias for `Option<A>.pure(_:)`
+    ///
+    /// - Parameter a: Value to be wrapped in an `Option`.
+    /// - Returns: An option wrapping the value passed as an argument.
     public static func some(_ a: A) -> Option<A> {
         return Option(a)
     }
-    
-    /**
-     Constucts an instance of `Option` with absence of a value.
-     
-     It is an alias for `Option<A>.empty()`
-     */
+
+    /// Constucts an instance of `Option` with absence of a value.
+    ///
+    /// It is an alias for `Option<A>.empty()`
+    ///
+    /// - Returns: An option with no present value
     public static func none() -> Option<A> {
         return Option(nil)
     }
-    
-    /**
-     Converts a native Swift optional into a value of `Option<A>`.
-     
-     - parameter a: Optional value to be converted.
-     */
+
+    /// Converts a native Swift optional into a value of `Option<A>`.
+    ///
+    /// - Parameter a: Optional value to be converted.
+    /// - Returns: An Option with the same structure as the argument.
     public static func fromOptional(_ a: A?) -> Option<A> {
         return Option(a)
     }
@@ -48,9 +48,10 @@ public final class Option<A>: OptionOf<A> {
         self.value = value
     }
 
-    /**
-     Safe downcast to `Option<A>`.
-     */
+    /// Safe downcasting.
+    ///
+    /// - Parameter fa: Option in higher-kind form.
+    /// - Returns: Value cast to Option.
     public static func fix(_ fa: OptionOf<A>) -> Option<A> {
         return fa as! Option<A>
     }
@@ -58,32 +59,30 @@ public final class Option<A>: OptionOf<A> {
     internal var isDefined: Bool {
         return !isEmpty
     }
-    
-    /**
-     Applies a function based on the presence or absence of a value.
-     
-     - parameter ifEmpty: A closure that is executed when there is no value in the `Option`.
-     - parameter f: A closure that is executed where there is a value in the `Option`. In such case, the the inner value is sent as an argument of `f`.
-     */
+
+    /// Applies a function based on the presence or absence of a value.
+    ///
+    /// - Parameters:
+    ///   - ifEmpty: A closure that is executed when there is no value in the `Option`.
+    ///   - f: A closure that is executed where there is a value in the `Option`. In such case, the the inner value is sent as an argument of `f`.
+    /// - Returns: Result of applying the corresponding closure based on the value of this object.
     public func fold<B>(_ ifEmpty: () -> B, _ f: (A) -> B) -> B {
         guard let value = self.value else { return ifEmpty() }
         return f(value)
     }
-    
-    /**
-     Applies a predicate to the wrapped value of this option, returning it if the value does not match the predicate, or none otherwise.
-     
-     - parameter predicate: Boolean predicate to test the wrapped value.
-     */
+
+    /// Applies a predicate to the wrapped value of this option, returning it if the value does not match the predicate, or none otherwise.
+    ///
+    /// - Parameter predicate: Boolean predicate to test the wrapped value.
+    /// - Returns: This value if it does not match the predicate, or none otherwise.
     public func filterNot(_ predicate: @escaping (A) -> Bool) -> Kind<ForOption, A> {
         return filter(predicate >>> not)
     }
-    
-    /**
-     Obtains the wrapped value, or a default value if absent.
-     
-     - parameter defaultValue: Value to be returned if this option is empty.
-     */
+
+    /// Obtains the wrapped value, or a default value if absent.
+    ///
+    /// - Parameter defaultValue: Value to be returned if this option is empty.
+    /// - Returns: The value wrapped in this Option, if present, or the value provided as an argument, otherwise.
     public func getOrElse(_ defaultValue: A) -> A {
         return getOrElse(constant(defaultValue))
     }
@@ -93,38 +92,41 @@ public final class Option<A>: OptionOf<A> {
      
      - parameter defaultValue: Closure to be evaluated if there is no wrapped value in this option.
      */
+
+    /// Obtains the wrapped value, or a default value if absent.
+    ///
+    /// - Parameter defaultValue: Closure to be evaluated if there is no wrapped value in this option.
+    /// - Returns: The value wrapped in this Option, if present, or the result of running the closure provided as an argument, otherwise.
     public func getOrElse(_ defaultValue: () -> A) -> A {
         return fold(defaultValue, id)
     }
-    
-    /**
-     Obtains this option, or a default value if this option is empty.
-     
-     - parameter defaultValue: Default option value to be returned if this option is empty.
-     */
+
+    /// Obtains this option, or a default value if this option is empty.
+    ///
+    /// - Parameter defaultValue: Default option value to be returned if this option is empty.
+    /// - Returns: This option, if has a present value, or the value provided as an argument, otherwise.
     public func orElse(_ defaultValue: Option<A>) -> Option<A> {
         return orElse(constant(defaultValue))
     }
-    
-    /**
-     Obtains this option, or a default value if this option is empty.
-     
-     - parameter defaultValue: Closure returning an option for the empty case.
-     */
+
+    /// Obtains this option, or a default value if this option is empty.
+    ///
+    /// - Parameter defaultValue: Closure returning an option for the empty case.
+    /// - Returns: This option, if has a present value, or the result of running the closure provided as an argument, otherwise.
     public func orElse(_ defaultValue: () -> Option<A>) -> Option<A> {
         return fold(defaultValue, Option.some)
     }
-    
-    /**
-     Converts this option into a native Swift optional `A?`.
-     */
+
+    /// Converts this option into a native Swift optional `A?`.
+    ///
+    /// - Returns: A Swift Optional with the same structure as this value.
     public func toOptional() -> A? {
         return fold(constant(nil), id)
     }
-    
-    /**
-     Converts this option into an empty array, if absent, or a singleton array, if present.
-     */
+
+    /// Converts this option into an array.
+    ///
+    /// - Returns: An empty array if this value is absent, or a singleton array, if present.
     public func toArray() -> [A] {
         return fold(constant([]), { a in [a] })
     }
@@ -132,9 +134,7 @@ public final class Option<A>: OptionOf<A> {
 
 // MARK: Protocol conformances
 
-/**
- Conformance of `Option` to `CustomStringConvertible`.
- */
+/// Conformance of `Option` to `CustomStringConvertible`.
 extension Option: CustomStringConvertible {
     public var description: String {
         return fold({ "None" },
@@ -142,9 +142,7 @@ extension Option: CustomStringConvertible {
     }
 }
 
-/**
- Conformance of `Option` to `CustomDebugStringConvertible`, given that the type parameter `A` also conforms to `CustomDebugStringConvertible`.
- */
+/// Conformance of `Option` to `CustomDebugStringConvertible`, given that the type parameter `A` also conforms to `CustomDebugStringConvertible`.
 extension Option: CustomDebugStringConvertible where A: CustomDebugStringConvertible {
     public var debugDescription : String {
         return fold(constant("None"),
@@ -152,6 +150,7 @@ extension Option: CustomDebugStringConvertible where A: CustomDebugStringConvert
     }
 }
 
+/// Instance of `EquatableK` for `Option`.
 extension ForOption: EquatableK {
     public static func eq<A>(_ lhs: Kind<ForOption, A>, _ rhs: Kind<ForOption, A>) -> Bool where A : Equatable {
         let ol = Option.fix(lhs)
@@ -161,18 +160,21 @@ extension ForOption: EquatableK {
     }
 }
 
+/// Instance of `Functor` for `Option`.
 extension ForOption: Functor {
     public static func map<A, B>(_ fa: Kind<ForOption, A>, _ f: @escaping (A) -> B) -> Kind<ForOption, B> {
         return Option.fix(fa).fold(Option.none, Option.some <<< f)
     }
 }
 
+/// Instance of `Applicative` for `Option`.
 extension ForOption: Applicative {
     public static func pure<A>(_ a: A) -> Kind<ForOption, A> {
         return Option.some(a)
     }
 }
 
+/// Instance of `Monad` for `Option`.
 extension ForOption: Monad {
     public static func flatMap<A, B>(_ fa: Kind<ForOption, A>, _ f: @escaping (A) -> Kind<ForOption, B>) -> Kind<ForOption, B> {
         let option = Option.fix(fa)
@@ -188,6 +190,7 @@ extension ForOption: Monad {
     }
 }
 
+/// Instance of `ApplicativeError` for `Option`.
 extension ForOption: ApplicativeError {
     public typealias E = Unit
 
@@ -200,16 +203,20 @@ extension ForOption: ApplicativeError {
     }
 }
 
+/// Instance of `MonadError` for `Option`.
 extension ForOption: MonadError {}
 
+/// Instance of `FunctorFilter` for `Option`.
 extension ForOption: FunctorFilter {}
 
+/// Instance of `MonadFilter` for `Option`.
 extension ForOption: MonadFilter {
     public static func empty<A>() -> Kind<ForOption, A> {
         return Option.none()
     }
 }
 
+/// Instance of `Foldable` for `Option`.
 extension ForOption: Foldable {
     public static func foldLeft<A, B>(_ fa: Kind<ForOption, A>, _ b: B, _ f: @escaping (B, A) -> B) -> B {
         let option = Option.fix(fa)
@@ -224,6 +231,7 @@ extension ForOption: Foldable {
     }
 }
 
+/// Instance of `Traverse` for `Option`.
 extension ForOption: Traverse {
     public static func traverse<G: Applicative, A, B>(_ fa: Kind<ForOption, A>, _ f: @escaping (A) -> Kind<G, B>) -> Kind<G, Kind<ForOption, B>> {
         let option = Option.fix(fa)
@@ -232,6 +240,7 @@ extension ForOption: Traverse {
     }
 }
 
+/// Instance of `TraverseFilter` for `Option`.
 extension ForOption: TraverseFilter {
     public static func traverseFilter<A, B, G: Applicative>(_ fa: Kind<ForOption, A>, _ f: @escaping (A) -> Kind<G, Kind<ForOption, B>>) -> Kind<G, Kind<ForOption, B>> {
         let option = Option.fix(fa)
@@ -239,6 +248,7 @@ extension ForOption: TraverseFilter {
     }
 }
 
+/// Instance of `Semigroup` for `Option`, provided that `A` has an instance of `Semigroup`.
 extension Option: Semigroup where A: Semigroup {
     public func combine(_ other: Option<A>) -> Option<A> {
         return self.fold(constant(other),
@@ -248,6 +258,7 @@ extension Option: Semigroup where A: Semigroup {
     }
 }
 
+/// Instance of `Monoid` for `Option`, provided that `A` has an instance of `Monoid`.
 extension Option: Monoid where A: Monoid {
     public static func empty() -> Option<A> {
         return Option(A.empty())
@@ -256,7 +267,22 @@ extension Option: Monoid where A: Monoid {
 
 // MARK: Optional extensions
 extension Optional {
+
+    /// Converts this Optional value into a `Bow.Option`.
+    ///
+    /// This is an alias for `Optional.k()`.
+    ///
+    /// - Returns: An Option value with the same structure as this value.
     func toOption() -> Option<Wrapped> {
         return Option<Wrapped>.fromOptional(self)
+    }
+
+    /// Converts this Optional value into a `Bow.Option`.
+    ///
+    /// This is an alias for `Optional.k()`.
+    ///
+    /// - Returns: An Option value with the same structure as this value.
+    func k() -> Option<Wrapped> {
+        return toOption()
     }
 }

--- a/Sources/Bow/Data/Option.swift
+++ b/Sources/Bow/Data/Option.swift
@@ -9,14 +9,6 @@ public typealias OptionOf<A> = Kind<ForOption, A>
 /// Represents optional values. Instances of this type may represent the presence of a value (`some`) or absence of it (`none`). This type is isomorphic to native Swift `Optional<A>` (usually written `A?`), with the addition of behaving as a Higher Kinded Type.
 public final class Option<A>: OptionOf<A> {
     private let value: A?
-    /**
-     Constructs an instance of `Option` with presence of a value of the type parameter.
-     
-     It is an alias for `Option<A>.pure(_:)`
-     
-     - parameter a: Value to be wrapped in an `Option<A>`.
-     */
-
     /// Constructs an instance of `Option` with presence of a value of the type parameter.
     ///
     /// It is an alias for `Option<A>.pure(_:)`

--- a/Sources/Bow/Data/Option.swift
+++ b/Sources/Bow/Data/Option.swift
@@ -79,12 +79,6 @@ public final class Option<A>: OptionOf<A> {
         return getOrElse(constant(defaultValue))
     }
     
-    /**
-     Obtains the wrapped value, or a default value if absent.
-     
-     - parameter defaultValue: Closure to be evaluated if there is no wrapped value in this option.
-     */
-
     /// Obtains the wrapped value, or a default value if absent.
     ///
     /// - Parameter defaultValue: Closure to be evaluated if there is no wrapped value in this option.


### PR DESCRIPTION
## Goal

Use the triple slash syntax (`///`) autogenerated by Xcode in the docs for `Option` to keep consistency across the codebase.
