### PR TITLE
API docs for Invariant, Functor, Applicative and Monad

### DIFF
--- a/Sources/Bow/Typeclasses/Applicative.swift
+++ b/Sources/Bow/Typeclasses/Applicative.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-/// An Applicative Functor is a `Functor` that also provides functionality to embed pure expressions, and sequence computations and combine their results.
+/// An Applicative Functor is a `Functor` that also provides functionality to lift pure expressions, and sequence computations and combine their results.
 ///
 /// Instances of this typeclass must obey the following laws:
 ///

--- a/Sources/Bow/Typeclasses/Applicative.swift
+++ b/Sources/Bow/Typeclasses/Applicative.swift
@@ -1,69 +1,181 @@
 import Foundation
 
+/// An Applicative Functor is a `Functor` that also provides functionality to embed pure expressions, and sequence computations and combine their results.
+///
+/// Instances of this typeclass must obey the following laws:
+///
+/// 1. Identity
+///
+///         ap(pure(id), v) == v
+///
+/// 2. Composition
+///
+///         ap(ap(ap(pure(compose), u), v), w) == compose(u, compose(v, w))
+///
+/// 3. Homomorphism
+///
+///         ap(pure(f), pure(x)) == pure(f(x))
+///
+/// 4. Interchange
+///
+///         ap(fa, pure(b)) == ap(pure({ x in x(a) }), fa)
 public protocol Applicative: Functor {
+    /// Lifts a value to the context type implementing this instance of `Applicative`.
+    ///
+    /// - Parameter a: Value to be lifted.
+    /// - Returns: Provided value in the context type implementing this instance.
     static func pure<A>(_ a: A) -> Kind<Self, A>
+
+    /// Sequential application.
+    ///
+    /// - Parameters:
+    ///   - ff: A function in the context implementing this instance.
+    ///   - fa: A value in the context implementing this instance.
+    /// - Returns: A value in the context implementing this instance, resulting of the transformation of the contained original value with the contained function.
     static func ap<A, B>(_ ff: Kind<Self, (A) -> B>, _ fa: Kind<Self, A>) -> Kind<Self, B>
 }
 
