### PR TITLE
Uses @autoclosure in constant functions

### DIFF
--- a/Sources/Bow/Syntax/Predef.swift
+++ b/Sources/Bow/Syntax/Predef.swift
@@ -17,40 +17,40 @@ public func id<A>(_ a : A) -> A {
 ///
 /// - Parameter a: Constant value to return.
 /// - Returns: A 0-ary function that constantly return the value provided as argument.
-public func constant<A>(_ a : A) -> () -> A {
-    return { a }
+public func constant<A>(_ a: @autoclosure @escaping () -> A) -> () -> A {
+    return a
 }
 
 /// Provides a constant function.
 ///
 /// - Parameter a: Constant value to return.
 /// - Returns: A 1-ary function that constantly return the value provided as argument, regardless of its input parameter.
-public func constant<A, B>(_ a : A) -> (B) -> A {
-    return { _ in a }
+public func constant<A, B>(_ a: @autoclosure @escaping () -> A) -> (B) -> A {
+    return { _ in return a() }
 }
 
 /// Provides a constant function.
 ///
 /// - Parameter a: Constant value to return.
 /// - Returns: A 2-ary function that constantly return the value provided as argument, regardless of its input parameters.
-public func constant<A, B, C>(_ a : A) -> (B, C) -> A {
-    return { _, _ in a }
+public func constant<A, B, C>(_ a: @autoclosure @escaping () -> A) -> (B, C) -> A {
+    return { _, _ in a() }
 }
 
 /// Provides a constant function.
 ///
 /// - Parameter a: Constant value to return.
 /// - Returns: A 3-ary function that constantly return the value provided as argument, regardless of its input parameters.
-public func constant<A, B, C, D>(_ a : A) -> (B, C, D) -> A {
-    return { _, _, _ in a }
+public func constant<A, B, C, D>(_ a: @autoclosure @escaping () -> A) -> (B, C, D) -> A {
+    return { _, _, _ in a() }
 }
 
 /// Provides a constant function.
 ///
 /// - Parameter a: Constant value to return.
 /// - Returns: A 4-ary function that constantly return the value provided as argument, regardless of its input parameters.
-public func constant<A, B, C, D, E>(_ a : A) -> (B, C, D, E) -> A {
-    return { _, _, _, _ in a }
+public func constant<A, B, C, D, E>(_ a: @autoclosure @escaping () -> A) -> (B, C, D, E) -> A {
+    return { _, _, _, _ in a() }
 }
 
 /**

--- a/Sources/Bow/Typeclasses/Selective.swift
+++ b/Sources/Bow/Typeclasses/Selective.swift
@@ -50,7 +50,7 @@ public extension Selective {
     ///   - e: Computation that will be executed if the first evaluates to `false`.
     /// - Returns: Composition of the computations.
     public static func ifS<A>(_ x: Kind<Self, Bool>, _ t: Kind<Self, A>, _ e: Kind<Self, A>) -> Kind<Self, A> {
-        return branch(selector(x), map(t, constant), map(e, constant))
+        return branch(selector(x), map(t, { tt in constant(tt) }), map(e, { ee in constant(ee) }))
     }
 
     /// A lifted version of lazy boolean or.
@@ -81,7 +81,7 @@ public extension Selective {
     /// - Returns: Composition of the two computations.
     public static func fromOptionS<A>(_ x: Kind<Self, A>, _ mx: Kind<Self, Option<A>>) -> Kind<Self, A> {
         let s = map(mx) { a in Option.fix(a.map(Either<(), A>.right)).getOrElse(Either.left(())) }
-        return select(s, map(x, constant))
+        return select(s, map(x, { xx in constant(xx) }))
     }
 
     /// A lifted version of `any`. Retains the short-circuiting behavior.


### PR DESCRIPTION
## Related issues

Issue: #247 

## Goal

Provide a lazy implementation of `constant`.

## Implementation details

@autoclosure is a syntax sugar to be able to use a function as a parameter without wrapping it between `{}`, however, the signature of the function will specify a function as the parameter, because of this, some usages have been adapted to the new syntax.

## Testing details

Tests not affected