### PR TITLE
Add postfix operator for downcasting

### DIFF
--- a/Sources/Bow/Arrow/Cokleisli.swift
+++ b/Sources/Bow/Arrow/Cokleisli.swift
@@ -21,6 +21,10 @@ public class Cokleisli<F, A, B>: CokleisliOf<F, A, B> {
     }
 }
 
+/// Safe downcast.
+///
+/// - Parameter value: Value in higher-kind form.
+/// - Returns: Value cast to Cokleisli.
 public postfix func ^<F, A, B>(_ value: Kind<CokleisliPartial<F, A>, B>) -> Cokleisli<F, A, B> {
     return Cokleisli.fix(value)
 }

--- a/Sources/Bow/Arrow/Cokleisli.swift
+++ b/Sources/Bow/Arrow/Cokleisli.swift
@@ -21,6 +21,10 @@ public class Cokleisli<F, A, B>: CokleisliOf<F, A, B> {
     }
 }
 
+public postfix func ^<F, A, B>(_ value: Kind<CokleisliPartial<F, A>, B>) -> Cokleisli<F, A, B> {
+    return Cokleisli.fix(value)
+}
+
 extension Cokleisli where F: Comonad {
     public static func ask() -> Cokleisli<F, B, B> {
         return Cokleisli<F, B, B>({ fb in fb.extract() })

--- a/Sources/Bow/Arrow/Function0.swift
+++ b/Sources/Bow/Arrow/Function0.swift
@@ -33,6 +33,14 @@ public class Function0<A>: Function0Of<A> {
     }
 }
 
+/// Safe downcast.
+///
+/// - Parameter fa: Value in the higher-kind form.
+/// - Returns: Value cast to `Function0`.
+public postfix func ^<A>(_ fa: Function0Of<A>) -> Function0<A> {
+    return Function0.fix(fa)
+}
+
 // MARK: Protocol conformances
 
 extension ForFunction0: EquatableK {

--- a/Sources/Bow/Arrow/Function1.swift
+++ b/Sources/Bow/Arrow/Function1.swift
@@ -37,6 +37,14 @@ public class Function1<I, O>: Function1Of<I, O> {
     }
 }
 
+/// Safe downcast.
+///
+/// - Parameter fa: Value in the higher-kind form.
+/// - Returns: Value cast to `Function1`.
+public postfix func ^<I, O>(_ fa: Function1Of<I, O>) -> Function1<I, O> {
+    return Function1.fix(fa)
+}
+
 // MARK: Protocol conformances
 
 extension Function1Partial: Functor {

--- a/Sources/Bow/Arrow/Kleisli.swift
+++ b/Sources/Bow/Arrow/Kleisli.swift
@@ -21,6 +21,10 @@ public class Kleisli<F, D, A>: KleisliOf<F, D, A> {
     }
 }
 
+/// Safe downcast.
+///
+/// - Parameter fa: Value in higher-kind form.
+/// - Returns: Value cast to Kleisli.
 public postfix func ^<F, D, A>(_ fa: KleisliOf<F, D, A>) -> Kleisli<F, D, A> {
     return Kleisli.fix(fa)
 }

--- a/Sources/Bow/Arrow/Kleisli.swift
+++ b/Sources/Bow/Arrow/Kleisli.swift
@@ -21,6 +21,10 @@ public class Kleisli<F, D, A>: KleisliOf<F, D, A> {
     }
 }
 
