### PR TITLE
Add Selective Applicative Functors

### DIFF
--- a/Bow.xcodeproj/project.pbxproj
+++ b/Bow.xcodeproj/project.pbxproj
@@ -89,6 +89,7 @@
 		1166A07A22119F720032CD4E /* EqualityFunctions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1166A07822119E640032CD4E /* EqualityFunctions.swift */; };
 		11A435622212C60A000C5E31 /* EquatableLaws.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11A435602212C59F000C5E31 /* EquatableLaws.swift */; };
 		11A4356422131ACC000C5E31 /* BoolInstances.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11A4356322131ACC000C5E31 /* BoolInstances.swift */; };
+		11D36A19223261EC00CBD85F /* Selective.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11D36A18223261EC00CBD85F /* Selective.swift */; };
 		11D97EE4219EBAA1008FC004 /* Nimble.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8BA0F384217E2D3400969984 /* Nimble.framework */; };
 		11D97EE5219EBAA1008FC004 /* SwiftCheck.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8BA0F385217E2D3400969984 /* SwiftCheck.framework */; };
 		11D97EF2219EBC0F008FC004 /* AsyncLaws.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BA0F3A2217E2DEF00969984 /* AsyncLaws.swift */; };
@@ -573,6 +574,7 @@
 		1166A07822119E640032CD4E /* EqualityFunctions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EqualityFunctions.swift; sourceTree = "<group>"; };
 		11A435602212C59F000C5E31 /* EquatableLaws.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EquatableLaws.swift; sourceTree = "<group>"; };
 		11A4356322131ACC000C5E31 /* BoolInstances.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoolInstances.swift; sourceTree = "<group>"; };
+		11D36A18223261EC00CBD85F /* Selective.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Selective.swift; sourceTree = "<group>"; };
 		11D97EEA219EBAA1008FC004 /* BowEffectsLaws.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = BowEffectsLaws.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		11D97EEB219EBAA1008FC004 /* Bow-EffectsLaws-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; name = "Bow-EffectsLaws-Info.plist"; path = "/Users/tomasruizlopez/Development/bow/Bow-EffectsLaws-Info.plist"; sourceTree = "<absolute>"; };
 		11DDCD1B217F171900844D9D /* Memoization.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Memoization.swift; sourceTree = "<group>"; };
@@ -1441,6 +1443,7 @@
 				8BA0F48F217E2E9200969984 /* MonoidK.swift */,
 				8BA0F4A1217E2E9200969984 /* NonEmptyReducible.swift */,
 				8BA0F49D217E2E9200969984 /* Reducible.swift */,
+				11D36A18223261EC00CBD85F /* Selective.swift */,
 				8BA0F4AC217E2E9200969984 /* Semigroup.swift */,
 				8BA0F496217E2E9200969984 /* SemigroupK.swift */,
 				8BA0F49B217E2E9200969984 /* Traverse.swift */,
@@ -2562,6 +2565,7 @@
 				11A4356422131ACC000C5E31 /* BoolInstances.swift in Sources */,
 				8BA0F507217E2E9200969984 /* EitherT.swift in Sources */,
 				8BA0F643217E2E9200969984 /* Applicative.swift in Sources */,
+				11D36A19223261EC00CBD85F /* Selective.swift in Sources */,
 				8BA0F657217E2E9200969984 /* MonadCombine.swift in Sources */,
 				8BA0F58B217E2E9200969984 /* Ior.swift in Sources */,
 				8BA0F5BF217E2E9200969984 /* Coreader.swift in Sources */,

--- a/Bow.xcodeproj/project.pbxproj
+++ b/Bow.xcodeproj/project.pbxproj
@@ -90,6 +90,7 @@
 		11A435622212C60A000C5E31 /* EquatableLaws.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11A435602212C59F000C5E31 /* EquatableLaws.swift */; };
 		11A4356422131ACC000C5E31 /* BoolInstances.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11A4356322131ACC000C5E31 /* BoolInstances.swift */; };
 		11D36A19223261EC00CBD85F /* Selective.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11D36A18223261EC00CBD85F /* Selective.swift */; };
+		11D36A1C2232789900CBD85F /* SelectiveLaws.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11D36A1A2232787A00CBD85F /* SelectiveLaws.swift */; };
 		11D97EE4219EBAA1008FC004 /* Nimble.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8BA0F384217E2D3400969984 /* Nimble.framework */; };
 		11D97EE5219EBAA1008FC004 /* SwiftCheck.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8BA0F385217E2D3400969984 /* SwiftCheck.framework */; };
 		11D97EF2219EBC0F008FC004 /* AsyncLaws.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BA0F3A2217E2DEF00969984 /* AsyncLaws.swift */; };
@@ -575,6 +576,7 @@
 		11A435602212C59F000C5E31 /* EquatableLaws.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EquatableLaws.swift; sourceTree = "<group>"; };
 		11A4356322131ACC000C5E31 /* BoolInstances.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoolInstances.swift; sourceTree = "<group>"; };
 		11D36A18223261EC00CBD85F /* Selective.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Selective.swift; sourceTree = "<group>"; };
+		11D36A1A2232787A00CBD85F /* SelectiveLaws.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectiveLaws.swift; sourceTree = "<group>"; };
 		11D97EEA219EBAA1008FC004 /* BowEffectsLaws.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = BowEffectsLaws.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		11D97EEB219EBAA1008FC004 /* Bow-EffectsLaws-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; name = "Bow-EffectsLaws-Info.plist"; path = "/Users/tomasruizlopez/Development/bow/Bow-EffectsLaws-Info.plist"; sourceTree = "<absolute>"; };
 		11DDCD1B217F171900844D9D /* Memoization.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Memoization.swift; sourceTree = "<group>"; };
@@ -1201,6 +1203,7 @@
 				8BA0F3C5217E2DEF00969984 /* MonadWriterLaws.swift */,
 				8BA0F3D4217E2DEF00969984 /* MonoidKLaws.swift */,
 				8BA0F3BD217E2DEF00969984 /* MonoidLaws.swift */,
+				11D36A1A2232787A00CBD85F /* SelectiveLaws.swift */,
 				8BA0F3CF217E2DEF00969984 /* SemigroupKLaws.swift */,
 				8BA0F3BE217E2DEF00969984 /* SemigroupLaws.swift */,
 				8BA0F3D3217E2DEF00969984 /* TraverseFilterLaws.swift */,
@@ -2275,6 +2278,7 @@
 				1122942A219D8BDE006D66C5 /* FunctorLaws.swift in Sources */,
 				1122942B219D8BDE006D66C5 /* InvariantLaws.swift in Sources */,
 				1122942C219D8BDE006D66C5 /* MonadCombineLaws.swift in Sources */,
+				11D36A1C2232789900CBD85F /* SelectiveLaws.swift in Sources */,
 				1122942D219D8BDE006D66C5 /* MonadErrorLaws.swift in Sources */,
 				1122942E219D8BDE006D66C5 /* MonadFilterLaws.swift in Sources */,
 				1122942F219D8BDE006D66C5 /* MonadLaws.swift in Sources */,

--- a/Sources/Bow/Arrow/Cokleisli.swift
+++ b/Sources/Bow/Arrow/Cokleisli.swift
@@ -59,6 +59,7 @@ extension CokleisliPartial: Applicative {
     }
 }
 
+// MARK: Instance of `Selective` for `Cokleisli`
 extension CokleisliPartial: Selective {}
 
 extension CokleisliPartial: Monad {

--- a/Sources/Bow/Arrow/Cokleisli.swift
+++ b/Sources/Bow/Arrow/Cokleisli.swift
@@ -59,6 +59,8 @@ extension CokleisliPartial: Applicative {
     }
 }
 
