### PR TITLE
Add docs for FunctionK

### DIFF
--- a/Sources/Bow/Arrow/FunctionK.swift
+++ b/Sources/Bow/Arrow/FunctionK.swift
@@ -1,21 +1,21 @@
 import Foundation
 
-public protocol FunctionK {
-    associatedtype F
-    associatedtype G
-    
-    func invoke<A>(_ fa : Kind<F, A>) -> Kind<G, A>
+open class FunctionK<F, G> {
+    public init() {}
+
+    open func invoke<A>(_ fa: Kind<F, A>) -> Kind<G, A> {
+        fatalError("FunctionK.invoke must be implemented in subclasses")
+    }
 }
 
-public class IdFunctionK<M> : FunctionK {
-    public typealias F = M
-    public typealias G = M
-    
-    public static var id : IdFunctionK<M> {
-        return IdFunctionK<M>()
+public extension FunctionK where F == G {
+    public static var id: FunctionK<F, F> {
+        return IdFunctionK<F>()
     }
-    
-    public func invoke<A>(_ fa: Kind<M, A>) -> Kind<M, A> {
+}
+
+fileprivate class IdFunctionK<F>: FunctionK<F, F> {
+    override func invoke<A>(_ fa: Kind<F, A>) -> Kind<F, A> {
         return fa
     }
 }

--- a/Sources/Bow/Arrow/FunctionK.swift
+++ b/Sources/Bow/Arrow/FunctionK.swift
@@ -6,6 +6,14 @@ open class FunctionK<F, G> {
     open func invoke<A>(_ fa: Kind<F, A>) -> Kind<G, A> {
         fatalError("FunctionK.invoke must be implemented in subclasses")
     }
+
+    public func andThen<H>(_ g: FunctionK<G, H>) -> FunctionK<F, H> {
+        return ComposedFunctionK<F, G, H>(self, g)
+    }
+
+    public func compose<H>(_ g: FunctionK<H, F>) -> FunctionK<H, G> {
+        return ComposedFunctionK<H, F, G>(g, self)
+    }
 }
 
 public extension FunctionK where F == G {
@@ -17,5 +25,19 @@ public extension FunctionK where F == G {
 fileprivate class IdFunctionK<F>: FunctionK<F, F> {
     override func invoke<A>(_ fa: Kind<F, A>) -> Kind<F, A> {
         return fa
+    }
+}
+
+fileprivate class ComposedFunctionK<F, G, H>: FunctionK<F, H> {
+    fileprivate let f: FunctionK<F, G>
+    fileprivate let g: FunctionK<G, H>
+
+    init(_ f: FunctionK<F, G>, _ g: FunctionK<G, H>) {
+        self.f = f
+        self.g = g
+    }
+
+    override func invoke<A>(_ fa: Kind<F, A>) -> Kind<H, A> {
+        return g.invoke(f.invoke(fa))
     }
 }

--- a/Sources/Bow/Arrow/FunctionK.swift
+++ b/Sources/Bow/Arrow/FunctionK.swift
@@ -1,26 +1,49 @@
 import Foundation
 
+/// A transformation between two kinds.
+///
+/// As `Function1<A, B>` represents a transformation from `A` to `B`, `FunctionK<F, G>` represents a transformation from `Kind<F, A>` to `Kind<G, A>`. Subclasses of `FunctionK` need to implement `invoke`.
 open class FunctionK<F, G> {
+    /// Initializer
     public init() {}
 
+    /// Invokes this transformation.
+    ///
+    /// - Parameter fa: Input to this function
+    /// - Returns: Transformed input.
     open func invoke<A>(_ fa: Kind<F, A>) -> Kind<G, A> {
         fatalError("FunctionK.invoke must be implemented in subclasses")
     }
 
+    /// Composes this function with another one.
+    ///
+    /// - Parameter g: Function to compose with this one.
+    /// - Returns: A function that transform the input with this function and the received one afterwards.
     public func andThen<H>(_ g: FunctionK<G, H>) -> FunctionK<F, H> {
         return ComposedFunctionK<F, G, H>(self, g)
     }
 
+    /// Composes this function with another one.
+    ///
+    /// - Parameter g: Function to compose with this one.
+    /// - Returns: A function that transform the input with the received function and this one afterwards.
     public func compose<H>(_ g: FunctionK<H, F>) -> FunctionK<H, G> {
         return ComposedFunctionK<H, F, G>(g, self)
     }
 }
 
+// MARK: Identity FunctionK
+
 public extension FunctionK where F == G {
+    /// Identity `FunctionK`.
+    ///
+    /// It returns the input unmodified.
     public static var id: FunctionK<F, F> {
         return IdFunctionK<F>()
     }
 }
+
+// MARK: Identity and Composed FunctionK
 
 fileprivate class IdFunctionK<F>: FunctionK<F, F> {
     override func invoke<A>(_ fa: Kind<F, A>) -> Kind<F, A> {

--- a/Sources/Bow/Data/Coproduct.swift
+++ b/Sources/Bow/Data/Coproduct.swift
@@ -15,7 +15,7 @@ public class Coproduct<F, G, A>: CoproductOf<F, G, A> {
         self.run = run
     }
 
-    public func fold<H, FuncKF, FuncKG>(_ f: FuncKF, _ g: FuncKG) -> Kind<H, A> where FuncKF: FunctionK, FuncKF.F == F, FuncKF.G == H, FuncKG : FunctionK, FuncKG.F == G, FuncKG.G == H {
+    public func fold<H>(_ f: FunctionK<F, H>, _ g: FunctionK<G, H>) -> Kind<H, A> {
         return run.fold({ fa in f.invoke(fa) }, { ga in g.invoke(ga) })
     }
 }

--- a/Tests/BowFreeTests/FreeTest.swift
+++ b/Tests/BowFreeTests/FreeTest.swift
@@ -69,11 +69,8 @@ fileprivate let program = Free.fix(Free<ForOps, Int>.binding({ Ops<Any>.value(10
                                                            { value in Ops<Any>.add(value, 10) },
                                                            { _ , added in Ops<Any>.subtract(added, 50) }))
 
-fileprivate class OptionInterpreter : FunctionK {
-    fileprivate typealias F = ForOps
-    fileprivate typealias G = ForOption
-    
-    fileprivate func invoke<A>(_ fa: Kind<ForOps, A>) -> OptionOf<A> {
+fileprivate class OptionInterpreter: FunctionK<ForOps, ForOption> {
+    override func invoke<A>(_ fa: Kind<ForOps, A>) -> OptionOf<A> {
         let op = Ops.fix(fa)
         switch op {
         case let value as Value: return Option<Int>.pure(value.a) as! Kind<ForOption, A>
@@ -85,11 +82,8 @@ fileprivate class OptionInterpreter : FunctionK {
     }
 }
 
-fileprivate class IdInterpreter: FunctionK {
-    fileprivate typealias F = ForOps
-    fileprivate typealias G = ForId
-    
-    fileprivate func invoke<A>(_ fa: Kind<ForOps, A>) -> IdOf<A> {
+fileprivate class IdInterpreter: FunctionK<ForOps, ForId> {
+    override func invoke<A>(_ fa: Kind<ForOps, A>) -> IdOf<A> {
         let op = Ops.fix(fa)
         switch op {
         case let value as Value: return Id<Int>.pure(value.a) as! IdOf<A>


### PR DESCRIPTION
## Related issues

- Closes #173.

## Goal

- Add API docs for FunctionK.
- Changes `FunctionK` from a protocol to an abstract class.

## Implementation details

Changing `FunctionK` from protocol to class eases the readability of the code and makes it easier to implement for clients. Also, composition of FunctionK is introduced.
