### PR TITLE
Add missing functions to Try

### DIFF
--- a/Sources/Bow/Data/Try.swift
+++ b/Sources/Bow/Data/Try.swift
@@ -123,7 +123,7 @@ public postfix func ^<A>(_ fa: TryOf<A>) -> Try<A> {
     return Try.fix(fa)
 }
 
-class Success<A>: Try<A> {
+private class Success<A>: Try<A> {
     fileprivate let value: A
     
     init(_ value: A) {
@@ -131,7 +131,7 @@ class Success<A>: Try<A> {
     }
 }
 
-class Failure<A>: Try<A> {
+private class Failure<A>: Try<A> {
     fileprivate let error: Error
     
     init(_ error: Error) {

--- a/Sources/Bow/Data/Try.swift
+++ b/Sources/Bow/Data/Try.swift
@@ -7,7 +7,7 @@ import Foundation
 /// - unsupportedOperation: The invoked operation is unsupported for the value receiving it.
 public enum TryError: Error {
     case illegalState
-    case predicateError
+    case predicateDoesNotMatch
     case unsupportedOperation(String)
 }
 

--- a/Sources/Bow/Data/Try.swift
+++ b/Sources/Bow/Data/Try.swift
@@ -18,13 +18,15 @@ public final class ForTry {}
 public typealias TryOf<A> = Kind<ForTry, A>
 
 /// Describes the result of an operation that may have thrown errors or succeeded. The type parameter corresponds to the result type of the operation.
-public class Try<A>: TryOf<A> {
+public final class Try<A>: TryOf<A> {
+    private let value: _Try<A>
+
     /// Creates a successful Try value.
     ///
     /// - Parameter value: Value to be wrapped in a successful Try.
     /// - Returns: A `Try` value wrapping the successful value.
     public static func success(_ value: A) -> Try<A> {
-        return Success<A>(value)
+        return Try(.success(value))
     }
     
     /// Creates a failed Try value.
@@ -32,7 +34,7 @@ public class Try<A>: TryOf<A> {
     /// - Parameter error: An error.
     /// - Returns: A `Try` value wrapping the error.
     public static func failure(_ error: Error) -> Try<A> {
-        return Failure<A>(error)
+        return Try(.failure(error))
     }
 
     /// Creates a failed Try value.
@@ -55,7 +57,11 @@ public class Try<A>: TryOf<A> {
             return failure(error)
         }
     }
-    
+
+    private init(_ value: _Try<A>) {
+        self.value = value
+    }
+
     /// Safe downcast.
     ///
     /// - Parameter fa: Value in the higher-kind form.
@@ -71,16 +77,14 @@ public class Try<A>: TryOf<A> {
     ///   - fa: Closure to apply if the contained value in this `Try` is a successful value.
     /// - Returns: Result of applying the corresponding closure to this value.
     public func fold<B>(_ fe: (Error) -> B, _ fa: (A) throws -> B) -> B {
-        switch self {
-            case let failure as Failure<A>: return fe(failure.error)
-            case let success as Success<A>:
-                do {
-                    return try fa(success.value)
-                } catch let error {
-                    return fe(error)
-                }
-            default:
-                fatalError("Try must only have Success or Failure cases")
+        switch value {
+        case let .success(a):
+            do {
+                return try fa(a)
+            } catch let error {
+                return fe(error)
+            }
+        case let .failure(e): return fe(e)
         }
     }
 
@@ -180,20 +184,9 @@ public postfix func ^<A>(_ fa: TryOf<A>) -> Try<A> {
     return Try.fix(fa)
 }
 
-private class Success<A>: Try<A> {
-    fileprivate let value: A
-    
-    init(_ value: A) {
-        self.value = value
-    }
-}
-
-private class Failure<A>: Try<A> {
-    fileprivate let error: Error
-    
-    init(_ error: Error) {
-        self.error = error
-    }
+private enum _Try<A> {
+    case success(A)
+    case failure(Error)
 }
 
 // MARK: Conformance of `Try` to `CustomStringConvertible`
@@ -292,3 +285,19 @@ extension ForTry: Traverse {
     }
 }
 
+// MARK: Instance of `Semigroup` for `Try`
+extension Try: Semigroup where A: Semigroup {
+    public func combine(_ other: Try<A>) -> Try<A> {
+        return self.fold(constant(other),
+                         { a in other.fold(Try.failure,
+                                           { b in Try.success(a.combine(b)) })
+                         })
+    }
+}
+
+// MARK: Instance of `Monoid` for `Try`
+extension Try: Monoid where A: Monoid {
+    public static func empty() -> Try<A> {
+        return Try.success(A.empty())
+    }
+}

--- a/Sources/Bow/Data/Try.swift
+++ b/Sources/Bow/Data/Try.swift
@@ -285,6 +285,16 @@ extension ForTry: Traverse {
     }
 }
 
+// MARK: Instance of `FunctorFilter` for `Try`
+extension ForTry: FunctorFilter {
+    public static func mapFilter<A, B>(_ fa: Kind<ForTry, A>, _ f: @escaping (A) -> Kind<ForOption, B>) -> Kind<ForTry, B> {
+        return Try.fix(fa).flatMap { a in
+            f(a)^.fold(constant(raiseError(TryError.predicateError)), pure)
+        }
+    }
+}
+
+
 // MARK: Instance of `Semigroup` for `Try`
 extension Try: Semigroup where A: Semigroup {
     public func combine(_ other: Try<A>) -> Try<A> {

--- a/Tests/BowTests/Data/TryTest.swift
+++ b/Tests/BowTests/Data/TryTest.swift
@@ -41,6 +41,10 @@ class TryTest: XCTestCase {
         TraverseLaws<ForTry>.check(generator: self.generator)
     }
 
+    func testFunctorFilterLaws() {
+        FunctorFilterLaws<ForTry>.check(generator: self.generator)
+    }
+
     func testSemigroupLaws() {
         property("Try semigroup laws") <- forAll { (a: Int, b: Int, c: Int) in
             return SemigroupLaws<Try<Int>>.check(

--- a/Tests/BowTests/Data/TryTest.swift
+++ b/Tests/BowTests/Data/TryTest.swift
@@ -1,4 +1,5 @@
 import XCTest
+import SwiftCheck
 @testable import BowLaws
 @testable import Bow
 
@@ -38,5 +39,20 @@ class TryTest: XCTestCase {
     
     func testTraverseLaws() {
         TraverseLaws<ForTry>.check(generator: self.generator)
+    }
+
+    func testSemigroupLaws() {
+        property("Try semigroup laws") <- forAll { (a: Int, b: Int, c: Int) in
+            return SemigroupLaws<Try<Int>>.check(
+                a: Try.success(a),
+                b: Try.success(b),
+                c: Try.success(c))
+        }
+    }
+
+    func testMonoidLaws() {
+        property("Try monoid laws") <- forAll { (a: Int) in
+            return MonoidLaws<Try<Int>>.check(a: Try.success(a))
+        }
     }
 }


### PR DESCRIPTION
## Related issues

- Closes #225 
- Closes #233 

## Goal

Add missing functionality to Try respect to the Arrow version.

## Implementation details

Some missing functions and instances have been added. Some notes:

- Instance to `Hashable` has not been added. All instances of `Hashable` should be added separately in a single PR.
- `rescue` is deprecated and replaced by `handleErrorWith` from `ApplicativeError`, which is already present.
- `flatten` is already present from `Monad`.
- `exists` is already present from `Foldable`.

## Testing details

Laws for Semigroup and Monoid are tested.
