### PR TITLE
Add docs for MonadCombine, MonadReader, MonadState and MonadWriter

### DIFF
--- a/Sources/Bow/Typeclasses/MonadCombine.swift
+++ b/Sources/Bow/Typeclasses/MonadCombine.swift
@@ -1,8 +1,13 @@
 import Foundation
 
+/// A MonadCombine has the capabilities of `MonadFilter` and `Alternative` together.
 public protocol MonadCombine: MonadFilter, Alternative {}
 
 public extension MonadCombine {
+    /// Fold over the inner structure to combine all of the values with our combine method inherited from `MonoidK.
+    ///
+    /// - Parameter fga: Nested contexts value.
+    /// - Returns: A value in the context implementing this instance where the inner context has been folded.
     public static func unite<G: Foldable, A>(_ fga: Kind<Self, Kind<G, A>>) -> Kind<Self, A> {
         return flatMap(fga, { ga in G.foldLeft(ga, empty(), { acc, a in combineK(acc, pure(a)) })})
     }
@@ -11,7 +16,13 @@ public extension MonadCombine {
 // MARK: Syntax for MonadCombine
 
 public extension Kind where F: MonadCombine {
-    public static func unite<G: Foldable, A>(_ fga: Kind<F, Kind<G, A>>) -> Kind<F, A> {
+    /// Fold over the inner structure to combine all of the values with our combine method inherited from `MonoidK.
+    ///
+    /// This is a convenience method to call `MonadCombine.unite` as a static method of this type.
+    ///
+    /// - Parameter fga: Nested contexts value.
+    /// - Returns: A value in the context implementing this instance where the inner context has been folded.
+    public static func unite<G: Foldable>(_ fga: Kind<F, Kind<G, A>>) -> Kind<F, A> {
         return F.unite(fga)
     }
 }

--- a/Sources/Bow/Typeclasses/MonadReader.swift
+++ b/Sources/Bow/Typeclasses/MonadReader.swift
@@ -1,13 +1,29 @@
 import Foundation
 
+/// A MonadReader is a `Monad` with capabilities to read values from a shared environment.
 public protocol MonadReader: Monad {
+    /// Type of the shared environment
     associatedtype D
     
+    /// Retrieves the shared environment.
+    ///
+    /// - Returns: Shared environment.
     static func ask() -> Kind<Self, D>
+
+    /// Executes a computation in a modified environment.
+    ///
+    /// - Parameters:
+    ///   - fa: Computation to execute.
+    ///   - f: Funtion to modify the environment.
+    /// - Returns: Computation in the modified environment.
     static func local<A>(_ fa: Kind<Self, A>, _ f: @escaping (D) -> D) -> Kind<Self, A>
 }
 
 public extension MonadReader {
+    /// Retrieves a function of the current environment.
+    ///
+    /// - Parameter f: Selector function to apply to the environment.
+    /// - Returns: A value extracted from the environment, in the context implementing this instance.
     public static func reader<A>(_ f: @escaping (D) -> A) -> Kind<Self, A> {
         return map(ask(), f)
     }
@@ -16,14 +32,32 @@ public extension MonadReader {
 // MARK: Syntax for MonadReader
 
 public extension Kind where F: MonadReader {
+    /// Retrieves the shared environment.
+    ///
+    /// This is a convenience method to call `MonadReader.ask` as a static method of this type.
+    ///
+    /// - Returns: Shared environment.
     public static func ask() -> Kind<F, F.D> {
         return F.ask()
     }
 
+    /// Executes this computation in a modified environment.
+    ///
+    /// This is a convenience method to call `MonadReader.local` as an instance method of this type.
+    ///
+    /// - Parameters:
+    ///   - f: Funtion to modify the environment.
+    /// - Returns: Computation in the modified environment.
     public func local(_ f: @escaping (F.D) -> F.D) -> Kind<F, A> {
         return F.local(self, f)
     }
 
+    /// Retrieves a function of the current environment.
+    ///
+    /// This is a convenience method to call `MonadReader.reader` as a static method of this type.
+    ///
+    /// - Parameter f: Selector function to apply to the environment.
+    /// - Returns: A value extracted from the environment, in the context implementing this instance.
     public static func reader(_ f: @escaping (F.D) -> A) -> Kind<F, A> {
         return F.reader(f)
     }

--- a/Sources/Bow/Typeclasses/MonadState.swift
+++ b/Sources/Bow/Typeclasses/MonadState.swift
@@ -1,13 +1,27 @@
 import Foundation
 
+/// A MonadState is a `Monad` that maintains a state.
 public protocol MonadState: Monad {
+    /// Type of the state maintained in this instance
     associatedtype S
     
+    /// Retrieves the state from the internals of the monad.
+    ///
+    /// - Returns: Maintained state.
     static func get() -> Kind<Self, S>
+
+    /// Replaces the state inside the monad.
+    ///
+    /// - Parameter s: New state.
+    /// - Returns: Unit.
     static func set(_ s: S) -> Kind<Self, ()>
 }
 
 public extension MonadState {
+    /// Embeds a state action into the monad.
+    ///
+    /// - Parameter f: A function that receives the state and computes a value and a new state.
+    /// - Returns: A value with the output of the function and the new state.
     public static func state<A>(_ f: @escaping (S) -> (S, A)) -> Kind<Self, A> {
         return flatMap(get(), { s in
             let result = f(s)
@@ -15,10 +29,18 @@ public extension MonadState {
         })
     }
     
+    /// Modifies the internal state.
+    ///
+    /// - Parameter f: Function that modifies the state.
+    /// - Returns: Unit.
     public static func modify(_ f: @escaping (S) -> S) -> Kind<Self, ()> {
         return flatMap(get(), { s in set(f(s))})
     }
     
+    /// Retrieves a specific component of the state.
+    ///
+    /// - Parameter f: Projection function to obtain part of the state.
+    /// - Returns: A specific part of the state.
     public static func inspect<A>(_ f: @escaping (S) -> A) -> Kind<Self, A> {
         return map(get(), f)
     }
@@ -27,22 +49,51 @@ public extension MonadState {
 // MARK: Syntax for MonadState
 
 public extension Kind where F: MonadState {
+    /// Retrieves the state from the internals of the monad.
+    ///
+    /// This is a convenience method to call `MonadState.get` as a static method of this type.
+    ///
+    /// - Returns: Maintained state.
     public static func get() -> Kind<F, F.S> {
         return F.get()
     }
 
+    /// Replaces the state inside the monad.
+    ///
+    /// This is a convenience method to call `MonadState.set` as a static method of this type.
+    ///
+    /// - Parameter s: New state.
+    /// - Returns: Unit.
     public static func set(_ s: F.S) -> Kind<F, ()> {
         return F.set(s)
     }
 
+    /// Embeds a state action into the monad.
+    ///
+    /// This is a convenience method to call `MonadState.state` as a static method of this type.
+    ///
+    /// - Parameter f: A function that receives the state and computes a value and a new state.
+    /// - Returns: A value with the output of the function and the new state.
     public static func state(_ f: @escaping (F.S) -> (F.S, A)) -> Kind<F, A> {
         return F.state(f)
     }
 
+    /// Modifies the internal state.
+    ///
+    /// This is a convenience method to call `MonadState.modify` as a static method of this type.
+    ///
+    /// - Parameter f: Function that modifies the state.
+    /// - Returns: Unit.
     public static func modify(_ f: @escaping (F.S) -> F.S) -> Kind<F, ()> {
         return F.modify(f)
     }
 
+    /// Retrieves a specific component of the state.
+    ///
+    /// This is a convenience method to call `MonadState.inspect` as a static method of this type.
+    ///
+    /// - Parameter f: Projection function to obtain part of the state.
+    /// - Returns: A specific part of the state.
     public static func inspect(_ f: @escaping (F.S) -> A) -> Kind<F, A> {
         return F.inspect(f)
     }

--- a/Sources/Bow/Typeclasses/MonadWriter.swift
+++ b/Sources/Bow/Typeclasses/MonadWriter.swift
@@ -1,22 +1,54 @@
 import Foundation
 
-public protocol MonadWriter : Monad {
+/// A MonadWriter is a `Monad` with the ability to produce a stream of data in addition to the computed values.
+public protocol MonadWriter: Monad {
+    /// Type of the side stream of data produced by this monad
     associatedtype W
     
+    /// Embeds a writer action.
+    ///
+    /// - Parameter aw: A tupe of the writer type and a value.
+    /// - Returns: The writer action embedded in the context implementing this instance.
     static func writer<A>(_ aw: (W, A)) -> Kind<Self, A>
+
+    /// Adds the side stream of data to the result of a computation.
+    ///
+    /// - Parameter fa: A computation.
+    /// - Returns: The result of the computation paired with the side stream of data.
     static func listen<A>(_ fa: Kind<Self, A>) -> Kind<Self, (W, A)>
+
+    /// Performs a computation and transforms the side stream of data.
+    ///
+    /// - Parameter fa: A computation that transform the stream of data.
+    /// - Returns: Result of the computation.
     static func pass<A>(_ fa: Kind<Self, ((W) -> W, A)>) -> Kind<Self, A>
 }
 
 public extension MonadWriter {
+    /// Produces a new value of the side stream of data.
+    ///
+    /// - Parameter w: New value.
+    /// - Returns: Unit.
     public static func tell(_ w: W) -> Kind<Self, ()> {
         return writer((w, ()))
     }
     
+    /// Performs a computation and transforms the side stream of data, pairing it with the result of the computation.
+    ///
+    /// - Parameters:
+    ///   - fa: A computation.
+    ///   - f: A function to transform the side stream of data.
+    /// - Returns: A tuple of the transformation of the side stream and the result of the computation.
     public static func listens<A, B>(_ fa: Kind<Self, A>, _ f: @escaping (W) -> B) -> Kind<Self, (B, A)> {
         return map(listen(fa), { pair in (f(pair.0), pair.1) })
     }
     
+    /// Transforms the side stream of data of a given computation.
+    ///
+    /// - Parameters:
+    ///   - fa: A computation.
+    ///   - f: Transforming function.
+    /// - Returns: A computation with the same result as the provided one, with the transformed side stream of data.
     public static func censor<A>(_ fa: Kind<Self, A>, _ f: @escaping (W) -> W) -> Kind<Self, A> {
         return self.flatMap(self.listen(fa), { pair in writer((f(pair.0), pair.1)) })
     }
@@ -25,26 +57,63 @@ public extension MonadWriter {
 // MARK: Syntax for MonadWriter
 
 public extension Kind where F: MonadWriter {
+    /// Embeds a writer action.
+    ///
+    /// This is a convenience method to call `MonadWriter.writer` as a static method of this type.
+    ///
+    /// - Parameter aw: A tupe of the writer type and a value.
+    /// - Returns: The writer action embedded in the context implementing this instance.
     public static func writer(_ aw: (F.W, A)) -> Kind<F, A> {
         return F.writer(aw)
     }
 
+    /// Adds the side stream of data to the result of this computation.
+    ///
+    /// This is a convenience method to call `MonadWriter.listen` as an instance method of this type.
+    ///
+    /// - Returns: The result of the computation paired with the side stream of data.
     public func listen() -> Kind<F, (F.W, A)> {
         return F.listen(self)
     }
 
+    /// Performs a computation and transforms the side stream of data.
+    ///
+    /// This is a convenience method to call `MonadWriter.pass` as a static method of this type.
+    ///
+    /// - Parameter fa: A computation that transform the stream of data.
+    /// - Returns: Result of the computation.
     public static func pass(_ fa: Kind<F, ((F.W) -> F.W, A)>) -> Kind<F, A> {
         return F.pass(fa)
     }
 
+    /// Produces a new value of the side stream of data.
+    ///
+    /// This is a convenience method to call `MonadWriter.tell` as a static method of this type.
+    ///
+    /// - Parameter w: New value.
+    /// - Returns: Unit.
     public static func tell(_ w: F.W) -> Kind<F, ()> {
         return F.tell(w)
     }
 
+    /// Performs this computation and transforms the side stream of data, pairing it with the result of this computation.
+    ///
+    /// This is a convenience method to call `MonadWriter.listens` as an instance method of this type.
+    ///
+    /// - Parameters:
+    ///   - f: A function to transform the side stream of data.
+    /// - Returns: A tuple of the transformation of the side stream and the result of the computation.
     public func listens<B>(_ f: @escaping (F.W) -> B) -> Kind<F, (B, A)> {
         return F.listens(self, f)
     }
 
+    /// Transforms the side stream of data of this computation.
+    ///
+    /// This is a convenience method to call `MonadWriter.censor` as an instance method of this type.
+    ///
+    /// - Parameters:
+    ///   - f: Transforming function.
+    /// - Returns: A computation with the same result as the provided one, with the transformed side stream of data.
     public func censor(_ f: @escaping (F.W) -> F.W) -> Kind<F, A> {
         return F.censor(self, f)
     }


### PR DESCRIPTION
## Related issues

- Closes #175.
- Closes #176.
- Closes #177.
- Closes #178.

## Goal

Add API docs for MonadCombine, MonadReader, MonadState and MonadWriter.