### PR TITLE
Remove edit button from doc pages

### DIFF
--- a/docs/_includes/_doc-wrapper.html
+++ b/docs/_includes/_doc-wrapper.html
@@ -3,11 +3,6 @@
         <button type="button" id="main-toggle" class="sidebar-toggle">
             <i class="fa fa-lg fa-bars menu-icon"></i>
         </button>
-        <a target="_blank"
-          href="{{site.github_repository}}/edit/master/docs{{page.url | replace: '_', ''}}README.md">
-          <i class="fa fa-pencil"></i>
-            Edit
-        </a>
     </div>
     <div class="doc-content">
         {{ content }}


### PR DESCRIPTION
* With the current way of generating documentation through `nef`, the edit button is deprecated.