+public postfix func ^<F, D, A>(_ fa: KleisliOf<F, D, A>) -> Kleisli<F, D, A> {
+    return Kleisli.fix(fa)
+}
+
 extension Kleisli where F: Monad {
     public func zip<B>(_ o: Kleisli<F, D, B>) -> Kleisli<F, D, (A, B)> {
         return Kleisli<F, D, (A, B)>.fix(self.flatMap({ a in

--- a/Sources/Bow/Data/ArrayK.swift
+++ b/Sources/Bow/Data/ArrayK.swift
@@ -40,6 +40,10 @@ public final class ArrayK<A>: ArrayKOf<A> {
     }
 }
 
+/// Safe downcast.
+///
+/// - Parameter fa: Value in higher-kind form.
+/// - Returns: Value cast to ArrayK.
 public postfix func ^<A>(_ fa: ArrayKOf<A>) -> ArrayK<A> {
     return ArrayK.fix(fa)
 }

--- a/Sources/Bow/Data/ArrayK.swift
+++ b/Sources/Bow/Data/ArrayK.swift
@@ -40,6 +40,10 @@ public final class ArrayK<A>: ArrayKOf<A> {
     }
 }
 
+public postfix func ^<A>(_ fa: ArrayKOf<A>) -> ArrayK<A> {
+    return ArrayK.fix(fa)
+}
+
 public extension Array {
     public func k() -> ArrayK<Element> {
         return ArrayK(self)

--- a/Sources/Bow/Data/Const.swift
+++ b/Sources/Bow/Data/Const.swift
@@ -20,6 +20,10 @@ public final class Const<A, T>: ConstOf<A, T> {
     }
 }
 
+/// Safe downcast.
+///
+/// - Parameter fa: Value in higher-kind form.
+/// - Returns: Value cast to Const.
 public postfix func ^<A, T>(_ fa: ConstOf<A, T>) -> Const<A, T> {
     return Const.fix(fa)
 }

--- a/Sources/Bow/Data/Const.swift
+++ b/Sources/Bow/Data/Const.swift
@@ -7,7 +7,7 @@ public typealias ConstOf<A, T> = Kind<ConstPartial<A>, T>
 public final class Const<A, T>: ConstOf<A, T> {
     public let value: A
 
-    public static func fix(_ fa: ConstOf<A, T>) -> Const<A, T>{
+    public static func fix(_ fa: ConstOf<A, T>) -> Const<A, T> {
         return fa as! Const<A, T>
     }
     
@@ -18,6 +18,10 @@ public final class Const<A, T>: ConstOf<A, T> {
     public func retag<U>() -> Const<A, U> {
         return Const<A, U>(value)
     }
+}
+
+public postfix func ^<A, T>(_ fa: ConstOf<A, T>) -> Const<A, T> {
+    return Const.fix(fa)
 }
 
 extension Const: CustomStringConvertible {

--- a/Sources/Bow/Data/Coproduct.swift
+++ b/Sources/Bow/Data/Coproduct.swift
@@ -20,6 +20,10 @@ public class Coproduct<F, G, A>: CoproductOf<F, G, A> {
     }
 }
 
+/// Safe downcast.
+///
+/// - Parameter fa: Value in higher-kind form.
+/// - Returns: Value cast to Coproduct.
 public postfix func ^<F, G, A>(_ fa: CoproductOf<F, G, A>) -> Coproduct<F, G, A> {
     return Coproduct.fix(fa)
 }

--- a/Sources/Bow/Data/Coproduct.swift
+++ b/Sources/Bow/Data/Coproduct.swift
@@ -20,6 +20,10 @@ public class Coproduct<F, G, A>: CoproductOf<F, G, A> {
     }
 }
 
+public postfix func ^<F, G, A>(_ fa: CoproductOf<F, G, A>) -> Coproduct<F, G, A> {
+    return Coproduct.fix(fa)
+}
+
 extension CoproductPartial: EquatableK where F: EquatableK, G: EquatableK {
     public static func eq<A>(_ lhs: Kind<CoproductPartial<F, G>, A>, _ rhs: Kind<CoproductPartial<F, G>, A>) -> Bool where A : Equatable {
         return Coproduct.fix(lhs).run == Coproduct.fix(rhs).run

--- a/Sources/Bow/Data/Day.swift
+++ b/Sources/Bow/Data/Day.swift
@@ -30,6 +30,10 @@ public class Day<F: Comonad, G: Comonad, A> : DayOf<F, G, A> {
     }
 }
 
+public postfix func ^<F, G, A>(_ value : DayOf<F, G, A>) -> Day<F, G, A> {
+    return Day.fix(value)
+}
+
 public extension Day where F: Applicative, G: Applicative {
     public static func from(_ a: A) -> Day<F, G, A> {
         return DefaultDay(left: F.pure(unit),

--- a/Sources/Bow/Data/Day.swift
+++ b/Sources/Bow/Data/Day.swift
@@ -30,7 +30,11 @@ public class Day<F: Comonad, G: Comonad, A> : DayOf<F, G, A> {
     }
 }
 
-public postfix func ^<F, G, A>(_ value : DayOf<F, G, A>) -> Day<F, G, A> {
+/// Safe downcast.
+///
+/// - Parameter value: Value in higher-kind form.
+/// - Returns: Value cast to Day.
+public postfix func ^<F, G, A>(_ value: DayOf<F, G, A>) -> Day<F, G, A> {
     return Day.fix(value)
 }
 

--- a/Sources/Bow/Data/DictionaryK.swift
+++ b/Sources/Bow/Data/DictionaryK.swift
@@ -60,6 +60,10 @@ public class DictionaryK<K: Hashable, A> : DictionaryKOf<K, A> {
     }
 }
 
+/// Safe downcast.
+///
+/// - Parameter fa: Value in higher-kind form.
+/// - Returns: Value cast to DictionaryK.
 public postfix func ^<K, A>(_ fa: DictionaryKOf<K, A>) -> DictionaryK<K, A> {
     return DictionaryK.fix(fa)
 }

--- a/Sources/Bow/Data/DictionaryK.swift
+++ b/Sources/Bow/Data/DictionaryK.swift
@@ -60,6 +60,10 @@ public class DictionaryK<K: Hashable, A> : DictionaryKOf<K, A> {
     }
 }
 
+public postfix func ^<K, A>(_ fa: DictionaryKOf<K, A>) -> DictionaryK<K, A> {
+    return DictionaryK.fix(fa)
+}
+
 public extension Dictionary {
     public func k() -> DictionaryK<Key, Value> {
         return DictionaryK<Key, Value>(self)

--- a/Sources/Bow/Data/Either.swift
+++ b/Sources/Bow/Data/Either.swift
@@ -125,6 +125,14 @@ public class Either<A, B>: EitherOf<A, B> {
     }
 }
 
+/// Safe downcast.
+///
+/// - Parameter fa: Value in the higher-kind form.
+/// - Returns: Value cast to Either.
+public postfix func ^<A, B>(_ fa: EitherOf<A, B>) -> Either<A, B> {
+    return Either.fix(fa)
+}
+
 class Left<A, B> : Either<A, B> {
     let a : A
     

--- a/Sources/Bow/Data/Eval.swift
+++ b/Sources/Bow/Data/Eval.swift
@@ -54,6 +54,10 @@ public class Eval<A> : EvalOf<A> {
     }
 }
 
+public postfix func ^<A>(_ fa : EvalOf<A>) -> Eval<A> {
+    return Eval.fix(fa)
+}
+
 class Now<A> : Eval<A> {
     fileprivate let a : A
     

--- a/Sources/Bow/Data/Eval.swift
+++ b/Sources/Bow/Data/Eval.swift
@@ -54,6 +54,10 @@ public class Eval<A> : EvalOf<A> {
     }
 }
 
+/// Safe downcast.
+///
+/// - Parameter fa: Value in higher-kind form.
+/// - Returns: Value cast to Eval.
 public postfix func ^<A>(_ fa : EvalOf<A>) -> Eval<A> {
     return Eval.fix(fa)
 }

--- a/Sources/Bow/Data/Id.swift
+++ b/Sources/Bow/Data/Id.swift
@@ -26,6 +26,14 @@ public class Id<A>: IdOf<A> {
     }
 }
 
+/// Safe downcast.
+///
+/// - Parameter fa: Value in the higher-kind form.
+/// - Returns: Value cast to `Id`.
+public postfix func ^<A>(_ fa: IdOf<A>) -> Id<A> {
+    return Id.fix(fa)
+}
+
 // MARK: Protocol conformances
 /// Conformance of `Id` to `CustomStringConvertible`.
 extension Id: CustomStringConvertible {

--- a/Sources/Bow/Data/Ior.swift
+++ b/Sources/Bow/Data/Ior.swift
@@ -98,6 +98,10 @@ public class Ior<A, B> : IorOf<A, B> {
     }
 }
 
+public postfix func ^<A, B>(_ fa : IorOf<A, B>) -> Ior<A, B> {
+    return Ior.fix(fa)
+}
+
 class IorLeft<A, B> : Ior<A, B> {
     fileprivate let a : A
     

--- a/Sources/Bow/Data/Ior.swift
+++ b/Sources/Bow/Data/Ior.swift
@@ -98,6 +98,10 @@ public class Ior<A, B> : IorOf<A, B> {
     }
 }
 
+/// Safe downcast.
+///
+/// - Parameter fa: Value in higher-kind form.
+/// - Returns: Value cast to Ior.
 public postfix func ^<A, B>(_ fa : IorOf<A, B>) -> Ior<A, B> {
     return Ior.fix(fa)
 }

--- a/Sources/Bow/Data/Moore.swift
+++ b/Sources/Bow/Data/Moore.swift
@@ -18,6 +18,10 @@ public class Moore<E, V>: MooreOf<E, V> {
     }
 }
 
+public postfix func ^<E, V>(_ value: MooreOf<E, V>) -> Moore<E, V> {
+    return Moore.fix(value)
+}
+
 extension MoorePartial: Functor {
     public static func map<A, B>(_ fa: Kind<MoorePartial<E>, A>, _ f: @escaping (A) -> B) -> Kind<MoorePartial<E>, B> {
         let moore = Moore.fix(fa)

--- a/Sources/Bow/Data/Moore.swift
+++ b/Sources/Bow/Data/Moore.swift
@@ -18,6 +18,10 @@ public class Moore<E, V>: MooreOf<E, V> {
     }
 }
 
+/// Safe downcast.
+///
+/// - Parameter value: Value in higher-kind form.
+/// - Returns: Value cast to Moore.
 public postfix func ^<E, V>(_ value: MooreOf<E, V>) -> Moore<E, V> {
     return Moore.fix(value)
 }

--- a/Sources/Bow/Data/NonEmptyArray.swift
+++ b/Sources/Bow/Data/NonEmptyArray.swift
@@ -64,6 +64,10 @@ public final class NonEmptyArray<A>: NonEmptyArrayOf<A> {
     }
 }
 
+public postfix func ^<A>(_ fa: NonEmptyArrayOf<A>) -> NonEmptyArray<A> {
+    return NonEmptyArray.fix(fa)
+}
+
 public extension NonEmptyArray where A: Equatable {
     public func contains(element : A) -> Bool {
         return head == element || tail.contains(where: { $0 == element })

--- a/Sources/Bow/Data/NonEmptyArray.swift
+++ b/Sources/Bow/Data/NonEmptyArray.swift
@@ -64,6 +64,10 @@ public final class NonEmptyArray<A>: NonEmptyArrayOf<A> {
     }
 }
 
+/// Safe downcast.
+///
+/// - Parameter fa: Value in higher-kind form.
+/// - Returns: Value cast to NonEmptyArray.
 public postfix func ^<A>(_ fa: NonEmptyArrayOf<A>) -> NonEmptyArray<A> {
     return NonEmptyArray.fix(fa)
 }

--- a/Sources/Bow/Data/Option.swift
+++ b/Sources/Bow/Data/Option.swift
@@ -118,6 +118,14 @@ public final class Option<A>: OptionOf<A> {
     }
 }
 
+/// Safe downcasting.
+///
+/// - Parameter fa: Option in higher-kind form.
+/// - Returns: Value cast to Option.
+public postfix func ^<A>(_ fa: OptionOf<A>) -> Option<A> {
+    return Option.fix(fa)
+}
+
 // MARK: Protocol conformances
 
 /// Conformance of `Option` to `CustomStringConvertible`.

--- a/Sources/Bow/Data/SetK.swift
+++ b/Sources/Bow/Data/SetK.swift
@@ -27,6 +27,10 @@ public final class SetK<A: Hashable>: SetKOf<A> {
 	}
 }
 
+public postfix func ^<A>(_ fa: SetKOf<A>) -> SetK<A> {
+    return SetK.fix(fa)
+}
+
 extension SetK: Semigroup {
     public func combine(_ other: SetK<A>) -> SetK<A> {
         return self + other

--- a/Sources/Bow/Data/SetK.swift
+++ b/Sources/Bow/Data/SetK.swift
@@ -27,6 +27,10 @@ public final class SetK<A: Hashable>: SetKOf<A> {
 	}
 }
 
+/// Safe downcast.
+///
+/// - Parameter fa: Value in higher-kind form.
+/// - Returns: Value cast to SetK.
 public postfix func ^<A>(_ fa: SetKOf<A>) -> SetK<A> {
     return SetK.fix(fa)
 }

--- a/Sources/Bow/Data/State.swift
+++ b/Sources/Bow/Data/State.swift
@@ -12,3 +12,7 @@ public class State<S, A>: StateOf<S, A> {
         super.init(Id.pure({ s in Id.pure(run(s)) }))
     }
 }
+
+public postfix func ^<S, A>(_ value: StateOf<S, A>) -> State<S, A> {
+    return State.fix(value)
+}

--- a/Sources/Bow/Data/State.swift
+++ b/Sources/Bow/Data/State.swift
@@ -13,6 +13,10 @@ public class State<S, A>: StateOf<S, A> {
     }
 }
 
+/// Safe downcast.
+///
+/// - Parameter value: Value in higher-kind form.
+/// - Returns: Value cast to State.
 public postfix func ^<S, A>(_ value: StateOf<S, A>) -> State<S, A> {
     return State.fix(value)
 }

--- a/Sources/Bow/Data/Store.swift
+++ b/Sources/Bow/Data/Store.swift
@@ -23,6 +23,10 @@ public class Store<S, V> : StoreOf<S, V> {
     }
 }
 
+/// Safe downcast.
+///
+/// - Parameter value: Value in higher-kind form.
+/// - Returns: Value cast to Store.
 public postfix func ^<S, V>(_ value: StoreOf<S, V>) -> Store<S, V> {
     return Store.fix(value)
 }

--- a/Sources/Bow/Data/Store.swift
+++ b/Sources/Bow/Data/Store.swift
@@ -23,6 +23,10 @@ public class Store<S, V> : StoreOf<S, V> {
     }
 }
 
+public postfix func ^<S, V>(_ value: StoreOf<S, V>) -> Store<S, V> {
+    return Store.fix(value)
+}
+
 extension StorePartial: Functor {
     public static func map<A, B>(_ fa: Kind<StorePartial<S>, A>, _ f: @escaping (A) -> B) -> Kind<StorePartial<S>, B> {
         let store = Store.fix(fa)

--- a/Sources/Bow/Data/Sum.swift
+++ b/Sources/Bow/Data/Sum.swift
@@ -37,7 +37,11 @@ public class Sum<F, G, V> : SumOf<F, G, V> {
     }
 }
 
-public postfix func ^<F, G, V>(_ value : SumOf<F, G, V>) -> Sum<F, G, V> {
+/// Safe downcast.
+///
+/// - Parameter value: Value in higher-kind form.
+/// - Returns: Value cast to Sum.
+public postfix func ^<F, G, V>(_ value: SumOf<F, G, V>) -> Sum<F, G, V> {
     return Sum.fix(value)
 }
 

--- a/Sources/Bow/Data/Sum.swift
+++ b/Sources/Bow/Data/Sum.swift
@@ -37,6 +37,9 @@ public class Sum<F, G, V> : SumOf<F, G, V> {
     }
 }
 
+public postfix func ^<F, G, V>(_ value : SumOf<F, G, V>) -> Sum<F, G, V> {
+    return Sum.fix(value)
+}
 
 extension SumPartial: Invariant where F: Functor, G: Functor {}
 

--- a/Sources/Bow/Data/Try.swift
+++ b/Sources/Bow/Data/Try.swift
@@ -67,6 +67,10 @@ public class Try<A>: TryOf<A> {
     }
 }
 
+/// Safe downcast.
+///
+/// - Parameter fa: Value in higher-kind form.
+/// - Returns: Value cast to Try.
 public postfix func ^<A>(_ fa: TryOf<A>) -> Try<A> {
     return Try.fix(fa)
 }

--- a/Sources/Bow/Data/Try.swift
+++ b/Sources/Bow/Data/Try.swift
@@ -67,6 +67,10 @@ public class Try<A>: TryOf<A> {
     }
 }
 
+public postfix func ^<A>(_ fa: TryOf<A>) -> Try<A> {
+    return Try.fix(fa)
+}
+
 class Success<A>: Try<A> {
     fileprivate let value: A
     

--- a/Sources/Bow/Data/Validated.swift
+++ b/Sources/Bow/Data/Validated.swift
@@ -78,6 +78,10 @@ public class Validated<E, A>: ValidatedOf<E, A> {
     }
 }
 
+public postfix func ^<E, A>(_ fa: ValidatedOf<E, A>) -> Validated<E, A> {
+    return Validated.fix(fa)
+}
+
 class Valid<E, A>: Validated<E, A> {
     fileprivate let value: A
     

--- a/Sources/Bow/Data/Validated.swift
+++ b/Sources/Bow/Data/Validated.swift
@@ -78,6 +78,10 @@ public class Validated<E, A>: ValidatedOf<E, A> {
     }
 }
 
+/// Safe downcast.
+///
+/// - Parameter fa: Value in higher-kind form.
+/// - Returns: Value cast to Validated.
 public postfix func ^<E, A>(_ fa: ValidatedOf<E, A>) -> Validated<E, A> {
     return Validated.fix(fa)
 }

--- a/Sources/Bow/Syntax/HigherKinds.swift
+++ b/Sources/Bow/Syntax/HigherKinds.swift
@@ -35,3 +35,5 @@ public typealias Kind4<F, A, B, C, D> = Kind<Kind3<F, A, B, C>, D>
 /// This class simulates Higher-Kinded Type support in Swift. `Kind5<F, A, B, C, D, E>` is an alias for `F<A, B, C, D, E>`, which is not syntactically valid in Swift.
 /// Classes that want to have HKT support must extend this class. Type parameter `F` is reserved for a witness to prevent circular references in the inheritance relationship. By convention, witnesses are named like the class they represent, with the prefix `For`.
 public typealias Kind5<F, A, B, C, D, E> = Kind<Kind4<F, A, B, C, D>, E>
+
+postfix operator ^

--- a/Sources/Bow/Transformers/EitherT.swift
+++ b/Sources/Bow/Transformers/EitherT.swift
@@ -16,6 +16,10 @@ public class EitherT<F, A, B> : EitherTOf<F, A, B> {
     }
 }
 
