### PR TITLE
add @escaping keyword to runAsync<A> methods of Async and IO

### DIFF
--- a/Sources/BowBrightFutures/FutureK.swift
+++ b/Sources/BowBrightFutures/FutureK.swift
@@ -115,7 +115,7 @@ extension FutureKPartial: MonadDefer {
 }
 
 extension FutureKPartial: BowEffects.Async {
-    public static func runAsync<A>(_ fa: @escaping ((Either<E, A>) -> ()) throws -> ()) -> Kind<FutureKPartial<E>, A> {
+    public static func runAsync<A>(_ fa: @escaping (@escaping (Either<E, A>) -> ()) throws -> ()) -> Kind<FutureKPartial<E>, A> {
         return Future { complete in
             do {
                 try fa { either in

--- a/Sources/BowEffects/IO.swift
+++ b/Sources/BowEffects/IO.swift
@@ -362,7 +362,7 @@ extension IOPartial: MonadDefer {
 }
 
 extension IOPartial: Async {
-    public static func runAsync<A>(_ fa: @escaping ((Either<E, A>) -> ()) throws -> ()) -> Kind<IOPartial<E>, A> {
+    public static func runAsync<A>(_ fa: @escaping (@escaping (Either<E, A>) -> ()) throws -> ()) -> Kind<IOPartial<E>, A> {
         return AsyncIO(fa)
     }
 }

--- a/Sources/BowEffects/Typeclasses/Async.swift
+++ b/Sources/BowEffects/Typeclasses/Async.swift
@@ -1,7 +1,7 @@
 import Foundation
 import Bow
 
-public typealias Proc<E, A> = (Callback<E, A>) throws -> ()
+public typealias Proc<E, A> = (@escaping Callback<E, A>) throws -> ()
 public typealias Callback<E, A> = (Either<E, A>) -> ()
 
 public protocol Async: MonadDefer {

--- a/Sources/BowRx/MaybeK.swift
+++ b/Sources/BowRx/MaybeK.swift
@@ -107,7 +107,7 @@ extension ForMaybeK: MonadDefer {
 }
 
 extension ForMaybeK: Async {
-    public static func runAsync<A>(_ fa: @escaping ((Either<Error, A>) -> ()) throws -> ()) -> Kind<ForMaybeK, A> {
+    public static func runAsync<A>(_ fa: @escaping (@escaping(Either<Error, A>) -> ()) throws -> ()) -> Kind<ForMaybeK, A> {
         return Maybe.create { emitter in
             do {
                 try fa { either in

--- a/Sources/BowRx/ObservableK.swift
+++ b/Sources/BowRx/ObservableK.swift
@@ -134,7 +134,7 @@ extension ForObservableK: MonadDefer {
 }
 
 extension ForObservableK: Async {
-    public static func runAsync<A>(_ fa: @escaping ((Either<ForObservableK.E, A>) -> ()) throws -> ()) -> Kind<ForObservableK, A> {
+    public static func runAsync<A>(_ fa: @escaping (@escaping(Either<ForObservableK.E, A>) -> ()) throws -> ()) -> Kind<ForObservableK, A> {
         return Observable.create { emitter in
             do {
                 try fa { either in

--- a/Sources/BowRx/SingleK.swift
+++ b/Sources/BowRx/SingleK.swift
@@ -106,7 +106,7 @@ extension ForSingleK: MonadDefer {
 }
 
 extension ForSingleK: Async {
-    public static func runAsync<A>(_ fa: @escaping ((Either<Error, A>) -> ()) throws -> ()) -> Kind<ForSingleK, A> {
+    public static func runAsync<A>(_ fa: @escaping (@escaping (Either<Error, A>) -> ()) throws -> ()) -> Kind<ForSingleK, A> {
         return Single<A>.create { emitter in
             do {
                 try fa { (either : Either<Error, A>) in


### PR DESCRIPTION
## Related issues


## Goal

let a user call the callback defined in the runAsync PR, previous to this PR, the compiler would complain about the callback being non-escaping (Closure use of non-escaping parameter 'callback' may allow it to escape)

## Implementation details

add @escaping to the runAsync method in IO.swift and Async.swift

## Testing details

if you want me to add tests, where do you want me to put those ? :)