### PR TITLE
Add missing functions and instances to Function1

### DIFF
--- a/Sources/Bow/Arrow/Function0.swift
+++ b/Sources/Bow/Arrow/Function0.swift
@@ -43,18 +43,21 @@ public postfix func ^<A>(_ fa: Function0Of<A>) -> Function0<A> {
 
 // MARK: Protocol conformances
 
+// MARK: Instance of `EquatableK` for `Function0`
 extension ForFunction0: EquatableK {
     public static func eq<A>(_ lhs: Kind<ForFunction0, A>, _ rhs: Kind<ForFunction0, A>) -> Bool where A : Equatable {
         return Function0.fix(lhs).extract() == Function0.fix(rhs).extract()
     }
 }
 
+// MARK: Instance of `Functor` for `Function0`
 extension ForFunction0: Functor {
     public static func map<A, B>(_ fa: Kind<ForFunction0, A>, _ f: @escaping (A) -> B) -> Kind<ForFunction0, B> {
         return Function0(Function0.fix(fa).f >>> f)
     }
 }
 
+// MARK: Instance of `Applicative` for `Function0`
 extension ForFunction0: Applicative {
     public static func pure<A>(_ a: A) -> Kind<ForFunction0, A> {
         return Function0(constant(a))
@@ -64,6 +67,7 @@ extension ForFunction0: Applicative {
 // MARK: Instance of `Selective` for `Function0`
 extension ForFunction0: Selective {}
 
+// MARK: Instance of `Monad` for `Function0`
 extension ForFunction0: Monad {
     public static func flatMap<A, B>(_ fa: Kind<ForFunction0, A>, _ f: @escaping (A) -> Kind<ForFunction0, B>) -> Kind<ForFunction0, B> {
         return f(Function0.fix(fa).f())
@@ -79,6 +83,7 @@ extension ForFunction0: Monad {
     }
 }
 
+// MARK: Instance of `Comonad` for `Function0`
 extension ForFunction0: Comonad {
     public static func coflatMap<A, B>(_ fa: Kind<ForFunction0, A>, _ f: @escaping (Kind<ForFunction0, A>) -> B) -> Kind<ForFunction0, B> {
         return Function0<B>({ f(Function0.fix(fa)) })
@@ -89,4 +94,5 @@ extension ForFunction0: Comonad {
     }
 }
 
+// MARK: Instance of `Bimonad` for `Function0`
 extension ForFunction0: Bimonad {}

--- a/Sources/Bow/Arrow/Function1.swift
+++ b/Sources/Bow/Arrow/Function1.swift
@@ -10,7 +10,7 @@ public final class Function1Partial<I>: Kind<ForFunction1, I> {}
 public typealias Function1Of<I, O> = Kind<Function1Partial<I>, O>
 
 /// This data type acts as a wrapper over functions. It receives two type parameters representing the input and output type of the function. The wrapper adds capabilities to use a function as a Higher Kinded Type and conform to typeclasses that have this requirement.
-public class Function1<I, O>: Function1Of<I, O> {
+public final class Function1<I, O>: Function1Of<I, O> {
     fileprivate let f: (I) -> O
     
     /// Safe downcast.
@@ -113,5 +113,12 @@ extension Function1Partial: MonadReader {
 
     public static func local<A>(_ fa: Kind<Function1Partial<I>, A>, _ f: @escaping (I) -> I) -> Kind<Function1Partial<I>, A> {
         return Function1(f >>> Function1.fix(fa).f)
+    }
+}
+
+// MARK: Instance of `Semigroup` for Function1
+extension Function1: Semigroup where O: Semigroup {
+    public func combine(_ other: Function1<I, O>) -> Function1<I, O> {
+        return Function1 { i in self.invoke(i).combine(other.invoke(i)) }
     }
 }

--- a/Sources/Bow/Arrow/Function1.swift
+++ b/Sources/Bow/Arrow/Function1.swift
@@ -35,6 +35,30 @@ public class Function1<I, O>: Function1Of<I, O> {
     public func invoke(_ value: I) -> O {
         return f(value)
     }
+
+    /// Composes with another function.
+    ///
+    /// - Parameter f: Function to compose.
+    /// - Returns: Composition of the two functions.
+    public func compose<A>(_ f: Function1<A, I>) -> Function1<A, O> {
+        return Function1<A, O>(self.f <<< f.f)
+    }
+
+    /// Concatenates another function.
+    ///
+    /// - Parameter f: Function to concatenate.
+    /// - Returns: Concatenation of the two functions.
+    public func andThen<A>(_ f: Function1<O, A>) -> Function1<I, A> {
+        return f.compose(self)
+    }
+
+    /// Composes with another function.
+    ///
+    /// - Parameter f: Function to compose.
+    /// - Returns: Composition of the two functions.
+    public func contramap<A>(_ f: @escaping (A) -> I) -> Function1<A, O> {
+        return Function1<A, O>(self.f <<< f)
+    }
 }
 
 /// Safe downcast.

--- a/Sources/Bow/Arrow/Function1.swift
+++ b/Sources/Bow/Arrow/Function1.swift
@@ -47,12 +47,14 @@ public postfix func ^<I, O>(_ fa: Function1Of<I, O>) -> Function1<I, O> {
 
 // MARK: Protocol conformances
 
+// MARK: Instance of `Functor` for `Function1`
 extension Function1Partial: Functor {
     public static func map<A, B>(_ fa: Kind<Function1Partial<I>, A>, _ f: @escaping (A) -> B) -> Kind<Function1Partial<I>, B> {
         return Function1(Function1.fix(fa).f >>> f)
     }
 }
 
+// MARK: Instance of `Applicative` for `Function1`
 extension Function1Partial: Applicative {
     public static func pure<A>(_ a: A) -> Kind<Function1Partial<I>, A> {
         return Function1(constant(a))
@@ -62,6 +64,7 @@ extension Function1Partial: Applicative {
 // MARK: Instance of `Selective` for `Function1`
 extension Function1Partial: Selective {}
 
+// MARK: Instance of `Monad` for `Function1`
 extension Function1Partial: Monad {
     public static func flatMap<A, B>(_ fa: Kind<Function1Partial<I>, A>, _ f: @escaping (A) -> Kind<Function1Partial<I>, B>) -> Kind<Function1Partial<I>, B> {
         return Function1<I, B>({ i in Function1.fix(f(Function1.fix(fa).f(i))).f(i) })
@@ -76,6 +79,7 @@ extension Function1Partial: Monad {
     }
 }
 
+// MARK: Instance of `MonadReader` for `Function1`
 extension Function1Partial: MonadReader {
     public typealias D = I
 

--- a/Tests/BowTests/Arrow/Function1Test.swift
+++ b/Tests/BowTests/Arrow/Function1Test.swift
@@ -1,4 +1,5 @@
 import XCTest
+import SwiftCheck
 @testable import BowLaws
 @testable import Bow
 
@@ -23,5 +24,16 @@ class Function1Test: XCTestCase {
 
     func testMonadLaws() {
         MonadLaws<Function1Partial<Int>>.check()
+    }
+
+    func testSemigroupLaws() {
+        func testSemigroupLaws() {
+            property("Function1 semigroup laws") <- forAll() { (f: ArrowOf<Int, Int>, g: ArrowOf<Int, Int>, h: ArrowOf<Int, Int>) in
+                return SemigroupLaws<Function1<Int, Int>>.check(
+                    a: Function1(f.getArrow),
+                    b: Function1(g.getArrow),
+                    c: Function1(h.getArrow))
+            }
+        }
     }
 }


### PR DESCRIPTION
## Related issues

- Closes #223 
- Closes #229 

## Goal

Update Function1 with missing things respect to the Arrow version. Instances for `Category`, `Contravariant` and `Profunctor` are not possible to write at the moment and therefore are left out of this PR.