### PR TITLE
Set a z-index for buttons explicitely

### DIFF
--- a/docs/_sass/components/_buttons.scss
+++ b/docs/_sass/components/_buttons.scss
@@ -12,6 +12,7 @@
   text-align: center;
   transition: background $base-duration $base-timing;
   outline: none;
+  z-index: 1;
 
   &:visited {
     color: $white;


### PR DESCRIPTION
* Set a z-index for buttons explicitly to avoid non interactive buttons on complex positioned layouts.