+public postfix func ^<F, A, B>(_ fa: EitherTOf<F, A, B>) -> EitherT<F, A, B> {
+    return EitherT.fix(fa)
+}
+
 extension EitherT where F: Functor {
     public func fold<C>(_ fa: @escaping (A) -> C, _ fb: @escaping (B) -> C) -> Kind<F, C> {
         return value.map { either in either.fold(fa, fb) }

--- a/Sources/Bow/Transformers/EitherT.swift
+++ b/Sources/Bow/Transformers/EitherT.swift
@@ -16,6 +16,10 @@ public class EitherT<F, A, B> : EitherTOf<F, A, B> {
     }
 }
 
+/// Safe downcast.
+///
+/// - Parameter fa: Value in higher-kind form.
+/// - Returns: Value cast to EitherT.
 public postfix func ^<F, A, B>(_ fa: EitherTOf<F, A, B>) -> EitherT<F, A, B> {
     return EitherT.fix(fa)
 }

--- a/Sources/Bow/Transformers/OptionT.swift
+++ b/Sources/Bow/Transformers/OptionT.swift
@@ -16,6 +16,10 @@ public class OptionT<F, A> : OptionTOf<F, A> {
     }
 }
 
+public postfix func ^<F, A>(_ fa : OptionTOf<F, A>) -> OptionT<F, A> {
+    return OptionT.fix(fa)
+}
+
 extension OptionT where F: Functor {
     public func fold<B>(_ ifEmpty: @escaping () -> B, _ f: @escaping (A) -> B) -> Kind<F, B> {
         return value.map { option in option.fold(ifEmpty, f) }

--- a/Sources/Bow/Transformers/OptionT.swift
+++ b/Sources/Bow/Transformers/OptionT.swift
@@ -16,6 +16,10 @@ public class OptionT<F, A> : OptionTOf<F, A> {
     }
 }
 
+/// Safe downcast.
+///
+/// - Parameter fa: Value in higher-kind form.
+/// - Returns: Value cast to OptionT.
 public postfix func ^<F, A>(_ fa : OptionTOf<F, A>) -> OptionT<F, A> {
     return OptionT.fix(fa)
 }

--- a/Sources/Bow/Transformers/StateT.swift
+++ b/Sources/Bow/Transformers/StateT.swift
@@ -16,6 +16,10 @@ public class StateT<F, S, A>: StateTOf<F, S, A> {
     }
 }
 
