### PR TITLE
Result API docs and minor fixes

### DIFF
--- a/Sources/Bow/Data/NonEmptyArray.swift
+++ b/Sources/Bow/Data/NonEmptyArray.swift
@@ -155,7 +155,7 @@ public extension NonEmptyArray where A: Equatable {
 // Conformance of `NonEmptyArray` to `CustomStringConvertible`
 extension NonEmptyArray: CustomStringConvertible {
     public var description: String {
-        return "NonEmptyArray(\(self.all())"
+        return "NonEmptyArray(\(self.all()))"
     }
 }
 

--- a/Sources/Bow/Data/Result.swift
+++ b/Sources/Bow/Data/Result.swift
@@ -10,6 +10,10 @@ public extension Result {
     func toValidated() -> Validated<Failure, Success> {
         return fold(Validated.invalid, Validated.valid)
     }
+    
+    func toValidatedNEA() -> ValidatedNEA<Failure, Success> {
+        return toValidated().toValidatedNEA()
+    }
 
     func toOption() -> Option<Success> {
         return fold(constant(Option.none()), Option.some)

--- a/Sources/Bow/Data/Result.swift
+++ b/Sources/Bow/Data/Result.swift
@@ -1,24 +1,46 @@
 public extension Result {
+    
+    /// Converts this Result into an Either value.
+    ///
+    /// - Returns: An Either.left if this is a Result.failure, or an Either.right if this is a Result.success
     func toEither() -> Either<Failure, Success> {
         return fold(Either.left, Either.right)
     }
 
+    /// Converts this Result into a Try value.
+    ///
+    /// - Returns: A Try.failure if this is a Result.failure, or a Try.success if this is a Result.success
     func toTry() -> Try<Success> {
         return fold(Try.failure, Try.success)
     }
-
+    
+    /// Converts this Result into a Validated value.
+    ///
+    /// - Returns: A Validated.invalid if this is a Result.failure, or a Validated.valid if this is a Result.success.
     func toValidated() -> Validated<Failure, Success> {
         return fold(Validated.invalid, Validated.valid)
     }
     
+    /// Converts this Result into a ValidatedNEA value.
+    ///
+    /// - Returns: A Validated.invalid with a NonEmptyArray of the Failure type if this is a Result.failure, or a Validated.valid if this is a Result.success.
     func toValidatedNEA() -> ValidatedNEA<Failure, Success> {
         return toValidated().toValidatedNEA()
     }
 
+    /// Converts this Result into an Option value.
+    ///
+    /// - Returns: Option.none if this is a Result.failure, or Option.some if this is a Result.success.
     func toOption() -> Option<Success> {
         return fold(constant(Option.none()), Option.some)
     }
 
+    /// Applies the corresponding closure based on the value contained in this result.
+    ///
+    /// - Parameters:
+    ///   - ifFailure: Closure to be applied if this is a Result.failure.
+    ///   - ifSuccess: Closure to be applied if this is a Result.success.
+    /// - Returns: Output of the execution of the corresponding closure, based on the internal value of this Result.
     func fold<B>(_ ifFailure: @escaping (Failure) -> B,
                  _ ifSuccess: @escaping (Success) -> B) -> B {
         switch self {
@@ -28,13 +50,23 @@ public extension Result {
     }
 }
 
+// MARK: Conversion to Result when the left type conforms to Error
+
 public extension Either where A: Error {
+    /// Converts this Either into a Result value.
+    ///
+    /// - Returns: A Result.success if this is an Either.right, or a Result.failure if this is an Either.left.
     func toResult() -> Result<B, A> {
         return self.fold(Result.failure, Result.success)
     }
 }
 
+// MARK: Conversion to Result when the invalid type conforms to Error
+
 public extension Validated where E: Error {
+    /// Converts this Validated into a Result value.
+    ///
+    /// - Returns: A Result.success if this is a Validated.valid, or a Result.failure if this is a Validated.invalid.
     func toResult() -> Result<A, E> {
         return self.fold(Result.failure, Result.success)
     }

--- a/contents/Documentation/Quick start.playground/Pages/Resources.xcplaygroundpage/Contents.swift
+++ b/contents/Documentation/Quick start.playground/Pages/Resources.xcplaygroundpage/Contents.swift
@@ -21,7 +21,7 @@
 
  ## Presentations
 
- Be the first one showing here!
+ - [Error management and data validation with Bow](https://truizlop.github.io/DataValidationBow/#/) by Tomás Ruiz-López at AltConf Madrid. June 2019.
 
  ## Blog posts
 

--- a/contents/Documentation/Quick start.playground/contents.xcplayground
+++ b/contents/Documentation/Quick start.playground/contents.xcplayground
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<playground version='6.0' target-platform='macos' display-mode='raw' executeOnSourceChanges='false'>
+<playground version='6.0' target-platform='macos' display-mode='raw'>
     <pages>
         <page name='Getting started'/>
         <page name='Modules'/>


### PR DESCRIPTION
## Goal

- Provide API docs for extensions to convert from/to Result in Swift 5.
- Fix typo in NonEmptyArray.
- Add presentation about Error management.