+// MARK: Related functions
 public extension Applicative {
-//    public static func map<A, B>(_ fa: Kind<Self, A>, _ f: @escaping (A) -> B) -> Kind<Self, B>{
-//        return ap(pure(f), fa)
-//    }
-    
+    /// Creates a tuple in the context implementing this instance from two values in the same context.
+    ///
+    /// - Parameters:
+    ///   - fa: 1st value for the tuple.
+    ///   - fb: 2nd value for the tuple.
+    /// - Returns: A tuple of the provided values in the context implementing this instance.
     public static func product<A, B>(_ fa: Kind<Self, A>, _ fb: Kind<Self, B>) -> Kind<Self, (A, B)> {
-        return ap(map(fa, { (a : A) in { (b : B) in (a, b) }}), fb)
+        return ap(map(fa, { (a: A) in { (b: B) in (a, b) }}), fb)
     }
     
+    /// Adds an element to the right of a tuple in the context implementing this instance.
+    ///
+    /// - Parameters:
+    ///   - fa: A tuple of two elements in the context implementing this instance.
+    ///   - fz: A value in the context implementing this instance.
+    /// - Returns: A tuple with the value of the second argument added to the right of the tuple, in the context implementing this instance.
     public static func product<A, B, Z>(_ fa: Kind<Self, (A, B)>, _ fz: Kind<Self, Z>) -> Kind<Self, (A, B, Z)> {
         return map(product(fa, fz), { a, b in (a.0, a.1, b) })
     }
-    
+
+    /// Adds an element to the right of a tuple in the context implementing this instance.
+    ///
+    /// - Parameters:
+    ///   - fa: A tuple of three elements in the context implementing this instance.
+    ///   - fz: A value in the context implementing this instance.
+    /// - Returns: A tuple with the value of the second argument added to the right of the tuple, in the context implementing this instance.
     public static func product<A, B, C, Z>(_ fa: Kind<Self, (A, B, C)>, _ fz: Kind<Self, Z>) -> Kind<Self, (A, B, C, Z)> {
         return map(product(fa, fz), { a, b in (a.0, a.1, a.2, b) })
     }
-    
+
+    /// Adds an element to the right of a tuple in the context implementing this instance.
+    ///
+    /// - Parameters:
+    ///   - fa: A tuple of four elements in the context implementing this instance.
+    ///   - fz: A value in the context implementing this instance.
+    /// - Returns: A tuple with the value of the second argument added to the right of the tuple, in the context implementing this instance.
     public static func product<A, B, C, D, Z>(_ fa: Kind<Self, (A, B, C, D)>, _ fz: Kind<Self, Z>) -> Kind<Self, (A, B, C, D, Z)> {
         return map(product(fa, fz), { a, b in (a.0, a.1, a.2, a.3, b) })
     }
-    
+
+    /// Adds an element to the right of a tuple in the context implementing this instance.
+    ///
+    /// - Parameters:
+    ///   - fa: A tuple of five elements in the context implementing this instance.
+    ///   - fz: A value in the context implementing this instance.
+    /// - Returns: A tuple with the value of the second argument added to the right of the tuple, in the context implementing this instance.
     public static func product<A, B, C, D, E, Z>(_ fa: Kind<Self, (A, B, C, D, E)>, _ fz: Kind<Self, Z>) -> Kind<Self, (A, B, C, D, E, Z)> {
         return map(product(fa, fz), { a, b in (a.0, a.1, a.2, a.3, a.4, b) })
     }
-    
+
+    /// Adds an element to the right of a tuple in the context implementing this instance.
+    ///
+    /// - Parameters:
+    ///   - fa: A tuple of six elements in the context implementing this instance.
+    ///   - fz: A value in the context implementing this instance.
+    /// - Returns: A tuple with the value of the second argument added to the right of the tuple, in the context implementing this instance.
     public static func product<A, B, C, D, E, G, Z>(_ fa: Kind<Self, (A, B, C, D, E, G)>, _ fz: Kind<Self, Z>) -> Kind<Self, (A, B, C, D, E, G, Z)> {
         return map(product(fa, fz), { a, b in (a.0, a.1, a.2, a.3, a.4, a.5, b) })
     }
-    
+
+    /// Adds an element to the right of a tuple in the context implementing this instance.
+    ///
+    /// - Parameters:
+    ///   - fa: A tuple of seven elements in the context implementing this instance.
+    ///   - fz: A value in the context implementing this instance.
+    /// - Returns: A tuple with the value of the second argument added to the right of the tuple, in the context implementing this instance.
     public static func product<A, B, C, D, E, G, H, Z>(_ fa: Kind<Self, (A, B, C, D, E, G, H)>, _ fz: Kind<Self, Z>) -> Kind<Self, (A, B, C, D, E, G, H, Z)> {
         return map(product(fa, fz), { a, b in (a.0, a.1, a.2, a.3, a.4, a.5, a.6, b) })
     }
-    
-    public static func product<A, B, C, D, E, G, H, I, Z>(_ fa: Kind<Self, (A, B, C, D, E, G, H, I)>, _ fz : Kind<Self, Z>) -> Kind<Self, (A, B, C, D, E, G, H, I, Z)> {
+
+    /// Adds an element to the right of a tuple in the context implementing this instance.
+    ///
+    /// - Parameters:
+    ///   - fa: A tuple of eight elements in the context implementing this instance.
+    ///   - fz: A value in the context implementing this instance.
+    /// - Returns: A tuple with the value of the second argument added to the right of the tuple, in the context implementing this instance.
+    public static func product<A, B, C, D, E, G, H, I, Z>(_ fa: Kind<Self, (A, B, C, D, E, G, H, I)>, _ fz: Kind<Self, Z>) -> Kind<Self, (A, B, C, D, E, G, H, I, Z)> {
         return map(product(fa, fz), { a, b in (a.0, a.1, a.2, a.3, a.4, a.5, a.6, a.7, b) })
     }
     
+    /// Performs two computations in the context implementing this instance and combines their result using the provided function.
+    ///
+    /// - Parameters:
+    ///   - fa: A value in the context implementing this instance.
+    ///   - fb: A lazy value in the context implementing this instance.
+    ///   - f: A function to combine the result of the computations.
+    /// - Returns: A lazy value with the result of combining the results of each computation.
     public static func map2Eval<A, B, Z>(_ fa: Kind<Self, A>, _ fb: Eval<Kind<Self, B>>, _ f: @escaping (A, B) -> Z) -> Eval<Kind<Self, Z>> {
         return Eval.fix(fb.map{ fc in map(fa, fc, f) })
     }
     
+    /// Creates a tuple out of two values in the context implementing this instance.
+    ///
+    /// - Parameters:
+    ///   - a: 1st value of the tuple.
+    ///   - b: 2nd value of the tuple.
+    /// - Returns: A tuple in the context implementing this instance.
     public static func tupled<A, B>(_ a: Kind<Self, A>,
                              _ b : Kind<Self, B>) -> Kind<Self, (A, B)> {
         return product(a, b)
     }
-    
+
+    /// Creates a tuple out of three values in the context implementing this instance.
+    ///
+    /// - Parameters:
+    ///   - a: 1st value of the tuple.
+    ///   - b: 2nd value of the tuple.
+    ///   - c: 3rd value of the tuple.
+    /// - Returns: A tuple in the context implementing this instance.
     public static func tupled<A, B, C>(_ a: Kind<Self, A>,
                                 _ b: Kind<Self, B>,
                                 _ c: Kind<Self, C>) -> Kind<Self, (A, B, C)> {
         return product(product(a, b), c)
     }
-    
+
+    /// Creates a tuple out of four values in the context implementing this instance.
+    ///
+    /// - Parameters:
+    ///   - a: 1st value of the tuple.
+    ///   - b: 2nd value of the tuple.
+    ///   - c: 3rd value of the tuple.
+    ///   - d: 4th value of the tuple.
+    /// - Returns: A tuple in the context implementing this instance.
     public static func tupled<A, B, C, D>(_ a: Kind<Self, A>,
                                    _ b: Kind<Self, B>,
                                    _ c: Kind<Self, C>,
                                    _ d: Kind<Self, D>) -> Kind<Self, (A, B, C, D)> {
         return product(product(product(a, b), c), d)
     }
-    
+
+    /// Creates a tuple out of five values in the context implementing this instance.
+    ///
+    /// - Parameters:
+    ///   - a: 1st value of the tuple.
+    ///   - b: 2nd value of the tuple.
+    ///   - c: 3rd value of the tuple.
+    ///   - d: 4th value of the tuple.
+    ///   - e: 5th value of the tuple.
+    /// - Returns: A tuple in the context implementing this instance.
     public static func tupled<A, B, C, D, E>(_ a: Kind<Self, A>,
                                       _ b: Kind<Self, B>,
                                       _ c: Kind<Self, C>,
@@ -71,7 +183,17 @@ public extension Applicative {
                                       _ e: Kind<Self, E>) -> Kind<Self, (A, B, C, D, E)> {
         return product(product(product(product(a, b), c), d), e)
     }
-    
+
+    /// Creates a tuple out of six values in the context implementing this instance.
+    ///
+    /// - Parameters:
+    ///   - a: 1st value of the tuple.
+    ///   - b: 2nd value of the tuple.
+    ///   - c: 3rd value of the tuple.
+    ///   - d: 4th value of the tuple.
+    ///   - e: 5th value of the tuple.
+    ///   - g: 6th value of the tuple.
+    /// - Returns: A tuple in the context implementing this instance.
     public static func tupled<A, B, C, D, E, G>(_ a: Kind<Self, A>,
                                          _ b: Kind<Self, B>,
                                          _ c: Kind<Self, C>,
@@ -80,7 +202,18 @@ public extension Applicative {
                                          _ g: Kind<Self, G>) -> Kind<Self, (A, B, C, D, E, G)> {
         return product(product(product(product(product(a, b), c), d), e), g)
     }
-    
+
+    /// Creates a tuple out of seven values in the context implementing this instance.
+    ///
+    /// - Parameters:
+    ///   - a: 1st value of the tuple.
+    ///   - b: 2nd value of the tuple.
+    ///   - c: 3rd value of the tuple.
+    ///   - d: 4th value of the tuple.
+    ///   - e: 5th value of the tuple.
+    ///   - g: 6th value of the tuple.
+    ///   - h: 7th value of the tuple.
+    /// - Returns: A tuple in the context implementing this instance.
     public static func tupled<A, B, C, D, E, G, H>(_ a: Kind<Self, A>,
                                             _ b: Kind<Self, B>,
                                             _ c: Kind<Self, C>,
@@ -90,7 +223,19 @@ public extension Applicative {
                                             _ h: Kind<Self, H>) -> Kind<Self, (A, B, C, D, E, G, H)> {
         return product(product(product(product(product(product(a, b), c), d), e), g), h)
     }
-    
+
+    /// Creates a tuple out of eight values in the context implementing this instance.
+    ///
+    /// - Parameters:
+    ///   - a: 1st value of the tuple.
+    ///   - b: 2nd value of the tuple.
+    ///   - c: 3rd value of the tuple.
+    ///   - d: 4th value of the tuple.
+    ///   - e: 5th value of the tuple.
+    ///   - g: 6th value of the tuple.
+    ///   - h: 7th value of the tuple.
+    ///   - i: 8th value of the tuple.
+    /// - Returns: A tuple in the context implementing this instance.
     public static func tupled<A, B, C, D, E, G, H, I>(_ a: Kind<Self, A>,
                                                _ b: Kind<Self, B>,
                                                _ c: Kind<Self, C>,
@@ -101,7 +246,20 @@ public extension Applicative {
                                                _ i: Kind<Self, I>) -> Kind<Self, (A, B, C, D, E, G, H, I)> {
         return product(product(product(product(product(product(product(a, b), c), d), e), g), h), i)
     }
-    
+
+    /// Creates a tuple out of nine values in the context implementing this instance.
+    ///
+    /// - Parameters:
+    ///   - a: 1st value of the tuple.
+    ///   - b: 2nd value of the tuple.
+    ///   - c: 3rd value of the tuple.
+    ///   - d: 4th value of the tuple.
+    ///   - e: 5th value of the tuple.
+    ///   - g: 6th value of the tuple.
+    ///   - h: 7th value of the tuple.
+    ///   - i: 8th value of the tuple.
+    ///   - j: 9th value of the tuple.
+    /// - Returns: A tuple in the context implementing this instance.
     public static func tupled<A, B, C, D, E, G, H, I, J>(_ a: Kind<Self, A>,
                                                   _ b: Kind<Self, B>,
                                                   _ c: Kind<Self, C>,
@@ -113,20 +271,44 @@ public extension Applicative {
                                                   _ j: Kind<Self, J>) -> Kind<Self, (A, B, C, D, E, G, H, I, J)> {
         return product(product(product(product(product(product(product(product(a, b), c), d), e), g), h), i), j)
     }
-    
+
+    /// Combines the result of two computations in the context implementing this instance, using the provided function.
+    ///
+    /// - Parameters:
+    ///   - a: 1st computation.
+    ///   - b: 2nd computation.
+    ///   - f: Combination function.
+    /// - Returns: Result of combining the provided computations, in the context implementing this instance.
     public static func map<A, B, Z>(_ a: Kind<Self, A>,
                       _ b: Kind<Self, B>,
                       _ f: @escaping (A, B) -> Z) -> Kind<Self, Z> {
         return map(tupled(a, b), f)
     }
-    
+
+    /// Combines the result of three computations in the context implementing this instance, using the provided function.
+    ///
+    /// - Parameters:
+    ///   - a: 1st computation.
+    ///   - b: 2nd computation.
+    ///   - c: 3rd computation.
+    ///   - f: Combination function.
+    /// - Returns: Result of combining the provided computations, in the context implementing this instance.
     public static func map<A, B, C, Z>(_ a: Kind<Self, A>,
                          _ b: Kind<Self, B>,
                          _ c: Kind<Self, C>,
                          _ f: @escaping (A, B, C) -> Z) -> Kind<Self, Z> {
         return map(tupled(a, b, c), f)
     }
-    
+
+    /// Combines the result of four computations in the context implementing this instance, using the provided function.
+    ///
+    /// - Parameters:
+    ///   - a: 1st computation.
+    ///   - b: 2nd computation.
+    ///   - c: 3rd computation.
+    ///   - d: 4th computation.
+    ///   - f: Combination function.
+    /// - Returns: Result of combining the provided computations, in the context implementing this instance.
     public static func map<A, B, C, D, Z>(_ a: Kind<Self, A>,
                             _ b: Kind<Self, B>,
                             _ c: Kind<Self, C>,
@@ -134,7 +316,17 @@ public extension Applicative {
                             _ f: @escaping (A, B, C, D) -> Z) -> Kind<Self, Z> {
         return map(tupled(a, b, c, d), f)
     }
-    
+
+    /// Combines the result of five computations in the context implementing this instance, using the provided function.
+    ///
+    /// - Parameters:
+    ///   - a: 1st computation.
+    ///   - b: 2nd computation.
+    ///   - c: 3rd computation.
+    ///   - d: 4th computation.
+    ///   - e: 5th computation.
+    ///   - f: Combination function.
+    /// - Returns: Result of combining the provided computations, in the context implementing this instance.
     public static func map<A, B, C, D, E, Z>(_ a: Kind<Self, A>,
                                _ b: Kind<Self, B>,
                                _ c: Kind<Self, C>,
@@ -143,7 +335,18 @@ public extension Applicative {
                                _ f: @escaping (A, B, C, D, E) -> Z) -> Kind<Self, Z> {
         return map(tupled(a, b, c, d, e), f)
     }
-    
+
+    /// Combines the result of six computations in the context implementing this instance, using the provided function.
+    ///
+    /// - Parameters:
+    ///   - a: 1st computation.
+    ///   - b: 2nd computation.
+    ///   - c: 3rd computation.
+    ///   - d: 4th computation.
+    ///   - e: 5th computation.
+    ///   - g: 6th computation.
+    ///   - f: Combination function.
+    /// - Returns: Result of combining the provided computations, in the context implementing this instance.
     public static func map<A, B, C, D, E, G, Z>(_ a: Kind<Self, A>,
                                   _ b: Kind<Self, B>,
                                   _ c: Kind<Self, C>,
@@ -153,7 +356,19 @@ public extension Applicative {
                                   _ f: @escaping (A, B, C, D, E, G) -> Z) -> Kind<Self, Z> {
         return map(tupled(a, b, c, d, e, g), f)
     }
-    
+
+    /// Combines the result of seven computations in the context implementing this instance, using the provided function.
+    ///
+    /// - Parameters:
+    ///   - a: 1st computation.
+    ///   - b: 2nd computation.
+    ///   - c: 3rd computation.
+    ///   - d: 4th computation.
+    ///   - e: 5th computation.
+    ///   - g: 6th computation.
+    ///   - h: 7th computation.
+    ///   - f: Combination function.
+    /// - Returns: Result of combining the provided computations, in the context implementing this instance.
     public static func map<A, B, C, D, E, G, H, Z>(_ a: Kind<Self, A>,
                                      _ b: Kind<Self, B>,
                                      _ c: Kind<Self, C>,
@@ -164,7 +379,20 @@ public extension Applicative {
                                      _ f: @escaping (A, B, C, D, E, G, H) -> Z) -> Kind<Self, Z> {
         return map(tupled(a, b, c, d, e, g, h), f)
     }
-    
+
+    /// Combines the result of eight computations in the context implementing this instance, using the provided function.
+    ///
+    /// - Parameters:
+    ///   - a: 1st computation.
+    ///   - b: 2nd computation.
+    ///   - c: 3rd computation.
+    ///   - d: 4th computation.
+    ///   - e: 5th computation.
+    ///   - g: 6th computation.
+    ///   - h: 7th computation.
+    ///   - i: 8th computation.
+    ///   - f: Combination function.
+    /// - Returns: Result of combining the provided computations, in the context implementing this instance.
     public static func map<A, B, C, D, E, G, H, I, Z>(_ a: Kind<Self, A>,
                                         _ b: Kind<Self, B>,
                                         _ c: Kind<Self, C>,
@@ -176,7 +404,21 @@ public extension Applicative {
                                         _ f: @escaping (A, B, C, D, E, G, H, I) -> Z) -> Kind<Self, Z> {
         return map(tupled(a, b, c, d, e, g, h, i), f)
     }
-    
+
+    /// Combines the result of nine computations in the context implementing this instance, using the provided function.
+    ///
+    /// - Parameters:
+    ///   - a: 1st computation.
+    ///   - b: 2nd computation.
+    ///   - c: 3rd computation.
+    ///   - d: 4th computation.
+    ///   - e: 5th computation.
+    ///   - g: 6th computation.
+    ///   - h: 7th computation.
+    ///   - i: 8th computation.
+    ///   - j: 9th computation.
+    ///   - f: Combination function.
+    /// - Returns: Result of combining the provided computations, in the context implementing this instance.
     public static func map<A, B, C, D, E, G, H, I, J, Z>(_ a: Kind<Self, A>,
                                            _ b: Kind<Self, B>,
                                            _ c: Kind<Self, C>,
@@ -193,57 +435,161 @@ public extension Applicative {
 
 // MARK: Syntax for Applicative
 public extension Kind where F: Applicative {
+    /// Lifts a value to the context type implementing this instance of `Applicative`.
+    ///
+    /// This is a convenience method to call `Applicative.pure` as a static method of this type.
+    ///
+    /// - Parameter a: Value to be lifted.
+    /// - Returns: Provided value in the context type implementing this instance.
     public static func pure(_ a: A) -> Kind<F, A> {
         return F.pure(a)
     }
 
+    /// Sequential application.
+    ///
+    /// This is a convenience method to call `Applicative.ap` as an instance method of this type.
+    ///
+    /// - Parameters:
+    ///   - fa: A value in the context implementing this instance.
+    /// - Returns: A value in the context implementing this instance, resulting of the transformation of the contained original value with the contained function.
     public func ap<AA, B>(_ fa: Kind<F, AA>) -> Kind<F, B> where A == (AA) -> B {
         return F.ap(self, fa)
     }
 
+    /// Creates a tuple in the context implementing this instance from two values in the same context.
+    ///
+    /// This is a convenience method to call `Applicative.product` as a static method of this type.
+    ///
+    /// - Parameters:
+    ///   - fa: 1st value for the tuple.
+    ///   - fb: 2nd value for the tuple.
+    /// - Returns: A tuple of the provided values in the context implementing this instance.
     public static func product<A, B>(_ fa: Kind<F, A>, _ fb: Kind<F, B>) -> Kind<F, (A, B)> {
         return F.product(fa, fb)
     }
 
+    /// Adds an element to the right of a tuple in the context implementing this instance.
+    ///
+    /// This is a convenience method to call `Applicative.product` as a static method of this type.
+    ///
+    /// - Parameters:
+    ///   - fa: A tuple of two elements in the context implementing this instance.
+    ///   - fz: A value in the context implementing this instance.
+    /// - Returns: A tuple with the value of the second argument added to the right of the tuple, in the context implementing this instance.
     public static func product<A, B, Z>(_ fa: Kind<F, (A, B)>, _ fz: Kind<F, Z>) -> Kind<F, (A, B, Z)> {
         return F.product(fa, fz)
     }
 
+    /// Adds an element to the right of a tuple in the context implementing this instance.
+    ///
+    /// This is a convenience method to call `Applicative.product` as a static method of this type.
+    ///
+    /// - Parameters:
+    ///   - fa: A tuple of three elements in the context implementing this instance.
+    ///   - fz: A value in the context implementing this instance.
+    /// - Returns: A tuple with the value of the second argument added to the right of the tuple, in the context implementing this instance.
     public static func product<A, B, C, Z>(_ fa: Kind<F, (A, B, C)>, _ fz: Kind<F, Z>) -> Kind<F, (A, B, C, Z)> {
         return F.product(fa, fz)
     }
 
+    /// Adds an element to the right of a tuple in the context implementing this instance.
+    ///
+    /// This is a convenience method to call `Applicative.product` as a static method of this type.
+    ///
+    /// - Parameters:
+    ///   - fa: A tuple of four elements in the context implementing this instance.
+    ///   - fz: A value in the context implementing this instance.
+    /// - Returns: A tuple with the value of the second argument added to the right of the tuple, in the context implementing this instance.
     public static func product<A, B, C, D, Z>(_ fa: Kind<F, (A, B, C, D)>, _ fz: Kind<F, Z>) -> Kind<F, (A, B, C, D, Z)> {
         return F.product(fa, fz)
     }
 
+    /// Adds an element to the right of a tuple in the context implementing this instance.
+    ///
+    /// This is a convenience method to call `Applicative.product` as a static method of this type.
+    ///
+    /// - Parameters:
+    ///   - fa: A tuple of five elements in the context implementing this instance.
+    ///   - fz: A value in the context implementing this instance.
+    /// - Returns: A tuple with the value of the second argument added to the right of the tuple, in the context implementing this instance.
     public static func product<A, B, C, D, E, Z>(_ fa: Kind<F, (A, B, C, D, E)>, _ fz: Kind<F, Z>) -> Kind<F, (A, B, C, D, E, Z)> {
         return F.product(fa, fz)
     }
 
+    /// Adds an element to the right of a tuple in the context implementing this instance.
+    ///
+    /// This is a convenience method to call `Applicative.product` as a static method of this type.
+    ///
+    /// - Parameters:
+    ///   - fa: A tuple of six elements in the context implementing this instance.
+    ///   - fz: A value in the context implementing this instance.
+    /// - Returns: A tuple with the value of the second argument added to the right of the tuple, in the context implementing this instance.
     public static func product<A, B, C, D, E, G, Z>(_ fa: Kind<F, (A, B, C, D, E, G)>, _ fz: Kind<F, Z>) -> Kind<F, (A, B, C, D, E, G, Z)> {
         return F.product(fa, fz)
     }
 
+    /// Adds an element to the right of a tuple in the context implementing this instance.
+    ///
+    /// This is a convenience method to call `Applicative.product` as a static method of this type.
+    ///
+    /// - Parameters:
+    ///   - fa: A tuple of seven elements in the context implementing this instance.
+    ///   - fz: A value in the context implementing this instance.
+    /// - Returns: A tuple with the value of the second argument added to the right of the tuple, in the context implementing this instance.
     public static func product<A, B, C, D, E, G, H, Z>(_ fa: Kind<F, (A, B, C, D, E, G, H)>, _ fz: Kind<F, Z>) -> Kind<F, (A, B, C, D, E, G, H, Z)> {
         return F.product(fa, fz)
     }
 
+    /// Adds an element to the right of a tuple in the context implementing this instance.
+    ///
+    /// This is a convenience method to call `Applicative.product` as a static method of this type.
+    ///
+    /// - Parameters:
+    ///   - fa: A tuple of eight elements in the context implementing this instance.
+    ///   - fz: A value in the context implementing this instance.
+    /// - Returns: A tuple with the value of the second argument added to the right of the tuple, in the context implementing this instance.
     public static func product<A, B, C, D, E, G, H, I, Z>(_ fa: Kind<F, (A, B, C, D, E, G, H, I)>, _ fz : Kind<F, Z>) -> Kind<F, (A, B, C, D, E, G, H, I, Z)> {
         return F.product(fa, fz)
     }
 
+    /// Creates a tuple out of two values in the context implementing this instance.
+    ///
+    /// This is a convenience method to call `Applicative.tupled` as a static method of this type.
+    ///
+    /// - Parameters:
+    ///   - a: 1st value of the tuple.
+    ///   - b: 2nd value of the tuple.
+    /// - Returns: A tuple in the context implementing this instance.
     public static func tupled<A, B>(_ a: Kind<F, A>,
                                     _ b : Kind<F, B>) -> Kind<F, (A, B)> {
         return F.tupled(a, b)
     }
 
+    /// Creates a tuple out of three values in the context implementing this instance.
+    ///
+    /// This is a convenience method to call `Applicative.tupled` as a static method of this type.
+    ///
+    /// - Parameters:
+    ///   - a: 1st value of the tuple.
+    ///   - b: 2nd value of the tuple.
+    ///   - c: 3rd value of the tuple.
+    /// - Returns: A tuple in the context implementing this instance.
     public static func tupled<A, B, C>(_ a: Kind<F, A>,
                                        _ b: Kind<F, B>,
                                        _ c: Kind<F, C>) -> Kind<F, (A, B, C)> {
         return F.tupled(a, b, c)
     }
 
+    /// Creates a tuple out of four values in the context implementing this instance.
+    ///
+    /// This is a convenience method to call `Applicative.tupled` as a static method of this type.
+    ///
+    /// - Parameters:
+    ///   - a: 1st value of the tuple.
+    ///   - b: 2nd value of the tuple.
+    ///   - c: 3rd value of the tuple.
+    ///   - d: 4th value of the tuple.
+    /// - Returns: A tuple in the context implementing this instance.
     public static func tupled<A, B, C, D>(_ a: Kind<F, A>,
                                           _ b: Kind<F, B>,
                                           _ c: Kind<F, C>,
@@ -251,6 +597,17 @@ public extension Kind where F: Applicative {
         return F.tupled(a, b, c, d)
     }
 
+    /// Creates a tuple out of five values in the context implementing this instance.
+    ///
+    /// This is a convenience method to call `Applicative.tupled` as a static method of this type.
+    ///
+    /// - Parameters:
+    ///   - a: 1st value of the tuple.
+    ///   - b: 2nd value of the tuple.
+    ///   - c: 3rd value of the tuple.
+    ///   - d: 4th value of the tuple.
+    ///   - e: 5th value of the tuple.
+    /// - Returns: A tuple in the context implementing this instance.
     public static func tupled<A, B, C, D, E>(_ a: Kind<F, A>,
                                              _ b: Kind<F, B>,
                                              _ c: Kind<F, C>,
@@ -259,6 +616,18 @@ public extension Kind where F: Applicative {
         return F.tupled(a, b, c, d, e)
     }
 
+    /// Creates a tuple out of six values in the context implementing this instance.
+    ///
+    /// This is a convenience method to call `Applicative.tupled` as a static method of this type.
+    ///
+    /// - Parameters:
+    ///   - a: 1st value of the tuple.
+    ///   - b: 2nd value of the tuple.
+    ///   - c: 3rd value of the tuple.
+    ///   - d: 4th value of the tuple.
+    ///   - e: 5th value of the tuple.
+    ///   - g: 6th value of the tuple.
+    /// - Returns: A tuple in the context implementing this instance.
     public static func tupled<A, B, C, D, E, G>(_ a: Kind<F, A>,
                                                 _ b: Kind<F, B>,
                                                 _ c: Kind<F, C>,
@@ -268,6 +637,19 @@ public extension Kind where F: Applicative {
         return F.tupled(a, b, c, d, e, g)
     }
 
+    /// Creates a tuple out of seven values in the context implementing this instance.
+    ///
+    /// This is a convenience method to call `Applicative.tupled` as a static method of this type.
+    ///
+    /// - Parameters:
+    ///   - a: 1st value of the tuple.
+    ///   - b: 2nd value of the tuple.
+    ///   - c: 3rd value of the tuple.
+    ///   - d: 4th value of the tuple.
+    ///   - e: 5th value of the tuple.
+    ///   - g: 6th value of the tuple.
+    ///   - h: 7th value of the tuple.
+    /// - Returns: A tuple in the context implementing this instance.
     public static func tupled<A, B, C, D, E, G, H>(_ a: Kind<F, A>,
                                                    _ b: Kind<F, B>,
                                                    _ c: Kind<F, C>,
@@ -278,6 +660,20 @@ public extension Kind where F: Applicative {
         return F.tupled(a, b, c, d, e, g, h)
     }
 
+    /// Creates a tuple out of eight values in the context implementing this instance.
+    ///
+    /// This is a convenience method to call `Applicative.tupled` as a static method of this type.
+    ///
+    /// - Parameters:
+    ///   - a: 1st value of the tuple.
+    ///   - b: 2nd value of the tuple.
+    ///   - c: 3rd value of the tuple.
+    ///   - d: 4th value of the tuple.
+    ///   - e: 5th value of the tuple.
+    ///   - g: 6th value of the tuple.
+    ///   - h: 7th value of the tuple.
+    ///   - i: 8th value of the tuple.
+    /// - Returns: A tuple in the context implementing this instance.
     public static func tupled<A, B, C, D, E, G, H, I>(_ a: Kind<F, A>,
                                                       _ b: Kind<F, B>,
                                                       _ c: Kind<F, C>,
@@ -289,6 +685,21 @@ public extension Kind where F: Applicative {
         return F.tupled(a, b, c, d, e, g, h, i)
     }
 
+    /// Creates a tuple out of nine values in the context implementing this instance.
+    ///
+    /// This is a convenience method to call `Applicative.tupled` as a static method of this type.
+    ///
+    /// - Parameters:
+    ///   - a: 1st value of the tuple.
+    ///   - b: 2nd value of the tuple.
+    ///   - c: 3rd value of the tuple.
+    ///   - d: 4th value of the tuple.
+    ///   - e: 5th value of the tuple.
+    ///   - g: 6th value of the tuple.
+    ///   - h: 7th value of the tuple.
+    ///   - i: 8th value of the tuple.
+    ///   - j: 9th value of the tuple.
+    /// - Returns: A tuple in the context implementing this instance.
     public static func tupled<A, B, C, D, E, G, H, I, J>(_ a: Kind<F, A>,
                                                          _ b: Kind<F, B>,
                                                          _ c: Kind<F, C>,
@@ -301,12 +712,31 @@ public extension Kind where F: Applicative {
         return F.tupled(a, b, c, d, e, g, h, i, j)
     }
 
+    /// Combines the result of two computations in the context implementing this instance, using the provided function.
+    ///
+    /// This is a convenience method to call `Applicative.map` as a static method of this type.
+    ///
+    /// - Parameters:
+    ///   - a: 1st computation.
+    ///   - b: 2nd computation.
+    ///   - f: Combination function.
+    /// - Returns: Result of combining the provided computations, in the context implementing this instance.
     public static func map<A, B, Z>(_ a: Kind<F, A>,
                                     _ b: Kind<F, B>,
                                     _ f: @escaping (A, B) -> Z) -> Kind<F, Z> {
         return F.map(a, b, f)
     }
 
+    /// Combines the result of three computations in the context implementing this instance, using the provided function.
+    ///
+    /// This is a convenience method to call `Applicative.map` as a static method of this type.
+    ///
+    /// - Parameters:
+    ///   - a: 1st computation.
+    ///   - b: 2nd computation.
+    ///   - c: 3rd computation.
+    ///   - f: Combination function.
+    /// - Returns: Result of combining the provided computations, in the context implementing this instance.
     public static func map<A, B, C, Z>(_ a: Kind<F, A>,
                                        _ b: Kind<F, B>,
                                        _ c: Kind<F, C>,
@@ -314,6 +744,17 @@ public extension Kind where F: Applicative {
         return F.map(a, b, c, f)
     }
 
+    /// Combines the result of four computations in the context implementing this instance, using the provided function.
+    ///
+    /// This is a convenience method to call `Applicative.map` as a static method of this type.
+    ///
+    /// - Parameters:
+    ///   - a: 1st computation.
+    ///   - b: 2nd computation.
+    ///   - c: 3rd computation.
+    ///   - d: 4th computation.
+    ///   - f: Combination function.
+    /// - Returns: Result of combining the provided computations, in the context implementing this instance.
     public static func map<A, B, C, D, Z>(_ a: Kind<F, A>,
                                           _ b: Kind<F, B>,
                                           _ c: Kind<F, C>,
@@ -322,6 +763,18 @@ public extension Kind where F: Applicative {
         return F.map(a, b, c, d, f)
     }
 
+    /// Combines the result of five computations in the context implementing this instance, using the provided function.
+    ///
+    /// This is a convenience method to call `Applicative.map` as a static method of this type.
+    ///
+    /// - Parameters:
+    ///   - a: 1st computation.
+    ///   - b: 2nd computation.
+    ///   - c: 3rd computation.
+    ///   - d: 4th computation.
+    ///   - e: 5th computation.
+    ///   - f: Combination function.
+    /// - Returns: Result of combining the provided computations, in the context implementing this instance.
     public static func map<A, B, C, D, E, Z>(_ a: Kind<F, A>,
                                              _ b: Kind<F, B>,
                                              _ c: Kind<F, C>,
@@ -331,6 +784,19 @@ public extension Kind where F: Applicative {
         return F.map(a, b, c, d, e, f)
     }
 
+    /// Combines the result of six computations in the context implementing this instance, using the provided function.
+    ///
+    /// This is a convenience method to call `Applicative.map` as a static method of this type.
+    ///
+    /// - Parameters:
+    ///   - a: 1st computation.
+    ///   - b: 2nd computation.
+    ///   - c: 3rd computation.
+    ///   - d: 4th computation.
+    ///   - e: 5th computation.
+    ///   - g: 6th computation.
+    ///   - f: Combination function.
+    /// - Returns: Result of combining the provided computations, in the context implementing this instance.
     public static func map<A, B, C, D, E, G, Z>(_ a: Kind<F, A>,
                                                 _ b: Kind<F, B>,
                                                 _ c: Kind<F, C>,
@@ -341,6 +807,20 @@ public extension Kind where F: Applicative {
         return F.map(a, b, c, d, e, g, f)
     }
 
+    /// Combines the result of seven computations in the context implementing this instance, using the provided function.
+    ///
+    /// This is a convenience method to call `Applicative.map` as a static method of this type.
+    ///
+    /// - Parameters:
+    ///   - a: 1st computation.
+    ///   - b: 2nd computation.
+    ///   - c: 3rd computation.
+    ///   - d: 4th computation.
+    ///   - e: 5th computation.
+    ///   - g: 6th computation.
+    ///   - h: 7th computation.
+    ///   - f: Combination function.
+    /// - Returns: Result of combining the provided computations, in the context implementing this instance.
     public static func map<A, B, C, D, E, G, H, Z>(_ a: Kind<F, A>,
                                                    _ b: Kind<F, B>,
                                                    _ c: Kind<F, C>,
@@ -352,6 +832,21 @@ public extension Kind where F: Applicative {
         return F.map(a, b, c, d, e, g, h, f)
     }
 
+    /// Combines the result of eight computations in the context implementing this instance, using the provided function.
+    ///
+    /// This is a convenience method to call `Applicative.map` as a static method of this type.
+    ///
+    /// - Parameters:
+    ///   - a: 1st computation.
+    ///   - b: 2nd computation.
+    ///   - c: 3rd computation.
+    ///   - d: 4th computation.
+    ///   - e: 5th computation.
+    ///   - g: 6th computation.
+    ///   - h: 7th computation.
+    ///   - i: 8th computation.
+    ///   - f: Combination function.
+    /// - Returns: Result of combining the provided computations, in the context implementing this instance.
     public static func map<A, B, C, D, E, G, H, I, Z>(_ a: Kind<F, A>,
                                                       _ b: Kind<F, B>,
                                                       _ c: Kind<F, C>,
@@ -364,6 +859,22 @@ public extension Kind where F: Applicative {
         return F.map(a, b, c, d, e, g, h, i, f)
     }
 
+    /// Combines the result of nine computations in the context implementing this instance, using the provided function.
+    ///
+    /// This is a convenience method to call `Applicative.map` as a static method of this type.
+    ///
+    /// - Parameters:
+    ///   - a: 1st computation.
+    ///   - b: 2nd computation.
+    ///   - c: 3rd computation.
+    ///   - d: 4th computation.
+    ///   - e: 5th computation.
+    ///   - g: 6th computation.
+    ///   - h: 7th computation.
+    ///   - i: 8th computation.
+    ///   - j: 9th computation.
+    ///   - f: Combination function.
+    /// - Returns: Result of combining the provided computations, in the context implementing this instance.
     public static func map<A, B, C, D, E, G, H, I, J, Z>(_ a: Kind<F, A>,
                                                          _ b: Kind<F, B>,
                                                          _ c: Kind<F, C>,

--- a/Sources/Bow/Typeclasses/Functor.swift
+++ b/Sources/Bow/Typeclasses/Functor.swift
@@ -1,35 +1,88 @@
 import Foundation
 
+/// A Functor provides a type the ability to transform its value type into another type, while preserving its structure.
+///
+/// Using the encoding for HKTs in Bow, in the type `Kind<F, A>`, `A` is the value type and `F` represents the structure of the type. An instance of `Functor` for `F` allows to transform `A` into another type, while maintaining `F` unchanged.
 public protocol Functor: Invariant {
+    /// Creates a new value transforming the type using the provided function, preserving the structure of the original type.
+    ///
+    /// The implementation of this function must obey two laws:
+    ///
+    /// 1. Preserve identity:
+    ///
+    ///         map(fa, id) == fa
+    ///
+    /// 2. Preserve composition:
+    ///
+    ///         map(map(fa, f), g) == map(fa, compose(g, f))
+    ///
+    /// - Parameters:
+    ///   - fa: A value in the context of the type implementing this instance of `Functor`.
+    ///   - f: A transforming function.
+    /// - Returns: The result of transforming the value type using the provided function, maintaining the structure of the original value.
     static func map<A, B>(_ fa: Kind<Self, A>, _ f: @escaping (A) -> B) -> Kind<Self, B>
 }
 
+// MARK: Related functions
 public extension Functor {
+    // Docs inherited from `Invariant`
     public static func imap<A, B>(_ fa: Kind<Self, A>, _ f: @escaping (A) -> B, _ g: @escaping (B) -> A) -> Kind<Self, B> {
         return map(fa, f)
     }
 
-    public static func lift<A, B>(_ f : @escaping (A) -> B) -> (Kind<Self, A>) -> Kind<Self, B> {
+    /// Given a function, provides a new function lifted to the context type implementing this instance of `Functor`.
+    ///
+    /// - Parameter f: Function to be lifted.
+    /// - Returns: Function in the context implementing this instance of `Functor`.
+    public static func lift<A, B>(_ f: @escaping (A) -> B) -> (Kind<Self, A>) -> Kind<Self, B> {
         return { fa in map(fa, f) }
     }
 
-    public static func void<A>(_ fa : Kind<Self, A>) -> Kind<Self, ()> {
+    /// Replaces the value type by the `Void` type.
+    ///
+    /// - Parameter fa: Value to be transformed.
+    /// - Returns: New value in the context implementing this instance of `Functor`, with `Void` as value type.
+    public static func void<A>(_ fa: Kind<Self, A>) -> Kind<Self, ()> {
         return map(fa, {_ in })
     }
 
-    public static func fproduct<A, B>(_ fa : Kind<Self, A>, _ f : @escaping (A) -> B) -> Kind<Self, (A, B)> {
+    /// Transforms the value type and pairs it with its original value.
+    ///
+    /// - Parameters:
+    ///   - fa: Value to be transformed.
+    ///   - f: Transforming function.
+    /// - Returns: A pair with the original value and its transformation, in the context of the original value.
+    public static func fproduct<A, B>(_ fa: Kind<Self, A>, _ f: @escaping (A) -> B) -> Kind<Self, (A, B)> {
         return map(fa, { a in (a, f(a)) })
     }
 
-    public static func `as`<A, B>(_ fa : Kind<Self, A>, _ b : B) -> Kind<Self, B> {
+    /// Transforms the value type with a constant value.
+    ///
+    /// - Parameters:
+    ///   - fa: Value to be transformed.
+    ///   - b: Constant value to replace the value type.
+    /// - Returns: A new value with the structure of the original value, with its value type transformed.
+    public static func `as`<A, B>(_ fa: Kind<Self, A>, _ b: B) -> Kind<Self, B> {
         return map(fa, { _ in b })
     }
 
-    public static func tupleLeft<A, B>(_ fa : Kind<Self, A>, _ b : B) -> Kind<Self, (B, A)> {
+    /// Transforms the value type by making a tuple with a new constant value to the left of the original value type.
+    ///
+    /// - Parameters:
+    ///   - fa: Value to be transformed.
+    ///   - b: Constant value for the tuple.
+    /// - Returns: A new value with the structure of the original value, with a tuple in its value type.
+    public static func tupleLeft<A, B>(_ fa: Kind<Self, A>, _ b: B) -> Kind<Self, (B, A)> {
         return map(fa, { a in (b, a) })
     }
 
-    public static func tupleRight<A, B>(_ fa : Kind<Self, A>, _ b : B) -> Kind<Self, (A, B)> {
+    /// Transforms the value type by making a tuple with a new constant value to the right of the original value type.
+    ///
+    /// - Parameters:
+    ///   - fa: Value to be transformed.
+    ///   - b: Constant value for the tuple.
+    /// - Returns: A new value with the structure of the original value, with a tuple in its value type.
+    public static func tupleRight<A, B>(_ fa: Kind<Self, A>, _ b: B) -> Kind<Self, (A, B)> {
         return map(fa, { a in (a, b) })
     }
 }
@@ -37,31 +90,77 @@ public extension Functor {
 // MARK: Syntax for Functor
 
 public extension Kind where F: Functor {
-    public func map<B>(_ f : @escaping (A) -> B) -> Kind<F, B> {
+    /// Creates a new value transforming the type using the provided function, preserving the structure of the original type.
+    ///
+    /// This is a convenience method to call `Functor.map` as an instance method in this type.
+    ///
+    /// - Parameters:
+    ///   - f: A transforming function.
+    /// - Returns: The result of transforming the value type using the provided function, maintaining the structure of the original value.
+    public func map<B>(_ f: @escaping (A) -> B) -> Kind<F, B> {
         return F.map(self, f)
     }
 
-    public static func lift<A, B>(_ f : @escaping (A) -> B) -> (Kind<F, A>) -> Kind<F, B> {
+    /// Given a function, provides a new function lifted to the context type implementing this instance of `Functor`.
+    ///
+    /// This is a convenience method to call `Functor.lift` as a static method in this type.
+    ///
+    /// - Parameter f: Function to be lifted.
+    /// - Returns: Function in the context implementing this instance of `Functor`.
+    public static func lift<A, B>(_ f: @escaping (A) -> B) -> (Kind<F, A>) -> Kind<F, B> {
         return { fa in fa.map(f) }
     }
 
+    /// Replaces the value type by the `Void` type.
+    ///
+    /// This is a convenience method to call `Functor.void` as an instance method of this type.
+    ///
+    /// - Returns: New value in the context implementing this instance of `Functor`, with `Void` as value type.
     public func void() -> Kind<F, ()> {
         return F.void(self)
     }
 
-    public func fproduct<B>(_ f : @escaping (A) -> B) -> Kind<F, (A, B)> {
+    /// Transforms the value type and pairs it with its original value.
+    ///
+    /// This is a conveninence method to call `Functor.fproduct` as an instance method of is type.
+    ///
+    /// - Parameters:
+    ///   - f: Transforming function.
+    /// - Returns: A pair with the original value and its transformation, in the context of the original value.
+    public func fproduct<B>(_ f: @escaping (A) -> B) -> Kind<F, (A, B)> {
         return F.fproduct(self, f)
     }
 
-    public func `as`<B>(_ b : B) -> Kind<F, B> {
+    /// Transforms the value type with a constant value.
+    ///
+    /// This is a convenience method to call `Functor.as` as an instance method of this type.
+    ///
+    /// - Parameters:
+    ///   - b: Constant value to replace the value type.
+    /// - Returns: A new value with the structure of the original value, with its value type transformed.
+    public func `as`<B>(_ b: B) -> Kind<F, B> {
         return F.as(self, b)
     }
 
-    public func tupleLeft<B>(_ b : B) -> Kind<F, (B, A)> {
+    /// Transforms the value type by making a tuple with a new constant value to the left of the original value type.
+    ///
+    /// This is a conveninence method to call `Functor.tupleLeft` as an instance method of this type.
+    ///
+    /// - Parameters:
+    ///   - b: Constant value for the tuple.
+    /// - Returns: A new value with the structure of the original value, with a tuple in its value type.
+    public func tupleLeft<B>(_ b: B) -> Kind<F, (B, A)> {
         return F.tupleLeft(self, b)
     }
 
-    public func tupleRight<B>(_ b : B) -> Kind<F, (A, B)> {
+    /// Transforms the value type by making a tuple with a new constant value to the right of the original value type.
+    ///
+    /// This is a convenience method to call `Functor.tupleRight` as an instance method of this type.
+    ///
+    /// - Parameters:
+    ///   - b: Constant value for the tuple.
+    /// - Returns: A new value with the structure of the original value, with a tuple in its value type.
+    public func tupleRight<B>(_ b: B) -> Kind<F, (A, B)> {
         return F.tupleRight(self, b)
     }
 }

--- a/Sources/Bow/Typeclasses/Functor.swift
+++ b/Sources/Bow/Typeclasses/Functor.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-/// A Functor provides a type the ability to transform its value type into another type, while preserving its structure.
+/// A Functor provides a type with the ability to transform its value type into another type, while preserving its structure.
 ///
 /// Using the encoding for HKTs in Bow, in the type `Kind<F, A>`, `A` is the value type and `F` represents the structure of the type. An instance of `Functor` for `F` allows to transform `A` into another type, while maintaining `F` unchanged.
 public protocol Functor: Invariant {

--- a/Sources/Bow/Typeclasses/Invariant.swift
+++ b/Sources/Bow/Typeclasses/Invariant.swift
@@ -1,12 +1,33 @@
 import Foundation
 
+/// An Invariant Functor provides a type the ability to transform its value type into another type. An instance of `Functor` or `Contravariant` are Invariant Functors as well.
 public protocol Invariant {
+    /// Transforms the value type using the functions provided.
+    ///
+    /// The implementation of this function must obey the following laws:
+    ///
+    ///     imap(fa, id, id) == fa
+    ///     imap(imap(fa, f1, g1), f2, g2) == imap(fa, compose(f2, f1), compose(g2, g1))
+    ///
+    /// - Parameters:
+    ///   - fa: Value whose value type will be transformed.
+    ///   - f: Transforming function.
+    ///   - g: Transforming function.
+    /// - Returns: A new value in the same context as the original value, with the value type transformed.
     static func imap<A, B>(_ fa : Kind<Self, A>, _ f : @escaping (A) -> B, _ g : @escaping (B) -> A) -> Kind<Self, B>
 }
 
 // MARK: Syntax for Invariant
 
 public extension Kind where F: Invariant {
+    /// Transforms the value type using the functions provided.
+    ///
+    /// This is a conveninece method to call `Invariant.imap` as an instance method.
+    ///
+    /// - Parameters:
+    ///   - f: Transforming function.
+    ///   - g: Transforming function.
+    /// - Returns: A new value in the same context as the original value, with the value type transformed.
     func imap<B>(_ f : @escaping (A) -> B, _ g : @escaping (B) -> A) -> Kind<F, B> {
         return F.imap(self, f, g)
     }

--- a/Sources/Bow/Typeclasses/Monad.swift
+++ b/Sources/Bow/Typeclasses/Monad.swift
@@ -1,50 +1,135 @@
 import Foundation
 
+/// A Monad provides functionality to sequence operations that are dependent from one another.
+///
+/// Instances of `Monad` must obey the following rules:
+///
+///     flatMap(pure(a), f) == f(a)
+///     flatMap(fa, pure) == fa
+///     flatMap(fa) { a in flatMap(f(a), g) } == flatMap(flatMap(fa, f), g)
+///
+/// Also, instances of `Monad` derive a default implementation for `Applicative.ap` as:
+///
+///     ap(ff, fa) == flapMap(ff, { f in map(fa, f) }
 public protocol Monad: Applicative {
+    /// Sequentially compose two computations, passing any value produced by the first as an argument to the second.
+    ///
+    /// - Parameters:
+    ///   - fa: First computation.
+    ///   - f: A function describing the second computation, which depends on the value of the first.
+    /// - Returns: Result of composing the two computations.
     static func flatMap<A, B>(_ fa: Kind<Self, A>, _ f: @escaping (A) -> Kind<Self, B>) -> Kind<Self, B>
+
+    /// Monadic tail recursion.
+    ///
+    /// - Parameters:
+    ///   - a: Initial value for the recursion.
+    ///   - f: A function describing a recursive step.
+    /// - Returns: Result of evaluating recursively the provided function with the initial value.
     static func tailRecM<A, B>(_ a: A, _ f : @escaping (A) -> Kind<Self, Either<A, B>>) -> Kind<Self, B>
 }
 
+// MARK: Related functions
+
 public extension Monad {
+    // Docs inherited from `Applicative`
     public static func ap<A, B>(_ ff: Kind<Self, (A) -> B>, _ fa: Kind<Self, A>) -> Kind<Self, B> {
         return self.flatMap(ff, { f in map(fa, f) })
     }
-    
+
+    /// Flattens a nested structure of the context implementing this instance into a single layer.
+    ///
+    /// - Parameter ffa: Value with a nested structure.
+    /// - Returns: Value with a single context structure.
     public static func flatten<A>(_ ffa: Kind<Self, Kind<Self, A>>) -> Kind<Self, A> {
         return self.flatMap(ffa, id)
     }
     
+    /// Sequentially compose two computations, discarding the value produced by the first.
+    ///
+    /// - Parameters:
+    ///   - fa: 1st computation.
+    ///   - fb: 2nd computation.
+    /// - Returns: Result of running the second computation after the first one.
     public static func followedBy<A, B>(_ fa: Kind<Self, A>, _ fb: Kind<Self, B>) -> Kind<Self, B> {
         return self.flatMap(fa, { _ in fb })
     }
-    
+
+    /// Sequentially compose a computation with a lazy computation, discarding the value produced by the first.
+    ///
+    /// - Parameters:
+    ///   - fa: Regular computation.
+    ///   - fb: Lazy computation.
+    /// - Returns: Result of running the second computation after the first one.
     public static func followedByEval<A, B>(_ fa: Kind<Self, A>, _ fb: Eval<Kind<Self, B>>) -> Kind<Self, B> {
         return self.flatMap(fa, { _ in fb.value() })
     }
-    
+
+    /// Sequentially compose two computations, discarding the value produced by the second.
+    ///
+    /// - Parameters:
+    ///   - fa: 1st computation.
+    ///   - fb: 2nd computation.
+    /// - Returns: Result produced from the first computation after both are computed.
     public static func forEffect<A, B>(_ fa: Kind<Self, A>, _ fb: Kind<Self, B>) -> Kind<Self, A> {
         return self.flatMap(fa, { a in self.map(fb, { _ in a })})
     }
-    
+
+    /// Sequentially compose a computation with a lazy computation, discarding the value produced by the second.
+    ///
+    /// - Parameters:
+    ///   - fa: Regular computation.
+    ///   - fb: Lazy computation.
+    /// - Returns: Result produced from the first computation after both are computed.
     public static func forEffectEval<A, B>(_ fa: Kind<Self, A>, _ fb: Eval<Kind<Self, B>>) -> Kind<Self, A> {
         return self.flatMap(fa, { a in self.map(fb.value(), constant(a)) })
     }
-    
+
+    /// Pair the result of a computation with the result of applying a function to such result.
+    ///
+    /// - Parameters:
+    ///   - fa: A computation in the context implementing this instance.
+    ///   - f: A function to be applied to the result of the computation.
+    /// - Returns: A tuple of the result of the computation paired with the result of the function, in the context implementing this instance.
     public static func mproduct<A, B>(_ fa: Kind<Self, A>, _ f: @escaping (A) -> Kind<Self, B>) -> Kind<Self, (A, B)> {
         return self.flatMap(fa, { a in self.map(f(a), { b in (a, b) }) })
     }
     
+    /// Conditionally apply a closure based on the boolean result of a computation.
+    ///
+    /// - Parameters:
+    ///   - fa: A boolean computation.
+    ///   - ifTrue: Closure to be applied if the computation evaluates to `true`.
+    ///   - ifFalse: Closure to be applied if the computation evaluates to `false`.
+    /// - Returns: Result of applying the corresponding closure based on the result of the computation.
     public static func ifM<B>(_ fa: Kind<Self, Bool>, _ ifTrue: @escaping () -> Kind<Self, B>, _ ifFalse: @escaping () -> Kind<Self, B>) -> Kind<Self, B> {
         return flatMap(fa, { a in a ? ifTrue() : ifFalse() })
     }
     
     // MARK: Monad comprehensions
     
+    /// Monad comprehensions for two closures producing computations.
+    ///
+    /// Each closure is expected to provide a computation whose result may be used in subsequent computations. For this reason, the `ith` closure receives all values generated by the instructions evaluated before it.
+    ///
+    /// - Parameters:
+    ///   - f: 1st closure providing a computation.
+    ///   - fb: 2nd closure providing a computation.
+    /// - Returns: Result of evaluating the last computation.
     public static func binding<B, C>(_ f: () -> Kind<Self, B>,
                               _ fb: @escaping (B) -> Kind<Self, C>) -> Kind<Self, C> {
         return flatMap(f(), fb)
     }
-    
+
+    /// Monad comprehensions for three closures producing computations.
+    ///
+    /// Each closure is expected to provide a computation whose result may be used in subsequent computations. For this reason, the `ith` closure receives all values generated by the instructions evaluated before it.
+    ///
+    /// - Parameters:
+    ///   - f: 1st closure providing a computation.
+    ///   - fb: 2nd closure providing a computation.
+    ///   - fc: 3rd closure providing a computation.
+    /// - Returns: Result of evaluating the last computation.
     public static func binding<B, C, D>(_ f: () -> Kind<Self, B>,
                                  _ fb: @escaping (B) -> Kind<Self, C>,
                                  _ fc: @escaping (B, C) -> Kind<Self, D>) -> Kind<Self, D> {
@@ -54,7 +139,17 @@ public extension Monad {
             })
         })
     }
-    
+
+    /// Monad comprehensions for four closures producing computations.
+    ///
+    /// Each closure is expected to provide a computation whose result may be used in subsequent computations. For this reason, the `ith` closure receives all values generated by the instructions evaluated before it.
+    ///
+    /// - Parameters:
+    ///   - f: 1st closure providing a computation.
+    ///   - fb: 2nd closure providing a computation.
+    ///   - fc: 3rd closure providing a computation.
+    ///   - fd: 4th closure providing a computation.
+    /// - Returns: Result of evaluating the last computation.
     public static func binding<B, C, D, E>(_ f: () -> Kind<Self, B>,
                                     _ fb: @escaping (B) -> Kind<Self, C>,
                                     _ fc: @escaping (B, C) -> Kind<Self, D>,
@@ -67,7 +162,18 @@ public extension Monad {
             })
         })
     }
-    
+
+    /// Monad comprehensions for five closures producing computations.
+    ///
+    /// Each closure is expected to provide a computation whose result may be used in subsequent computations. For this reason, the `ith` closure receives all values generated by the instructions evaluated before it.
+    ///
+    /// - Parameters:
+    ///   - f: 1st closure providing a computation.
+    ///   - fb: 2nd closure providing a computation.
+    ///   - fc: 3rd closure providing a computation.
+    ///   - fd: 4th closure providing a computation.
+    ///   - fe: 5th closure providing a computation.
+    /// - Returns: Result of evaluating the last computation.
     public static func binding<B, C, D, E, G>(_ f: () -> Kind<Self, B>,
                                        _ fb: @escaping (B) -> Kind<Self, C>,
                                        _ fc: @escaping (B, C) -> Kind<Self, D>,
@@ -83,7 +189,19 @@ public extension Monad {
             })
         })
     }
-    
+
+    /// Monad comprehensions for six closures producing computations.
+    ///
+    /// Each closure is expected to provide a computation whose result may be used in subsequent computations. For this reason, the `ith` closure receives all values generated by the instructions evaluated before it.
+    ///
+    /// - Parameters:
+    ///   - f: 1st closure providing a computation.
+    ///   - fb: 2nd closure providing a computation.
+    ///   - fc: 3rd closure providing a computation.
+    ///   - fd: 4th closure providing a computation.
+    ///   - fe: 5th closure providing a computation.
+    ///   - fg: 6th closure providing a computation.
+    /// - Returns: Result of evaluating the last computation.
     public static func binding<B, C, D, E, G, H>(_ f: () -> Kind<Self, B>,
                                           _ fb: @escaping (B) -> Kind<Self, C>,
                                           _ fc: @escaping (B, C) -> Kind<Self, D>,
@@ -102,7 +220,20 @@ public extension Monad {
             })
         })
     }
-    
+
+    /// Monad comprehensions for seven closures producing computations.
+    ///
+    /// Each closure is expected to provide a computation whose result may be used in subsequent computations. For this reason, the `ith` closure receives all values generated by the instructions evaluated before it.
+    ///
+    /// - Parameters:
+    ///   - f: 1st closure providing a computation.
+    ///   - fb: 2nd closure providing a computation.
+    ///   - fc: 3rd closure providing a computation.
+    ///   - fd: 4th closure providing a computation.
+    ///   - fe: 5th closure providing a computation.
+    ///   - fg: 6th closure providing a computation.
+    ///   - fh: 7th closure providing a computation.
+    /// - Returns: Result of evaluating the last computation.
     public static func binding<B, C, D, E, G, H, I>(_ f: () -> Kind<Self, B>,
                                              _ fb: @escaping (B) -> Kind<Self, C>,
                                              _ fc: @escaping (B, C) -> Kind<Self, D>,
@@ -124,7 +255,21 @@ public extension Monad {
             })
         })
     }
-    
+
+    /// Monad comprehensions for eight closures producing computations.
+    ///
+    /// Each closure is expected to provide a computation whose result may be used in subsequent computations. For this reason, the `ith` closure receives all values generated by the instructions evaluated before it.
+    ///
+    /// - Parameters:
+    ///   - f: 1st closure providing a computation.
+    ///   - fb: 2nd closure providing a computation.
+    ///   - fc: 3rd closure providing a computation.
+    ///   - fd: 4th closure providing a computation.
+    ///   - fe: 5th closure providing a computation.
+    ///   - fg: 6th closure providing a computation.
+    ///   - fh: 7th closure providing a computation.
+    ///   - fi: 8th closure providing a computation.
+    /// - Returns: Result of evaluating the last computation.
     public static func binding<B, C, D, E, G, H, I, J>(_ f : () -> Kind<Self, B>,
                                                 _ fb: @escaping (B) -> Kind<Self, C>,
                                                 _ fc: @escaping (B, C) -> Kind<Self, D>,
@@ -149,7 +294,22 @@ public extension Monad {
             })
         })
     }
-    
+
+    /// Monad comprehensions for nine closures producing computations.
+    ///
+    /// Each closure is expected to provide a computation whose result may be used in subsequent computations. For this reason, the `ith` closure receives all values generated by the instructions evaluated before it.
+    ///
+    /// - Parameters:
+    ///   - f: 1st closure providing a computation.
+    ///   - fb: 2nd closure providing a computation.
+    ///   - fc: 3rd closure providing a computation.
+    ///   - fd: 4th closure providing a computation.
+    ///   - fe: 5th closure providing a computation.
+    ///   - fg: 6th closure providing a computation.
+    ///   - fh: 7th closure providing a computation.
+    ///   - fi: 8th closure providing a computation.
+    ///   - fj: 9th closure providing a computation.
+    /// - Returns: Result of evaluating the last computation.
     public static func binding<B, C, D, E, G, H, I, J, K>(_ f: () -> Kind<Self, B>,
                                                    _ fb: @escaping (B) -> Kind<Self, C>,
                                                    _ fc: @escaping (B, C) -> Kind<Self, D>,
@@ -182,50 +342,140 @@ public extension Monad {
 // MARK: Syntax for Monad
 
 public extension Kind where F: Monad {
+    /// Sequentially compose this computation with another one, passing any value produced by the first as an argument to the second.
+    ///
+    /// This is a convenience method to call `Monad.flatMap` as an instance method of this type.
+    ///
+    /// - Parameters:
+    ///   - f: A function describing the second computation, which depends on the value of the first.
+    /// - Returns: Result of composing the two computations.
     public func flatMap<B>(_ f: @escaping (A) -> Kind<F, B>) -> Kind<F, B> {
         return F.flatMap(self, f)
     }
 
+    /// Monadic tail recursion.
+    ///
+    /// This is a convenience method to call `Monad.tailRecM` as a static method of this type.
+    ///
+    /// - Parameters:
+    ///   - a: Initial value for the recursion.
+    ///   - f: A function describing a recursive step.
+    /// - Returns: Result of evaluating recursively the provided function with the initial value.
     public static func tailRecM<B>(_ a: A, _ f: @escaping (A) -> Kind<F, Either<A, B>>) -> Kind<F, B> {
         return F.tailRecM(a, f)
     }
 
+    /// Flattens a nested structure of the context implementing this instance into a single layer.
+    ///
+    /// This is a convenience method to call `Monad.flatten` as a static method of this type.
+    ///
+    /// - Parameter ffa: Value with a nested structure.
+    /// - Returns: Value with a single context structure.
     public static func flatten(_ ffa: Kind<F, Kind<F, A>>) -> Kind<F, A> {
         return F.flatten(ffa)
     }
 
+    /// Sequentially compose with another computation, discarding the value produced by the this one.
+    ///
+    /// This is a convenience method to call `Monad.followedBy` as an instance method of this type.
+    ///
+    /// - Parameters:
+    ///   - fb: A computation.
+    /// - Returns: Result of running the second computation after the first one.
     public func followedBy<B>(_ fb: Kind<F, B>) -> Kind<F, B> {
         return F.followedBy(self, fb)
     }
 
+    /// Sequentially compose a computation with a lazy computation, discarding the value produced by this one.
+    ///
+    /// This is a convenience method to call `Monad.followedByEval` as an instance method of this type.
+    ///
+    /// - Parameters:
+    ///   - fb: Lazy computation.
+    /// - Returns: Result of running the second computation after the first one.
     public func followedByEval<B>(_ fb: Eval<Kind<F, B>>) -> Kind<F, B> {
         return F.followedByEval(self, fb)
     }
 
+    /// Sequentially compose with another computation, discarding the value produced by the received one.
+    ///
+    /// This is a convenience method to call `Monad.forEffect` as an instance method of this type.
+    ///
+    /// - Parameters:
+    ///   - fb: A computation.
+    /// - Returns: Result produced from the first computation after both are computed.
     public func forEffect<B>(_ fb: Kind<F, B>) -> Kind<F, A> {
         return F.forEffect(self, fb)
     }
 
+    /// Sequentially composen with a lazy computation, discarding the value produced by the received one.
+    ///
+    /// This is a convenience method to call `Monad.forEffectEval` as an instance method of this type.
+    ///
+    /// - Parameters:
+    ///   - fb: Lazy computation.
+    /// - Returns: Result produced from the first computation after both are computed.
     public func forEffectEval<B>(_ fb: Eval<Kind<F, B>>) -> Kind<F, A> {
         return F.forEffectEval(self, fb)
     }
 
+    /// Pair the result of this computation with the result of applying a function to such result.
+    ///
+    /// This is a convenience method to call `Monad.mproduct` as an instance method.
+    ///
+    /// - Parameters:
+    ///   - f: A function to be applied to the result of the computation.
+    /// - Returns: A tuple of the result of this computation paired with the result of the function, in the context implementing this instance.
     public func mproduct<B>(_ f: @escaping (A) -> Kind<F, B>) -> Kind<F, (A, B)> {
         return F.mproduct(self, f)
     }
 
     // MARK: Syntax for Monad Comprehensions
+
+    /// Monad comprehensions for two closures producing computations.
+    ///
+    /// Each closure is expected to provide a computation whose result may be used in subsequent computations. For this reason, the `ith` closure receives all values generated by the instructions evaluated before it.
+    ///
+    /// This is a convenience method to call `Monad.binding` as a static method of this type.
+    ///
+    /// - Parameters:
+    ///   - f: 1st closure providing a computation.
+    ///   - fb: 2nd closure providing a computation.
+    /// - Returns: Result of evaluating the last computation.
     public static func binding<B, C>(_ f: () -> Kind<F, B>,
                                      _ fb: @escaping (B) -> Kind<F, C>) -> Kind<F, C> {
         return F.binding(f, fb)
     }
 
+    /// Monad comprehensions for three closures producing computations.
+    ///
+    /// Each closure is expected to provide a computation whose result may be used in subsequent computations. For this reason, the `ith` closure receives all values generated by the instructions evaluated before it.
+    ///
+    /// This is a convenience method to call `Monad.binding` as a static method of this type.
+    ///
+    /// - Parameters:
+    ///   - f: 1st closure providing a computation.
+    ///   - fb: 2nd closure providing a computation.
+    ///   - fc: 3rd closure providing a computation.
+    /// - Returns: Result of evaluating the last computation.
     public static func binding<B, C, D>(_ f: () -> Kind<F, B>,
                                         _ fb: @escaping (B) -> Kind<F, C>,
                                         _ fc: @escaping (B, C) -> Kind<F, D>) -> Kind<F, D> {
         return F.binding(f, fb, fc)
     }
 
+    /// Monad comprehensions for four closures producing computations.
+    ///
+    /// Each closure is expected to provide a computation whose result may be used in subsequent computations. For this reason, the `ith` closure receives all values generated by the instructions evaluated before it.
+    ///
+    /// This is a convenience method to call `Monad.binding` as a static method of this type.
+    ///
+    /// - Parameters:
+    ///   - f: 1st closure providing a computation.
+    ///   - fb: 2nd closure providing a computation.
+    ///   - fc: 3rd closure providing a computation.
+    ///   - fd: 4th closure providing a computation.
+    /// - Returns: Result of evaluating the last computation.
     public static func binding<B, C, D, E>(_ f: () -> Kind<F, B>,
                                            _ fb: @escaping (B) -> Kind<F, C>,
                                            _ fc: @escaping (B, C) -> Kind<F, D>,
@@ -233,6 +483,19 @@ public extension Kind where F: Monad {
         return F.binding(f, fb, fc, fd)
     }
 
+    /// Monad comprehensions for five closures producing computations.
+    ///
+    /// Each closure is expected to provide a computation whose result may be used in subsequent computations. For this reason, the `ith` closure receives all values generated by the instructions evaluated before it.
+    ///
+    /// This is a convenience method to call `Monad.binding` as a static method of this type.
+    ///
+    /// - Parameters:
+    ///   - f: 1st closure providing a computation.
+    ///   - fb: 2nd closure providing a computation.
+    ///   - fc: 3rd closure providing a computation.
+    ///   - fd: 4th closure providing a computation.
+    ///   - fe: 5th closure providing a computation.
+    /// - Returns: Result of evaluating the last computation.
     public static func binding<B, C, D, E, G>(_ f: () -> Kind<F, B>,
                                               _ fb: @escaping (B) -> Kind<F, C>,
                                               _ fc: @escaping (B, C) -> Kind<F, D>,
@@ -241,6 +504,20 @@ public extension Kind where F: Monad {
         return F.binding(f, fb, fc, fd, fe)
     }
 
+    /// Monad comprehensions for six closures producing computations.
+    ///
+    /// Each closure is expected to provide a computation whose result may be used in subsequent computations. For this reason, the `ith` closure receives all values generated by the instructions evaluated before it.
+    ///
+    /// This is a convenience method to call `Monad.binding` as a static method of this type.
+    ///
+    /// - Parameters:
+    ///   - f: 1st closure providing a computation.
+    ///   - fb: 2nd closure providing a computation.
+    ///   - fc: 3rd closure providing a computation.
+    ///   - fd: 4th closure providing a computation.
+    ///   - fe: 5th closure providing a computation.
+    ///   - fg: 6th closure providing a computation.
+    /// - Returns: Result of evaluating the last computation.
     public static func binding<B, C, D, E, G, H>(_ f: () -> Kind<F, B>,
                                                  _ fb: @escaping (B) -> Kind<F, C>,
                                                  _ fc: @escaping (B, C) -> Kind<F, D>,
@@ -250,6 +527,21 @@ public extension Kind where F: Monad {
         return F.binding(f, fb, fc, fd, fe, fg)
     }
 
+    /// Monad comprehensions for seven closures producing computations.
+    ///
+    /// Each closure is expected to provide a computation whose result may be used in subsequent computations. For this reason, the `ith` closure receives all values generated by the instructions evaluated before it.
+    ///
+    /// This is a convenience method to call `Monad.binding` as a static method of this type.
+    ///
+    /// - Parameters:
+    ///   - f: 1st closure providing a computation.
+    ///   - fb: 2nd closure providing a computation.
+    ///   - fc: 3rd closure providing a computation.
+    ///   - fd: 4th closure providing a computation.
+    ///   - fe: 5th closure providing a computation.
+    ///   - fg: 6th closure providing a computation.
+    ///   - fh: 7th closure providing a computation.
+    /// - Returns: Result of evaluating the last computation.
     public static func binding<B, C, D, E, G, H, I>(_ f: () -> Kind<F, B>,
                                                     _ fb: @escaping (B) -> Kind<F, C>,
                                                     _ fc: @escaping (B, C) -> Kind<F, D>,
@@ -260,6 +552,22 @@ public extension Kind where F: Monad {
         return F.binding(f, fb, fc, fd, fe, fg, fh)
     }
 
+    /// Monad comprehensions for eight closures producing computations.
+    ///
+    /// Each closure is expected to provide a computation whose result may be used in subsequent computations. For this reason, the `ith` closure receives all values generated by the instructions evaluated before it.
+    ///
+    /// This is a convenience method to call `Monad.binding` as a static method of this type.
+    ///
+    /// - Parameters:
+    ///   - f: 1st closure providing a computation.
+    ///   - fb: 2nd closure providing a computation.
+    ///   - fc: 3rd closure providing a computation.
+    ///   - fd: 4th closure providing a computation.
+    ///   - fe: 5th closure providing a computation.
+    ///   - fg: 6th closure providing a computation.
+    ///   - fh: 7th closure providing a computation.
+    ///   - fi: 8th closure providing a computation.
+    /// - Returns: Result of evaluating the last computation.
     public static func binding<B, C, D, E, G, H, I, J>(_ f: () -> Kind<F, B>,
                                                        _ fb: @escaping (B) -> Kind<F, C>,
                                                        _ fc: @escaping (B, C) -> Kind<F, D>,
@@ -271,6 +579,23 @@ public extension Kind where F: Monad {
         return F.binding(f, fb, fc, fd, fe, fg, fh, fi)
     }
 
+    /// Monad comprehensions for nine closures producing computations.
+    ///
+    /// Each closure is expected to provide a computation whose result may be used in subsequent computations. For this reason, the `ith` closure receives all values generated by the instructions evaluated before it.
+    ///
+    /// This is a convenience method to call `Monad.binding` as a static method of this type.
+    ///
+    /// - Parameters:
+    ///   - f: 1st closure providing a computation.
+    ///   - fb: 2nd closure providing a computation.
+    ///   - fc: 3rd closure providing a computation.
+    ///   - fd: 4th closure providing a computation.
+    ///   - fe: 5th closure providing a computation.
+    ///   - fg: 6th closure providing a computation.
+    ///   - fh: 7th closure providing a computation.
+    ///   - fi: 8th closure providing a computation.
+    ///   - fj: 9th closure providing a computation.
+    /// - Returns: Result of evaluating the last computation.
     public static func binding<B, C, D, E, G, H, I, J, K>(_ f: () -> Kind<F, B>,
                                                           _ fb: @escaping (B) -> Kind<F, C>,
                                                           _ fc: @escaping (B, C) -> Kind<F, D>,
@@ -285,7 +610,17 @@ public extension Kind where F: Monad {
 
 }
 
+// MARK: Related functions
+
 public extension Kind where F: Monad, A == Bool {
+    /// Conditionally apply a closure based on the boolean result of this computation.
+    ///
+    /// This is a convenience method to call `Monad.ifM` as an instance method.
+    ///
+    /// - Parameters:
+    ///   - ifTrue: Closure to be applied if the computation evaluates to `true`.
+    ///   - ifFalse: Closure to be applied if the computation evaluates to `false`.
+    /// - Returns: Result of applying the corresponding closure based on the result of the computation.
     public func ifM<B>(_ ifTrue: @escaping () -> Kind<F, B>, _ ifFalse: @escaping () -> Kind<F, B>) -> Kind<F, B> {
         return F.ifM(self, ifTrue, ifFalse)
     }

--- a/Sources/Bow/Typeclasses/Monad.swift
+++ b/Sources/Bow/Typeclasses/Monad.swift
@@ -22,6 +22,10 @@ public protocol Monad: Applicative {
 
     /// Monadic tail recursion.
     ///
+    /// `tailRecM` can be used for computations that can potentially make the stack overflow.
+    ///
+    /// Initially introduced in [Stack Safety for Free](https://functorial.com/stack-safety-for-free/index.pdf)
+    ///
     /// - Parameters:
     ///   - a: Initial value for the recursion.
     ///   - f: A function describing a recursive step.
@@ -55,11 +59,11 @@ public extension Monad {
         return self.flatMap(fa, { _ in fb })
     }
 
-    /// Sequentially compose a computation with a lazy computation, discarding the value produced by the first.
+    /// Sequentially compose a computation with a potentially lazy one, discarding the value produced by the first.
     ///
     /// - Parameters:
     ///   - fa: Regular computation.
-    ///   - fb: Lazy computation.
+    ///   - fb: Potentially lazy computation.
     /// - Returns: Result of running the second computation after the first one.
     public static func followedByEval<A, B>(_ fa: Kind<Self, A>, _ fb: Eval<Kind<Self, B>>) -> Kind<Self, B> {
         return self.flatMap(fa, { _ in fb.value() })
@@ -75,11 +79,11 @@ public extension Monad {
         return self.flatMap(fa, { a in self.map(fb, { _ in a })})
     }
 
-    /// Sequentially compose a computation with a lazy computation, discarding the value produced by the second.
+    /// Sequentially compose a computation with a potentially lazy one, discarding the value produced by the second.
     ///
     /// - Parameters:
     ///   - fa: Regular computation.
-    ///   - fb: Lazy computation.
+    ///   - fb: Potentially lazy computation.
     /// - Returns: Result produced from the first computation after both are computed.
     public static func forEffectEval<A, B>(_ fa: Kind<Self, A>, _ fb: Eval<Kind<Self, B>>) -> Kind<Self, A> {
         return self.flatMap(fa, { a in self.map(fb.value(), constant(a)) })
@@ -386,7 +390,7 @@ public extension Kind where F: Monad {
         return F.followedBy(self, fb)
     }
 
-    /// Sequentially compose a computation with a lazy computation, discarding the value produced by this one.
+    /// Sequentially compose this computation with a potentially lazy one, discarding the value produced by this one.
     ///
     /// This is a convenience method to call `Monad.followedByEval` as an instance method of this type.
     ///
@@ -408,7 +412,7 @@ public extension Kind where F: Monad {
         return F.forEffect(self, fb)
     }
 
-    /// Sequentially composen with a lazy computation, discarding the value produced by the received one.
+    /// Sequentially compose with a potentially lazy computation, discarding the value produced by the received one.
     ///
     /// This is a convenience method to call `Monad.forEffectEval` as an instance method of this type.
     ///

--- a/Sources/BowRecursionSchemes/Recursion.swift
+++ b/Sources/BowRecursionSchemes/Recursion.swift
@@ -15,6 +15,7 @@ public extension Functor {
     }
 }
 
+// MARK: Syntax for F-Algebras
 public extension Kind where F: Functor {
     public static func hylo<B>(_ algebra: @escaping Algebra<F, Eval<B>>,
                                _ coalgebra: @escaping Coalgebra<F, A>,


### PR DESCRIPTION
## Related issues

- Closes #147.
- Closes #148.
- Closes #149.
- Closes #150.

## Goal

Add API docs for `Invariant`, `Functor`, `Applicative` and `Monad`.