+/// Safe downcast.
+///
+/// - Parameter fa: Value in higher-kind form.
+/// - Returns: Value cast to StateT.
 public postfix func ^<F, S, A>(_ fa : StateTOf<F, S, A>) -> StateT<F, S, A> {
     return StateT.fix(fa)
 }

--- a/Sources/Bow/Transformers/StateT.swift
+++ b/Sources/Bow/Transformers/StateT.swift
@@ -16,6 +16,10 @@ public class StateT<F, S, A>: StateTOf<F, S, A> {
     }
 }
 
+public postfix func ^<F, S, A>(_ fa : StateTOf<F, S, A>) -> StateT<F, S, A> {
+    return StateT.fix(fa)
+}
+
 public extension StateT where F == ForId {
     public func run(_ initialState: S) -> (S, A) {
         return Id.fix(self.runM(initialState)).value

--- a/Sources/Bow/Transformers/WriterT.swift
+++ b/Sources/Bow/Transformers/WriterT.swift
@@ -16,6 +16,10 @@ public class WriterT<F, W, A>: WriterTOf<F, W, A> {
     }
 }
 
+/// Safe downcast.
+///
+/// - Parameter fa: Value in higher-kind form.
+/// - Returns: Value cast to WriterT.
 public postfix func ^<F, W, A>(_ fa : WriterTOf<F, W, A>) -> WriterT<F, W, A> {
     return WriterT.fix(fa)
 }

--- a/Sources/Bow/Transformers/WriterT.swift
+++ b/Sources/Bow/Transformers/WriterT.swift
@@ -16,6 +16,10 @@ public class WriterT<F, W, A>: WriterTOf<F, W, A> {
     }
 }
 