+extension CokleisliPartial: Selective {}
+
 extension CokleisliPartial: Monad {
     public static func flatMap<A, B>(_ fa: Kind<CokleisliPartial<F, I>, A>, _ f: @escaping (A) -> Kind<CokleisliPartial<F, I>, B>) -> Kind<CokleisliPartial<F, I>, B> {
         let cok = Cokleisli.fix(fa)

--- a/Sources/Bow/Arrow/Function0.swift
+++ b/Sources/Bow/Arrow/Function0.swift
@@ -53,6 +53,7 @@ extension ForFunction0: Applicative {
     }
 }
 
+// MARK: Instance of `Selective` for `Function0`
 extension ForFunction0: Selective {}
 
 extension ForFunction0: Monad {

--- a/Sources/Bow/Arrow/Function0.swift
+++ b/Sources/Bow/Arrow/Function0.swift
@@ -53,6 +53,8 @@ extension ForFunction0: Applicative {
     }
 }
 
+extension ForFunction0: Selective {}
+
 extension ForFunction0: Monad {
     public static func flatMap<A, B>(_ fa: Kind<ForFunction0, A>, _ f: @escaping (A) -> Kind<ForFunction0, B>) -> Kind<ForFunction0, B> {
         return f(Function0.fix(fa).f())

--- a/Sources/Bow/Arrow/Function1.swift
+++ b/Sources/Bow/Arrow/Function1.swift
@@ -51,6 +51,7 @@ extension Function1Partial: Applicative {
     }
 }
 
+// MARK: Instance of `Selective` for `Function1`
 extension Function1Partial: Selective {}
 
 extension Function1Partial: Monad {

--- a/Sources/Bow/Arrow/Function1.swift
+++ b/Sources/Bow/Arrow/Function1.swift
@@ -51,6 +51,8 @@ extension Function1Partial: Applicative {
     }
 }
 
+extension Function1Partial: Selective {}
+
 extension Function1Partial: Monad {
     public static func flatMap<A, B>(_ fa: Kind<Function1Partial<I>, A>, _ f: @escaping (A) -> Kind<Function1Partial<I>, B>) -> Kind<Function1Partial<I>, B> {
         return Function1<I, B>({ i in Function1.fix(f(Function1.fix(fa).f(i))).f(i) })

--- a/Sources/Bow/Arrow/Kleisli.swift
+++ b/Sources/Bow/Arrow/Kleisli.swift
@@ -65,6 +65,8 @@ extension KleisliPartial: Applicative where F: Applicative {
     }
 }
 
+extension KleisliPartial: Selective where F: Monad {}
+
 extension KleisliPartial: Monad where F: Monad {
     public static func flatMap<A, B>(_ fa: Kind<KleisliPartial<F, D>, A>, _ f: @escaping (A) -> Kind<KleisliPartial<F, D>, B>) -> Kind<KleisliPartial<F, D>, B> {
         return Kleisli<F, D, B>({ d in Kleisli.fix(fa).run(d).flatMap { a in Kleisli.fix(f(a)).run(d) } })

--- a/Sources/Bow/Arrow/Kleisli.swift
+++ b/Sources/Bow/Arrow/Kleisli.swift
@@ -65,6 +65,7 @@ extension KleisliPartial: Applicative where F: Applicative {
     }
 }
 
+// MARK: Instance of `Selective` for `Kleisli`
 extension KleisliPartial: Selective where F: Monad {}
 
 extension KleisliPartial: Monad where F: Monad {

--- a/Sources/Bow/Data/ArrayK.swift
+++ b/Sources/Bow/Data/ArrayK.swift
@@ -78,6 +78,7 @@ extension ForArrayK: Applicative {
     }
 }
 
+// MARK: Instance of `Selective` for `ArrayK`
 extension ForArrayK: Selective {}
 
 extension ForArrayK: Monad {

--- a/Sources/Bow/Data/ArrayK.swift
+++ b/Sources/Bow/Data/ArrayK.swift
@@ -78,6 +78,8 @@ extension ForArrayK: Applicative {
     }
 }
 
+extension ForArrayK: Selective {}
+
 extension ForArrayK: Monad {
     public static func flatMap<A, B>(_ fa: Kind<ForArrayK, A>, _ f: @escaping (A) -> Kind<ForArrayK, B>) -> Kind<ForArrayK, B> {
         let fixed = ArrayK<A>.fix(fa)

--- a/Sources/Bow/Data/Either.swift
+++ b/Sources/Bow/Data/Either.swift
@@ -183,6 +183,7 @@ extension EitherPartial: Applicative {
     }
 }
 
+// MARK: Instance of `Selective` for `Either`
 extension EitherPartial: Selective {}
 
 /// Instance of `Monad` for `Either`.

--- a/Sources/Bow/Data/Either.swift
+++ b/Sources/Bow/Data/Either.swift
@@ -183,6 +183,8 @@ extension EitherPartial: Applicative {
     }
 }
 
+extension EitherPartial: Selective {}
+
 /// Instance of `Monad` for `Either`.
 extension EitherPartial: Monad {
     public static func flatMap<A, B>(_ fa: Kind<EitherPartial<L>, A>, _ f: @escaping (A) -> Kind<EitherPartial<L>, B>) -> Kind<EitherPartial<L>, B> {

--- a/Sources/Bow/Data/Eval.swift
+++ b/Sources/Bow/Data/Eval.swift
@@ -276,6 +276,7 @@ extension ForEval: Applicative {
     }
 }
 
+// MARK: Instance of `Selective` for `Eval`
 extension ForEval: Selective {}
 
 extension ForEval: Monad {

--- a/Sources/Bow/Data/Eval.swift
+++ b/Sources/Bow/Data/Eval.swift
@@ -276,6 +276,8 @@ extension ForEval: Applicative {
     }
 }
 
+extension ForEval: Selective {}
+
 extension ForEval: Monad {
     public static func flatMap<A, B>(_ fa: Kind<ForEval, A>, _ f: @escaping (A) -> Kind<ForEval, B>) -> Kind<ForEval, B> {
         let ff: (A) -> Eval<B> = { a in Eval.fix(f(a)) }

--- a/Sources/Bow/Data/Id.swift
+++ b/Sources/Bow/Data/Id.swift
@@ -60,6 +60,7 @@ extension ForId: Applicative {
     }
 }
 
+// MARK: Instance of `Selective` for `Id`
 extension ForId: Selective {}
 
 extension ForId: Monad {

--- a/Sources/Bow/Data/Id.swift
+++ b/Sources/Bow/Data/Id.swift
@@ -60,6 +60,8 @@ extension ForId: Applicative {
     }
 }
 
+extension ForId: Selective {}
+
 extension ForId: Monad {
     public static func flatMap<A, B>(_ fa: Kind<ForId, A>, _ f: @escaping (A) -> Kind<ForId, B>) -> Kind<ForId, B> {
         let id = Id<A>.fix(fa)

--- a/Sources/Bow/Data/Ior.swift
+++ b/Sources/Bow/Data/Ior.swift
@@ -165,6 +165,7 @@ extension IorPartial: Applicative where L: Semigroup {
     }
 }
 
+// MARK: Instance of `Selective` for `Ior`
 extension IorPartial: Selective where L: Semigroup {}
 
 extension IorPartial: Monad where L: Semigroup {

--- a/Sources/Bow/Data/Ior.swift
+++ b/Sources/Bow/Data/Ior.swift
@@ -165,6 +165,8 @@ extension IorPartial: Applicative where L: Semigroup {
     }
 }
 
+extension IorPartial: Selective where L: Semigroup {}
+
 extension IorPartial: Monad where L: Semigroup {
     public static func flatMap<A, B>(_ fa: Kind<IorPartial<L>, A>, _ f: @escaping (A) -> Kind<IorPartial<L>, B>) -> Kind<IorPartial<L>, B> {
         return Ior.fix(fa).fold(

--- a/Sources/Bow/Data/NonEmptyArray.swift
+++ b/Sources/Bow/Data/NonEmptyArray.swift
@@ -105,6 +105,7 @@ extension ForNonEmptyArray: Applicative {
     }
 }
 
+// MARK: Instance of `Selective` for `NonEmptyArray`
 extension ForNonEmptyArray: Selective {}
 
 extension ForNonEmptyArray: Monad {

--- a/Sources/Bow/Data/NonEmptyArray.swift
+++ b/Sources/Bow/Data/NonEmptyArray.swift
@@ -105,6 +105,8 @@ extension ForNonEmptyArray: Applicative {
     }
 }
 
+extension ForNonEmptyArray: Selective {}
+
 extension ForNonEmptyArray: Monad {
     public static func flatMap<A, B>(_ fa: Kind<ForNonEmptyArray, A>, _ f: @escaping (A) -> Kind<ForNonEmptyArray, B>) -> Kind<ForNonEmptyArray, B> {
         let nea = NonEmptyArray.fix(fa)

--- a/Sources/Bow/Data/Option.swift
+++ b/Sources/Bow/Data/Option.swift
@@ -160,6 +160,8 @@ extension ForOption: Applicative {
     }
 }
 
+extension ForOption: Selective {}
+
 /// Instance of `Monad` for `Option`.
 extension ForOption: Monad {
     public static func flatMap<A, B>(_ fa: Kind<ForOption, A>, _ f: @escaping (A) -> Kind<ForOption, B>) -> Kind<ForOption, B> {

--- a/Sources/Bow/Data/Option.swift
+++ b/Sources/Bow/Data/Option.swift
@@ -160,6 +160,7 @@ extension ForOption: Applicative {
     }
 }
 
+// MARK: Instance of `Selective` for `Option`
 extension ForOption: Selective {}
 
 /// Instance of `Monad` for `Option`.

--- a/Sources/Bow/Data/Try.swift
+++ b/Sources/Bow/Data/Try.swift
@@ -118,6 +118,8 @@ extension ForTry: Applicative {
     }
 }
 
+extension ForTry: Selective {}
+
 extension ForTry: Monad {
     public static func flatMap<A, B>(_ fa: Kind<ForTry, A>, _ f: @escaping (A) -> Kind<ForTry, B>) -> Kind<ForTry, B> {
         let trya = Try<A>.fix(fa)

--- a/Sources/Bow/Data/Try.swift
+++ b/Sources/Bow/Data/Try.swift
@@ -118,6 +118,7 @@ extension ForTry: Applicative {
     }
 }
 
+// MARK: Instance of `Selective` for `Try`
 extension ForTry: Selective {}
 
 extension ForTry: Monad {

--- a/Sources/Bow/Data/Validated.swift
+++ b/Sources/Bow/Data/Validated.swift
@@ -138,6 +138,7 @@ extension ValidatedPartial: Applicative where I: Semigroup {
     }
 }
 
+// MARK: Instance of `Selective` for `Validated`
 extension ValidatedPartial: Selective where I: Semigroup {
     public static func select<A, B>(_ fab: Kind<ValidatedPartial<I>, Either<A, B>>, _ f: Kind<ValidatedPartial<I>, (A) -> B>) -> Kind<ValidatedPartial<I>, B> {
         return Validated.fix(fab).fold(

--- a/Sources/Bow/Data/Validated.swift
+++ b/Sources/Bow/Data/Validated.swift
@@ -138,6 +138,16 @@ extension ValidatedPartial: Applicative where I: Semigroup {
     }
 }
 
+extension ValidatedPartial: Selective where I: Semigroup {
+    public static func select<A, B>(_ fab: Kind<ValidatedPartial<I>, Either<A, B>>, _ f: Kind<ValidatedPartial<I>, (A) -> B>) -> Kind<ValidatedPartial<I>, B> {
+        return Validated.fix(fab).fold(
+            { e in Validated.invalid(e) },
+            { eab in eab.fold({ a in map(f, { ff in ff(a) }) },
+                              { b in Validated.valid(b) })
+            })
+    }
+}
+
 extension ValidatedPartial: ApplicativeError where I: Semigroup {
     public typealias E = I
 

--- a/Sources/Bow/Transformers/EitherT.swift
+++ b/Sources/Bow/Transformers/EitherT.swift
@@ -94,6 +94,7 @@ extension EitherTPartial: Applicative where F: Applicative {
     }
 }
 
+// MARK: Instance of `Selective` for `EitherT`
 extension EitherTPartial: Selective where F: Monad {}
 
 extension EitherTPartial: Monad where F: Monad {

--- a/Sources/Bow/Transformers/EitherT.swift
+++ b/Sources/Bow/Transformers/EitherT.swift
@@ -94,6 +94,8 @@ extension EitherTPartial: Applicative where F: Applicative {
     }
 }
 
+extension EitherTPartial: Selective where F: Monad {}
+
 extension EitherTPartial: Monad where F: Monad {
     public static func flatMap<A, B>(_ fa: Kind<EitherTPartial<F, L>, A>, _ f: @escaping (A) -> Kind<EitherTPartial<F, L>, B>) -> Kind<EitherTPartial<F, L>, B> {
         let eta = EitherT.fix(fa)

--- a/Sources/Bow/Transformers/OptionT.swift
+++ b/Sources/Bow/Transformers/OptionT.swift
@@ -114,6 +114,8 @@ extension OptionTPartial: Applicative where F: Applicative {
     }
 }
 
+extension OptionTPartial: Selective where F: Monad {}
+
 extension OptionTPartial: Monad where F: Monad {
     public static func flatMap<A, B>(_ fa: Kind<OptionTPartial<F>, A>, _ f: @escaping (A) -> Kind<OptionTPartial<F>, B>) -> Kind<OptionTPartial<F>, B> {
         let ota = OptionT.fix(fa)

--- a/Sources/Bow/Transformers/OptionT.swift
+++ b/Sources/Bow/Transformers/OptionT.swift
@@ -114,6 +114,7 @@ extension OptionTPartial: Applicative where F: Applicative {
     }
 }
 
+// MARK: Instance of `Selective` for `OptionT`
 extension OptionTPartial: Selective where F: Monad {}
 
 extension OptionTPartial: Monad where F: Monad {

--- a/Sources/Bow/Transformers/StateT.swift
+++ b/Sources/Bow/Transformers/StateT.swift
@@ -94,6 +94,8 @@ extension StateTPartial: Applicative where F: Monad {
     }
 }
 
+extension StateTPartial: Selective where F: Monad {}
+
 extension StateTPartial: Monad where F: Monad {
     public static func flatMap<A, B>(_ fa: Kind<StateTPartial<F, S>, A>, _ f: @escaping (A) -> Kind<StateTPartial<F, S>, B>) -> Kind<StateTPartial<F, S>, B> {
         let sta = StateT.fix(fa)

--- a/Sources/Bow/Transformers/StateT.swift
+++ b/Sources/Bow/Transformers/StateT.swift
@@ -94,6 +94,7 @@ extension StateTPartial: Applicative where F: Monad {
     }
 }
 
+// MARK: Instance of `Selective` for `StateT`
 extension StateTPartial: Selective where F: Monad {}
 
 extension StateTPartial: Monad where F: Monad {

--- a/Sources/Bow/Transformers/WriterT.swift
+++ b/Sources/Bow/Transformers/WriterT.swift
@@ -143,6 +143,8 @@ extension WriterTPartial: Applicative where F: Monad, W: Monoid {
     }
 }
 
+extension WriterTPartial: Selective where F: Monad, W: Monoid {}
+
 extension WriterTPartial: Monad where F: Monad, W: Monoid {
     public static func flatMap<A, B>(_ fa: Kind<WriterTPartial<F, W>, A>, _ f: @escaping (A) -> Kind<WriterTPartial<F, W>, B>) -> Kind<WriterTPartial<F, W>, B> {
         let wa = WriterT.fix(fa)

--- a/Sources/Bow/Transformers/WriterT.swift
+++ b/Sources/Bow/Transformers/WriterT.swift
@@ -143,6 +143,7 @@ extension WriterTPartial: Applicative where F: Monad, W: Monoid {
     }
 }
 
+// MARK: Instance of `Selective` for `WriterT`
 extension WriterTPartial: Selective where F: Monad, W: Monoid {}
 
 extension WriterTPartial: Monad where F: Monad, W: Monoid {

--- a/Sources/Bow/Typeclasses/Applicative.swift
+++ b/Sources/Bow/Typeclasses/Applicative.swift
@@ -37,6 +37,27 @@ public protocol Applicative: Functor {
 
 // MARK: Related functions
 public extension Applicative {
+    /// Sequentially compose two computations, discarding the value produced by the first.
+    ///
+    /// - Parameters:
+    ///   - fa: 1st computation.
+    ///   - fb: 2nd computation.
+    /// - Returns: Result of running the second computation after the first one.
+    public static func sequenceRight<A, B>(_ fa: Kind<Self, A>, _ fb: Kind<Self, B>) -> Kind<Self, B> {
+        return map(fa, fb) { _, b in b }
+    }
+
+    /// Sequentially compose two computations, discarding the value produced by the second.
+    ///
+    /// - Parameters:
+    ///   - fa: 1st computation.
+    ///   - fb: 2nd computation.
+    /// - Returns: Result produced from the first computation after both are computed.
+
+    public static func sequenceLeft<A, B>(_ fa: Kind<Self, A>, _ fb: Kind<Self, B>) -> Kind<Self, A> {
+        return map(fa, fb) { a, _ in a }
+    }
+
     /// Creates a tuple in the context implementing this instance from two values in the same context.
     ///
     /// - Parameters:

--- a/Sources/Bow/Typeclasses/Monad.swift
+++ b/Sources/Bow/Typeclasses/Monad.swift
@@ -11,7 +11,7 @@ import Foundation
 /// Also, instances of `Monad` derive a default implementation for `Applicative.ap` as:
 ///
 ///     ap(ff, fa) == flapMap(ff, { f in map(fa, f) }
-public protocol Monad: Applicative {
+public protocol Monad: Selective {
     /// Sequentially compose two computations, passing any value produced by the first as an argument to the second.
     ///
     /// - Parameters:
@@ -39,6 +39,12 @@ public extension Monad {
     // Docs inherited from `Applicative`
     public static func ap<A, B>(_ ff: Kind<Self, (A) -> B>, _ fa: Kind<Self, A>) -> Kind<Self, B> {
         return self.flatMap(ff, { f in map(fa, f) })
+    }
+
+    // Docs inherited from `Selective`
+    static func select<A, B>(_ fab: Kind<Self, Either<A, B>>, _ f: Kind<Self, (A) -> B>) -> Kind<Self, B> {
+        return flatMap(fab) { eab in eab.fold({ a in map(f, { ff in ff(a) }) },
+                                              { b in pure(b) })}
     }
 
     /// Flattens a nested structure of the context implementing this instance into a single layer.

--- a/Sources/Bow/Typeclasses/Selective.swift
+++ b/Sources/Bow/Typeclasses/Selective.swift
@@ -51,3 +51,51 @@ public extension Selective {
         return Eval.later { whenS(x, whileS(x).value()) }
     }
 }
+
+// MARK: Syntax for Selective
+
+public extension Kind where F: Selective {
+    public func select<AA, B>(_ f: Kind<F, (AA) -> B>) -> Kind<F, B> where A == Either<AA, B> {
+        return F.select(self, f)
+    }
+
+    public func branch<AA, B, C>(_ fa: Kind<F, (AA) -> C>, _ fb: Kind<F, (B) -> C>) -> Kind<F, C> where A == Either<AA, B> {
+        return F.branch(self, fa, fb)
+    }
+
+    public static func fromOptionS(_ x: Kind<F, A>, _ mx: Kind<F, Option<A>>) -> Kind<F, A> {
+        return F.fromOptionS(x, mx)
+    }
+}
+
+public extension Kind where F: Selective, A == Bool {
+    public static func whenS(_ cond: Kind<F, Bool>, _ f: Kind<F, ()>) -> Kind<F, ()> {
+        return F.whenS(cond, f)
+    }
+
+    public static func ifS<A>(_ x: Kind<F, Bool>, _ t: Kind<F, A>, _ e: Kind<F, A>) -> Kind<F, A> {
+        return F.ifS(x, t, e)
+    }
+
+    public static func orS(_ x: Kind<F, Bool>, _ y: Kind<F, Bool>) -> Kind<F, Bool> {
+        return F.orS(x, y)
+    }
+
+    public static func andS(_ x: Kind<F, Bool>, _ y: Kind<F, Bool>) -> Kind<F, Bool> {
+        return F.andS(x, y)
+    }
+
+    public static func whileS(_ x: Kind<F, Bool>) -> Eval<Kind<F, ()>> {
+        return F.whileS(x)
+    }
+}
+
+public extension ArrayK {
+    public func anyS<F: Selective>(_ p: @escaping (A) -> Kind<F, Bool>) -> Kind<F, Bool> {
+        return F.anyS(p, self)
+    }
+
+    public func allS<F: Selective>(_ p: @escaping (A) -> Kind<F, Bool>) -> Kind<F, Bool> {
+        return F.anyS(p, self)
+    }
+}

--- a/Sources/Bow/Typeclasses/Selective.swift
+++ b/Sources/Bow/Typeclasses/Selective.swift
@@ -1,0 +1,53 @@
+import Foundation
+
+public protocol Selective: Applicative {
+    static func select<A, B>(_ fab: Kind<Self, Either<A, B>>, _ f: Kind<Self, (A) -> B>) -> Kind<Self, B>
+}
+
+// MARK: Related functions
+
+public extension Selective {
+    private static func selector(_ x: Kind<Self, Bool>) -> Kind<Self, Either<(), ()>> {
+        return map(x, { flag in flag ? Either.left(()) : Either.right(()) })
+    }
+
+    public static func whenS(_ cond: Kind<Self, Bool>, _ f: Kind<Self, ()>) -> Kind<Self, ()> {
+        let effect = map(f) { ff in { (_: ()) in } }
+        return select(selector(cond), effect)
+    }
+
+    public static func branch<A, B, C>(_ fab: Kind<Self, Either<A, B>>, _ fa: Kind<Self, (A) -> C>, _ fb: Kind<Self, (B) -> C>) -> Kind<Self, C> {
+        let x = map(fab) { eab in Either.fix(eab.map(Either<B, C>.left)) }
+        let y = map(fa) { f in { a in Either<B, C>.right(f(a)) } }
+        return select(select(x, y), fb)
+    }
+
+    public static func ifS<A>(_ x: Kind<Self, Bool>, _ t: Kind<Self, A>, _ e: Kind<Self, A>) -> Kind<Self, A> {
+        return branch(selector(x), map(t, constant), map(e, constant))
+    }
+
+    public static func orS(_ x: Kind<Self, Bool>, _ y: Kind<Self, Bool>) -> Kind<Self, Bool> {
+        return ifS(x, pure(true), y)
+    }
+
+    public static func andS(_ x: Kind<Self, Bool>, _ y: Kind<Self, Bool>) -> Kind<Self, Bool> {
+        return ifS(x, y, pure(false))
+    }
+
+    public static func fromOptionS<A>(_ x: Kind<Self, A>, _ mx: Kind<Self, Option<A>>) -> Kind<Self, A> {
+        let s = map(mx) { a in Option.fix(a.map(Either<(), A>.right)).getOrElse(Either.left(())) }
+        return select(s, map(x, constant))
+    }
+
+    public static func anyS<A>(_ p: @escaping (A) -> Kind<Self, Bool>, _ array: ArrayK<A>) -> Kind<Self, Bool> {
+        return array.foldRight(Eval.now(pure(false))) { a, b in Eval.later { orS(p(a), b.value()) } }.value()
+    }
+
+    public static func allS<A>(_ p: @escaping (A) -> Kind<Self, Bool>, _ array: ArrayK<A>) -> Kind<Self, Bool> {
+        return array.foldRight(Eval.now(pure(true))) { a, b in Eval.later { andS(p(a), b.value()) } }.value()
+    }
+
+    public static func whileS(_ x: Kind<Self, Bool>) -> Eval<Kind<Self, ()>> {
+        return Eval.later { whenS(x, whileS(x).value()) }
+    }
+}

--- a/Sources/Bow/Typeclasses/Selective.swift
+++ b/Sources/Bow/Typeclasses/Selective.swift
@@ -1,6 +1,13 @@
 import Foundation
 
+/// The Selective typeclass represents Selective Applicative Functors, described in [this paper](https://www.staff.ncl.ac.uk/andrey.mokhov/selective-functors.pdf). Selective Applicative Functors enrich Applicative Functors by providing an operation that composes two effectful computations where the second depends on the first.
 public protocol Selective: Applicative {
+    /// Conditionally applies the second computation based on the result of the first.
+    ///
+    /// - Parameters:
+    ///   - fab: A computation that results in an `Either` value.
+    ///   - f: A computation that is executed in case the first computation evaluates to a left value.
+    /// - Returns: Composition of the two computations.
     static func select<A, B>(_ fab: Kind<Self, Either<A, B>>, _ f: Kind<Self, (A) -> B>) -> Kind<Self, B>
 }
 
@@ -11,42 +18,96 @@ public extension Selective {
         return map(x, { flag in flag ? Either.left(()) : Either.right(()) })
     }
 
+    /// Evaluates the second computation when the first evaluates to `true`.
+    ///
+    /// - Parameters:
+    ///   - cond: A computation evaluating to a boolean value.
+    ///   - f: A computation that will be evaluated if the first computation evaluates to `true`.
+    /// - Returns: Composition of the two computations.
     public static func whenS(_ cond: Kind<Self, Bool>, _ f: Kind<Self, ()>) -> Kind<Self, ()> {
         let effect = map(f) { ff in { (_: ()) in } }
         return select(selector(cond), effect)
     }
 
+    /// Evaluates one out of two computations based on the result of another computation.
+    ///
+    /// - Parameters:
+    ///   - fab: Computation producing an `Either` value, to decide which computation is executed afterwards.
+    ///   - fa: Computation that will be executed if `fab` evaluates to an `Either.left` value.
+    ///   - fb: Computation that will be executed if `fab` evaluates to an `Either.right` value.
+    /// - Returns: Composition of the computations.
     public static func branch<A, B, C>(_ fab: Kind<Self, Either<A, B>>, _ fa: Kind<Self, (A) -> C>, _ fb: Kind<Self, (B) -> C>) -> Kind<Self, C> {
         let x = map(fab) { eab in Either.fix(eab.map(Either<B, C>.left)) }
         let y = map(fa) { f in { a in Either<B, C>.right(f(a)) } }
         return select(select(x, y), fb)
     }
 
+    /// Evaluates one out of two computations based on the result of another computation.
+    ///
+    /// - Parameters:
+    ///   - x: Computation producing a boolean value to decide which computation is exectured afterwards.
+    ///   - t: Computation that will be executed if the first evaluates to `true`.
+    ///   - e: Computation that will be executed if the first evaluates to `false`.
+    /// - Returns: Composition of the computations.
     public static func ifS<A>(_ x: Kind<Self, Bool>, _ t: Kind<Self, A>, _ e: Kind<Self, A>) -> Kind<Self, A> {
         return branch(selector(x), map(t, constant), map(e, constant))
     }
 
+    /// A lifted version of lazy boolean or.
+    ///
+    /// - Parameters:
+    ///   - x: Computation to be or'ed.
+    ///   - y: Computation to be or'ed.
+    /// - Returns: Result of the or operation on the two computations.
     public static func orS(_ x: Kind<Self, Bool>, _ y: Kind<Self, Bool>) -> Kind<Self, Bool> {
         return ifS(x, pure(true), y)
     }
 
+    /// A lifted version of lazy boolean and.
+    ///
+    /// - Parameters:
+    ///   - x: Computation to be and'ed.
+    ///   - y: Computation to be and'ed.
+    /// - Returns: Result of the and operation on the two computations.
     public static func andS(_ x: Kind<Self, Bool>, _ y: Kind<Self, Bool>) -> Kind<Self, Bool> {
         return ifS(x, y, pure(false))
     }
 
+    /// Evaluates an optional computation, providing a default value for the empty case.
+    ///
+    /// - Parameters:
+    ///   - x: Default value for the empty case.
+    ///   - mx: A computation resulting in an optional value.
+    /// - Returns: Composition of the two computations.
     public static func fromOptionS<A>(_ x: Kind<Self, A>, _ mx: Kind<Self, Option<A>>) -> Kind<Self, A> {
         let s = map(mx) { a in Option.fix(a.map(Either<(), A>.right)).getOrElse(Either.left(())) }
         return select(s, map(x, constant))
     }
 
+    /// A lifted version of `any`. Retains the short-circuiting behavior.
+    ///
+    /// - Parameters:
+    ///   - p: A lifted predicate to find any element of the `array` that matches it.
+    ///   - array: An array to look for an element that matches the predicate in.
+    /// - Returns: A boolean computation describing if any element of the array matches the predicate.
     public static func anyS<A>(_ p: @escaping (A) -> Kind<Self, Bool>, _ array: ArrayK<A>) -> Kind<Self, Bool> {
         return array.foldRight(Eval.now(pure(false))) { a, b in Eval.later { orS(p(a), b.value()) } }.value()
     }
 
+    /// A lifted version of `all`. Retains the short-circuiting behavior.
+    ///
+    /// - Parameters:
+    ///   - p: A lifted predicate to check all elements of the `array` match it.
+    ///   - array: An array to check if all elements match the predicate.
+    /// - Returns: A boolean computation describing if all elements of the array match the predicate.
     public static func allS<A>(_ p: @escaping (A) -> Kind<Self, Bool>, _ array: ArrayK<A>) -> Kind<Self, Bool> {
         return array.foldRight(Eval.now(pure(true))) { a, b in Eval.later { andS(p(a), b.value()) } }.value()
     }
 
+    /// Evaluates a computation as long as it evaluates to `true`.
+    ///
+    /// - Parameter x: A computation.
+    /// - Returns: A potentially lazy computation.
     public static func whileS(_ x: Kind<Self, Bool>) -> Eval<Kind<Self, ()>> {
         return Eval.later { whenS(x, whileS(x).value()) }
     }
@@ -55,46 +116,102 @@ public extension Selective {
 // MARK: Syntax for Selective
 
 public extension Kind where F: Selective {
+    /// Conditionally applies a computation based on the result of this computation.
+    ///
+    /// - Parameters:
+    ///   - f: A computation that is executed in case the receiving computation evaluates to a left value.
+    /// - Returns: Composition of the two computations.
     public func select<AA, B>(_ f: Kind<F, (AA) -> B>) -> Kind<F, B> where A == Either<AA, B> {
         return F.select(self, f)
     }
 
+    /// Evaluates one out of two computations based on the result of this computation.
+    ///
+    /// - Parameters:
+    ///   - fa: Computation that will be executed if this computation evaluates to an `Either.left` value.
+    ///   - fb: Computation that will be executed if this computation evaluates to an `Either.right` value.
+    /// - Returns: Composition of the computations.
     public func branch<AA, B, C>(_ fa: Kind<F, (AA) -> C>, _ fb: Kind<F, (B) -> C>) -> Kind<F, C> where A == Either<AA, B> {
         return F.branch(self, fa, fb)
     }
 
+    // Evaluates an optional computation, providing a default value for the empty case.
+    ///
+    /// - Parameters:
+    ///   - x: Default value for the empty case.
+    ///   - mx: A computation resulting in an optional value.
+    /// - Returns: Composition of the two computations.
     public static func fromOptionS(_ x: Kind<F, A>, _ mx: Kind<F, Option<A>>) -> Kind<F, A> {
         return F.fromOptionS(x, mx)
     }
 }
 
 public extension Kind where F: Selective, A == Bool {
+    /// Evaluates the second computation when the first evaluates to `true`.
+    ///
+    /// - Parameters:
+    ///   - cond: A computation evaluating to a boolean value.
+    ///   - f: A computation that will be evaluated if the first computation evaluates to `true`.
+    /// - Returns: Composition of the two computations.
     public static func whenS(_ cond: Kind<F, Bool>, _ f: Kind<F, ()>) -> Kind<F, ()> {
         return F.whenS(cond, f)
     }
 
+    /// Evaluates one out of two computations based on the result of another computation.
+    ///
+    /// - Parameters:
+    ///   - x: Computation producing a boolean value to decide which computation is exectured afterwards.
+    ///   - t: Computation that will be executed if the first evaluates to `true`.
+    ///   - e: Computation that will be executed if the first evaluates to `false`.
+    /// - Returns: Composition of the computations.
     public static func ifS<A>(_ x: Kind<F, Bool>, _ t: Kind<F, A>, _ e: Kind<F, A>) -> Kind<F, A> {
         return F.ifS(x, t, e)
     }
 
+    /// A lifted version of lazy boolean or.
+    ///
+    /// - Parameters:
+    ///   - x: Computation to be or'ed.
+    ///   - y: Computation to be or'ed.
+    /// - Returns: Result of the or operation on the two computations.
     public static func orS(_ x: Kind<F, Bool>, _ y: Kind<F, Bool>) -> Kind<F, Bool> {
         return F.orS(x, y)
     }
 
+    /// A lifted version of lazy boolean and.
+    ///
+    /// - Parameters:
+    ///   - x: Computation to be and'ed.
+    ///   - y: Computation to be and'ed.
+    /// - Returns: Result of the and operation on the two computations.
     public static func andS(_ x: Kind<F, Bool>, _ y: Kind<F, Bool>) -> Kind<F, Bool> {
         return F.andS(x, y)
     }
 
+    /// Evaluates a computation as long as it evaluates to `true`.
+    ///
+    /// - Parameter x: A computation.
+    /// - Returns: A potentially lazy computation.
     public static func whileS(_ x: Kind<F, Bool>) -> Eval<Kind<F, ()>> {
         return F.whileS(x)
     }
 }
 
 public extension ArrayK {
+    /// A lifted version of `any`. Retains the short-circuiting behavior.
+    ///
+    /// - Parameters:
+    ///   - p: A lifted predicate to find any element of this array that matches it.
+    /// - Returns: A boolean computation describing if any element of the array matches the predicate.
     public func anyS<F: Selective>(_ p: @escaping (A) -> Kind<F, Bool>) -> Kind<F, Bool> {
         return F.anyS(p, self)
     }
 
+    /// A lifted version of `all`. Retains the short-circuiting behavior.
+    ///
+    /// - Parameters:
+    ///   - p: A lifted predicate to check all elements of this array match it.
+    /// - Returns: A boolean computation describing if all elements of the array match the predicate.
     public func allS<F: Selective>(_ p: @escaping (A) -> Kind<F, Bool>) -> Kind<F, Bool> {
         return F.anyS(p, self)
     }

--- a/Sources/BowBrightFutures/FutureK.swift
+++ b/Sources/BowBrightFutures/FutureK.swift
@@ -73,6 +73,8 @@ extension FutureKPartial: Applicative {
     }
 }
 
+extension FutureKPartial: Selective {}
+
 extension FutureKPartial: Monad {
     public static func flatMap<A, B>(_ fa: Kind<FutureKPartial<E>, A>, _ f: @escaping (A) -> Kind<FutureKPartial<E>, B>) -> Kind<FutureKPartial<E>, B> {
         return FutureK.fix(fa).value.flatMap { a in FutureK.fix(f(a)).value }.k()

--- a/Sources/BowBrightFutures/FutureK.swift
+++ b/Sources/BowBrightFutures/FutureK.swift
@@ -73,6 +73,7 @@ extension FutureKPartial: Applicative {
     }
 }
 
+// MARK: Instance of `Selective` for `FutureK`
 extension FutureKPartial: Selective {}
 
 extension FutureKPartial: Monad {

--- a/Sources/BowEffects/IO.swift
+++ b/Sources/BowEffects/IO.swift
@@ -311,6 +311,8 @@ extension IOPartial: Applicative {
     }
 }
 
+extension IOPartial: Selective {}
+
 extension IOPartial: Monad {
     public static func flatMap<A, B>(_ fa: Kind<IOPartial<E>, A>, _ f: @escaping (A) -> Kind<IOPartial<E>, B>) -> Kind<IOPartial<E>, B> {
         return Join(IO.fix(IO.fix(fa).map { x in IO.fix(f(x)) }))

--- a/Sources/BowEffects/IO.swift
+++ b/Sources/BowEffects/IO.swift
@@ -311,6 +311,7 @@ extension IOPartial: Applicative {
     }
 }
 
+// MARK: Instance of `Selective` for `IO`
 extension IOPartial: Selective {}
 
 extension IOPartial: Monad {

--- a/Sources/BowFree/Free.swift
+++ b/Sources/BowFree/Free.swift
@@ -132,6 +132,7 @@ extension FreePartial: Applicative {
     }
 }
 
+// MARK: Instance of `Selective` for `Free`
 extension FreePartial: Selective {}
 
 extension FreePartial: Monad {

--- a/Sources/BowFree/Free.swift
+++ b/Sources/BowFree/Free.swift
@@ -132,6 +132,8 @@ extension FreePartial: Applicative {
     }
 }
 
+extension FreePartial: Selective {}
+
 extension FreePartial: Monad {
     public static func flatMap<A, B>(_ fa: Kind<FreePartial<S>, A>, _ f: @escaping (A) -> Kind<FreePartial<S>, B>) -> Kind<FreePartial<S>, B> {
         return FlatMapped(Free.fix(fa), { a in Free.fix(f(a)) })

--- a/Sources/BowRx/MaybeK.swift
+++ b/Sources/BowRx/MaybeK.swift
@@ -53,6 +53,8 @@ extension ForMaybeK: Applicative {
     }
 }
 
+extension ForMaybeK: Selective {}
+
 extension ForMaybeK: Monad {
     public static func flatMap<A, B>(_ fa: Kind<ForMaybeK, A>, _ f: @escaping (A) -> Kind<ForMaybeK, B>) -> Kind<ForMaybeK, B> {
         return MaybeK.fix(fa).value.flatMap { a in MaybeK<B>.fix(f(a)).value }.k()

--- a/Sources/BowRx/MaybeK.swift
+++ b/Sources/BowRx/MaybeK.swift
@@ -53,6 +53,7 @@ extension ForMaybeK: Applicative {
     }
 }
 
+// MARK: Instance of `Selective` for `MaybeK`
 extension ForMaybeK: Selective {}
 
 extension ForMaybeK: Monad {

--- a/Sources/BowRx/ObservableK.swift
+++ b/Sources/BowRx/ObservableK.swift
@@ -63,6 +63,7 @@ extension ForObservableK: Applicative {
     }
 }
 
+// MARK: Instance of `Selective` for `ObservableK`
 extension ForObservableK: Selective {}
 
 extension ForObservableK: Monad {

--- a/Sources/BowRx/ObservableK.swift
+++ b/Sources/BowRx/ObservableK.swift
@@ -63,6 +63,8 @@ extension ForObservableK: Applicative {
     }
 }
 
+extension ForObservableK: Selective {}
+
 extension ForObservableK: Monad {
     public static func flatMap<A, B>(_ fa: Kind<ForObservableK, A>, _ f: @escaping (A) -> Kind<ForObservableK, B>) -> Kind<ForObservableK, B> {
         return ObservableK.fix(fa).value.flatMap { a in ObservableK<B>.fix(f(a)).value }.k()

--- a/Sources/BowRx/SingleK.swift
+++ b/Sources/BowRx/SingleK.swift
@@ -62,6 +62,7 @@ extension ForSingleK: Applicative {
     }
 }
 
+// MARK: Instance of `Selective` for `SingleK`
 extension ForSingleK: Selective {}
 
 extension ForSingleK: Monad {

--- a/Sources/BowRx/SingleK.swift
+++ b/Sources/BowRx/SingleK.swift
@@ -62,6 +62,8 @@ extension ForSingleK: Applicative {
     }
 }
 
+extension ForSingleK: Selective {}
+
 extension ForSingleK: Monad {
     public static func flatMap<A, B>(_ fa: Kind<ForSingleK, A>, _ f: @escaping (A) -> Kind<ForSingleK, B>) -> Kind<ForSingleK, B> {
         return SingleK.fix(fa).value.flatMap { x in SingleK.fix(f(x)).value }.k()

--- a/Tests/BowBrightFuturesTests/FutureKTest.swift
+++ b/Tests/BowBrightFuturesTests/FutureKTest.swift
@@ -52,6 +52,10 @@ class FutureKTest: XCTestCase {
             ApplicativeLaws<FutureKPartial<CategoryError>>.check()
         }
     }
+
+    func testSelectiveLaws() {
+        SelectiveLaws<FutureKPartial<CategoryError>>.check()
+    }
     
     func testMonadLaws() {
         DispatchQueue.global(qos: .userInteractive).async {

--- a/Tests/BowBrightFuturesTests/FutureKTest.swift
+++ b/Tests/BowBrightFuturesTests/FutureKTest.swift
@@ -54,7 +54,9 @@ class FutureKTest: XCTestCase {
     }
 
     func testSelectiveLaws() {
-        SelectiveLaws<FutureKPartial<CategoryError>>.check()
+        DispatchQueue.global(qos: .userInteractive).async {
+            SelectiveLaws<FutureKPartial<CategoryError>>.check()
+        }
     }
     
     func testMonadLaws() {

--- a/Tests/BowEffectsTests/IOTest.swift
+++ b/Tests/BowEffectsTests/IOTest.swift
@@ -20,6 +20,10 @@ class IOTest: XCTestCase {
     func testApplicativeLaws() {
         ApplicativeLaws<IOPartial<CategoryError>>.check()
     }
+
+    func testSelectiveLaws() {
+        SelectiveLaws<IOPartial<CategoryError>>.check()
+    }
     
     func testMonadLaws() {
         MonadLaws<IOPartial<CategoryError>>.check()

--- a/Tests/BowFreeTests/FreeTest.swift
+++ b/Tests/BowFreeTests/FreeTest.swift
@@ -120,6 +120,10 @@ class FreeTest: XCTestCase {
     func testApplicativeLaws() {
         ApplicativeLaws<FreePartial<ForId>>.check()
     }
+
+    func testSelectiveLaws() {
+        SelectiveLaws<FreePartial<ForId>>.check()
+    }
     
     func testMonadLaws() {
         MonadLaws<FreePartial<ForId>>.check()

--- a/Tests/BowLaws/SelectiveLaws.swift
+++ b/Tests/BowLaws/SelectiveLaws.swift
@@ -1,0 +1,42 @@
+import SwiftCheck
+@testable import Bow
+
+public class SelectiveLaws<F: Selective & EquatableK> {
+    public static func check() {
+        identity()
+        distributibity()
+        associativity()
+    }
+
+    private static func identity() {
+        property("Identity") <- forAll { (x: Int) in
+            let input = F.pure(Either<Int, Int>.right(x))
+            return F.select(input, F.pure(id)) ==
+                F.map(input) { x in x.fold(id, id) }
+        }
+    }
+
+    private static func distributibity() {
+        property("Distributivity") <- forAll { (a: Int, b: ArrowOf<Int, Int>, c: ArrowOf<Int, Int>) in
+            let x = F.pure(Either<Int, Int>.right(a))
+            let f = F.pure(b.getArrow)
+            let g = F.pure(c.getArrow)
+            return F.select(x, F.sequenceRight(f, g)) == F.sequenceRight(F.select(x, f), F.select(x, g))
+        }
+    }
+
+    private static func associativity() {
+        property("Associativity") <- forAll { (a: Int, b: ArrowOf<Int, Int>, c: ArrowOf<Int, Int>) in
+            let x = F.pure(Either<Int, Int>.right(a))
+            let y = F.pure(Either<Int, (Int) -> Int>.right(b.getArrow))
+            let z = F.pure({ (_: Int) in c.getArrow })
+
+            let m : Kind<F, Either<Int, Either<(Int, Int), Int>>> = F.map(x) { x in Either.fix(x.map(Either<(Int, Int), Int>.right)) }
+            let n : Kind<F, (Int) -> Either<(Int, Int), Int>> = F.map(y) { y in { a in y.bimap({ l in (l, a) }, { r in r(a) }) }}
+            let q : Kind<F, ((Int, Int)) -> Int> = F.map(z) { z in { a in z(a.0)(a.1) } }
+
+            return F.select(x, F.select(y, z)) ==
+                F.select(F.select(m, n), q)
+        }
+    }
+}

--- a/Tests/BowRxTests/MaybeKTest.swift
+++ b/Tests/BowRxTests/MaybeKTest.swift
@@ -20,7 +20,11 @@ class MaybeKTest: XCTestCase {
     func testApplicativeLaws() {
         ApplicativeLaws<ForMaybeK>.check()
     }
-    
+
+    func testSelectiveLaws() {
+        SelectiveLaws<ForMaybeK>.check()
+    }
+
     func testMonadLaws() {
         MonadLaws<ForMaybeK>.check()
     }

--- a/Tests/BowRxTests/ObservableKTest.swift
+++ b/Tests/BowRxTests/ObservableKTest.swift
@@ -20,7 +20,11 @@ class ObservableKTest: XCTestCase {
     func testApplicativeLaws() {
         ApplicativeLaws<ForObservableK>.check()
     }
-    
+
+    func testSelectiveLaws() {
+        SelectiveLaws<ForObservableK>.check()
+    }
+
     func testMonadLaws() {
         MonadLaws<ForObservableK>.check()
     }

--- a/Tests/BowRxTests/SingleKTest.swift
+++ b/Tests/BowRxTests/SingleKTest.swift
@@ -20,7 +20,11 @@ class SingleKTest: XCTestCase {
     func testApplicativeLaws() {
         ApplicativeLaws<ForSingleK>.check()
     }
-    
+
+    func testSelectiveLaws() {
+        SelectiveLaws<ForSingleK>.check()
+    }
+
     func testMonadLaws() {
         MonadLaws<ForSingleK>.check()
     }

--- a/Tests/BowTests/Arrow/Function0Test.swift
+++ b/Tests/BowTests/Arrow/Function0Test.swift
@@ -19,7 +19,11 @@ class Function0Test: XCTestCase {
     func testApplicativeLaws() {
         ApplicativeLaws<ForFunction0>.check()
     }
-    
+
+    func testSelectiveLaws() {
+        SelectiveLaws<ForFunction0>.check()
+    }
+
     func testMonadLaws() {
         MonadLaws<ForFunction0>.check()
     }

--- a/Tests/BowTests/Arrow/Function1Test.swift
+++ b/Tests/BowTests/Arrow/Function1Test.swift
@@ -16,7 +16,11 @@ class Function1Test: XCTestCase {
     func testApplicativeLaws() {
         ApplicativeLaws<Function1Partial<Int>>.check()
     }
-    
+
+    func testSelectiveLaws() {
+        SelectiveLaws<Function1Partial<Int>>.check()
+    }
+
     func testMonadLaws() {
         MonadLaws<Function1Partial<Int>>.check()
     }

--- a/Tests/BowTests/Arrow/KleisliTest.swift
+++ b/Tests/BowTests/Arrow/KleisliTest.swift
@@ -14,7 +14,11 @@ class KleisliTest: XCTestCase {
     func testApplicativeLaws() {
         ApplicativeLaws<KleisliPartial<ForId, Int>>.check()
     }
-    
+
+    func testSelectiveLaws() {
+        SelectiveLaws<KleisliPartial<ForId, Int>>.check()
+    }
+
     func testMonadLaws() {
         MonadLaws<KleisliPartial<ForId, Int>>.check()
     }

--- a/Tests/BowTests/Data/ArrayKTest.swift
+++ b/Tests/BowTests/Data/ArrayKTest.swift
@@ -26,7 +26,11 @@ class ArrayKTest: XCTestCase {
     func testApplicativeLaws() {
         ApplicativeLaws<ForArrayK>.check()
     }
-    
+
+    func testSelectiveLaws() {
+        SelectiveLaws<ForArrayK>.check()
+    }
+
     func testMonadLaws() {
         MonadLaws<ForArrayK>.check()
     }

--- a/Tests/BowTests/Data/EitherTest.swift
+++ b/Tests/BowTests/Data/EitherTest.swift
@@ -21,7 +21,11 @@ class EitherTest: XCTestCase {
     func testApplicativeLaws() {
         ApplicativeLaws<EitherPartial<Int>>.check()
     }
-    
+
+    func testSelectiveLaws() {
+        SelectiveLaws<EitherPartial<Int>>.check()
+    }
+
     func testMonadLaws() {
         MonadLaws<EitherPartial<Int>>.check()
     }

--- a/Tests/BowTests/Data/IdTest.swift
+++ b/Tests/BowTests/Data/IdTest.swift
@@ -19,7 +19,11 @@ class IdTest: XCTestCase {
     func testApplicativeLaws() {
         ApplicativeLaws<ForId>.check()
     }
-    
+
+    func testSelectiveLaws() {
+        SelectiveLaws<ForId>.check()
+    }
+
     func testMonadLaws() {
         MonadLaws<ForId>.check()
     }

--- a/Tests/BowTests/Data/IorTest.swift
+++ b/Tests/BowTests/Data/IorTest.swift
@@ -24,7 +24,11 @@ class IorTest: XCTestCase {
     func testApplicativeLaws() {
         ApplicativeLaws<IorPartial<Int>>.check()
     }
-    
+
+    func testSelectiveLaws() {
+        SelectiveLaws<IorPartial<Int>>.check()
+    }
+
     func testMonadLaws() {
         MonadLaws<IorPartial<Int>>.check()
     }

--- a/Tests/BowTests/Data/NonEmptyArrayTest.swift
+++ b/Tests/BowTests/Data/NonEmptyArrayTest.swift
@@ -20,7 +20,11 @@ class NonEmptyArrayTest: XCTestCase {
     func testApplicativeLaws() {
         ApplicativeLaws<ForNonEmptyArray>.check()
     }
-    
+
+    func testSelectiveLaws() {
+        SelectiveLaws<ForNonEmptyArray>.check()
+    }
+
     func testMonadLaws() {
         MonadLaws<ForNonEmptyArray>.check()
     }

--- a/Tests/BowTests/Data/OptionTest.swift
+++ b/Tests/BowTests/Data/OptionTest.swift
@@ -20,7 +20,11 @@ class OptionTest: XCTestCase {
     func testApplicativeLaws() {
         ApplicativeLaws<ForOption>.check()
     }
-    
+
+    func testSelectiveLaws() {
+        SelectiveLaws<ForOption>.check()
+    }
+
     func testMonadLaws() {
         MonadLaws<ForOption>.check()
     }

--- a/Tests/BowTests/Data/TryTest.swift
+++ b/Tests/BowTests/Data/TryTest.swift
@@ -19,7 +19,11 @@ class TryTest: XCTestCase {
     func testApplicativeLaws() {
         ApplicativeLaws<ForTry>.check()
     }
-    
+
+    func testSelectiveLaws() {
+        SelectiveLaws<ForTry>.check()
+    }
+
     func testMonadLaws() {
         MonadLaws<ForTry>.check()
     }

--- a/Tests/BowTests/Data/ValidatedTest.swift
+++ b/Tests/BowTests/Data/ValidatedTest.swift
@@ -22,7 +22,7 @@ class ValidatedTest: XCTestCase {
     }
     
     func testSelectiveLaws() {
-        SelectiveLaws<ValidatedPartial<Int>.check()
+        SelectiveLaws<ValidatedPartial<Int>>.check()
     }
     
     func testSemigroupKLaws() {

--- a/Tests/BowTests/Data/ValidatedTest.swift
+++ b/Tests/BowTests/Data/ValidatedTest.swift
@@ -21,6 +21,10 @@ class ValidatedTest: XCTestCase {
         ApplicativeLaws<ValidatedPartial<Int>>.check()
     }
     
+    func testSelectiveLaws() {
+        SelectiveLaws<ValidatedPartial<Int>.check()
+    }
+    
     func testSemigroupKLaws() {
         SemigroupKLaws<ValidatedPartial<Int>>.check(generator: self.generator)
     }

--- a/Tests/BowTests/Transformers/EitherTTest.swift
+++ b/Tests/BowTests/Transformers/EitherTTest.swift
@@ -21,7 +21,11 @@ class EitherTTest: XCTestCase {
     func testApplicativeLaws() {
         ApplicativeLaws<EitherTPartial<ForId, Int>>.check()
     }
-    
+
+    func testSelectiveLaws() {
+        SelectiveLaws<EitherTPartial<ForId, Int>>.check()
+    }
+
     func testMonadLaws() {
         MonadLaws<EitherTPartial<ForId, Int>>.check()
     }

--- a/Tests/BowTests/Transformers/OptionTTest.swift
+++ b/Tests/BowTests/Transformers/OptionTTest.swift
@@ -20,6 +20,10 @@ class OptionTTest: XCTestCase {
     func testApplicativeLaws() {
         ApplicativeLaws<OptionTPartial<ForId>>.check()
     }
+
+    func testSelectiveLaws() {
+        SelectiveLaws<OptionTPartial<ForId>>.check()
+    }
     
     func testMonadLaws() {
         MonadLaws<OptionTPartial<ForId>>.check()

--- a/Tests/BowTests/Transformers/StateTTest.swift
+++ b/Tests/BowTests/Transformers/StateTTest.swift
@@ -23,7 +23,11 @@ class StateTTest: XCTestCase {
     func testApplicativeLaws() {
         ApplicativeLaws<StateTPartial<ForId, Int>>.check()
     }
-    
+
+    func testSelectiveLaws() {
+        SelectiveLaws<StateTPartial<ForId, Int>>.check()
+    }
+
     func testMonadLaws() {
         MonadLaws<StateTPartial<ForId, Int>>.check()
     }

--- a/Tests/BowTests/Transformers/WriterTTest.swift
+++ b/Tests/BowTests/Transformers/WriterTTest.swift
@@ -19,7 +19,11 @@ class WriterTTest: XCTestCase {
     func testApplicativeLaws() {
         ApplicativeLaws<WriterTPartial<ForId, Int>>.check()
     }
-    
+
+    func testSelectiveLaws() {
+        SelectiveLaws<WriterTPartial<ForId, Int>>.check()
+    }
+
     func testMonadLaws() {
         MonadLaws<WriterTPartial<ForId, Int>>.check()
     }


### PR DESCRIPTION
## Goal

Add the new `Selective` typeclass described in [this paper](https://www.staff.ncl.ac.uk/andrey.mokhov/selective-functors.pdf).

## Implementation details

- Typeclass `Selective` has been added.
- `Monad` provides a default implementation for `Selective`.
- Instances of `Selective` for each data type have been added, based on the monadic implementation.

## Testing details

- Laws for `Selective` have been added.
- Laws are tested for each instance of `Selective`.
