### PR TITLE
API docs for SemigroupK, MonoidK and Alternative

### DIFF
--- a/Sources/Bow/Typeclasses/Alternative.swift
+++ b/Sources/Bow/Typeclasses/Alternative.swift
@@ -1,3 +1,4 @@
 import Foundation
 
+/// An Alternative is an `Applicative` with `MonoidK` capabilities.
 public protocol Alternative: Applicative, MonoidK {}

--- a/Sources/Bow/Typeclasses/MonoidK.swift
+++ b/Sources/Bow/Typeclasses/MonoidK.swift
@@ -1,21 +1,30 @@
 import Foundation
 
+/// A MonoidK is a `SemigroupK` that also has an empty element.
 public protocol MonoidK: SemigroupK {
+    /// Empty element.
+    ///
+    /// This element must obey the following laws:
+    ///
+    ///     combineK(fa, emptyK()) == combineK(emptyK(), fa) == fa
+    ///
+    /// - Returns: A value representing the empty element of this MonoidK instance.
     static func emptyK<A>() -> Kind<Self, A>
 }
 
-/*
-public extension MonoidK {
-    static func algebra<B>() -> MonoidAlgebra<Self, B> {
-        return MonoidAlgebra(combineK: combineK)
-    }
-}
+// MARK: Syntax for MonoidK
 
-public class MonoidAlgebra<F: MonoidK, B>: SemigroupAlgebra<F, B>, Monoid {
-    public static var empty: MonoidAlgebra<F, B>
-
-    public static var empty: Kind<F, B> {
+public extension Kind where F: MonoidK {
+    /// Empty element.
+    ///
+    /// This element must obey the following laws:
+    ///
+    ///     combineK(fa, emptyK()) == combineK(emptyK(), fa) == fa
+    ///
+    /// This is a convenience method to call `MonoidK.emptyK` as a static method of this type.
+    ///
+    /// - Returns: A value representing the empty element of this MonoidK instance.
+    static func emptyK() -> Kind<F, A> {
         return F.emptyK()
     }
 }
-*/

--- a/Sources/Bow/Typeclasses/SemigroupK.swift
+++ b/Sources/Bow/Typeclasses/SemigroupK.swift
@@ -1,34 +1,30 @@
 import Foundation
 
+/// SemigroupK is a `Semigroup` that operates on kinds with one type parameter.
 public protocol SemigroupK {
+    /// Combines two values of the same type in the context implementing this instance.
+    ///
+    /// Implementations of this method must obey the associative law:
+    ///
+    ///     combineK(fa, combineK(fb, fc)) == combineK(combineK(fa, fb), fc)
+    ///
+    /// - Parameters:
+    ///   - x: Left value in the combination.
+    ///   - y: Right value in the combination.
+    /// - Returns: Combination of the two values.
     static func combineK<A>(_ x: Kind<Self, A>, _ y: Kind<Self, A>) -> Kind<Self, A>
 }
-
-/*
- public extension SemigroupK {
-    public static func algebra<B>() -> SemigroupAlgebra<Self, B> {
-        return SemigroupAlgebra(combineK: combineK)
-    }
-}
-
-public class SemigroupAlgebra<F, B> : Semigroup {
-    public typealias A = Kind<F, B>
-    
-    private let combineK : (Kind<F, B>, Kind<F, B>) -> Kind<F, B>
-    
-    init(combineK : @escaping (Kind<F, B>, Kind<F, B>) -> Kind<F, B>) {
-        self.combineK = combineK
-    }
-    
-    public func combine(_ a: Kind<F, B>, _ b: Kind<F, B>) -> Kind<F, B> {
-        return combineK(a, b)
-    }
-}
-*/
 
 // MARK: Syntax for SemigroupK
 
 public extension Kind where F: SemigroupK {
+    /// Combines this value with another value of the same type.
+    ///
+    /// This is a convenience method to call `SemigroupK.combineK` as an instance method of this type.
+    ///
+    /// - Parameters:
+    ///   - y: Right value in the combination.
+    /// - Returns: Combination of the two values.
     public func combineK(_ y: Kind<F, A>) -> Kind<F, A> {
         return F.combineK(self, y)
     }


### PR DESCRIPTION
## Related issues

- Closes #152.
- Closes #153.
- Closes #154.

## Goal

Adds API docs for `SemigroupK`, `MonoidK` and `Alternative`.