+public postfix func ^<F, W, A>(_ fa : WriterTOf<F, W, A>) -> WriterT<F, W, A> {
+    return WriterT.fix(fa)
+}
+
 extension WriterT where F: Functor {
     public static func putT(_ fa: Kind<F, A>, _ w: W) -> WriterT<F, W, A> {
         return WriterT(fa.map { a in (w, a) })

--- a/Sources/BowBrightFutures/FutureK.swift
+++ b/Sources/BowBrightFutures/FutureK.swift
@@ -61,6 +61,10 @@ public class FutureK<E: Error, A>: FutureKOf<E, A> {
     }
 }
 
+public postfix func ^<E, A>(_ value : FutureKOf<E, A>) -> FutureK<E, A> {
+    return FutureK.fix(value)
+}
+
 extension FutureKPartial: Functor {
     public static func map<A, B>(_ fa: Kind<FutureKPartial<E>, A>, _ f: @escaping (A) -> B) -> Kind<FutureKPartial<E>, B> {
         return FutureK.fix(fa).value.map(f).k()

--- a/Sources/BowBrightFutures/FutureK.swift
+++ b/Sources/BowBrightFutures/FutureK.swift
@@ -61,7 +61,11 @@ public class FutureK<E: Error, A>: FutureKOf<E, A> {
     }
 }
 
-public postfix func ^<E, A>(_ value : FutureKOf<E, A>) -> FutureK<E, A> {
+/// Safe downcast.
+///
+/// - Parameter value: Value in higher-kind form.
+/// - Returns: Value cast to FutureK.
+public postfix func ^<E, A>(_ value: FutureKOf<E, A>) -> FutureK<E, A> {
     return FutureK.fix(value)
 }
 

--- a/Sources/BowEffects/IO.swift
+++ b/Sources/BowEffects/IO.swift
@@ -157,6 +157,10 @@ public class IO<E: Error, A>: IOOf<E, A> {
     }
 }
 
+public postfix func ^<E, A>(_ fa: IOOf<E, A>) -> IO<E, A> {
+    return IO.fix(fa)
+}
+
 fileprivate class Pure<E: Error, A>: IO<E, A> {
     let a: A
     

--- a/Sources/BowEffects/IO.swift
+++ b/Sources/BowEffects/IO.swift
@@ -157,6 +157,10 @@ public class IO<E: Error, A>: IOOf<E, A> {
     }
 }
 
+/// Safe downcast.
+///
+/// - Parameter fa: Value in higher-kind form.
+/// - Returns: Value cast to IO.
 public postfix func ^<E, A>(_ fa: IOOf<E, A>) -> IO<E, A> {
     return IO.fix(fa)
 }

--- a/Sources/BowFree/Cofree.swift
+++ b/Sources/BowFree/Cofree.swift
@@ -32,6 +32,10 @@ public class Cofree<S, A>: CofreeOf<S, A> {
     }
 }
 
+/// Safe downcast.
+///
+/// - Parameter fa: Value in higher-kind form.
+/// - Returns: Value cast to Cofree.
 public postfix func ^<S, A>(_ fa: CofreeOf<S, A>) -> Cofree<S, A> {
     return Cofree.fix(fa)
 }

--- a/Sources/BowFree/Cofree.swift
+++ b/Sources/BowFree/Cofree.swift
@@ -32,6 +32,10 @@ public class Cofree<S, A>: CofreeOf<S, A> {
     }
 }
 
