### PR TITLE
Add docs for FunctorFilter, MonadFilter and TraverseFilter

### DIFF
--- a/Sources/Bow/Typeclasses/FunctorFilter.swift
+++ b/Sources/Bow/Typeclasses/FunctorFilter.swift
@@ -1,14 +1,33 @@
 import Foundation
 
+/// A FunctorFilter provides the same capabilities as a `Functor`, while filtering out elements simultaneously.
 public protocol FunctorFilter: Functor {
+    /// Maps the value/s in the context implementing this instance, filtering out the ones resulting in `Option.none`.
+    ///
+    /// - Parameters:
+    ///   - fa: A value in the context implementing this instance.
+    ///   - f: A function to map objects and filter them out.
+    /// - Returns: Transformed and filtered values, in the context implementing this instance.
     static func mapFilter<A, B>(_ fa: Kind<Self, A>, _ f: @escaping (A) -> OptionOf<B>) -> Kind<Self, B>
 }
 
+// MARK: Related functions
+
 public extension FunctorFilter {
+    /// Removes the `Option.none` value/s in this context and extracts the `Option.some` ones.
+    ///
+    /// - Parameter fa: Optional values in the context implementing this instance.
+    /// - Returns: Plain values in the context implementing this instance.
     public static func flattenOption<A>(_ fa: Kind<Self, OptionOf<A>>) -> Kind<Self, A> {
         return mapFilter(fa, id)
     }
     
+    /// Filters out the value/s in the context implementing this instance that do not match the given predicate.
+    ///
+    /// - Parameters:
+    ///   - fa: Value in the context implementing this instance.
+    ///   - f: Filtering predicate.
+    /// - Returns: Filtered value in the context implementing this instance.
     public static func filter<A>(_ fa: Kind<Self, A>, _ f: @escaping (A) -> Bool) -> Kind<Self, A> {
         return mapFilter(fa, { a in f(a) ? Option.some(a) : Option.none() })
     }
@@ -17,14 +36,34 @@ public extension FunctorFilter {
 // MARK: Syntax for FunctorFilter
 
 public extension Kind where F: FunctorFilter {
+    /// Maps the value/s in the context implementing this instance, filtering out the ones resulting in `Option.none`.
+    ///
+    /// This is a convenience method to call `FunctorFilter.mapFilter` as an instance method of this type.
+    ///
+    /// - Parameters:
+    ///   - f: A function to map objects and filter them out.
+    /// - Returns: Transformed and filtered values, in this context.
     public func mapFilter<B>(_ f: @escaping (A) -> OptionOf<B>) -> Kind<F, B> {
         return F.mapFilter(self, f)
     }
 
+    /// Removes the `Option.none` value/s in this context and extracts the `Option.some` ones.
+    ///
+    /// This is a convenience method to call `FunctorFilter.flattenOption` as a static method of this type.
+    ///
+    /// - Parameter fa: Optional values in this context.
+    /// - Returns: Plain values in this context.
     public static func flattenOption(_ fa: Kind<F, OptionOf<A>>) -> Kind<F, A> {
         return F.flattenOption(fa)
     }
 
+    /// Filters out the value/s in this context that do not match the given predicate.
+    ///
+    /// This is a convenience method to call `FunctorFilter.filter` as a static method of this type.
+    ///
+    /// - Parameters:
+    ///   - f: Filtering predicate.
+    /// - Returns: Filtered value in this context.
     public func filter(_ f: @escaping (A) -> Bool) -> Kind<F, A> {
         return F.filter(self, f)
     }

--- a/Sources/Bow/Typeclasses/MonadFilter.swift
+++ b/Sources/Bow/Typeclasses/MonadFilter.swift
@@ -1,10 +1,19 @@
 import Foundation
 
+/// A MonadFilter is a `Monad` with `FunctorFilter` capabilities. It also provides functionality to create a value that represents an empty element in the context implementing an instance of this typeclass.
+///
+/// Implementing this typeclass automatically derives an implementation for `FunctorFilter.mapFilter`.
 public protocol MonadFilter: Monad, FunctorFilter {
+    /// Obtains an empty element in the context implementing this instance.
+    ///
+    /// - Returns: Empty element.
     static func empty<A>() -> Kind<Self, A>
 }
 
+// MARK: Related functions
+
 public extension MonadFilter {
+    // Docs inherited from `FunctorFilter`
     public static func mapFilter<A, B>(_ fa : Kind<Self, A>, _ f : @escaping (A) -> OptionOf<B>) -> Kind<Self, B>{
         return flatMap(fa, { a in
             Option<B>.fix(f(a)).fold(self.empty, self.pure)
@@ -15,6 +24,9 @@ public extension MonadFilter {
 // MARK: Syntax for MonadFilter
 
 public extension Kind where F: MonadFilter {
+    /// Obtains an empty element in this context.
+    ///
+    /// - Returns: Empty element.
     public static var empty: Kind<F, A> {
         return F.empty()
     }

--- a/Sources/Bow/Typeclasses/TraverseFilter.swift
+++ b/Sources/Bow/Typeclasses/TraverseFilter.swift
@@ -1,14 +1,35 @@
 import Foundation
 
+/// TraverseFilter represents array-like structures that can be traversed and filtered as a single combined operation. It provides the same capabilities as `Traverse` and `FunctorFilter` together.
 public protocol TraverseFilter: Traverse, FunctorFilter {
+    /// A combined traverse and filter operation. Filtering is handled using `Option` instead of Bool so that the output can be different than the input type.
+    ///
+    /// - Parameters:
+    ///   - fa: A value in the context implementing this instance.
+    ///   - f: A function to traverse and filter each value.
+    /// - Returns: Result of traversing this structure and filter values using the provided function.
     static func traverseFilter<A, B, G: Applicative>(_ fa: Kind<Self, A>, _ f: @escaping (A) -> Kind<G, OptionOf<B>>) -> Kind<G, Kind<Self, B>>
 }
 
+// MARK: Related functions
+
 public extension TraverseFilter {
+    /// Filters values in a different context.
+    ///
+    /// - Parameters:
+    ///   - fa: A value in the context implementing this instance.
+    ///   - f: A function to filter each value.
+    /// - Returns: Result of traversing this structure and filter values using the provided function.
     public static func filterA<A, G: Applicative>(_ fa: Kind<Self, A>, _ f: @escaping (A) -> Kind<G, Bool>) -> Kind<G, Kind<Self, A>> {
         return traverseFilter(fa, { a in G.map(f(a), { b in b ? Option.some(a) : Option.none() }) })
     }
-    
+
+    /// Filters values using a predicate.
+    ///
+    /// - Parameters:
+    ///   - fa: A value in the context implementing this instance.
+    ///   - f: A boolean predicate.
+    /// - Returns: Result of traversing this structure and filter values using the provided function.
     public static func filter<A>(_ fa: Kind<Self, A>, _ f: @escaping (A) -> Bool) -> Kind<Self, A> {
         return (filterA(fa, { a in Id.pure(f(a)) })).extract()
     }
@@ -17,10 +38,26 @@ public extension TraverseFilter {
 // MARK: Syntax for TraverseFilter
 
 public extension Kind where F: TraverseFilter {
+    /// A combined traverse and filter operation. Filtering is handled using `Option` instead of Bool so that the output can be different than the input type.
+    ///
+    /// This is a convenience method to call `TraverseFilter.traverseFilter` as an instance method of this type.
+    ///
+    /// - Parameters:
+    ///   - fa: A value in this context.
+    ///   - f: A function to traverse and filter each value.
+    /// - Returns: Result of traversing this structure and filter values using the provided function.
     public func traverseFilter<B, G: Applicative>(_ f: @escaping (A) -> Kind<G, OptionOf<B>>) -> Kind<G, Kind<F, B>> {
         return F.traverseFilter(self, f)
     }
 
+    /// Filters values in a different context.
+    ///
+    /// This is a convenience method to call `TraverseFilter.filterA` as an instance method of this type.
+    ///
+    /// - Parameters:
+    ///   - fa: A value in this context.
+    ///   - f: A function to filter each value.
+    /// - Returns: Result of traversing this structure and filter values using the provided function.
     public func filterA<G: Applicative>(_ f: @escaping (A) -> Kind<G, Bool>) -> Kind<G, Kind<F, A>> {
         return F.filterA(self, f)
     }


### PR DESCRIPTION
## Related issues

- Closes #165.
- Closes #166.
- Closes #167.

## Goal

Add API docs for FunctorFilter, MonadFilter and TraverseFilter.