+public postfix func ^<S, A>(_ fa: CofreeOf<S, A>) -> Cofree<S, A> {
+    return Cofree.fix(fa)
+}
+
 public extension Cofree where S: Functor {
     public static func unfold(_ a: A, _ f: @escaping (A) -> Kind<S, A>) -> Cofree<S, A> {
         return create(a, f)

--- a/Sources/BowFree/Coyoneda.swift
+++ b/Sources/BowFree/Coyoneda.swift
@@ -35,6 +35,10 @@ public class Coyoneda<F, P, A>: CoyonedaOf<F, P, A> {
     }
 }
 
+public postfix func ^<F, P, A>(_ fa : CoyonedaOf<F, P, A>) -> Coyoneda<F, P, A> {
+    return Coyoneda.fix(fa)
+}
+
 public extension Coyoneda where F: Functor {
     public func lower() -> Kind<F, A> {
         return F.map(pivot, transform())

--- a/Sources/BowFree/Coyoneda.swift
+++ b/Sources/BowFree/Coyoneda.swift
@@ -35,7 +35,11 @@ public class Coyoneda<F, P, A>: CoyonedaOf<F, P, A> {
     }
 }
 
-public postfix func ^<F, P, A>(_ fa : CoyonedaOf<F, P, A>) -> Coyoneda<F, P, A> {
+/// Safe downcast.
+///
+/// - Parameter fa: Value in higher-kind form.
+/// - Returns: Value cast to Coyoneda.
+public postfix func ^<F, P, A>(_ fa: CoyonedaOf<F, P, A>) -> Coyoneda<F, P, A> {
     return Coyoneda.fix(fa)
 }
 

--- a/Sources/BowFree/Free.swift
+++ b/Sources/BowFree/Free.swift
@@ -56,7 +56,11 @@ public class Free<S, A>: FreeOf<S, A> {
     }
 }
 
-public postfix func ^<S, A>(_ fa : FreeOf<S, A>) -> Free<S, A> {
+/// Safe downcast.
+///
+/// - Parameter fa: Value in higher-kind form.
+/// - Returns: Value cast to Free.
+public postfix func ^<S, A>(_ fa: FreeOf<S, A>) -> Free<S, A> {
     return Free.fix(fa)
 }
 

--- a/Sources/BowFree/Free.swift
+++ b/Sources/BowFree/Free.swift
@@ -56,6 +56,10 @@ public class Free<S, A>: FreeOf<S, A> {
     }
 }
 
+public postfix func ^<S, A>(_ fa : FreeOf<S, A>) -> Free<S, A> {
+    return Free.fix(fa)
+}
+
 public extension Free where S: Monad {
     public func run() -> Kind<S, A> {
         return self.foldMapK(FunctionK<S, S>.id)

--- a/Sources/BowFree/Yoneda.swift
+++ b/Sources/BowFree/Yoneda.swift
@@ -23,6 +23,10 @@ open class Yoneda<F, A>: YonedaOf<F, A> {
     }
 }
 
+public postfix func ^<F, A>(_ fa : YonedaOf<F, A>) -> Yoneda<F, A> {
+    return Yoneda.fix(fa)
+}
+
 public extension Yoneda where F: Functor {
     public static func apply(_ fa : Kind<F, A>) -> Yoneda<F, A> {
         return YonedaFunctor<F, A>(fa)

--- a/Sources/BowFree/Yoneda.swift
+++ b/Sources/BowFree/Yoneda.swift
@@ -23,7 +23,11 @@ open class Yoneda<F, A>: YonedaOf<F, A> {
     }
 }
 
-public postfix func ^<F, A>(_ fa : YonedaOf<F, A>) -> Yoneda<F, A> {
+/// Safe downcast.
+///
+/// - Parameter fa: Value in higher-kind form.
+/// - Returns: Value cast to Yoneda.
+public postfix func ^<F, A>(_ fa: YonedaOf<F, A>) -> Yoneda<F, A> {
     return Yoneda.fix(fa)
 }
 

--- a/Sources/BowRecursionSchemes/Data/Fix.swift
+++ b/Sources/BowRecursionSchemes/Data/Fix.swift
@@ -16,6 +16,10 @@ public class Fix<A>: FixOf<A> {
     }
 }
 
+public postfix func ^<A>(_ value: FixOf<A>) -> Fix<A> {
+    return Fix.fix(value)
+}
+
 extension ForFix: Recursive {
     public static func projectT<F: Functor>(_ tf: Kind<ForFix, F>) -> Kind<F, Kind<ForFix, F>> {
         return F.map(Fix.fix(tf).unFix, { x in x.value() })

--- a/Sources/BowRecursionSchemes/Data/Fix.swift
+++ b/Sources/BowRecursionSchemes/Data/Fix.swift
@@ -16,6 +16,10 @@ public class Fix<A>: FixOf<A> {
     }
 }
 
+/// Safe downcast.
+///
+/// - Parameter value: Value in higher-kind form.
+/// - Returns: Value cast to Fix.
 public postfix func ^<A>(_ value: FixOf<A>) -> Fix<A> {
     return Fix.fix(value)
 }

--- a/Sources/BowRecursionSchemes/Data/Mu.swift
+++ b/Sources/BowRecursionSchemes/Data/Mu.swift
@@ -14,6 +14,10 @@ open class Mu<F>: MuOf<F> {
     }
 }
 
+public postfix func ^<F>(_ value: MuOf<F>) -> Mu<F> {
+    return Mu.fix(value)
+}
+
 extension ForMu: Recursive {
     public static func projectT<F: Functor>(_ tf: Kind<ForMu, F>) -> Kind<F, Kind<ForMu, F>> {
         return cata(tf, { ff in

--- a/Sources/BowRecursionSchemes/Data/Mu.swift
+++ b/Sources/BowRecursionSchemes/Data/Mu.swift
@@ -14,6 +14,10 @@ open class Mu<F>: MuOf<F> {
     }
 }
 
+/// Safe downcast.
+///
+/// - Parameter value: Value in higher-kind form.
+/// - Returns: Value cast to Mu.
 public postfix func ^<F>(_ value: MuOf<F>) -> Mu<F> {
     return Mu.fix(value)
 }

--- a/Sources/BowRecursionSchemes/Data/Nu.swift
+++ b/Sources/BowRecursionSchemes/Data/Nu.swift
@@ -18,6 +18,10 @@ public class Nu<F>: NuOf<F> {
     }
 }
 
+public postfix func ^<F>(_ value: NuOf<F>) -> Nu<F> {
+    return Nu.fix(value)
+}
+
 extension ForNu: Recursive {
     public static func projectT<F: Functor>(_ tf: Kind<ForNu, F>) -> Kind<F, Kind<ForNu, F>> {
         let fix = Nu.fix(tf)

--- a/Sources/BowRecursionSchemes/Data/Nu.swift
+++ b/Sources/BowRecursionSchemes/Data/Nu.swift
@@ -18,6 +18,10 @@ public class Nu<F>: NuOf<F> {
     }
 }
 
+/// Safe downcast.
+///
+/// - Parameter value: Value in higher-kind form.
+/// - Returns: Value cast to Nu.
 public postfix func ^<F>(_ value: NuOf<F>) -> Nu<F> {
     return Nu.fix(value)
 }

--- a/Sources/BowRx/MaybeK.swift
+++ b/Sources/BowRx/MaybeK.swift
@@ -41,7 +41,7 @@ public class MaybeK<A>: MaybeKOf<A> {
     }
 }
 
-public postfix func ^(_ value : MaybeKOf<A>) -> MaybeK<A> {
+public postfix func ^<A>(_ value : MaybeKOf<A>) -> MaybeK<A> {
     return MaybeK.fix(value)
 }
 

--- a/Sources/BowRx/MaybeK.swift
+++ b/Sources/BowRx/MaybeK.swift
@@ -41,7 +41,11 @@ public class MaybeK<A>: MaybeKOf<A> {
     }
 }
 
-public postfix func ^<A>(_ value : MaybeKOf<A>) -> MaybeK<A> {
+/// Safe downcast.
+///
+/// - Parameter value: Value in higher-kind form.
+/// - Returns: Value cast to MaybeK.
+public postfix func ^<A>(_ value: MaybeKOf<A>) -> MaybeK<A> {
     return MaybeK.fix(value)
 }
 

--- a/Sources/BowRx/MaybeK.swift
+++ b/Sources/BowRx/MaybeK.swift
@@ -41,6 +41,10 @@ public class MaybeK<A>: MaybeKOf<A> {
     }
 }
 
+public postfix func ^(_ value : MaybeKOf<A>) -> MaybeK<A> {
+    return MaybeK.fix(value)
+}
+
 extension ForMaybeK: Functor {
     public static func map<A, B>(_ fa: Kind<ForMaybeK, A>, _ f: @escaping (A) -> B) -> Kind<ForMaybeK, B> {
         return MaybeK.fix(fa).value.map(f).k()

--- a/Sources/BowRx/ObservableK.swift
+++ b/Sources/BowRx/ObservableK.swift
@@ -51,6 +51,10 @@ public class ObservableK<A>: ObservableKOf<A> {
     }
 }
 
+public postfix func ^<A>(_ value: ObservableKOf<A>) -> ObservableK<A> {
+    return ObservableK.fix(value)
+}
+
 extension ForObservableK: Functor {
     public static func map<A, B>(_ fa: Kind<ForObservableK, A>, _ f: @escaping (A) -> B) -> Kind<ForObservableK, B> {
         return ObservableK.fix(fa).value.map(f).k()

--- a/Sources/BowRx/ObservableK.swift
+++ b/Sources/BowRx/ObservableK.swift
@@ -51,6 +51,10 @@ public class ObservableK<A>: ObservableKOf<A> {
     }
 }
 
+/// Safe downcast.
+///
+/// - Parameter value: Value in higher-kind form.
+/// - Returns: Value cast to ObservableK.
 public postfix func ^<A>(_ value: ObservableKOf<A>) -> ObservableK<A> {
     return ObservableK.fix(value)
 }

--- a/Sources/BowRx/SingleK.swift
+++ b/Sources/BowRx/SingleK.swift
@@ -50,6 +50,10 @@ public class SingleK<A>: SingleKOf<A> {
     }
 }
 
+public postfix func ^<A>(_ value: SingleKOf<A>) -> SingleK<A> {
+    return SingleK.fix(value)
+}
+
 extension ForSingleK: Functor {
     public static func map<A, B>(_ fa: Kind<ForSingleK, A>, _ f: @escaping (A) -> B) -> Kind<ForSingleK, B> {
         return SingleK.fix(fa).value.map(f).k()

--- a/Sources/BowRx/SingleK.swift
+++ b/Sources/BowRx/SingleK.swift
@@ -50,6 +50,10 @@ public class SingleK<A>: SingleKOf<A> {
     }
 }
 
+/// Safe downcast.
+///
+/// - Parameter value: Value in higher-kind form.
+/// - Returns: Value cast to SingleK.
 public postfix func ^<A>(_ value: SingleKOf<A>) -> SingleK<A> {
     return SingleK.fix(value)
 }

--- a/Tests/BowFreeTests/FreeTest.swift
+++ b/Tests/BowFreeTests/FreeTest.swift
@@ -37,6 +37,10 @@ fileprivate class Ops<A>: Kind<ForOps, A> {
     }
 }
 
+fileprivate postfix func ^<A>(_ fa: Kind<ForOps, A>) -> Ops<A> {
+    return Ops.fix(fa)
+}
+
 fileprivate class Value: Ops<Int> {
     let a: Int
     


### PR DESCRIPTION
## Goal

Operations described in typeclasses work at the `Kind` level. In some situations, after running a combinator in a typeclass, we need to use the concrete type of the result, not its `Kind` form. Currently, data types provide a static function `fix` for doing so, but writing it leads to verbose code and becomes difficult to read.

In order to avoid this, a postfix operator `^` has been introduced. This operator is overloaded for all types in the library and provide `fix` (i.e. downcasting) in a less verbose manner and allows for operator chaining. For instance, we went from:

```swift
Option.fix(Option.some(1).map { x in "\(x)" }).getOrElse("Empty")
```

To:

```swift
Option.some(1).map { x in "\(x)" }^.getOrElse("Empty")
```

The `^` operator is similar to the `?.` operator but generalized to operate on kinds where we need to access the specific methods of a concrete data type.

## Implementation details

A postfix operator `^` has been introduced. It has been overloaded for all data types in the library.
