### PR TITLE
Automatic derivation of optics

### DIFF
--- a/Bow.xcodeproj/project.pbxproj
+++ b/Bow.xcodeproj/project.pbxproj
@@ -488,6 +488,13 @@
 			remoteGlobalIDString = 1120978222A7EBC7007F3D9C;
 			remoteInfo = "Bow-Generators";
 		};
+		1126CA8022B0DDD100F840CB /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = OBJ_1 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 117DC0F722AE522000EF65F0;
+			remoteInfo = "Bow-BrightFuturesGenerators";
+		};
 		117DC0B422AE492700EF65F0 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = OBJ_1 /* Project object */;
@@ -2127,6 +2134,7 @@
 			buildRules = (
 			);
 			dependencies = (
+				1126CA8122B0DDD100F840CB /* PBXTargetDependency */,
 				11D97EF6219EBCE1008FC004 /* PBXTargetDependency */,
 				11229808219DD31E006D66C5 /* PBXTargetDependency */,
 				112297EE219DD2AB006D66C5 /* PBXTargetDependency */,
@@ -3288,6 +3296,11 @@
 			isa = PBXTargetDependency;
 			target = 1120978222A7EBC7007F3D9C /* Bow-Generators */;
 			targetProxy = 1126CA7C22AFBB6C00F840CB /* PBXContainerItemProxy */;
+		};
+		1126CA8122B0DDD100F840CB /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 117DC0F722AE522000EF65F0 /* Bow-BrightFuturesGenerators */;
+			targetProxy = 1126CA8022B0DDD100F840CB /* PBXContainerItemProxy */;
 		};
 		117DC0B322AE492700EF65F0 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;

--- a/Bow.xcodeproj/project.pbxproj
+++ b/Bow.xcodeproj/project.pbxproj
@@ -110,6 +110,7 @@
 		112297F5219DD2AB006D66C5 /* FutureKTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BA0F39F217E2DEF00969984 /* FutureKTest.swift */; };
 		112297FD219DD2AB006D66C5 /* BrightFutures.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8BA0F364217E2CB100969984 /* BrightFutures.framework */; };
 		1125054D220DD92B00861131 /* EquatableK.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1125054C220DD92B00861131 /* EquatableK.swift */; };
+		1126CA8A22B1144200F840CB /* AutoOptics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1126CA8922B1144200F840CB /* AutoOptics.swift */; };
 		113CD8F4219DD82F00730E58 /* RxSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8BA0F367217E2CB100969984 /* RxSwift.framework */; };
 		1166A07A22119F720032CD4E /* EqualityFunctions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1166A07822119E640032CD4E /* EqualityFunctions.swift */; };
 		117DC0CD22AE492700EF65F0 /* Nimble.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8BA0F384217E2D3400969984 /* Nimble.framework */; };
@@ -746,6 +747,7 @@
 		11229804219DD2AB006D66C5 /* BowBrightFuturesTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = BowBrightFuturesTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		11229805219DD2AB006D66C5 /* Bow-BrightFuturesTests-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; name = "Bow-BrightFuturesTests-Info.plist"; path = "/Users/tomasruizlopez/Development/bow/Support Files/Bow-BrightFuturesTests-Info.plist"; sourceTree = "<absolute>"; };
 		1125054C220DD92B00861131 /* EquatableK.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EquatableK.swift; sourceTree = "<group>"; };
+		1126CA8922B1144200F840CB /* AutoOptics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoOptics.swift; sourceTree = "<group>"; };
 		1166A07822119E640032CD4E /* EqualityFunctions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EqualityFunctions.swift; sourceTree = "<group>"; };
 		117DC0D322AE492700EF65F0 /* BowEffectsGenerators.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = BowEffectsGenerators.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		117DC0D422AE492700EF65F0 /* Bow-Effects-Generators-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; name = "Bow-Effects-Generators-Info.plist"; path = "/Users/tomasruizlopez/Development/bow/Bow-Effects-Generators-Info.plist"; sourceTree = "<absolute>"; };
@@ -1353,6 +1355,14 @@
 			path = BowBrightFuturesTests;
 			sourceTree = "<group>";
 		};
+		1126CA8822B1139B00F840CB /* Auto */ = {
+			isa = PBXGroup;
+			children = (
+				1126CA8922B1144200F840CB /* AutoOptics.swift */,
+			);
+			path = Auto;
+			sourceTree = "<group>";
+		};
 		117DC0D522AE499E00EF65F0 /* BowEffectsGenerators */ = {
 			isa = PBXGroup;
 			children = (
@@ -1434,6 +1444,7 @@
 				8BA0F4C9217E2E9200969984 /* Prism.swift */,
 				8BA0F4C0217E2E9200969984 /* Setter.swift */,
 				8BA0F4B4217E2E9200969984 /* Traversal.swift */,
+				1126CA8822B1139B00F840CB /* Auto */,
 				8BA0F4CF217E2E9200969984 /* DSL */,
 				8BA0F4C1217E2E9200969984 /* Instances */,
 				8BA0F4B5217E2E9200969984 /* STD */,
@@ -3020,6 +3031,7 @@
 				11E7172C219D722900B94845 /* Try+Optics.swift in Sources */,
 				11E7172D219D722900B94845 /* Validated+Optics.swift in Sources */,
 				11E7172E219D722900B94845 /* At.swift in Sources */,
+				1126CA8A22B1144200F840CB /* AutoOptics.swift in Sources */,
 				11E7172F219D722900B94845 /* Each.swift in Sources */,
 				11E71730219D722900B94845 /* FilterIndex.swift in Sources */,
 				11E71731219D722900B94845 /* Index.swift in Sources */,

--- a/Bow.xcodeproj/project.pbxproj
+++ b/Bow.xcodeproj/project.pbxproj
@@ -481,6 +481,13 @@
 			remoteGlobalIDString = 112297D3219DD148006D66C5;
 			remoteInfo = "Bow-BrightFutures";
 		};
+		1126CA7C22AFBB6C00F840CB /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = OBJ_1 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 1120978222A7EBC7007F3D9C;
+			remoteInfo = "Bow-Generators";
+		};
 		117DC0B422AE492700EF65F0 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = OBJ_1 /* Project object */;
@@ -1911,6 +1918,7 @@
 			buildRules = (
 			);
 			dependencies = (
+				1126CA7D22AFBB6C00F840CB /* PBXTargetDependency */,
 				1122943E219D8C54006D66C5 /* PBXTargetDependency */,
 			);
 			name = BowLaws;
@@ -3275,6 +3283,11 @@
 			isa = PBXTargetDependency;
 			target = 112297D3219DD148006D66C5 /* Bow-BrightFutures */;
 			targetProxy = 11229807219DD31E006D66C5 /* PBXContainerItemProxy */;
+		};
+		1126CA7D22AFBB6C00F840CB /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 1120978222A7EBC7007F3D9C /* Bow-Generators */;
+			targetProxy = 1126CA7C22AFBB6C00F840CB /* PBXContainerItemProxy */;
 		};
 		117DC0B322AE492700EF65F0 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;

--- a/Bow.xcodeproj/project.pbxproj
+++ b/Bow.xcodeproj/project.pbxproj
@@ -113,6 +113,7 @@
 		1126CA8A22B1144200F840CB /* AutoOptics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1126CA8922B1144200F840CB /* AutoOptics.swift */; };
 		1126CA8C22B115E100F840CB /* AutoLens.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1126CA8B22B115E100F840CB /* AutoLens.swift */; };
 		1126CA8E22B1253D00F840CB /* AutoOptional.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1126CA8D22B1253D00F840CB /* AutoOptional.swift */; };
+		1126CA9022B1262F00F840CB /* AutoPrism.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1126CA8F22B1262F00F840CB /* AutoPrism.swift */; };
 		113CD8F4219DD82F00730E58 /* RxSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8BA0F367217E2CB100969984 /* RxSwift.framework */; };
 		1166A07A22119F720032CD4E /* EqualityFunctions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1166A07822119E640032CD4E /* EqualityFunctions.swift */; };
 		117DC0CD22AE492700EF65F0 /* Nimble.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8BA0F384217E2D3400969984 /* Nimble.framework */; };
@@ -752,6 +753,7 @@
 		1126CA8922B1144200F840CB /* AutoOptics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoOptics.swift; sourceTree = "<group>"; };
 		1126CA8B22B115E100F840CB /* AutoLens.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoLens.swift; sourceTree = "<group>"; };
 		1126CA8D22B1253D00F840CB /* AutoOptional.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoOptional.swift; sourceTree = "<group>"; };
+		1126CA8F22B1262F00F840CB /* AutoPrism.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoPrism.swift; sourceTree = "<group>"; };
 		1166A07822119E640032CD4E /* EqualityFunctions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EqualityFunctions.swift; sourceTree = "<group>"; };
 		117DC0D322AE492700EF65F0 /* BowEffectsGenerators.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = BowEffectsGenerators.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		117DC0D422AE492700EF65F0 /* Bow-Effects-Generators-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; name = "Bow-Effects-Generators-Info.plist"; path = "/Users/tomasruizlopez/Development/bow/Bow-Effects-Generators-Info.plist"; sourceTree = "<absolute>"; };
@@ -1365,6 +1367,7 @@
 				1126CA8B22B115E100F840CB /* AutoLens.swift */,
 				1126CA8922B1144200F840CB /* AutoOptics.swift */,
 				1126CA8D22B1253D00F840CB /* AutoOptional.swift */,
+				1126CA8F22B1262F00F840CB /* AutoPrism.swift */,
 			);
 			path = Auto;
 			sourceTree = "<group>";
@@ -3043,6 +3046,7 @@
 				11E7172F219D722900B94845 /* Each.swift in Sources */,
 				11E71730219D722900B94845 /* FilterIndex.swift in Sources */,
 				11E71731219D722900B94845 /* Index.swift in Sources */,
+				1126CA9022B1262F00F840CB /* AutoPrism.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Bow.xcodeproj/project.pbxproj
+++ b/Bow.xcodeproj/project.pbxproj
@@ -495,6 +495,13 @@
 			remoteGlobalIDString = 117DC0F722AE522000EF65F0;
 			remoteInfo = "Bow-BrightFuturesGenerators";
 		};
+		1126CA8222B0DE3F00F840CB /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = OBJ_1 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 117DC0B222AE492700EF65F0;
+			remoteInfo = "Bow-EffectsGenerators";
+		};
 		117DC0B422AE492700EF65F0 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = OBJ_1 /* Project object */;
@@ -2053,6 +2060,7 @@
 			buildRules = (
 			);
 			dependencies = (
+				1126CA8322B0DE3F00F840CB /* PBXTargetDependency */,
 				11D97EF1219EBBB4008FC004 /* PBXTargetDependency */,
 				11229785219DC95B006D66C5 /* PBXTargetDependency */,
 				11229749219DC88F006D66C5 /* PBXTargetDependency */,
@@ -3301,6 +3309,11 @@
 			isa = PBXTargetDependency;
 			target = 117DC0F722AE522000EF65F0 /* Bow-BrightFuturesGenerators */;
 			targetProxy = 1126CA8022B0DDD100F840CB /* PBXContainerItemProxy */;
+		};
+		1126CA8322B0DE3F00F840CB /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 117DC0B222AE492700EF65F0 /* Bow-EffectsGenerators */;
+			targetProxy = 1126CA8222B0DE3F00F840CB /* PBXContainerItemProxy */;
 		};
 		117DC0B322AE492700EF65F0 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;

--- a/Bow.xcodeproj/project.pbxproj
+++ b/Bow.xcodeproj/project.pbxproj
@@ -502,6 +502,13 @@
 			remoteGlobalIDString = 117DC0B222AE492700EF65F0;
 			remoteInfo = "Bow-EffectsGenerators";
 		};
+		1126CA8422B0DE9E00F840CB /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = OBJ_1 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 117DC10E22AE563900EF65F0;
+			remoteInfo = "Bow-FreeGenerators";
+		};
 		117DC0B422AE492700EF65F0 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = OBJ_1 /* Project object */;
@@ -1951,6 +1958,7 @@
 			buildRules = (
 			);
 			dependencies = (
+				1126CA8522B0DE9E00F840CB /* PBXTargetDependency */,
 				1122947E219D8E15006D66C5 /* PBXTargetDependency */,
 				11229442219D8DF3006D66C5 /* PBXTargetDependency */,
 				11229444219D8DF3006D66C5 /* PBXTargetDependency */,
@@ -3314,6 +3322,11 @@
 			isa = PBXTargetDependency;
 			target = 117DC0B222AE492700EF65F0 /* Bow-EffectsGenerators */;
 			targetProxy = 1126CA8222B0DE3F00F840CB /* PBXContainerItemProxy */;
+		};
+		1126CA8522B0DE9E00F840CB /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 117DC10E22AE563900EF65F0 /* Bow-FreeGenerators */;
+			targetProxy = 1126CA8422B0DE9E00F840CB /* PBXContainerItemProxy */;
 		};
 		117DC0B322AE492700EF65F0 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;

--- a/Bow.xcodeproj/project.pbxproj
+++ b/Bow.xcodeproj/project.pbxproj
@@ -112,6 +112,7 @@
 		1125054D220DD92B00861131 /* EquatableK.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1125054C220DD92B00861131 /* EquatableK.swift */; };
 		1126CA8A22B1144200F840CB /* AutoOptics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1126CA8922B1144200F840CB /* AutoOptics.swift */; };
 		1126CA8C22B115E100F840CB /* AutoLens.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1126CA8B22B115E100F840CB /* AutoLens.swift */; };
+		1126CA8E22B1253D00F840CB /* AutoOptional.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1126CA8D22B1253D00F840CB /* AutoOptional.swift */; };
 		113CD8F4219DD82F00730E58 /* RxSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8BA0F367217E2CB100969984 /* RxSwift.framework */; };
 		1166A07A22119F720032CD4E /* EqualityFunctions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1166A07822119E640032CD4E /* EqualityFunctions.swift */; };
 		117DC0CD22AE492700EF65F0 /* Nimble.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8BA0F384217E2D3400969984 /* Nimble.framework */; };
@@ -750,6 +751,7 @@
 		1125054C220DD92B00861131 /* EquatableK.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EquatableK.swift; sourceTree = "<group>"; };
 		1126CA8922B1144200F840CB /* AutoOptics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoOptics.swift; sourceTree = "<group>"; };
 		1126CA8B22B115E100F840CB /* AutoLens.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoLens.swift; sourceTree = "<group>"; };
+		1126CA8D22B1253D00F840CB /* AutoOptional.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoOptional.swift; sourceTree = "<group>"; };
 		1166A07822119E640032CD4E /* EqualityFunctions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EqualityFunctions.swift; sourceTree = "<group>"; };
 		117DC0D322AE492700EF65F0 /* BowEffectsGenerators.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = BowEffectsGenerators.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		117DC0D422AE492700EF65F0 /* Bow-Effects-Generators-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; name = "Bow-Effects-Generators-Info.plist"; path = "/Users/tomasruizlopez/Development/bow/Bow-Effects-Generators-Info.plist"; sourceTree = "<absolute>"; };
@@ -1360,8 +1362,9 @@
 		1126CA8822B1139B00F840CB /* Auto */ = {
 			isa = PBXGroup;
 			children = (
-				1126CA8922B1144200F840CB /* AutoOptics.swift */,
 				1126CA8B22B115E100F840CB /* AutoLens.swift */,
+				1126CA8922B1144200F840CB /* AutoOptics.swift */,
+				1126CA8D22B1253D00F840CB /* AutoOptional.swift */,
 			);
 			path = Auto;
 			sourceTree = "<group>";
@@ -3020,6 +3023,7 @@
 				11E7171E219D722900B94845 /* At+Optics.swift in Sources */,
 				11E7171F219D722900B94845 /* Each+Optics.swift in Sources */,
 				11E71720219D722900B94845 /* EitherOpticsInstances.swift in Sources */,
+				1126CA8E22B1253D00F840CB /* AutoOptional.swift in Sources */,
 				11E71721219D722900B94845 /* ArrayKOpticsInstances.swift in Sources */,
 				11E71722219D722900B94845 /* OptionOpticsInstances.swift in Sources */,
 				11E71723219D722900B94845 /* NonEmptyArrayOpticsInstances.swift in Sources */,

--- a/Bow.xcodeproj/project.pbxproj
+++ b/Bow.xcodeproj/project.pbxproj
@@ -111,6 +111,7 @@
 		112297FD219DD2AB006D66C5 /* BrightFutures.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8BA0F364217E2CB100969984 /* BrightFutures.framework */; };
 		1125054D220DD92B00861131 /* EquatableK.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1125054C220DD92B00861131 /* EquatableK.swift */; };
 		1126CA8A22B1144200F840CB /* AutoOptics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1126CA8922B1144200F840CB /* AutoOptics.swift */; };
+		1126CA8C22B115E100F840CB /* AutoLens.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1126CA8B22B115E100F840CB /* AutoLens.swift */; };
 		113CD8F4219DD82F00730E58 /* RxSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8BA0F367217E2CB100969984 /* RxSwift.framework */; };
 		1166A07A22119F720032CD4E /* EqualityFunctions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1166A07822119E640032CD4E /* EqualityFunctions.swift */; };
 		117DC0CD22AE492700EF65F0 /* Nimble.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8BA0F384217E2D3400969984 /* Nimble.framework */; };
@@ -748,6 +749,7 @@
 		11229805219DD2AB006D66C5 /* Bow-BrightFuturesTests-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; name = "Bow-BrightFuturesTests-Info.plist"; path = "/Users/tomasruizlopez/Development/bow/Support Files/Bow-BrightFuturesTests-Info.plist"; sourceTree = "<absolute>"; };
 		1125054C220DD92B00861131 /* EquatableK.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EquatableK.swift; sourceTree = "<group>"; };
 		1126CA8922B1144200F840CB /* AutoOptics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoOptics.swift; sourceTree = "<group>"; };
+		1126CA8B22B115E100F840CB /* AutoLens.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoLens.swift; sourceTree = "<group>"; };
 		1166A07822119E640032CD4E /* EqualityFunctions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EqualityFunctions.swift; sourceTree = "<group>"; };
 		117DC0D322AE492700EF65F0 /* BowEffectsGenerators.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = BowEffectsGenerators.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		117DC0D422AE492700EF65F0 /* Bow-Effects-Generators-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; name = "Bow-Effects-Generators-Info.plist"; path = "/Users/tomasruizlopez/Development/bow/Bow-Effects-Generators-Info.plist"; sourceTree = "<absolute>"; };
@@ -1359,6 +1361,7 @@
 			isa = PBXGroup;
 			children = (
 				1126CA8922B1144200F840CB /* AutoOptics.swift */,
+				1126CA8B22B115E100F840CB /* AutoLens.swift */,
 			);
 			path = Auto;
 			sourceTree = "<group>";
@@ -3032,6 +3035,7 @@
 				11E7172D219D722900B94845 /* Validated+Optics.swift in Sources */,
 				11E7172E219D722900B94845 /* At.swift in Sources */,
 				1126CA8A22B1144200F840CB /* AutoOptics.swift in Sources */,
+				1126CA8C22B115E100F840CB /* AutoLens.swift in Sources */,
 				11E7172F219D722900B94845 /* Each.swift in Sources */,
 				11E71730219D722900B94845 /* FilterIndex.swift in Sources */,
 				11E71731219D722900B94845 /* Index.swift in Sources */,

--- a/Bow.xcodeproj/project.pbxproj
+++ b/Bow.xcodeproj/project.pbxproj
@@ -509,6 +509,13 @@
 			remoteGlobalIDString = 117DC10E22AE563900EF65F0;
 			remoteInfo = "Bow-FreeGenerators";
 		};
+		1126CA8622B0DF2B00F840CB /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = OBJ_1 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 117DC0DC22AE4D6C00EF65F0;
+			remoteInfo = "Bow-RxGenerators";
+		};
 		117DC0B422AE492700EF65F0 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = OBJ_1 /* Project object */;
@@ -2109,6 +2116,7 @@
 			buildRules = (
 			);
 			dependencies = (
+				1126CA8722B0DF2B00F840CB /* PBXTargetDependency */,
 				11D97EF4219EBC54008FC004 /* PBXTargetDependency */,
 				112297D0219DCFF9006D66C5 /* PBXTargetDependency */,
 				112297B4219DCFDE006D66C5 /* PBXTargetDependency */,
@@ -3327,6 +3335,11 @@
 			isa = PBXTargetDependency;
 			target = 117DC10E22AE563900EF65F0 /* Bow-FreeGenerators */;
 			targetProxy = 1126CA8422B0DE9E00F840CB /* PBXContainerItemProxy */;
+		};
+		1126CA8722B0DF2B00F840CB /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 117DC0DC22AE4D6C00EF65F0 /* Bow-RxGenerators */;
+			targetProxy = 1126CA8622B0DF2B00F840CB /* PBXContainerItemProxy */;
 		};
 		117DC0B322AE492700EF65F0 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;

--- a/Sources/Bow/Arrow/Cokleisli.swift
+++ b/Sources/Bow/Arrow/Cokleisli.swift
@@ -14,7 +14,7 @@ public typealias CoreaderT<F, A, B> = Cokleisli<F, A, B>
 
 /// Cokleisli represents a function with the signature `(Kind<F, A>) -> B`.
 public class Cokleisli<F, A, B>: CokleisliOf<F, A, B> {
-    internal let run: (Kind<F, A>) -> B
+    public let run: (Kind<F, A>) -> B
 
     /// Safe downcast.
     ///

--- a/Sources/Bow/Data/Option.swift
+++ b/Sources/Bow/Data/Option.swift
@@ -48,7 +48,8 @@ public final class Option<A>: OptionOf<A> {
         return fa as! Option<A>
     }
 
-    internal var isDefined: Bool {
+    /// Checks if this option contains a value
+    public var isDefined: Bool {
         return !isEmpty
     }
 

--- a/Sources/Bow/Data/Option.swift
+++ b/Sources/Bow/Data/Option.swift
@@ -257,7 +257,7 @@ extension Option: Semigroup where A: Semigroup {
 // MARK: Instance of `Monoid` for `Option`, provided that `A` has an instance of `Monoid`.
 extension Option: Monoid where A: Monoid {
     public static func empty() -> Option<A> {
-        return Option(A.empty())
+        return Option.none()
     }
 }
 

--- a/Sources/Bow/Data/Try.swift
+++ b/Sources/Bow/Data/Try.swift
@@ -299,7 +299,7 @@ extension ForTry: FunctorFilter {
 extension Try: Semigroup where A: Semigroup {
     public func combine(_ other: Try<A>) -> Try<A> {
         return self.fold(constant(other),
-                         { a in other.fold(Try.failure,
+                         { a in other.fold(constant(Try.success(a)),
                                            { b in Try.success(a.combine(b)) })
                          })
     }

--- a/Sources/Bow/Data/Try.swift
+++ b/Sources/Bow/Data/Try.swift
@@ -308,6 +308,6 @@ extension Try: Semigroup where A: Semigroup {
 // MARK: Instance of `Monoid` for `Try`
 extension Try: Monoid where A: Monoid {
     public static func empty() -> Try<A> {
-        return Try.success(A.empty())
+        return Try.failure(TryError.illegalState)
     }
 }

--- a/Sources/BowOptics/Auto/AutoLens.swift
+++ b/Sources/BowOptics/Auto/AutoLens.swift
@@ -1,0 +1,13 @@
+/// Protocol for automatic derivation of lenses
+public protocol AutoLens: AutoOptics {}
+
+public extension AutoLens {
+    /// Generates a Lens for the field indicated by its key path.
+    ///
+    /// - Parameter path: Key path identifying the field where the Lens focuses.
+    /// - Returns: A Lens focusing in the field.
+    static func lens<T>(for path: WritableKeyPath<Self, T>) -> Lens<Self, T> {
+        return Lens<Self, T>(get: { whole in whole[keyPath: path] },
+                             set: { whole, part in whole.copy(with: part, for: path) })
+    }
+}

--- a/Sources/BowOptics/Auto/AutoLens.swift
+++ b/Sources/BowOptics/Auto/AutoLens.swift
@@ -1,4 +1,4 @@
-/// Protocol for automatic derivation of lenses
+/// Protocol for automatic derivation of lenses.
 public protocol AutoLens: AutoOptics {}
 
 public extension AutoLens {

--- a/Sources/BowOptics/Auto/AutoOptics.swift
+++ b/Sources/BowOptics/Auto/AutoOptics.swift
@@ -1,4 +1,4 @@
-/// Base protocol for optics automatic derivation
+/// Base protocol for optics automatic derivation.
 public protocol AutoOptics {}
 
 public extension AutoOptics {

--- a/Sources/BowOptics/Auto/AutoOptics.swift
+++ b/Sources/BowOptics/Auto/AutoOptics.swift
@@ -1,0 +1,16 @@
+/// Base protocol for optics automatic derivation
+public protocol AutoOptics {}
+
+public extension AutoOptics {
+    /// Creates a copy of this object, replacing the value at the given key path by the provided value.
+    ///
+    /// - Parameters:
+    ///   - value: New value for the field in the copy.
+    ///   - path: Key path of the field that will be modified in the copy.
+    /// - Returns: A copy of this value with the modified field.
+    func copy<T>(with value: T, for path: WritableKeyPath<Self, T>) -> Self {
+        var copy = self
+        copy[keyPath: path] = value
+        return copy
+    }
+}

--- a/Sources/BowOptics/Auto/AutoOptional.swift
+++ b/Sources/BowOptics/Auto/AutoOptional.swift
@@ -1,0 +1,26 @@
+import Bow
+
+/// Protocol for automatic derivation of Optional optics.
+public protocol AutoOptional: AutoOptics {}
+
+public extension AutoOptional {
+    /// Generates an Optional optic that focuses on a nilable field.
+    ///
+    /// - Parameter path: Key path to a nilable field.
+    /// - Returns: An Optional optic focusing on the provided field.
+    static func optional<T>(for path: WritableKeyPath<Self, T?>) -> Optional<Self, T> {
+        return Optional<Self, T>(set: { whole, part in whole.copy(with: part, for: path) },
+                                 getOrModify: { whole in Option.fromOptional(whole[keyPath: path])
+                                    .fold({ Either.left(whole) }, Either.right) })
+    }
+    
+    /// Generates an Optional optic that focuses on an Option field.
+    ///
+    /// - Parameter path: Key path to an Option field.
+    /// - Returns: An Optional optic focusing on the provided field.
+    static func optional<T>(for path: WritableKeyPath<Self, Option<T>>) -> Optional<Self, T> {
+        return Optional<Self, T>(set: { whole, part in whole.copy(with: .some(part), for: path) },
+                                 getOrModify: { whole in whole[keyPath: path]
+                                    .fold({ Either.left(whole) }, Either.right) })
+    }
+}

--- a/Sources/BowOptics/Auto/AutoPrism.swift
+++ b/Sources/BowOptics/Auto/AutoPrism.swift
@@ -1,0 +1,30 @@
+import Bow
+
+/// Protocol for automatic derivation of Prism optics.
+public protocol AutoPrism: AutoOptics {}
+
+public extension AutoPrism {
+    /// Generates a prism for an enum case with no associated values.
+    ///
+    /// - Parameter case: Case where the Prism must focus.
+    /// - Returns: A Prism focusing on the provided case.
+    static func prism(for case: Self) -> Prism<Self, ()> {
+        return Prism<Self, ()>(getOrModify: { whole in (String(describing: whole) == String(describing: `case`)) ? Either.right(()) : Either.left(whole) },
+                               reverseGet: { _ in `case` })
+    }
+    
+    /// Generates a prism for an enum case with associated values.
+    ///
+    /// - Parameters:
+    ///   - constructor: Constructor for the case with associated values.
+    ///   - matching: Closure that matches the focused case of this prism and returns its associated values.
+    /// - Returns: A Prism focusing on the provided case.
+    static func prism<A>(for constructor: @escaping (A) -> Self, matching: @escaping (Self) -> A?) -> Prism<Self, A> {
+        return prism(for: constructor, matching: matching >>> Option.fromOptional)
+    }
+    
+    private static func prism<A>(for constructor: @escaping (A) -> Self, matching: @escaping (Self) -> Option<A>) -> Prism<Self, A> {
+        return Prism<Self, A>(getOrModify: { whole in matching(whole).fold({ Either.left(whole) }, Either.right) },
+                              reverseGet: constructor)
+    }
+}

--- a/Tests/BowBrightFuturesTests/FutureKTest.swift
+++ b/Tests/BowBrightFuturesTests/FutureKTest.swift
@@ -1,15 +1,16 @@
 import XCTest
 import BrightFutures
 @testable import BowLaws
-@testable import Bow
-@testable import BowBrightFutures
+import Bow
+import BowBrightFutures
+import BowBrightFuturesGenerators
 @testable import BowEffectsLaws
 
 private let forcedFutureQueue = DispatchQueue(label: "forcedFutureQueue", attributes: .concurrent)
 
 extension Future {
     private func forcedFuture(createFuture: @escaping () -> Future<T, E>) -> Either<E, T> {
-        var result : Future<T, E>?
+        var result: Future<T, E>?
         let sem = DispatchSemaphore(value: 0)
         forcedFutureQueue.async {
             result = createFuture()
@@ -34,14 +35,8 @@ extension FutureKPartial: EquatableK where E: Equatable {
 }
 
 class FutureKTest: XCTestCase {
-    let generator = { (x: Int) -> FutureKOf<CategoryError, Int> in
-        (x % 2 == 0) ?
-            FutureK.pure(x) :
-            FutureK.raiseError(CategoryError.arbitrary.generate)
-    }
-
     func testFunctorLaws() {
-        FunctorLaws<FutureKPartial<CategoryError>>.check(generator: self.generator)
+        FunctorLaws<FutureKPartial<CategoryError>>.check()
     }
     
     func testApplicativeLaws() {

--- a/Tests/BowEffectsTests/IOTest.swift
+++ b/Tests/BowEffectsTests/IOTest.swift
@@ -1,20 +1,18 @@
 import XCTest
 import SwiftCheck
 @testable import BowLaws
-@testable import Bow
-@testable import BowEffects
+import Bow
+import BowEffects
+import BowEffectsGenerators
 @testable import BowEffectsLaws
 
 class IOTest: XCTestCase {
-    
-    let generator = { (a : Int) in IO<CategoryError, Int>.pure(a) }
-
     func testEquatableLaws() {
-        EquatableKLaws.check(generator: self.generator)
+        EquatableKLaws<IOPartial<CategoryError>, Int>.check()
     }
     
     func testFunctorLaws() {
-        FunctorLaws<IOPartial<CategoryError>>.check(generator: self.generator)
+        FunctorLaws<IOPartial<CategoryError>>.check()
     }
     
     func testApplicativeLaws() {

--- a/Tests/BowFreeTests/FreeTest.swift
+++ b/Tests/BowFreeTests/FreeTest.swift
@@ -1,6 +1,7 @@
 import XCTest
-@testable import Bow
-@testable import BowFree
+import Bow
+import BowFree
+import BowFreeGenerators
 @testable import BowLaws
 
 fileprivate final class ForOps {}
@@ -113,12 +114,8 @@ class FreeTest: XCTestCase {
         XCTAssertEqual(y, Id.pure(-30))
     }
     
-    fileprivate var generator: (Int) -> FreeOf<ForId, Int> {
-        return { a in Free.liftF(Id(a)) }
-    }
-    
     func testFunctorLaws() {
-        FunctorLaws<FreePartial<ForId>>.check(generator: self.generator)
+        FunctorLaws<FreePartial<ForId>>.check()
     }
     
     func testApplicativeLaws() {

--- a/Tests/BowGenerators/Arrow/Kleisli+Gen.swift
+++ b/Tests/BowGenerators/Arrow/Kleisli+Gen.swift
@@ -13,6 +13,7 @@ extension Kleisli: Arbitrary where F: ArbitraryK, A: Arbitrary {
 
 extension KleisliPartial: ArbitraryK where F: ArbitraryK {
     public static func generate<A: Arbitrary>() -> Kind<KleisliPartial<F, D>, A> {
-        return Kleisli { _ in F.generate() }
+        let x: Kind<F, A> = F.generate()
+        return Kleisli { _ in x }
     }
 }

--- a/Tests/BowGenerators/Transformers/StateT+Gen.swift
+++ b/Tests/BowGenerators/Transformers/StateT+Gen.swift
@@ -13,7 +13,8 @@ extension StateT: Arbitrary where F: ArbitraryK & Applicative, S: Arbitrary, A: 
 
 extension StateTPartial: ArbitraryK where F: ArbitraryK & Applicative, S: Arbitrary {
     public static func generate<A: Arbitrary>() -> Kind<StateTPartial<F, S>, A> {
-        let f: (S) -> Kind<F, (S, A)> = { s in F.pure((s, A.arbitrary.generate)) }
+        let a = A.arbitrary.generate
+        let f: (S) -> Kind<F, (S, A)> = { s in F.pure((s, a)) }
         return StateT(F.pure(f))
     }
 }

--- a/Tests/BowLaws/AlternativeLaws.swift
+++ b/Tests/BowLaws/AlternativeLaws.swift
@@ -1,8 +1,8 @@
 import SwiftCheck
-@testable import Bow
+import Bow
+import BowGenerators
 
-class AlternativeLaws<F: Alternative & EquatableK> {
-    
+class AlternativeLaws<F: Alternative & EquatableK & ArbitraryK> {
     public static func check()  {
         rightAbsorption()
         leftDistributivity()
@@ -10,25 +10,25 @@ class AlternativeLaws<F: Alternative & EquatableK> {
     }
     
     private static func rightAbsorption() {
-        property("Right absorption") <- forAll { (f: ArrowOf<Int, Int>) in
-            return F.ap(F.emptyK(), F.pure(f.getArrow)) ==
+        property("Right absorption") <- forAll { (ff: KindOf<F, ArrowOf<Int, Int>>) in
+            return F.ap(F.emptyK(), ff.value) ==
                 F.emptyK() as Kind<F, Int>
         }
     }
     
     private static func leftDistributivity() {
-        property("Left distributivity") <- forAll { (x: Int, y: Int, f: ArrowOf<Int, Int>) in
-            return F.map(F.combineK(F.pure(x), F.pure(y)), f.getArrow) ==
-                F.combineK(F.map(F.pure(x), f.getArrow), F.map(F.pure(y), f.getArrow))
+        property("Left distributivity") <- forAll { (fx: KindOf<F, Int>, fy: KindOf<F, Int>, f: ArrowOf<Int, Int>) in
+            return F.map(F.combineK(fx.value, fy.value), f.getArrow) ==
+                F.combineK(F.map(fx.value, f.getArrow), F.map(fy.value, f.getArrow))
         }
     }
     
     private static func rightDistributivity() {
-        property("Left distributivity") <- forAll { (x: Int, f: ArrowOf<Int, Int>, g: ArrowOf<Int, Int>) in
+        property("Left distributivity") <- forAll { (fx: KindOf<F, Int>, f: ArrowOf<Int, Int>, g: ArrowOf<Int, Int>) in
             return F.ap(F.combineK(F.pure(f.getArrow), F.pure(g.getArrow)),
-                        F.pure(x)) ==
-                F.combineK(F.ap(F.pure(f.getArrow), F.pure(x)),
-                           F.ap(F.pure(g.getArrow), F.pure(x)))
+                        fx.value) ==
+                F.combineK(F.ap(F.pure(f.getArrow), fx.value),
+                           F.ap(F.pure(g.getArrow), fx.value))
         }
     }
 }

--- a/Tests/BowLaws/ApplicativeErrorLaws.swift
+++ b/Tests/BowLaws/ApplicativeErrorLaws.swift
@@ -1,9 +1,9 @@
 import Foundation
 import SwiftCheck
-@testable import Bow
+import Bow
+import BowGenerators
 
 class ApplicativeErrorLaws<F: ApplicativeError & EquatableK> where F.E: Equatable, F.E: Arbitrary {
-    
     static func check()  {
         handle()
         handleWith()

--- a/Tests/BowLaws/ApplicativeErrorLaws.swift
+++ b/Tests/BowLaws/ApplicativeErrorLaws.swift
@@ -1,4 +1,3 @@
-import Foundation
 import SwiftCheck
 import Bow
 import BowGenerators
@@ -49,8 +48,7 @@ class ApplicativeErrorLaws<F: ApplicativeError & EquatableK> where F.E: Equatabl
     }
     
     private static func attemptFromEitherConsistentWithPure() {
-        property("Attempt from either consistent with pure") <- forAll { (b: Int, a: F.E) in
-            let either = arc4random_uniform(2) == 0 ? Either.left(a) : Either.right(b)
+        property("Attempt from either consistent with pure") <- forAll { (either: Either<F.E, Int>) in
             return F.attempt(F.fromEither(either)) == F.pure(either)
         }
     }

--- a/Tests/BowLaws/ApplicativeLaws.swift
+++ b/Tests/BowLaws/ApplicativeLaws.swift
@@ -1,9 +1,9 @@
 import Foundation
 import SwiftCheck
-@testable import Bow
+import Bow
+import BowGenerators
 
-class ApplicativeLaws<F: Applicative & EquatableK> {
-    
+class ApplicativeLaws<F: Applicative & EquatableK & ArbitraryK> {
     static func check() {
         apIdentity()
         homomorphism()
@@ -15,8 +15,8 @@ class ApplicativeLaws<F: Applicative & EquatableK> {
     }
     
     private static func apIdentity() {
-        property("ap identity") <- forAll() { (a: Int) in
-            return F.ap(F.pure(id), F.pure(a)) == F.pure(a)
+        property("ap identity") <- forAll() { (fa: KindOf<F, Int>) in
+            return F.ap(F.pure(id), fa.value) == fa.value
         }
     }
     
@@ -34,9 +34,8 @@ class ApplicativeLaws<F: Applicative & EquatableK> {
     }
     
     private static func mapDerived() {
-        property("mad derived") <- forAll() { (a: Int, f: ArrowOf<Int, Int>) in
-            let fa = F.pure(a)
-            return F.map(fa, f.getArrow) == F.ap(F.pure(f.getArrow), fa)
+        property("mad derived") <- forAll() { (fa: KindOf<F, Int>, f: ArrowOf<Int, Int>) in
+            return F.map(fa.value, f.getArrow) == F.ap(F.pure(f.getArrow), fa.value)
         }
     }
     

--- a/Tests/BowLaws/BimonadLaws.swift
+++ b/Tests/BowLaws/BimonadLaws.swift
@@ -2,7 +2,6 @@ import Bow
 import BowGenerators
 
 class BimonadLaws<F: Bimonad & EquatableK & ArbitraryK> {
-    
     static func check() {
         MonadLaws<F>.check()
         ComonadLaws<F>.check()

--- a/Tests/BowLaws/BimonadLaws.swift
+++ b/Tests/BowLaws/BimonadLaws.swift
@@ -1,9 +1,10 @@
-@testable import Bow
+import Bow
+import BowGenerators
 
-class BimonadLaws<F: Bimonad & EquatableK> {
+class BimonadLaws<F: Bimonad & EquatableK & ArbitraryK> {
     
-    static func check(generator: @escaping (Int) -> Kind<F, Int>) {
+    static func check() {
         MonadLaws<F>.check()
-        ComonadLaws<F>.check(generator: generator)
+        ComonadLaws<F>.check()
     }
 }

--- a/Tests/BowLaws/ComonadLaws.swift
+++ b/Tests/BowLaws/ComonadLaws.swift
@@ -1,68 +1,61 @@
 import Foundation
 import SwiftCheck
-@testable import Bow
+import Bow
+import BowGenerators
 
-class ComonadLaws<F: Comonad & EquatableK> {
-    
-    static func check(generator: @escaping (Int) -> Kind<F, Int>) {
-        duplicateThenExtractIsId(generator)
-        duplicateThenMapExtractIsId(generator)
-        mapAndCoflatMapCoherence(generator)
-        leftIdentity(generator)
-        rightIdentity(generator)
-        cokleisliLeftIdentity(generator)
-        cokleisliRightIdentity(generator)
+class ComonadLaws<F: Comonad & EquatableK & ArbitraryK> {
+    static func check() {
+        duplicateThenExtractIsId()
+        duplicateThenMapExtractIsId()
+        mapAndCoflatMapCoherence()
+        leftIdentity()
+        rightIdentity()
+        cokleisliLeftIdentity()
+        cokleisliRightIdentity()
     }
     
-    private static func duplicateThenExtractIsId(_ generator: @escaping (Int) -> Kind<F, Int>) {
-        property("Duplicate then extract is equivalent to id") <- forAll { (a: Int) in
-            let fa = generator(a)
-            return F.extract(F.duplicate(fa)) == fa
+    private static func duplicateThenExtractIsId() {
+        property("Duplicate then extract is equivalent to id") <- forAll { (fa: KindOf<F, Int>) in
+            return F.extract(F.duplicate(fa.value)) == fa.value
         }
     }
     
-    private static func duplicateThenMapExtractIsId(_ generator: @escaping (Int) -> Kind<F, Int>) {
-        property("Duplicate then map extract is equivalent to id") <- forAll { (a: Int) in
-            let fa = generator(a)
-            return F.map(F.duplicate(fa), F.extract) == fa
+    private static func duplicateThenMapExtractIsId() {
+        property("Duplicate then map extract is equivalent to id") <- forAll { (fa: KindOf<F, Int>) in
+            return F.map(F.duplicate(fa.value), F.extract) == fa.value
         }
     }
     
-    private static func mapAndCoflatMapCoherence(_ generator: @escaping (Int) -> Kind<F, Int>) {
-        property("map and coflatMap coherence") <- forAll { (a: Int, f: ArrowOf<Int, Int>) in
-            let fa = generator(a)
-            return F.map(fa, f.getArrow) == F.coflatMap(fa, { a in f.getArrow(F.extract(a)) })
+    private static func mapAndCoflatMapCoherence() {
+        property("map and coflatMap coherence") <- forAll { (fa: KindOf<F, Int>, f: ArrowOf<Int, Int>) in
+            return F.map(fa.value, f.getArrow) == F.coflatMap(fa.value, { a in f.getArrow(F.extract(a)) })
         }
     }
     
-    private static func leftIdentity(_ generator: @escaping (Int) -> Kind<F, Int>) {
-        property("Left identity") <- forAll { (a: Int) in
-            let fa = generator(a)
-            return F.coflatMap(fa, F.extract) == fa
+    private static func leftIdentity() {
+        property("Left identity") <- forAll { (fa: KindOf<F, Int>) in
+            return F.coflatMap(fa.value, F.extract) == fa.value
         }
     }
     
-    private static func rightIdentity(_ generator: @escaping (Int) -> Kind<F, Int>) {
-        property("Right identity") <- forAll { (a: Int, b: Int) in
-            let fa = generator(a)
-            let f = { (_ : Kind<F, Int>) in generator(b) }
-            return F.extract(F.coflatMap(fa, f)) == f(fa)
+    private static func rightIdentity() {
+        property("Right identity") <- forAll { (fa: KindOf<F, Int>, fb: KindOf<F, Int>) in
+            let f = { (_ : Kind<F, Int>) in fb.value }
+            return F.extract(F.coflatMap(fa.value, f)) == f(fa.value)
         }
     }
     
-    private static func cokleisliLeftIdentity(_ generator: @escaping (Int) -> Kind<F, Int>) {
-        property("Cokleisli left identity") <- forAll { (a: Int, b: Int) in
-            let fa = generator(a)
-            let f = { (_: Kind<F, Int>) in generator(b) }
-            return Cokleisli(F.extract).andThen(Cokleisli(f)).run(fa) == f(fa)
+    private static func cokleisliLeftIdentity() {
+        property("Cokleisli left identity") <- forAll { (fa: KindOf<F, Int>, fb: KindOf<F, Int>) in
+            let f = { (_: Kind<F, Int>) in fb.value }
+            return Cokleisli(F.extract).andThen(Cokleisli(f)).run(fa.value) == f(fa.value)
         }
     }
     
-    private static func cokleisliRightIdentity(_ generator: @escaping (Int) -> Kind<F, Int>) {
-        property("Cokleisli right identity") <- forAll { (a: Int, b: Int) in
-            let fa = generator(a)
-            let f = { (_: Kind<F, Int>) in generator(b) }
-            return Cokleisli(f).andThen(Cokleisli(F.extract)).run(fa) == f(fa)
+    private static func cokleisliRightIdentity() {
+        property("Cokleisli right identity") <- forAll { (fa: KindOf<F, Int>, fb: KindOf<F, Int>) in
+            let f = { (_: Kind<F, Int>) in fb.value }
+            return Cokleisli(f).andThen(Cokleisli(F.extract)).run(fa.value) == f(fa.value)
         }
     }
 }

--- a/Tests/BowLaws/ComonadLaws.swift
+++ b/Tests/BowLaws/ComonadLaws.swift
@@ -1,4 +1,3 @@
-import Foundation
 import SwiftCheck
 import Bow
 import BowGenerators

--- a/Tests/BowLaws/ComparableLaws.swift
+++ b/Tests/BowLaws/ComparableLaws.swift
@@ -1,6 +1,5 @@
-import Foundation
 import SwiftCheck
-@testable import Bow
+import Bow
 
 class ComparableLaws<A: Comparable & Arbitrary> {
     

--- a/Tests/BowLaws/ContravariantLaws.swift
+++ b/Tests/BowLaws/ContravariantLaws.swift
@@ -1,26 +1,26 @@
 import Foundation
 import SwiftCheck
-@testable import Bow
+import Bow
+import BowGenerators
 
-class ContravariantLaws<F: Contravariant & EquatableK> {
+class ContravariantLaws<F: Contravariant & EquatableK & ArbitraryK> {
     
     static func check(generator: @escaping (Int) -> Kind<F, Int>) {
         InvariantLaws.check(generator: generator)
-        identity(generator)
-        composition(generator)
+        identity()
+        composition()
     }
     
-    private static func identity(_ generator: @escaping (Int) -> Kind<F, Int>) {
-            property("Identity") <- forAll { (a: Int) in
-                let fa = generator(a)
-                return F.contramap(fa, id) == id(fa)
-            }
+    private static func identity() {
+        property("Identity") <- forAll { (fa: KindOf<F, Int>) in
+            return F.contramap(fa.value, id) == id(fa.value)
+        }
     }
     
-    private static func composition(_ generator: @escaping (Int) -> Kind<F, Int>) {
-            property("Composition") <- forAll { (a: Int, f: ArrowOf<Int, Int>, g: ArrowOf<Int, Int>) in
-                let fa = generator(a)
-                return F.contramap(F.contramap(fa, f.getArrow), g.getArrow) == F.contramap(fa, f.getArrow <<< g.getArrow)
-            }
+    private static func composition() {
+        property("Composition") <- forAll { (fa: KindOf<F, Int>, f: ArrowOf<Int, Int>, g: ArrowOf<Int, Int>) in
+            return F.contramap(F.contramap(fa.value, f.getArrow), g.getArrow) ==
+                F.contramap(fa.value, f.getArrow <<< g.getArrow)
+        }
     }
 }

--- a/Tests/BowLaws/ContravariantLaws.swift
+++ b/Tests/BowLaws/ContravariantLaws.swift
@@ -1,4 +1,3 @@
-import Foundation
 import SwiftCheck
 import Bow
 import BowGenerators

--- a/Tests/BowLaws/ContravariantLaws.swift
+++ b/Tests/BowLaws/ContravariantLaws.swift
@@ -5,8 +5,8 @@ import BowGenerators
 
 class ContravariantLaws<F: Contravariant & EquatableK & ArbitraryK> {
     
-    static func check(generator: @escaping (Int) -> Kind<F, Int>) {
-        InvariantLaws.check(generator: generator)
+    static func check() {
+        InvariantLaws<F>.check()
         identity()
         composition()
     }

--- a/Tests/BowLaws/CustomStringConvertibleLaws.swift
+++ b/Tests/BowLaws/CustomStringConvertibleLaws.swift
@@ -1,5 +1,5 @@
 import SwiftCheck
-@testable import Bow
+import Bow
 
 class CustomStringConvertibleLaws<A: CustomStringConvertible & Arbitrary> {
     static func check(){

--- a/Tests/BowLaws/CustomStringConvertibleLaws.swift
+++ b/Tests/BowLaws/CustomStringConvertibleLaws.swift
@@ -1,15 +1,15 @@
 import SwiftCheck
 @testable import Bow
 
-class CustomStringConvertibleLaws<A: CustomStringConvertible> {
-    static func check(generator : @escaping (Int) -> A){
-        equality(generator)
+class CustomStringConvertibleLaws<A: CustomStringConvertible & Arbitrary> {
+    static func check(){
+        equality()
     }
     
-    private static func equality(_ generator: @escaping (Int) -> A) {
-        property("Equal objects must show equal content") <- forAll { (a : Int) in
-            let x1 = generator(a)
-            let x2 = generator(a)
+    private static func equality() {
+        property("Equal objects must show equal content") <- forAll { (a: A) in
+            let x1 = a
+            let x2 = a
             return x1.description == x2.description
         }
     }

--- a/Tests/BowLaws/EqualityFunctions.swift
+++ b/Tests/BowLaws/EqualityFunctions.swift
@@ -1,4 +1,3 @@
-import Foundation
 import Bow
 
 func isEqual<F: EquatableK & Functor>(_ fa: Kind<F, ()>, _ fb: Kind<F, ()>) -> Bool {

--- a/Tests/BowLaws/EquatableKLaws.swift
+++ b/Tests/BowLaws/EquatableKLaws.swift
@@ -1,4 +1,3 @@
-import Foundation
 import SwiftCheck
 import Bow
 import BowGenerators

--- a/Tests/BowLaws/EquatableKLaws.swift
+++ b/Tests/BowLaws/EquatableKLaws.swift
@@ -1,26 +1,24 @@
 import Foundation
 import SwiftCheck
-@testable import Bow
+import Bow
+import BowGenerators
 
-class EquatableKLaws<F: EquatableK, A: Arbitrary & Equatable> {
+class EquatableKLaws<F: EquatableK & ArbitraryK, A: Arbitrary & Equatable> {
     
-    static func check(generator: @escaping (A) -> Kind<F, A>) {
-        identityInEquality(generator: generator)
-        commutativityInEquality(generator: generator)
+    static func check() {
+        identityInEquality()
+        commutativityInEquality()
     }
     
-    private static func identityInEquality(generator: @escaping (A) -> Kind<F, A>) {
-        property("Identity: Every object is equal to itself") <- forAll() { (a : A) in
-            let fa = generator(a)
-            return fa == fa
+    private static func identityInEquality() {
+        property("Identity: Every object is equal to itself") <- forAll() { (fa: KindOf<F, A>) in
+            return fa.value == fa.value
         }
     }
     
-    private static func commutativityInEquality(generator: @escaping (A) -> Kind<F, A>) {
-        property("Equality is commutative") <- forAll() { (a : A, b : A) in
-            let fa = generator(a)
-            let fb = generator(b)
-            return (fa == fb) == (fb == fa)
+    private static func commutativityInEquality() {
+        property("Equality is commutative") <- forAll() { (fa: KindOf<F, A>, fb: KindOf<F, A>) in
+            return (fa.value == fb.value) == (fb.value == fa.value)
         }
     }
 }

--- a/Tests/BowLaws/EquatableLaws.swift
+++ b/Tests/BowLaws/EquatableLaws.swift
@@ -1,6 +1,5 @@
-import Foundation
 import SwiftCheck
-@testable import Bow
+import Bow
 
 class EquatableLaws<A: Equatable & Arbitrary> {
     static func check() {

--- a/Tests/BowLaws/FunctorFilterLaws.swift
+++ b/Tests/BowLaws/FunctorFilterLaws.swift
@@ -1,28 +1,25 @@
 import Foundation
 import SwiftCheck
-@testable import Bow
+import Bow
+import BowGenerators
 
-class FunctorFilterLaws<F: FunctorFilter & EquatableK> {
+class FunctorFilterLaws<F: FunctorFilter & EquatableK & ArbitraryK> {
     
-    static func check(generator: @escaping (Int) -> Kind<F, Int>) {
-        mapFilterComposition(generator)
-        mapFilterMapConsistency(generator)
+    static func check() {
+        mapFilterComposition()
+        mapFilterMapConsistency()
     }
     
-    private static func mapFilterComposition(_ generator: @escaping (Int) -> Kind<F, Int>) {
-        property("MapFilter composition") <- forAll { (a: Int, b: Int, c: Int) in
-            let fa = generator(a)
-            let f: (Int) -> Option<Int> = arc4random_uniform(2) == 0 ? { _ in Option.some(b) } : { _ in Option<Int>.none() }
-            let g: (Int) -> Option<Int> = arc4random_uniform(2) == 0 ? { _ in Option.some(c) } : { _ in Option<Int>.none() }
-            return F.mapFilter(F.mapFilter(fa, f), g) == F.mapFilter(fa, { x in f(x).flatMap(g) })
+    private static func mapFilterComposition() {
+        property("MapFilter composition") <- forAll { (fa: KindOf<F, Int>, f: ArrowOf<Int, Option<Int>>, g: ArrowOf<Int, Option<Int>>) in
+            return F.mapFilter(F.mapFilter(fa.value, f.getArrow), g.getArrow) == F.mapFilter(fa.value, { x in f.getArrow(x).flatMap(g.getArrow) })
         }
     }
     
-    private static func mapFilterMapConsistency(_ generator : @escaping (Int) -> Kind<F, Int>) {
-        property("Consistency between mapFilter and map") <- forAll { (a : Int, b : Int) in
-            let fa = generator(a)
-            let f: (Int) -> Int = { _ in b }
-            return F.mapFilter(fa, { x in Option.some(f(x)) }) == F.map(fa, f)
+    private static func mapFilterMapConsistency() {
+        property("Consistency between mapFilter and map") <- forAll { (fa: KindOf<F, Int>, b: Int) in
+            let f: (Int) -> Int = constant(b)
+            return F.mapFilter(fa.value, { x in Option.some(f(x)) }) == F.map(fa.value, f)
         }
     }
 }

--- a/Tests/BowLaws/FunctorFilterLaws.swift
+++ b/Tests/BowLaws/FunctorFilterLaws.swift
@@ -1,4 +1,3 @@
-import Foundation
 import SwiftCheck
 import Bow
 import BowGenerators

--- a/Tests/BowLaws/FunctorLaws.swift
+++ b/Tests/BowLaws/FunctorLaws.swift
@@ -1,4 +1,3 @@
-import Foundation
 import SwiftCheck
 import Bow
 import BowGenerators

--- a/Tests/BowLaws/FunctorLaws.swift
+++ b/Tests/BowLaws/FunctorLaws.swift
@@ -1,61 +1,56 @@
 import Foundation
 import SwiftCheck
-@testable import Bow
+import Bow
+import BowGenerators
 
-class FunctorLaws<F: Functor & EquatableK> {
+class FunctorLaws<F: Functor & EquatableK & ArbitraryK> {
     static func check(generator: @escaping (Int) -> Kind<F, Int>) {
         InvariantLaws.check(generator: generator)
-        covariantIdentity(generator)
-        covariantComposition(generator)
-        void(generator)
-        fproduct(generator)
-        tupleLeft(generator)
-        tupleRight(generator)
+        covariantIdentity()
+        covariantComposition()
+        void()
+        fproduct()
+        tupleLeft()
+        tupleRight()
     }
 
-    private static func covariantIdentity(_ generator: @escaping (Int) -> Kind<F, Int>) {
-        property("Identity is preserved under functor transformation") <- forAll() { (a : Int) in
-            let fa = generator(a)
-            return F.map(fa, id) == id(fa)
+    private static func covariantIdentity() {
+        property("Identity is preserved under functor transformation") <- forAll() { (fa: KindOf<F, Int>) in
+            return F.map(fa.value, id) == id(fa.value)
         }
     }
     
-    private static func covariantComposition(_ generator: @escaping (Int) -> Kind<F, Int>) {
-        property("Composition is preserved under functor transformation") <- forAll() { (a: Int, f: ArrowOf<Int, Int>, g: ArrowOf<Int, Int>) in
-            let fa = generator(a)
-            return F.map(F.map(fa, f.getArrow), g.getArrow) ==
-                F.map(fa, f.getArrow >>> g.getArrow)
+    private static func covariantComposition() {
+        property("Composition is preserved under functor transformation") <- forAll() { (fa: KindOf<F, Int>, f: ArrowOf<Int, Int>, g: ArrowOf<Int, Int>) in
+            return F.map(F.map(fa.value, f.getArrow), g.getArrow) ==
+                F.map(fa.value, f.getArrow >>> g.getArrow)
         }
     }
     
-    private static func void(_ generator: @escaping (Int) -> Kind<F, Int>) {
-        property("Void") <- forAll() { (a: Int, f: ArrowOf<Int, Int>) in
-            let fa = generator(a)
-            return isEqual(F.void(fa), F.void(F.map(fa, f.getArrow)))
+    private static func void() {
+        property("Void") <- forAll() { (fa: KindOf<F, Int>, f: ArrowOf<Int, Int>) in
+            return isEqual(F.void(fa.value), F.void(F.map(fa.value, f.getArrow)))
         }
     }
     
-    private static func fproduct(_ generator: @escaping (Int) -> Kind<F, Int>) {
-        property("fproduct") <- forAll { (a: Int, f: ArrowOf<Int, Int>) in
-            let fa = generator(a)
-            return F.map(F.fproduct(fa, f.getArrow), { x in x.1 }) ==
-                F.map(fa, f.getArrow)
+    private static func fproduct() {
+        property("fproduct") <- forAll { (fa: KindOf<F, Int>, f: ArrowOf<Int, Int>) in
+            return F.map(F.fproduct(fa.value, f.getArrow), { x in x.1 }) ==
+                F.map(fa.value, f.getArrow)
         }
     }
     
-    private static func tupleLeft(_ generator : @escaping (Int) -> Kind<F, Int>) {
-        property("tuple left") <- forAll { (a : Int, b : Int) in
-            let fa = generator(a)
-            return F.map(F.tupleLeft(fa, b), { x in x.0 }) ==
-                F.as(fa, b)
+    private static func tupleLeft() {
+        property("tuple left") <- forAll { (fa: KindOf<F, Int>, b: Int) in
+            return F.map(F.tupleLeft(fa.value, b), { x in x.0 }) ==
+                F.as(fa.value, b)
         }
     }
     
-    private static func tupleRight(_ generator : @escaping (Int) -> Kind<F, Int>) {
-        property("tuple right") <- forAll { (a : Int, b : Int) in
-            let fa = generator(a)
-            return F.map(F.tupleRight(fa, b), { x in x.1 }) ==
-                F.as(fa, b)
+    private static func tupleRight() {
+        property("tuple right") <- forAll { (fa: KindOf<F, Int>, b: Int) in
+            return F.map(F.tupleRight(fa.value, b), { x in x.1 }) ==
+                F.as(fa.value, b)
         }
     }
 }

--- a/Tests/BowLaws/FunctorLaws.swift
+++ b/Tests/BowLaws/FunctorLaws.swift
@@ -4,8 +4,8 @@ import Bow
 import BowGenerators
 
 class FunctorLaws<F: Functor & EquatableK & ArbitraryK> {
-    static func check(generator: @escaping (Int) -> Kind<F, Int>) {
-        InvariantLaws.check(generator: generator)
+    static func check() {
+        InvariantLaws<F>.check()
         covariantIdentity()
         covariantComposition()
         void()

--- a/Tests/BowLaws/InvariantLaws.swift
+++ b/Tests/BowLaws/InvariantLaws.swift
@@ -1,25 +1,24 @@
 import Foundation
 import SwiftCheck
-@testable import Bow
+import Bow
+import BowGenerators
 
-class InvariantLaws<F: Invariant & EquatableK> {
-    static func check(generator: @escaping (Int) -> Kind<F, Int>) {
-        self.identity(generator)
-        self.composition(generator)
+class InvariantLaws<F: Invariant & EquatableK & ArbitraryK> {
+    static func check() {
+        self.identity()
+        self.composition()
     }
     
-    private static func identity(_ generator : @escaping (Int) -> Kind<F, Int>) {
-        property("Identity") <- forAll { (a : Int) in
-            let fa = generator(a)
-            return F.imap(fa, id, id) == fa
+    private static func identity() {
+        property("Identity") <- forAll { (fa: KindOf<F, Int>) in
+            return F.imap(fa.value, id, id) == fa.value
         }
     }
     
-    private static func composition(_ generator : @escaping (Int) -> Kind<F, Int>) {
-        property("Composition") <- forAll { (a: Int, f1: ArrowOf<Int, Int>, f2: ArrowOf<Int, Int>, g1: ArrowOf<Int, Int>, g2: ArrowOf<Int, Int>) in
-            let fa = generator(a)
-            let left = F.imap(F.imap(fa, f1.getArrow, f2.getArrow), g1.getArrow, g2.getArrow)
-            let right = F.imap(fa, g1.getArrow <<< f1.getArrow, f2.getArrow <<< g2.getArrow)
+    private static func composition() {
+        property("Composition") <- forAll { (fa: KindOf<F, Int>, f1: ArrowOf<Int, Int>, f2: ArrowOf<Int, Int>, g1: ArrowOf<Int, Int>, g2: ArrowOf<Int, Int>) in
+            let left = F.imap(F.imap(fa.value, f1.getArrow, f2.getArrow), g1.getArrow, g2.getArrow)
+            let right = F.imap(fa.value, g1.getArrow <<< f1.getArrow, f2.getArrow <<< g2.getArrow)
             return left == right
         }
     }

--- a/Tests/BowLaws/InvariantLaws.swift
+++ b/Tests/BowLaws/InvariantLaws.swift
@@ -1,4 +1,3 @@
-import Foundation
 import SwiftCheck
 import Bow
 import BowGenerators

--- a/Tests/BowLaws/MonadCombineLaws.swift
+++ b/Tests/BowLaws/MonadCombineLaws.swift
@@ -4,6 +4,6 @@ import BowGenerators
 class MonadCombineLaws<F: MonadCombine & EquatableK & ArbitraryK> {
     static func check() {
         AlternativeLaws<F>.check()
-        MonadFilterLaws<F>.check(generator: F.pure)
+        MonadFilterLaws<F>.check()
     }
 }

--- a/Tests/BowLaws/MonadCombineLaws.swift
+++ b/Tests/BowLaws/MonadCombineLaws.swift
@@ -1,6 +1,7 @@
-@testable import Bow
+import Bow
+import BowGenerators
 
-class MonadCombineLaws<F: MonadCombine & EquatableK> {
+class MonadCombineLaws<F: MonadCombine & EquatableK & ArbitraryK> {
     static func check() {
         AlternativeLaws<F>.check()
         MonadFilterLaws<F>.check(generator: F.pure)

--- a/Tests/BowLaws/MonadErrorLaws.swift
+++ b/Tests/BowLaws/MonadErrorLaws.swift
@@ -1,4 +1,3 @@
-import Foundation
 import SwiftCheck
 import Bow
 import BowGenerators

--- a/Tests/BowLaws/MonadErrorLaws.swift
+++ b/Tests/BowLaws/MonadErrorLaws.swift
@@ -1,9 +1,9 @@
 import Foundation
 import SwiftCheck
-@testable import Bow
+import Bow
+import BowGenerators
 
-class MonadErrorLaws<F: MonadError & EquatableK> where F.E: Arbitrary {
-    
+class MonadErrorLaws<F: MonadError & EquatableK & ArbitraryK> where F.E: Arbitrary {
     static func check()  {
         leftZero()
         ensureConsistency()
@@ -17,10 +17,8 @@ class MonadErrorLaws<F: MonadError & EquatableK> where F.E: Arbitrary {
     }
     
     private static func ensureConsistency() {
-        property("Ensure consistency") <- forAll { (a: Int, p: ArrowOf<Int, Bool>, error: F.E) in
-            let fa = F.pure(a)
-            return F.ensure(fa, constant(error), p.getArrow) == F.flatMap(fa, { a in p.getArrow(a) ? F.pure(a) : F.raiseError(error) })
+        property("Ensure consistency") <- forAll { (fa: KindOf<F, Int>, p: ArrowOf<Int, Bool>, error: F.E) in
+            return F.ensure(fa.value, constant(error), p.getArrow) == F.flatMap(fa.value, { a in p.getArrow(a) ? F.pure(a) : F.raiseError(error) })
         }
     }
-    
 }

--- a/Tests/BowLaws/MonadFilterLaws.swift
+++ b/Tests/BowLaws/MonadFilterLaws.swift
@@ -1,32 +1,30 @@
 import Foundation
 import SwiftCheck
-@testable import Bow
+import Bow
+import BowGenerators
 
-class MonadFilterLaws<F: MonadFilter & EquatableK> {
-    
-    static func check(generator : @escaping (Int) -> Kind<F, Int>) {
-        leftEmpty(generator)
-        rightEmpty(generator)
-        consistency(generator)
+class MonadFilterLaws<F: MonadFilter & EquatableK & ArbitraryK> {
+    static func check() {
+        leftEmpty()
+        rightEmpty()
+        consistency()
     }
     
-    private static func leftEmpty(_ generator: @escaping (Int) -> Kind<F, Int>) {
-        property("Left empty") <- forAll { (_ : Int) in
-            return F.flatMap(F.empty(), generator) == F.empty()
+    private static func leftEmpty() {
+        property("Left empty") <- forAll { (f: ArrowOf<Int, Int>) in
+            return F.flatMap(F.empty(), f.getArrow >>> F.pure) == F.empty()
         }
     }
     
-    private static func rightEmpty(_ generator : @escaping (Int) -> Kind<F, Int>) {
-        property("Right empty") <- forAll { (a : Int) in
-            let fa = generator(a)
-            return F.flatMap(fa, constant(F.empty())) == F.empty() as Kind<F, Int>
+    private static func rightEmpty() {
+        property("Right empty") <- forAll { (fa: KindOf<F, Int>) in
+            return F.flatMap(fa.value, constant(F.empty())) == F.empty() as Kind<F, Int>
         }
     }
     
-    private static func consistency(_ generator : @escaping (Int) -> Kind<F, Int>)  {
-        property("Consistency") <- forAll { (a : Int, f : ArrowOf<Int, Bool>) in
-            let fa = generator(a)
-            return F.filter(fa, f.getArrow) == F.flatMap(fa, { a in f.getArrow(a) ? F.pure(a) : F.empty() })
+    private static func consistency()  {
+        property("Consistency") <- forAll { (fa: KindOf<F, Int>, f: ArrowOf<Int, Bool>) in
+            return F.filter(fa.value, f.getArrow) == F.flatMap(fa.value, { a in f.getArrow(a) ? F.pure(a) : F.empty() })
         }
     }
 }

--- a/Tests/BowLaws/MonadFilterLaws.swift
+++ b/Tests/BowLaws/MonadFilterLaws.swift
@@ -1,4 +1,3 @@
-import Foundation
 import SwiftCheck
 import Bow
 import BowGenerators

--- a/Tests/BowLaws/MonadLaws.swift
+++ b/Tests/BowLaws/MonadLaws.swift
@@ -1,4 +1,3 @@
-import Foundation
 import SwiftCheck
 import Nimble
 import Bow

--- a/Tests/BowLaws/MonadLaws.swift
+++ b/Tests/BowLaws/MonadLaws.swift
@@ -1,10 +1,10 @@
 import Foundation
 import SwiftCheck
 import Nimble
-@testable import Bow
+import Bow
+import BowGenerators
 
-class MonadLaws<F: Monad & EquatableK> {
-    
+class MonadLaws<F: Monad & EquatableK & ArbitraryK> {
     static func check() {
         leftIdentity()
         rightIdentity()

--- a/Tests/BowLaws/MonadStateLaws.swift
+++ b/Tests/BowLaws/MonadStateLaws.swift
@@ -1,6 +1,6 @@
 import Foundation
 import SwiftCheck
-@testable import Bow
+import Bow
 
 class MonadStateLaws<F: MonadState & EquatableK> where F.S == Int {
     

--- a/Tests/BowLaws/MonadStateLaws.swift
+++ b/Tests/BowLaws/MonadStateLaws.swift
@@ -1,4 +1,3 @@
-import Foundation
 import SwiftCheck
 import Bow
 

--- a/Tests/BowLaws/MonadWriterLaws.swift
+++ b/Tests/BowLaws/MonadWriterLaws.swift
@@ -1,4 +1,3 @@
-import Foundation
 import SwiftCheck
 import Bow
 

--- a/Tests/BowLaws/MonadWriterLaws.swift
+++ b/Tests/BowLaws/MonadWriterLaws.swift
@@ -1,9 +1,8 @@
 import Foundation
 import SwiftCheck
-@testable import Bow
+import Bow
 
 class MonadWriterLaws<F: MonadWriter & EquatableK> where F.W == Int {
-    
     static func check() {
         writerPure()
         tellFusion()
@@ -36,6 +35,4 @@ class MonadWriterLaws<F: MonadWriter & EquatableK> where F.W == Int {
             return isEqual(F.listen(F.writer(tuple)), F.map(F.tell(tuple.0), { _ in tuple }))
         }
     }
-
-    
 }

--- a/Tests/BowLaws/MonoidKLaws.swift
+++ b/Tests/BowLaws/MonoidKLaws.swift
@@ -1,25 +1,23 @@
 import Foundation
 import SwiftCheck
-@testable import Bow
+import Bow
+import BowGenerators
 
-class MonoidKLaws<F: MonoidK & EquatableK> {
-    
-    static func check(generator: @escaping (Int) -> Kind<F, Int>) {
-        leftIdentity(generator)
-        rightIdentity(generator)
+class MonoidKLaws<F: MonoidK & EquatableK & ArbitraryK> {
+    static func check() {
+        leftIdentity()
+        rightIdentity()
     }
     
-    private static func leftIdentity(_ generator : @escaping (Int) -> Kind<F, Int>) {
-        property("MonoidK left identity") <- forAll { (a : Int) in
-            let fa = generator(a)
-            return F.emptyK().combineK(fa) == fa
+    private static func leftIdentity() {
+        property("MonoidK left identity") <- forAll { (fa: KindOf<F, Int>) in
+            return F.emptyK().combineK(fa.value) == fa.value
         }
     }
     
-    private static func rightIdentity(_ generator : @escaping (Int) -> Kind<F, Int>) {
-        property("MonoidK left identity") <- forAll { (a : Int) in
-            let fa = generator(a)
-            return fa.combineK(F.emptyK()) == fa
+    private static func rightIdentity() {
+        property("MonoidK left identity") <- forAll { (fa: KindOf<F, Int>) in
+            return fa.value.combineK(F.emptyK()) == fa.value
         }
     }
 }

--- a/Tests/BowLaws/MonoidKLaws.swift
+++ b/Tests/BowLaws/MonoidKLaws.swift
@@ -1,4 +1,3 @@
-import Foundation
 import SwiftCheck
 import Bow
 import BowGenerators

--- a/Tests/BowLaws/MonoidLaws.swift
+++ b/Tests/BowLaws/MonoidLaws.swift
@@ -1,16 +1,21 @@
 import Bow
+import SwiftCheck
 
-class MonoidLaws<A: Monoid & Equatable> {
-    
-    static func check(a: A) -> Bool {
-        return leftIdentity(a) && rightIdentity(a)
+class MonoidLaws<A: Monoid & Equatable & Arbitrary> {
+    static func check() {
+        leftIdentity()
+        rightIdentity()
     }
     
-    private static func leftIdentity(_ a: A) -> Bool {
-        return A.empty().combine(a) == a
+    private static func leftIdentity() {
+        property("Left identity") <- forAll { (a: A) in
+            return A.empty().combine(a) == a
+        }
     }
     
-    private static func rightIdentity(_ a: A) -> Bool {
-        return a.combine(A.empty()) == a
+    private static func rightIdentity() {
+        property("Right identity") <- forAll { (a: A) in
+            return a.combine(A.empty()) == a
+        }
     }
 }

--- a/Tests/BowLaws/MonoidLaws.swift
+++ b/Tests/BowLaws/MonoidLaws.swift
@@ -1,5 +1,4 @@
-import Foundation
-@testable import Bow
+import Bow
 
 class MonoidLaws<A: Monoid & Equatable> {
     

--- a/Tests/BowLaws/SelectiveLaws.swift
+++ b/Tests/BowLaws/SelectiveLaws.swift
@@ -1,5 +1,5 @@
 import SwiftCheck
-@testable import Bow
+import Bow
 
 public class SelectiveLaws<F: Selective & EquatableK> {
     public static func check() {

--- a/Tests/BowLaws/SemigroupKLaws.swift
+++ b/Tests/BowLaws/SemigroupKLaws.swift
@@ -1,19 +1,17 @@
 import Foundation
 import SwiftCheck
-@testable import Bow
+import Bow
+import BowGenerators
 
-class SemigroupKLaws<F: SemigroupK & EquatableK> {
+class SemigroupKLaws<F: SemigroupK & EquatableK & ArbitraryK> {
     
-    static func check(generator : @escaping (Int) -> Kind<F, Int>) {
-        associative(generator)
+    static func check() {
+        associative()
     }
     
-    private static func associative(_ generator : @escaping (Int) -> Kind<F, Int>) {
-        property("SemigroupK combine is associative") <- forAll { (a: Int, b: Int, c: Int) in
-            let fa = generator(a)
-            let fb = generator(b)
-            let fc = generator(c)
-            return fa.combineK(fb.combineK(fc)) == fa.combineK(fb).combineK(fc)
+    private static func associative() {
+        property("SemigroupK combine is associative") <- forAll { (fa: KindOf<F, Int>, fb: KindOf<F, Int>, fc: KindOf<F, Int>) in
+            return fa.value.combineK(fb.value.combineK(fc.value)) == fa.value.combineK(fb.value).combineK(fc.value)
         }
     }
 }

--- a/Tests/BowLaws/SemigroupKLaws.swift
+++ b/Tests/BowLaws/SemigroupKLaws.swift
@@ -1,4 +1,3 @@
-import Foundation
 import SwiftCheck
 import Bow
 import BowGenerators

--- a/Tests/BowLaws/SemigroupLaws.swift
+++ b/Tests/BowLaws/SemigroupLaws.swift
@@ -1,17 +1,21 @@
 import SwiftCheck
 import Bow
 
-class SemigroupLaws<A: Semigroup & Equatable> {
-    
-    static func check(a: A, b: A, c: A) -> Bool {
-        return associativity(a, b, c) && reduction(a, b, c)
+class SemigroupLaws<A: Semigroup & Arbitrary & Equatable> {
+    static func check() {
+        associativity()
+        reduction()
     }
     
-    private static func associativity(_ a: A, _ b: A, _ c: A) -> Bool {
-        return a.combine(b).combine(c) == a.combine(b.combine(c))
+    private static func associativity() {
+        property("Associativity") <- forAll { (a: A, b: A, c: A) in
+            return a.combine(b).combine(c) == a.combine(b.combine(c))
+        }
     }
     
-    private static func reduction(_ a: A, _ b: A, _ c: A) -> Bool {
-        return A.combineAll(a, b, c) == a.combine(b).combine(c)
+    private static func reduction() {
+        property("Reduction") <- forAll { (a: A, b: A, c: A) in
+            return A.combineAll(a, b, c) == a.combine(b).combine(c)
+        }
     }
 }

--- a/Tests/BowLaws/SemigroupLaws.swift
+++ b/Tests/BowLaws/SemigroupLaws.swift
@@ -1,6 +1,5 @@
-import Foundation
 import SwiftCheck
-@testable import Bow
+import Bow
 
 class SemigroupLaws<A: Semigroup & Equatable> {
     

--- a/Tests/BowLaws/TraverseFilterLaws.swift
+++ b/Tests/BowLaws/TraverseFilterLaws.swift
@@ -1,24 +1,24 @@
 import SwiftCheck
-@testable import Bow
+import Bow
+import BowGenerators
 
-class TraverseFilterLaws<F: TraverseFilter & Applicative & EquatableK> {
+class TraverseFilterLaws<F: TraverseFilter & Applicative & EquatableK & ArbitraryK> {
     static func check() {
         identityTraverseFilter()
         filterAConsistentWithTraverseFilter()
     }
     
     private static func identityTraverseFilter() {
-        property("identity traverse filter") <- forAll { (x : Int) in
+        property("identity traverse filter") <- forAll { (x: Int) in
             let input = F.pure(x)
             return F.traverseFilter(input, { a in F.pure(Option<Int>.some(a)) }) == F.pure(input)
         }
     }
     
     private static func filterAConsistentWithTraverseFilter() {
-        property("filterA consistent with traverseFilter") <- forAll { (x : Int, bool : Bool) in
-            let input = F.pure(x)
-            let f = { (_ : Int) in F.pure(bool) }
-            return F.filterA(input, f) == F.traverseFilter(input, { a in F.map(f(a)){ b in b ? Option<Int>.some(a) : Option<Int>.none()} })
+        property("filterA consistent with traverseFilter") <- forAll { (input: KindOf<F, Int>, bool: KindOf<F, Bool>) in
+            let f = { (_ : Int) in bool.value }
+            return F.filterA(input.value, f) == F.traverseFilter(input.value, { a in F.map(f(a)){ b in b ? Option<Int>.some(a) : Option<Int>.none()} })
         }
     }
 }

--- a/Tests/BowLaws/TraverseLaws.swift
+++ b/Tests/BowLaws/TraverseLaws.swift
@@ -1,16 +1,16 @@
 import SwiftCheck
-@testable import Bow
+import Bow
+import BowGenerators
 
-class TraverseLaws<F: Traverse & EquatableK> {
-    static func check(generator: @escaping (Int) -> Kind<F, Int>) {
-        identityTraverse(generator)
+class TraverseLaws<F: Traverse & EquatableK & ArbitraryK> {
+    static func check() {
+        identityTraverse()
     }
     
-    private static func identityTraverse(_ generator: @escaping (Int) -> Kind<F, Int>) {
-        property("Identity traverse") <- forAll { (x: Int, y: Int) in
+    private static func identityTraverse() {
+        property("Identity traverse") <- forAll { (fa: KindOf<F, Int>, y: Int) in
             let f: (Int) -> Kind<ForId, Int> = { _ in Id<Int>(y) }
-            let fa = generator(x)
-            return Id.fix(F.traverse(fa, f)).value == F.map(F.map(fa, f), { a in Id.fix(a).value })
+            return Id.fix(F.traverse(fa.value, f)).value == F.map(F.map(fa.value, f), { a in Id.fix(a).value })
         }
     }
 }

--- a/Tests/BowRxTests/MaybeKTest.swift
+++ b/Tests/BowRxTests/MaybeKTest.swift
@@ -1,7 +1,8 @@
 import XCTest
 @testable import BowLaws
-@testable import Bow
+import Bow
 @testable import BowRx
+import BowRxGenerators
 @testable import BowEffectsLaws
 
 extension ForMaybeK: EquatableK {
@@ -11,10 +12,8 @@ extension ForMaybeK: EquatableK {
 }
 
 class MaybeKTest: XCTestCase {
-    let generator = { (x : Int) in MaybeK.pure(x) }
-    
     func testFunctorLaws() {
-        FunctorLaws<ForMaybeK>.check(generator: generator)
+        FunctorLaws<ForMaybeK>.check()
     }
     
     func testApplicativeLaws() {
@@ -30,6 +29,6 @@ class MaybeKTest: XCTestCase {
     }
     
     func testFoldableLaws() {
-        FoldableLaws<ForMaybeK>.check(generator: generator)
+        FoldableLaws<ForMaybeK>.check()
     }
 }

--- a/Tests/BowRxTests/ObservableKTest.swift
+++ b/Tests/BowRxTests/ObservableKTest.swift
@@ -1,7 +1,8 @@
 import XCTest
 @testable import BowLaws
-@testable import Bow
+import Bow
 @testable import BowRx
+import BowRxGenerators
 @testable import BowEffectsLaws
 
 extension ForObservableK: EquatableK {
@@ -11,10 +12,8 @@ extension ForObservableK: EquatableK {
 }
 
 class ObservableKTest: XCTestCase {
-    let generator = { (x : Int) -> ObservableKOf<Int> in ObservableK.pure(x) }
-    
     func testFunctorLaws() {
-        FunctorLaws<ForObservableK>.check(generator: generator)
+        FunctorLaws<ForObservableK>.check()
     }
     
     func testApplicativeLaws() {
@@ -30,10 +29,10 @@ class ObservableKTest: XCTestCase {
     }
     
     func testFoldableLaws() {
-        FoldableLaws<ForObservableK>.check(generator: generator)
+        FoldableLaws<ForObservableK>.check()
     }
     
     func testTraverseLaws() {
-        TraverseLaws<ForObservableK>.check(generator: generator)
+        TraverseLaws<ForObservableK>.check()
     }
 }

--- a/Tests/BowRxTests/SingleKTest.swift
+++ b/Tests/BowRxTests/SingleKTest.swift
@@ -1,7 +1,8 @@
 import XCTest
 @testable import BowLaws
-@testable import Bow
+import Bow
 @testable import BowRx
+import BowRxGenerators
 @testable import BowEffectsLaws
 
 extension ForSingleK: EquatableK {
@@ -11,10 +12,8 @@ extension ForSingleK: EquatableK {
 }
 
 class SingleKTest: XCTestCase {
-    let generator = { (x: Int) in SingleK.pure(x) }
-
     func testFunctorLaws() {
-        FunctorLaws<ForSingleK>.check(generator: generator)
+        FunctorLaws<ForSingleK>.check()
     }
     
     func testApplicativeLaws() {

--- a/Tests/BowTests/Arrow/Function0Test.swift
+++ b/Tests/BowTests/Arrow/Function0Test.swift
@@ -29,10 +29,10 @@ class Function0Test: XCTestCase {
     }
     
     func testComonadLaws() {
-        ComonadLaws<ForFunction0>.check(generator: self.generator)
+        ComonadLaws<ForFunction0>.check()
     }
     
     func testBimonadLaws() {
-        BimonadLaws<ForFunction0>.check(generator: self.generator)
+        BimonadLaws<ForFunction0>.check()
     }
 }

--- a/Tests/BowTests/Arrow/Function0Test.swift
+++ b/Tests/BowTests/Arrow/Function0Test.swift
@@ -3,11 +3,6 @@ import XCTest
 import Bow
 
 class Function0Test: XCTestCase {
-    
-    var generator: (Int) -> Function0Of<Int> {
-        return { a in Function0.pure(a) }
-    }
-
     func testEquatableLaws() {
         EquatableKLaws<ForFunction0, Int>.check()
     }

--- a/Tests/BowTests/Arrow/Function0Test.swift
+++ b/Tests/BowTests/Arrow/Function0Test.swift
@@ -13,7 +13,7 @@ class Function0Test: XCTestCase {
     }
     
     func testFunctorLaws() {
-        FunctorLaws<ForFunction0>.check(generator: self.generator)
+        FunctorLaws<ForFunction0>.check()
     }
     
     func testApplicativeLaws() {

--- a/Tests/BowTests/Arrow/Function0Test.swift
+++ b/Tests/BowTests/Arrow/Function0Test.swift
@@ -1,6 +1,6 @@
 import XCTest
 @testable import BowLaws
-@testable import Bow
+import Bow
 
 class Function0Test: XCTestCase {
     

--- a/Tests/BowTests/Arrow/Function0Test.swift
+++ b/Tests/BowTests/Arrow/Function0Test.swift
@@ -9,7 +9,7 @@ class Function0Test: XCTestCase {
     }
 
     func testEquatableLaws() {
-        EquatableKLaws.check(generator: self.generator)
+        EquatableKLaws<ForFunction0, Int>.check()
     }
     
     func testFunctorLaws() {

--- a/Tests/BowTests/Arrow/Function1Test.swift
+++ b/Tests/BowTests/Arrow/Function1Test.swift
@@ -11,7 +11,7 @@ extension Function1Partial: EquatableK where I == Int {
 
 class Function1Test: XCTestCase {
     func testFunctorLaws() {
-        FunctorLaws<Function1Partial<Int>>.check(generator: { a in Function1<Int, Int>.pure(a) })
+        FunctorLaws<Function1Partial<Int>>.check()
     }
     
     func testApplicativeLaws() {

--- a/Tests/BowTests/Arrow/Function1Test.swift
+++ b/Tests/BowTests/Arrow/Function1Test.swift
@@ -27,13 +27,6 @@ class Function1Test: XCTestCase {
     }
 
     func testSemigroupLaws() {
-        func testSemigroupLaws() {
-            property("Function1 semigroup laws") <- forAll() { (f: ArrowOf<Int, Int>, g: ArrowOf<Int, Int>, h: ArrowOf<Int, Int>) in
-                return SemigroupLaws<Function1<Int, Int>>.check(
-                    a: Function1(f.getArrow),
-                    b: Function1(g.getArrow),
-                    c: Function1(h.getArrow))
-            }
-        }
+        SemigroupLaws<Function1<Int, Int>>.check()
     }
 }

--- a/Tests/BowTests/Arrow/Function1Test.swift
+++ b/Tests/BowTests/Arrow/Function1Test.swift
@@ -1,7 +1,7 @@
 import XCTest
 import SwiftCheck
 @testable import BowLaws
-@testable import Bow
+import Bow
 
 extension Function1Partial: EquatableK where I == Int {
     public static func eq<A>(_ lhs: Kind<Function1Partial<I>, A>, _ rhs: Kind<Function1Partial<I>, A>) -> Bool where A : Equatable {

--- a/Tests/BowTests/Arrow/Function1Test.swift
+++ b/Tests/BowTests/Arrow/Function1Test.swift
@@ -1,5 +1,4 @@
 import XCTest
-import SwiftCheck
 @testable import BowLaws
 import Bow
 

--- a/Tests/BowTests/Arrow/KleisliTest.swift
+++ b/Tests/BowTests/Arrow/KleisliTest.swift
@@ -8,7 +8,7 @@ class KleisliTest: XCTestCase {
     }
     
     func testFunctorLaws() {
-        FunctorLaws<KleisliPartial<ForId, Int>>.check(generator: self.generator)
+        FunctorLaws<KleisliPartial<ForId, Int>>.check()
     }
     
     func testApplicativeLaws() {

--- a/Tests/BowTests/Arrow/KleisliTest.swift
+++ b/Tests/BowTests/Arrow/KleisliTest.swift
@@ -1,6 +1,6 @@
 import XCTest
 @testable import BowLaws
-@testable import Bow
+import Bow
 
 class KleisliTest: XCTestCase {
     var generator: (Int) -> KleisliOf<ForId, Int, Int> {

--- a/Tests/BowTests/Arrow/KleisliTest.swift
+++ b/Tests/BowTests/Arrow/KleisliTest.swift
@@ -3,10 +3,6 @@ import XCTest
 import Bow
 
 class KleisliTest: XCTestCase {
-    var generator: (Int) -> KleisliOf<ForId, Int, Int> {
-        return { a in Kleisli.pure(a) }
-    }
-    
     func testFunctorLaws() {
         FunctorLaws<KleisliPartial<ForId, Int>>.check()
     }

--- a/Tests/BowTests/Data/ArrayKTest.swift
+++ b/Tests/BowTests/Data/ArrayKTest.swift
@@ -59,7 +59,7 @@ class ArrayKTest: XCTestCase {
     }
     
     func testFunctorFilterLaws() {
-        FunctorFilterLaws<ForArrayK>.check(generator: self.generator)
+        FunctorFilterLaws<ForArrayK>.check()
     }
     
     func testMonadFilterLaws() {

--- a/Tests/BowTests/Data/ArrayKTest.swift
+++ b/Tests/BowTests/Data/ArrayKTest.swift
@@ -1,20 +1,8 @@
 import XCTest
-import SwiftCheck
 @testable import BowLaws
 import Bow
 
 class ArrayKTest: XCTestCase {
-    
-    var generator: (Int) -> ArrayKOf<Int> {
-        return { a in ArrayK<Int>.pure(a) }
-    }
-
-    func testA() {
-        let x = ArrayK([1, 2, 3, 4])
-        let y = x.map { a in 2 * a }
-        XCTAssertEqual(y, ArrayK([2, 4, 6, 8]))
-    }
-
     func testEquatableLaws() {
         EquatableKLaws<ForArrayK, Int>.check()
     }

--- a/Tests/BowTests/Data/ArrayKTest.swift
+++ b/Tests/BowTests/Data/ArrayKTest.swift
@@ -75,6 +75,6 @@ class ArrayKTest: XCTestCase {
     }
     
     func testTraverseLaws() {
-        TraverseLaws<ForArrayK>.check(generator: self.generator)
+        TraverseLaws<ForArrayK>.check()
     }
 }

--- a/Tests/BowTests/Data/ArrayKTest.swift
+++ b/Tests/BowTests/Data/ArrayKTest.swift
@@ -55,7 +55,7 @@ class ArrayKTest: XCTestCase {
     }
     
     func testMonoidKLaws() {
-        MonoidKLaws.check(generator: self.generator)
+        MonoidKLaws<ForArrayK>.check()
     }
     
     func testFunctorFilterLaws() {

--- a/Tests/BowTests/Data/ArrayKTest.swift
+++ b/Tests/BowTests/Data/ArrayKTest.swift
@@ -45,7 +45,7 @@ class ArrayKTest: XCTestCase {
     }
     
     func testSemigroupKLaws() {
-        SemigroupKLaws.check(generator: self.generator)
+        SemigroupKLaws<ForArrayK>.check()
     }
     
     func testMonoidLaws() {

--- a/Tests/BowTests/Data/ArrayKTest.swift
+++ b/Tests/BowTests/Data/ArrayKTest.swift
@@ -44,9 +44,7 @@ class ArrayKTest: XCTestCase {
     }
     
     func testMonoidLaws() {
-        property("ArrayK monoid laws") <- forAll() { (a: Int) in
-            return MonoidLaws<ArrayK<Int>>.check(a: ArrayK<Int>([a]))
-        }
+        MonoidLaws<ArrayK<Int>>.check()
     }
     
     func testMonoidKLaws() {

--- a/Tests/BowTests/Data/ArrayKTest.swift
+++ b/Tests/BowTests/Data/ArrayKTest.swift
@@ -36,12 +36,7 @@ class ArrayKTest: XCTestCase {
     }
     
     func testSemigroupLaws() {
-        property("ArrayK semigroup laws") <- forAll() { (a: Int, b: Int, c: Int) in
-            return SemigroupLaws<ArrayK<Int>>.check(
-                a: ArrayK<Int>([a]),
-                b: ArrayK<Int>([b]),
-                c: ArrayK<Int>([c]))
-        }
+        SemigroupLaws<ArrayK<Int>>.check()
     }
     
     func testSemigroupKLaws() {

--- a/Tests/BowTests/Data/ArrayKTest.swift
+++ b/Tests/BowTests/Data/ArrayKTest.swift
@@ -63,7 +63,7 @@ class ArrayKTest: XCTestCase {
     }
     
     func testMonadFilterLaws() {
-        MonadFilterLaws<ForArrayK>.check(generator: self.generator)
+        MonadFilterLaws<ForArrayK>.check()
     }
     
     func testFoldableLaws() {

--- a/Tests/BowTests/Data/ArrayKTest.swift
+++ b/Tests/BowTests/Data/ArrayKTest.swift
@@ -20,7 +20,7 @@ class ArrayKTest: XCTestCase {
     }
     
     func testFunctorLaws() {
-        FunctorLaws<ForArrayK>.check(generator: self.generator)
+        FunctorLaws<ForArrayK>.check()
     }
     
     func testApplicativeLaws() {

--- a/Tests/BowTests/Data/ArrayKTest.swift
+++ b/Tests/BowTests/Data/ArrayKTest.swift
@@ -16,7 +16,7 @@ class ArrayKTest: XCTestCase {
     }
 
     func testEquatableLaws() {
-        EquatableKLaws.check(generator: self.generator)
+        EquatableKLaws<ForArrayK, Int>.check()
     }
     
     func testFunctorLaws() {

--- a/Tests/BowTests/Data/ArrayKTest.swift
+++ b/Tests/BowTests/Data/ArrayKTest.swift
@@ -67,7 +67,7 @@ class ArrayKTest: XCTestCase {
     }
     
     func testFoldableLaws() {
-        FoldableLaws<ForArrayK>.check(generator: self.generator)
+        FoldableLaws<ForArrayK>.check()
     }
     
     func testMonadCombineLaws() {

--- a/Tests/BowTests/Data/ArrayKTest.swift
+++ b/Tests/BowTests/Data/ArrayKTest.swift
@@ -1,7 +1,7 @@
 import XCTest
 import SwiftCheck
 @testable import BowLaws
-@testable import Bow
+import Bow
 
 class ArrayKTest: XCTestCase {
     

--- a/Tests/BowTests/Data/ConstTest.swift
+++ b/Tests/BowTests/Data/ConstTest.swift
@@ -1,5 +1,4 @@
 import XCTest
-import SwiftCheck
 @testable import BowLaws
 import Bow
 
@@ -25,9 +24,7 @@ class ConstTest: XCTestCase {
     }
     
     func testMonoidLaws() {
-        property("Const monoid laws") <- forAll { (a: Int) in
-            return MonoidLaws<Const<Int, Int>>.check(a: Const<Int, Int>(a))
-        }
+        MonoidLaws<Const<Int, Int>>.check()
     }
     
     func testCustomStringConvertibleLaws() {

--- a/Tests/BowTests/Data/ConstTest.swift
+++ b/Tests/BowTests/Data/ConstTest.swift
@@ -9,7 +9,7 @@ class ConstTest: XCTestCase {
     }
 
     func testEquatableLaws() {
-        EquatableKLaws<ConstPartial<Int>, Int>.check(generator: self.generator)
+        EquatableKLaws<ConstPartial<Int>, Int>.check()
     }
     
     func testFunctorLaws() {

--- a/Tests/BowTests/Data/ConstTest.swift
+++ b/Tests/BowTests/Data/ConstTest.swift
@@ -1,7 +1,7 @@
 import XCTest
 import SwiftCheck
 @testable import BowLaws
-@testable import Bow
+import Bow
 
 class ConstTest: XCTestCase {
     var generator: (Int) -> Const<Int, Int> {
@@ -36,7 +36,7 @@ class ConstTest: XCTestCase {
     }
     
     func testCustomStringConvertibleLaws() {
-        CustomStringConvertibleLaws<Const<Int, Int>>.check(generator: self.generator)
+        CustomStringConvertibleLaws<Const<Int, Int>>.check()
     }
     
     func testFoldableLaws() {

--- a/Tests/BowTests/Data/ConstTest.swift
+++ b/Tests/BowTests/Data/ConstTest.swift
@@ -40,7 +40,7 @@ class ConstTest: XCTestCase {
     }
     
     func testFoldableLaws() {
-        FoldableLaws<ConstPartial<Int>>.check(generator: self.generator)
+        FoldableLaws<ConstPartial<Int>>.check()
     }
     
     func testTraverseLaws() {

--- a/Tests/BowTests/Data/ConstTest.swift
+++ b/Tests/BowTests/Data/ConstTest.swift
@@ -21,12 +21,7 @@ class ConstTest: XCTestCase {
     }
     
     func testSemigroupLaws() {
-        property("Const semigroup laws") <- forAll { (a: Int, b: Int, c: Int) in
-            return SemigroupLaws<Const<Int, Int>>.check(
-                a: Const<Int, Int>(a),
-                b: Const<Int, Int>(b),
-                c: Const<Int, Int>(c))
-        }
+        SemigroupLaws<Const<Int, Int>>.check()
     }
     
     func testMonoidLaws() {

--- a/Tests/BowTests/Data/ConstTest.swift
+++ b/Tests/BowTests/Data/ConstTest.swift
@@ -13,7 +13,7 @@ class ConstTest: XCTestCase {
     }
     
     func testFunctorLaws() {
-        FunctorLaws<ConstPartial<Int>>.check(generator: self.generator)
+        FunctorLaws<ConstPartial<Int>>.check()
     }
     
     func testApplicativeLaws() {

--- a/Tests/BowTests/Data/ConstTest.swift
+++ b/Tests/BowTests/Data/ConstTest.swift
@@ -44,6 +44,6 @@ class ConstTest: XCTestCase {
     }
     
     func testTraverseLaws() {
-        TraverseLaws<ConstPartial<Int>>.check(generator: self.generator)
+        TraverseLaws<ConstPartial<Int>>.check()
     }
 }

--- a/Tests/BowTests/Data/ConstTest.swift
+++ b/Tests/BowTests/Data/ConstTest.swift
@@ -3,10 +3,6 @@ import XCTest
 import Bow
 
 class ConstTest: XCTestCase {
-    var generator: (Int) -> Const<Int, Int> {
-        return { a in Const<Int, Int>(a) }
-    }
-
     func testEquatableLaws() {
         EquatableKLaws<ConstPartial<Int>, Int>.check()
     }

--- a/Tests/BowTests/Data/DayTest.swift
+++ b/Tests/BowTests/Data/DayTest.swift
@@ -13,7 +13,7 @@ class DayTest: XCTestCase {
     let cf = { (x : Int) in Day.from(left: Id(x), right: Id(0), f: +) }
 
     func testFunctorLaws() {
-        FunctorLaws<DayPartial<ForId, ForId>>.check(generator: cf)
+        FunctorLaws<DayPartial<ForId, ForId>>.check()
     }
 
     func testComonadLaws() {

--- a/Tests/BowTests/Data/DayTest.swift
+++ b/Tests/BowTests/Data/DayTest.swift
@@ -1,7 +1,7 @@
 import XCTest
 import Nimble
 @testable import BowLaws
-@testable import Bow
+import Bow
 
 extension DayPartial: EquatableK where F == ForId, G == ForId {
     public static func eq<A>(_ lhs: Kind<DayPartial<F, G>, A>, _ rhs: Kind<DayPartial<F, G>, A>) -> Bool where A : Equatable {

--- a/Tests/BowTests/Data/DayTest.swift
+++ b/Tests/BowTests/Data/DayTest.swift
@@ -10,14 +10,12 @@ extension DayPartial: EquatableK where F == ForId, G == ForId {
 }
 
 class DayTest: XCTestCase {
-    let cf = { (x : Int) in Day.from(left: Id(x), right: Id(0), f: +) }
-
     func testFunctorLaws() {
         FunctorLaws<DayPartial<ForId, ForId>>.check()
     }
 
     func testComonadLaws() {
-        ComonadLaws<DayPartial<ForId, ForId>>.check(generator: cf)
+        ComonadLaws<DayPartial<ForId, ForId>>.check()
     }
 
     let day = Day.from(left: Id(1), right: Id(1), f: { (left : Int, right : Int) in (left, right) })

--- a/Tests/BowTests/Data/EitherKTest.swift
+++ b/Tests/BowTests/Data/EitherKTest.swift
@@ -25,6 +25,6 @@ class EitherKTest: XCTestCase {
     }
     
     func testTraverseLaws() {
-        TraverseLaws<EitherKPartial<ForId, ForId>>.check(generator: self.generator)
+        TraverseLaws<EitherKPartial<ForId, ForId>>.check()
     }
 }

--- a/Tests/BowTests/Data/EitherKTest.swift
+++ b/Tests/BowTests/Data/EitherKTest.swift
@@ -9,7 +9,7 @@ class EitherKTest: XCTestCase {
     }
 
     func testEquatableLaws() {
-        EquatableKLaws<EitherKPartial<ForId, ForId>, Int>.check(generator: self.generator)
+        EquatableKLaws<EitherKPartial<ForId, ForId>, Int>.check()
     }
     
     func testFunctorLaws() {

--- a/Tests/BowTests/Data/EitherKTest.swift
+++ b/Tests/BowTests/Data/EitherKTest.swift
@@ -17,7 +17,7 @@ class EitherKTest: XCTestCase {
     }
     
     func testComonadLaws() {
-        ComonadLaws<EitherKPartial<ForId, ForId>>.check(generator: self.generator)
+        ComonadLaws<EitherKPartial<ForId, ForId>>.check()
     }
     
     func testFoldableLaws() {

--- a/Tests/BowTests/Data/EitherKTest.swift
+++ b/Tests/BowTests/Data/EitherKTest.swift
@@ -21,7 +21,7 @@ class EitherKTest: XCTestCase {
     }
     
     func testFoldableLaws() {
-        FoldableLaws<EitherKPartial<ForId, ForId>>.check(generator: self.generator)
+        FoldableLaws<EitherKPartial<ForId, ForId>>.check()
     }
     
     func testTraverseLaws() {

--- a/Tests/BowTests/Data/EitherKTest.swift
+++ b/Tests/BowTests/Data/EitherKTest.swift
@@ -3,11 +3,6 @@ import XCTest
 import Bow
 
 class EitherKTest: XCTestCase {
-    
-    var generator: (Int) -> EitherK<ForId, ForId, Int> {
-        return { a in EitherK<ForId, ForId, Int>(Either.right(Id(a))) }
-    }
-
     func testEquatableLaws() {
         EquatableKLaws<EitherKPartial<ForId, ForId>, Int>.check()
     }

--- a/Tests/BowTests/Data/EitherKTest.swift
+++ b/Tests/BowTests/Data/EitherKTest.swift
@@ -13,7 +13,7 @@ class EitherKTest: XCTestCase {
     }
     
     func testFunctorLaws() {
-        FunctorLaws<EitherKPartial<ForId, ForId>>.check(generator: self.generator)
+        FunctorLaws<EitherKPartial<ForId, ForId>>.check()
     }
     
     func testComonadLaws() {

--- a/Tests/BowTests/Data/EitherKTest.swift
+++ b/Tests/BowTests/Data/EitherKTest.swift
@@ -1,6 +1,6 @@
 import XCTest
 @testable import BowLaws
-@testable import Bow
+import Bow
 
 class EitherKTest: XCTestCase {
     

--- a/Tests/BowTests/Data/EitherTest.swift
+++ b/Tests/BowTests/Data/EitherTest.swift
@@ -51,7 +51,7 @@ class EitherTest: XCTestCase {
     }
     
     func testTraverseLaws() {
-        TraverseLaws<EitherPartial<Int>>.check(generator: self.generator)
+        TraverseLaws<EitherPartial<Int>>.check()
     }
     
     func testCheckers() {

--- a/Tests/BowTests/Data/EitherTest.swift
+++ b/Tests/BowTests/Data/EitherTest.swift
@@ -39,7 +39,7 @@ class EitherTest: XCTestCase {
     }
     
     func testSemigroupKLaws() {
-        SemigroupKLaws<EitherPartial<Int>>.check(generator: self.generator)
+        SemigroupKLaws<EitherPartial<Int>>.check()
     }
 
     func testCustomStringConvertibleLaws() {

--- a/Tests/BowTests/Data/EitherTest.swift
+++ b/Tests/BowTests/Data/EitherTest.swift
@@ -1,15 +1,9 @@
 import XCTest
 import Nimble
-import SwiftCheck
 @testable import BowLaws
 import Bow
 
 class EitherTest: XCTestCase {
-    
-    var generator : (Int) -> EitherOf<Int, Int> {
-        return { a in Either.pure(a) }
-    }
-
     func testEquatableLaws() {
         EquatableKLaws<EitherPartial<Int>, Int>.check()
     }

--- a/Tests/BowTests/Data/EitherTest.swift
+++ b/Tests/BowTests/Data/EitherTest.swift
@@ -15,7 +15,7 @@ class EitherTest: XCTestCase {
     }
     
     func testFunctorLaws() {
-        FunctorLaws<EitherPartial<Int>>.check(generator: self.generator)
+        FunctorLaws<EitherPartial<Int>>.check()
     }
     
     func testApplicativeLaws() {

--- a/Tests/BowTests/Data/EitherTest.swift
+++ b/Tests/BowTests/Data/EitherTest.swift
@@ -2,7 +2,7 @@ import XCTest
 import Nimble
 import SwiftCheck
 @testable import BowLaws
-@testable import Bow
+import Bow
 
 class EitherTest: XCTestCase {
     
@@ -43,10 +43,7 @@ class EitherTest: XCTestCase {
     }
 
     func testCustomStringConvertibleLaws() {
-        CustomStringConvertibleLaws.check(generator: { (a: Int) in
-            (a % 2 == 0) ?
-                Either<Int, Int>.right(a) :
-                Either<Int, Int>.left(a) })
+        CustomStringConvertibleLaws<Either<Int, Int>>.check()
     }
     
     func testFoldableLaws() {

--- a/Tests/BowTests/Data/EitherTest.swift
+++ b/Tests/BowTests/Data/EitherTest.swift
@@ -47,7 +47,7 @@ class EitherTest: XCTestCase {
     }
     
     func testFoldableLaws() {
-        FoldableLaws<EitherPartial<Int>>.check(generator: self.generator)
+        FoldableLaws<EitherPartial<Int>>.check()
     }
     
     func testTraverseLaws() {

--- a/Tests/BowTests/Data/EitherTest.swift
+++ b/Tests/BowTests/Data/EitherTest.swift
@@ -11,7 +11,7 @@ class EitherTest: XCTestCase {
     }
 
     func testEquatableLaws() {
-        EquatableKLaws<EitherPartial<Int>, Int>.check(generator: self.generator)
+        EquatableKLaws<EitherPartial<Int>, Int>.check()
     }
     
     func testFunctorLaws() {

--- a/Tests/BowTests/Data/EvalTest.swift
+++ b/Tests/BowTests/Data/EvalTest.swift
@@ -1,15 +1,5 @@
 import XCTest
-@testable import BowLaws
-@testable import Bow
+import BowLaws
+import Bow
 
-class EvalTest: XCTestCase {
-    
-    var generator: (Int) -> EvalOf<Int> {
-        return { a in Eval.pure(a) }
-    }
-
-    func testEquatableLaws() {
-        EquatableKLaws.check(generator: self.generator)
-    }
-    
-}
+class EvalTest: XCTestCase {}

--- a/Tests/BowTests/Data/IdTest.swift
+++ b/Tests/BowTests/Data/IdTest.swift
@@ -9,7 +9,7 @@ class IdTest: XCTestCase {
     }
 
     func testEquatableLaws() {
-        EquatableKLaws.check(generator: self.generator)
+        EquatableKLaws<ForId, Int>.check()
     }
     
     func testFunctorLaws() {

--- a/Tests/BowTests/Data/IdTest.swift
+++ b/Tests/BowTests/Data/IdTest.swift
@@ -1,7 +1,7 @@
 import XCTest
 import SwiftCheck
 @testable import BowLaws
-@testable import Bow
+import Bow
 
 class IdTest: XCTestCase {
     var generator : (Int) -> Id<Int> {
@@ -33,7 +33,7 @@ class IdTest: XCTestCase {
     }
     
     func testCustomStringConvertibleLaws() {
-        CustomStringConvertibleLaws.check(generator: self.generator)
+        CustomStringConvertibleLaws<Id<Int>>.check()
     }
     
     func testFoldableLaws() {

--- a/Tests/BowTests/Data/IdTest.swift
+++ b/Tests/BowTests/Data/IdTest.swift
@@ -45,6 +45,6 @@ class IdTest: XCTestCase {
     }
     
     func testTraverseLaws() {
-        TraverseLaws<ForId>.check(generator: self.generator)
+        TraverseLaws<ForId>.check()
     }
 }

--- a/Tests/BowTests/Data/IdTest.swift
+++ b/Tests/BowTests/Data/IdTest.swift
@@ -13,7 +13,7 @@ class IdTest: XCTestCase {
     }
     
     func testFunctorLaws() {
-        FunctorLaws<ForId>.check(generator: self.generator)
+        FunctorLaws<ForId>.check()
     }
     
     func testApplicativeLaws() {

--- a/Tests/BowTests/Data/IdTest.swift
+++ b/Tests/BowTests/Data/IdTest.swift
@@ -37,7 +37,7 @@ class IdTest: XCTestCase {
     }
     
     func testFoldableLaws() {
-        FoldableLaws<ForId>.check(generator: self.generator)
+        FoldableLaws<ForId>.check()
     }
     
     func testBimonadLaws() {

--- a/Tests/BowTests/Data/IdTest.swift
+++ b/Tests/BowTests/Data/IdTest.swift
@@ -29,7 +29,7 @@ class IdTest: XCTestCase {
     }
     
     func testComonadLaws() {
-        ComonadLaws<ForId>.check(generator: self.generator)
+        ComonadLaws<ForId>.check()
     }
     
     func testCustomStringConvertibleLaws() {
@@ -41,7 +41,7 @@ class IdTest: XCTestCase {
     }
     
     func testBimonadLaws() {
-        BimonadLaws<ForId>.check(generator: self.generator)
+        BimonadLaws<ForId>.check()
     }
     
     func testTraverseLaws() {

--- a/Tests/BowTests/Data/IdTest.swift
+++ b/Tests/BowTests/Data/IdTest.swift
@@ -1,13 +1,8 @@
 import XCTest
-import SwiftCheck
 @testable import BowLaws
 import Bow
 
 class IdTest: XCTestCase {
-    var generator : (Int) -> Id<Int> {
-        return { a in Id<Int>(a) }
-    }
-
     func testEquatableLaws() {
         EquatableKLaws<ForId, Int>.check()
     }

--- a/Tests/BowTests/Data/IorTest.swift
+++ b/Tests/BowTests/Data/IorTest.swift
@@ -38,7 +38,7 @@ class IorTest: XCTestCase {
     }
     
     func testFoldableLaws() {
-        FoldableLaws<IorPartial<Int>>.check(generator: self.generator)
+        FoldableLaws<IorPartial<Int>>.check()
     }
     
     func testCheckers() {

--- a/Tests/BowTests/Data/IorTest.swift
+++ b/Tests/BowTests/Data/IorTest.swift
@@ -14,7 +14,7 @@ class IorTest: XCTestCase {
     }
 
     func testEquatableLaws() {
-        EquatableKLaws.check(generator: self.generator)
+        EquatableKLaws<IorPartial<Int>, Int>.check()
     }
     
     func testFunctorLaws() {

--- a/Tests/BowTests/Data/IorTest.swift
+++ b/Tests/BowTests/Data/IorTest.swift
@@ -5,14 +5,6 @@ import SwiftCheck
 import Bow
 
 class IorTest: XCTestCase {
-    var generator = { (a : Int) -> Ior<Int, Int> in
-        switch a % 3 {
-        case 0 : return Ior.left(a)
-        case 1: return Ior.right(a)
-        default: return Ior.both(a, a)
-        }
-    }
-
     func testEquatableLaws() {
         EquatableKLaws<IorPartial<Int>, Int>.check()
     }
@@ -42,36 +34,31 @@ class IorTest: XCTestCase {
     }
     
     func testCheckers() {
-        property("Ior can only be one of left, right or both") <- forAll { (x : Int) in
-            let input = self.generator(x)
+        property("Ior can only be one of left, right or both") <- forAll { (input: Ior<Int, Int>) in
             return xor(input.isBoth, xor(input.isLeft, input.isRight))
         }
     }
     
     func testBimapConsitent() {
-        property("bimap is equivalent to map and mapLeft") <- forAll { (x : Int, f : ArrowOf<Int, Int>, g : ArrowOf<Int, Int>) in
-            let input = self.generator(x)
+        property("bimap is equivalent to map and mapLeft") <- forAll { (input: Ior<Int, Int>, f: ArrowOf<Int, Int>, g: ArrowOf<Int, Int>) in
             return input.bimap(f.getArrow, g.getArrow) == Ior.fix(input.map(g.getArrow)).mapLeft(f.getArrow)
         }
     }
     
     func testSwapIsomorphism() {
-        property("swap twice is equivalent to identity") <- forAll { (x : Int) in
-            let input = self.generator(x)
+        property("swap twice is equivalent to identity") <- forAll { (input: Ior<Int, Int>) in
             return input.swap().swap() == input
         }
     }
     
     func testToEither() {
-        property("left and right preserved in conversion to Either") <- forAll { (x : Int) in
-            let input = self.generator(x)
+        property("left and right preserved in conversion to Either") <- forAll { (input: Ior<Int, Int>) in
             return (input.isLeft && input.toEither().isLeft) || input.toEither().isRight
         }
     }
     
     func testToOption() {
-        property("right or both converted to some") <- forAll { (x : Int) in
-            let input = self.generator(x)
+        property("right or both converted to some") <- forAll { (input: Ior<Int, Int>) in
             return (input.isLeft && input.toOption().isEmpty) || input.toOption().isDefined
         }
     }

--- a/Tests/BowTests/Data/IorTest.swift
+++ b/Tests/BowTests/Data/IorTest.swift
@@ -18,7 +18,7 @@ class IorTest: XCTestCase {
     }
     
     func testFunctorLaws() {
-        FunctorLaws<IorPartial<Int>>.check(generator: self.generator)
+        FunctorLaws<IorPartial<Int>>.check()
     }
     
     func testApplicativeLaws() {

--- a/Tests/BowTests/Data/IorTest.swift
+++ b/Tests/BowTests/Data/IorTest.swift
@@ -2,7 +2,7 @@ import XCTest
 import Nimble
 import SwiftCheck
 @testable import BowLaws
-@testable import Bow
+import Bow
 
 class IorTest: XCTestCase {
     var generator = { (a : Int) -> Ior<Int, Int> in
@@ -34,7 +34,7 @@ class IorTest: XCTestCase {
     }
     
     func testCustomStringConvertibleLaws() {
-        CustomStringConvertibleLaws.check(generator: self.generator)
+        CustomStringConvertibleLaws<Ior<Int, Int>>.check()
     }
     
     func testFoldableLaws() {

--- a/Tests/BowTests/Data/MooreTest.swift
+++ b/Tests/BowTests/Data/MooreTest.swift
@@ -1,7 +1,7 @@
 import XCTest
 import Nimble
 @testable import BowLaws
-@testable import Bow
+import Bow
 
 extension MoorePartial: EquatableK {
     public static func eq<A>(_ lhs: Kind<MoorePartial<E>, A>, _ rhs: Kind<MoorePartial<E>, A>) -> Bool where A : Equatable {

--- a/Tests/BowTests/Data/MooreTest.swift
+++ b/Tests/BowTests/Data/MooreTest.swift
@@ -15,7 +15,7 @@ class MooreTest: XCTestCase {
     }
 
     func testFunctorLaws() {
-        FunctorLaws<MoorePartial<Int>>.check(generator: handle)
+        FunctorLaws<MoorePartial<Int>>.check()
     }
     
     func testComonadLaws() {

--- a/Tests/BowTests/Data/MooreTest.swift
+++ b/Tests/BowTests/Data/MooreTest.swift
@@ -10,10 +10,6 @@ extension MoorePartial: EquatableK {
 }
 
 class MooreTest: XCTestCase {
-    func handle(_ x: Int) -> Moore<Int, Int> {
-        return Moore(view: x, handle: handle)
-    }
-
     func testFunctorLaws() {
         FunctorLaws<MoorePartial<Int>>.check()
     }

--- a/Tests/BowTests/Data/MooreTest.swift
+++ b/Tests/BowTests/Data/MooreTest.swift
@@ -19,7 +19,7 @@ class MooreTest: XCTestCase {
     }
     
     func testComonadLaws() {
-        ComonadLaws<MoorePartial<Int>>.check(generator: handle)
+        ComonadLaws<MoorePartial<Int>>.check()
     }
     
     func handleRoute(_ route : String) -> Moore<String, Id<String>> {

--- a/Tests/BowTests/Data/NonEmptyArrayTest.swift
+++ b/Tests/BowTests/Data/NonEmptyArrayTest.swift
@@ -38,7 +38,7 @@ class NonEmptyArrayTest: XCTestCase {
     }
     
     func testTraverseLaws() {
-        TraverseLaws<ForNonEmptyArray>.check(generator: self.generator)
+        TraverseLaws<ForNonEmptyArray>.check()
     }
     
     func testSemigroupLaws() {

--- a/Tests/BowTests/Data/NonEmptyArrayTest.swift
+++ b/Tests/BowTests/Data/NonEmptyArrayTest.swift
@@ -30,11 +30,11 @@ class NonEmptyArrayTest: XCTestCase {
     }
     
     func testComonadLaws() {
-        ComonadLaws<ForNonEmptyArray>.check(generator: self.generator)
+        ComonadLaws<ForNonEmptyArray>.check()
     }
     
     func testBimonadLaws() {
-        BimonadLaws<ForNonEmptyArray>.check(generator: self.generator)
+        BimonadLaws<ForNonEmptyArray>.check()
     }
     
     func testTraverseLaws() {

--- a/Tests/BowTests/Data/NonEmptyArrayTest.swift
+++ b/Tests/BowTests/Data/NonEmptyArrayTest.swift
@@ -14,7 +14,7 @@ class NonEmptyArrayTest: XCTestCase {
     }
     
     func testFunctorLaws() {
-        FunctorLaws<ForNonEmptyArray>.check(generator: self.generator)
+        FunctorLaws<ForNonEmptyArray>.check()
     }
     
     func testApplicativeLaws() {

--- a/Tests/BowTests/Data/NonEmptyArrayTest.swift
+++ b/Tests/BowTests/Data/NonEmptyArrayTest.swift
@@ -1,7 +1,7 @@
 import XCTest
 import SwiftCheck
 @testable import BowLaws
-@testable import Bow
+import Bow
 
 class NonEmptyArrayTest: XCTestCase {
     
@@ -55,7 +55,7 @@ class NonEmptyArrayTest: XCTestCase {
     }
     
     func testCustomStringConvertibleLaws() {
-        CustomStringConvertibleLaws.check(generator: self.generator)
+        CustomStringConvertibleLaws<NEA<Int>>.check()
     }
     
     func testFoldableLaws() {

--- a/Tests/BowTests/Data/NonEmptyArrayTest.swift
+++ b/Tests/BowTests/Data/NonEmptyArrayTest.swift
@@ -59,7 +59,7 @@ class NonEmptyArrayTest: XCTestCase {
     }
     
     func testFoldableLaws() {
-        FoldableLaws<ForNonEmptyArray>.check(generator: self.generator)
+        FoldableLaws<ForNonEmptyArray>.check()
     }
     
     private let neaGenerator = Array<Int>.arbitrary.suchThat { array in array.count > 0 }

--- a/Tests/BowTests/Data/NonEmptyArrayTest.swift
+++ b/Tests/BowTests/Data/NonEmptyArrayTest.swift
@@ -10,7 +10,7 @@ class NonEmptyArrayTest: XCTestCase {
     }
 
     func testEquatableLaws() {
-        EquatableKLaws.check(generator: self.generator)
+        EquatableKLaws<ForNonEmptyArray, Int>.check()
     }
     
     func testFunctorLaws() {

--- a/Tests/BowTests/Data/NonEmptyArrayTest.swift
+++ b/Tests/BowTests/Data/NonEmptyArrayTest.swift
@@ -51,7 +51,7 @@ class NonEmptyArrayTest: XCTestCase {
     }
     
     func testSemigroupKLaws() {
-        SemigroupKLaws<ForNonEmptyArray>.check(generator: self.generator)
+        SemigroupKLaws<ForNonEmptyArray>.check()
     }
     
     func testCustomStringConvertibleLaws() {

--- a/Tests/BowTests/Data/NonEmptyArrayTest.swift
+++ b/Tests/BowTests/Data/NonEmptyArrayTest.swift
@@ -4,11 +4,6 @@ import SwiftCheck
 import Bow
 
 class NonEmptyArrayTest: XCTestCase {
-    
-    var generator: (Int) -> NonEmptyArray<Int> {
-        return { a in NonEmptyArray(head: a, tail: []) }
-    }
-
     func testEquatableLaws() {
         EquatableKLaws<ForNonEmptyArray, Int>.check()
     }
@@ -57,24 +52,16 @@ class NonEmptyArrayTest: XCTestCase {
         FoldableLaws<ForNonEmptyArray>.check()
     }
     
-    private let neaGenerator = Array<Int>.arbitrary.suchThat { array in array.count > 0 }
-    
     func testConcatenation() {
-        property("The length of the concatenation is equal to the sum of lenghts") <- forAll(self.neaGenerator, self.neaGenerator) { (x: Array<Int>, y: Array<Int>) in
-            let a = NonEmptyArray.fromArrayUnsafe(x)
-            let b = NonEmptyArray.fromArrayUnsafe(y)
+        property("The length of the concatenation is equal to the sum of lenghts") <- forAll { (a: NEA<Int>, b: NEA<Int>) in
             return a.count + b.count == (a + b).count
         }
         
-        property("Adding one element increases length in one") <- forAll(self.neaGenerator, Int.arbitrary) { (array: Array<Int>, element: Int) in
-            let nea = NonEmptyArray.fromArrayUnsafe(array)
+        property("Adding one element increases length in one") <- forAll { (nea: NEA<Int>, element: Int) in
             return (nea + element).count == nea.count + 1
         }
         
-        property("Result of concatenation contains all items from the original arrays") <- forAll(self.neaGenerator, self.neaGenerator) {
-            (x: Array<Int>, y: Array<Int>) in
-            let a = NonEmptyArray.fromArrayUnsafe(x)
-            let b = NonEmptyArray.fromArrayUnsafe(y)
+        property("Result of concatenation contains all items from the original arrays") <- forAll { (a: NEA<Int>, b: NEA<Int>) in
             let concatenation = a + b
             return concatenation.containsAll(elements: a.all()) &&
                     concatenation.containsAll(elements: b.all())

--- a/Tests/BowTests/Data/NonEmptyArrayTest.swift
+++ b/Tests/BowTests/Data/NonEmptyArrayTest.swift
@@ -42,12 +42,7 @@ class NonEmptyArrayTest: XCTestCase {
     }
     
     func testSemigroupLaws() {
-        property("NonEmptyArray semigroup laws") <- forAll { (a: Int, b: Int, c: Int) in
-            return SemigroupLaws<NonEmptyArray<Int>>.check(
-                a: NonEmptyArray<Int>(head: a, tail: []),
-                    b: NonEmptyArray<Int>(head: b, tail: []),
-                    c: NonEmptyArray<Int>(head: c, tail: []))
-        }
+        SemigroupLaws<NonEmptyArray<Int>>.check()
     }
     
     func testSemigroupKLaws() {

--- a/Tests/BowTests/Data/OptionTest.swift
+++ b/Tests/BowTests/Data/OptionTest.swift
@@ -10,7 +10,7 @@ class OptionTest: XCTestCase {
     }
 
     func testEquatableLaws() {
-        EquatableKLaws.check(generator: self.generator)
+        EquatableKLaws<ForOption, Int>.check()
     }
     
     func testFunctorLaws() {

--- a/Tests/BowTests/Data/OptionTest.swift
+++ b/Tests/BowTests/Data/OptionTest.swift
@@ -57,7 +57,7 @@ class OptionTest: XCTestCase {
     }
     
     func testFoldableLaws() {
-        FoldableLaws<ForOption>.check(generator: self.generator)
+        FoldableLaws<ForOption>.check()
     }
     
     func testTraverseLaws() {

--- a/Tests/BowTests/Data/OptionTest.swift
+++ b/Tests/BowTests/Data/OptionTest.swift
@@ -4,11 +4,6 @@ import SwiftCheck
 import Bow
 
 class OptionTest: XCTestCase {
-    
-    var generator: (Int) -> Option<Int> {
-        return { a in a % 2 == 0 ? Option.some(a) : Option.none() }
-    }
-
     func testEquatableLaws() {
         EquatableKLaws<ForOption, Int>.check()
     }
@@ -62,39 +57,34 @@ class OptionTest: XCTestCase {
     }
     
     func testFromToOption() {
-        property("fromOption - toOption isomorphism") <- forAll { (x: Int?, y: Int) in
-            let option = y % 2 == 0 ? Option<Int>.none() : Option<Int>.some(y)
+        property("fromOption - toOption isomorphism") <- forAll { (x: Int?, option: Option<Int>) in
             return Option.fromOptional(x).toOptional() == x &&
                 Option.fromOptional(option.toOptional()) == option
         }
     }
     
     func testDefinedOrEmpty() {
-        property("Option cannot be simultaneously empty and defined") <- forAll { (x: Int?) in
-            let option = Option.fromOptional(x)
+        property("Option cannot be simultaneously empty and defined") <- forAll { (option: Option<Int>) in
             return xor(option.isEmpty, option.isDefined)
         }
     }
     
     func testGetOrElse() {
-        property("getOrElse consistent with orElse") <- forAll { (x: Int?, y: Int) in
-            let option = Option.fromOptional(x)
+        property("getOrElse consistent with orElse") <- forAll { (option: Option<Int>, y: Int) in
             return Option<Int>.pure(option.getOrElse(y)) == Option.fix(option).orElse(Option.some(y))
         }
     }
     
     func testFilter() {
-        property("filter is opposite of filterNot") <- forAll { (x: Int, predicate: ArrowOf<Int, Bool>) in
-            let option = Option.fromOptional(x)
+        property("filter is opposite of filterNot") <- forAll { (option: Option<Int>, predicate: ArrowOf<Int, Bool>) in
             let none = Option<Int>.none()
-            return xor(option.filter(predicate.getArrow) == none, option.filterNot(predicate.getArrow) == none)
+            return xor(option.filter(predicate.getArrow) == none, option.filterNot(predicate.getArrow) == none) || option.isEmpty
         }
     }
     
     func testExistForAll() {
-        property("exists and forall are equivalent") <- forAll { (x: Int, predicate: ArrowOf<Int, Bool>) in
-            let option = Option.fromOptional(x)
-            return option.exists(predicate.getArrow) == option.forall(predicate.getArrow)
+        property("exists and forall are equivalent") <- forAll { (option: Option<Int>, predicate: ArrowOf<Int, Bool>) in
+            return option.exists(predicate.getArrow) == option.forall(predicate.getArrow) || option.isEmpty
         }
     }
 }

--- a/Tests/BowTests/Data/OptionTest.swift
+++ b/Tests/BowTests/Data/OptionTest.swift
@@ -14,7 +14,7 @@ class OptionTest: XCTestCase {
     }
     
     func testFunctorLaws() {
-        FunctorLaws<ForOption>.check(generator: self.generator)
+        FunctorLaws<ForOption>.check()
     }
     
     func testApplicativeLaws() {

--- a/Tests/BowTests/Data/OptionTest.swift
+++ b/Tests/BowTests/Data/OptionTest.swift
@@ -45,7 +45,7 @@ class OptionTest: XCTestCase {
     }
     
     func testFunctorFilterLaws() {
-        FunctorFilterLaws<ForOption>.check(generator: self.generator)
+        FunctorFilterLaws<ForOption>.check()
     }
     
     func testMonadFilterLaws() {

--- a/Tests/BowTests/Data/OptionTest.swift
+++ b/Tests/BowTests/Data/OptionTest.swift
@@ -30,12 +30,7 @@ class OptionTest: XCTestCase {
     }
     
     func testSemigroupLaws() {
-        property("Option semigroup laws") <- forAll { (a: Int, b: Int, c: Int) in
-            return SemigroupLaws<Option<Int>>.check(
-                a: Option.some(a),
-                b: Option.some(b),
-                c: Option.some(c))
-        }
+        SemigroupLaws<Option<Int>>.check()
     }
     
     func testMonoidLaws() {

--- a/Tests/BowTests/Data/OptionTest.swift
+++ b/Tests/BowTests/Data/OptionTest.swift
@@ -1,7 +1,7 @@
 import XCTest
 import SwiftCheck
 @testable import BowLaws
-@testable import Bow
+import Bow
 
 class OptionTest: XCTestCase {
     
@@ -53,7 +53,7 @@ class OptionTest: XCTestCase {
     }
     
     func testCustomStringConvertibleLaws() {
-        CustomStringConvertibleLaws.check(generator: self.generator)
+        CustomStringConvertibleLaws<Option<Int>>.check()
     }
     
     func testFoldableLaws() {

--- a/Tests/BowTests/Data/OptionTest.swift
+++ b/Tests/BowTests/Data/OptionTest.swift
@@ -34,9 +34,7 @@ class OptionTest: XCTestCase {
     }
     
     func testMonoidLaws() {
-        property("Option monoid laws") <- forAll { (a: Int) in
-            return MonoidLaws<Option<Int>>.check(a: Option.some(a))
-        }
+        MonoidLaws<Option<Int>>.check()
     }
     
     func testFunctorFilterLaws() {

--- a/Tests/BowTests/Data/OptionTest.swift
+++ b/Tests/BowTests/Data/OptionTest.swift
@@ -49,7 +49,7 @@ class OptionTest: XCTestCase {
     }
     
     func testMonadFilterLaws() {
-        MonadFilterLaws<ForOption>.check(generator: self.generator)
+        MonadFilterLaws<ForOption>.check()
     }
     
     func testCustomStringConvertibleLaws() {

--- a/Tests/BowTests/Data/OptionTest.swift
+++ b/Tests/BowTests/Data/OptionTest.swift
@@ -61,7 +61,7 @@ class OptionTest: XCTestCase {
     }
     
     func testTraverseLaws() {
-        TraverseLaws<ForOption>.check(generator: self.generator)
+        TraverseLaws<ForOption>.check()
     }
     
     func testTraverseFilterLaws() {

--- a/Tests/BowTests/Data/ResultTest.swift
+++ b/Tests/BowTests/Data/ResultTest.swift
@@ -8,24 +8,22 @@ enum ResultError: Int, Error {
     case unknown
 }
 
+extension ResultError: Arbitrary {
+    static var arbitrary: Gen<ResultError> {
+        return Gen.fromElements(of: [.warning, .fatal, .unknown])
+    }
+}
+
 class ResultTest: XCTestCase {
-    func generateEither(_ x: Int) -> Either<ResultError, Int> {
-        return x % 2 == 0 ? Either.left(.warning): Either.right(x)
-    }
-    
-    func generateValidated(_ x: Int) -> Validated<ResultError, Int> {
-        return x % 2 == 0 ? Validated.invalid(.fatal) : Validated.valid(x)
-    }
-    
     func testResultEitherIsomorphism() {
-        property("Either and Result are isomorphic") <- forAll { (x: Int) in
-            return self.generateEither(x).toResult().toEither() == self.generateEither(x)
+        property("Either and Result are isomorphic") <- forAll { (x: Either<ResultError, Int>) in
+            return x.toResult().toEither() == x
         }
     }
     
     func testResultValidateIsomorphism() {
-        property("Validated and Result are isomorphic") <- forAll { (x: Int) in
-            return self.generateValidated(x).toResult().toValidated() == self.generateValidated(x)
+        property("Validated and Result are isomorphic") <- forAll { (x: Validated<ResultError, Int>) in
+            return x.toResult().toValidated() == x
         }
     }
 }

--- a/Tests/BowTests/Data/ResultTest.swift
+++ b/Tests/BowTests/Data/ResultTest.swift
@@ -1,6 +1,6 @@
 import XCTest
 import SwiftCheck
-@testable import Bow
+import Bow
 
 enum ResultError: Int, Error {
     case warning

--- a/Tests/BowTests/Data/SetKTest.swift
+++ b/Tests/BowTests/Data/SetKTest.swift
@@ -1,7 +1,7 @@
 import XCTest
 import SwiftCheck
 @testable import BowLaws
-@testable import Bow
+import Bow
 
 class SetKTest: XCTestCase {
 

--- a/Tests/BowTests/Data/StoreTest.swift
+++ b/Tests/BowTests/Data/StoreTest.swift
@@ -17,7 +17,7 @@ class StoreTest: XCTestCase {
     }
     
     func testComonadLaws() {
-        ComonadLaws<StorePartial<Int>>.check(generator: intStore)
+        ComonadLaws<StorePartial<Int>>.check()
     }
     
     let greetingStore = { (name : String) in Store(state: name, render: { name in "Hi \(name)!"}) }

--- a/Tests/BowTests/Data/StoreTest.swift
+++ b/Tests/BowTests/Data/StoreTest.swift
@@ -13,7 +13,7 @@ class StoreTest: XCTestCase {
     let intStore = { (x: Int) in Store(state: x, render: id) }
 
     func testFunctorLaws() {
-        FunctorLaws<StorePartial<Int>>.check(generator: intStore)
+        FunctorLaws<StorePartial<Int>>.check()
     }
     
     func testComonadLaws() {

--- a/Tests/BowTests/Data/StoreTest.swift
+++ b/Tests/BowTests/Data/StoreTest.swift
@@ -10,8 +10,6 @@ extension StorePartial: EquatableK {
 }
 
 class StoreTest: XCTestCase {
-    let intStore = { (x: Int) in Store(state: x, render: id) }
-
     func testFunctorLaws() {
         FunctorLaws<StorePartial<Int>>.check()
     }

--- a/Tests/BowTests/Data/StoreTest.swift
+++ b/Tests/BowTests/Data/StoreTest.swift
@@ -1,7 +1,7 @@
 import XCTest
 import Nimble
 @testable import BowLaws
-@testable import Bow
+import Bow
 
 extension StorePartial: EquatableK {
     public static func eq<A>(_ lhs: Kind<StorePartial<S>, A>, _ rhs: Kind<StorePartial<S>, A>) -> Bool where A: Equatable {

--- a/Tests/BowTests/Data/SumTest.swift
+++ b/Tests/BowTests/Data/SumTest.swift
@@ -13,7 +13,7 @@ class SumTest: XCTestCase {
     let generator = { (x: Int) in Sum.left(Id(x), Id(x)) }
     
     func testFunctorLaws() {
-        FunctorLaws.check(generator: generator)
+        FunctorLaws<SumPartial<ForId, ForId>>.check()
     }
     
     func testComonadLaws() {

--- a/Tests/BowTests/Data/SumTest.swift
+++ b/Tests/BowTests/Data/SumTest.swift
@@ -10,8 +10,6 @@ extension SumPartial: EquatableK where F: Comonad, G: Comonad {
 }
 
 class SumTest: XCTestCase {
-    let generator = { (x: Int) in Sum.left(Id(x), Id(x)) }
-    
     func testFunctorLaws() {
         FunctorLaws<SumPartial<ForId, ForId>>.check()
     }

--- a/Tests/BowTests/Data/SumTest.swift
+++ b/Tests/BowTests/Data/SumTest.swift
@@ -1,7 +1,7 @@
 import XCTest
 import Nimble
 @testable import BowLaws
-@testable import Bow
+import Bow
 
 extension SumPartial: EquatableK where F: Comonad, G: Comonad {
     public static func eq<A>(_ lhs: Kind<SumPartial<F, G>, A>, _ rhs: Kind<SumPartial<F, G>, A>) -> Bool where A : Equatable {

--- a/Tests/BowTests/Data/SumTest.swift
+++ b/Tests/BowTests/Data/SumTest.swift
@@ -17,7 +17,7 @@ class SumTest: XCTestCase {
     }
     
     func testComonadLaws() {
-        ComonadLaws.check(generator: generator)
+        ComonadLaws<SumPartial<ForId, ForId>>.check()
     }
     
     let abSum = Sum.left(Id("A"), Id("B"))

--- a/Tests/BowTests/Data/TryTest.swift
+++ b/Tests/BowTests/Data/TryTest.swift
@@ -1,7 +1,7 @@
 import XCTest
 import SwiftCheck
 @testable import BowLaws
-@testable import Bow
+import Bow
 
 class TryTest: XCTestCase {
     
@@ -30,7 +30,7 @@ class TryTest: XCTestCase {
     }
     
     func testCustomStringConvertibleLaws() {
-        CustomStringConvertibleLaws.check(generator: self.generator)
+        CustomStringConvertibleLaws<Try<Int>>.check()
     }
     
     func testFoldableLaws() {

--- a/Tests/BowTests/Data/TryTest.swift
+++ b/Tests/BowTests/Data/TryTest.swift
@@ -34,7 +34,7 @@ class TryTest: XCTestCase {
     }
     
     func testFoldableLaws() {
-        FoldableLaws<ForTry>.check(generator: self.generator)
+        FoldableLaws<ForTry>.check()
     }
     
     func testTraverseLaws() {

--- a/Tests/BowTests/Data/TryTest.swift
+++ b/Tests/BowTests/Data/TryTest.swift
@@ -1,14 +1,8 @@
 import XCTest
-import SwiftCheck
 @testable import BowLaws
 import Bow
 
 class TryTest: XCTestCase {
-    
-    var generator : (Int) -> Try<Int> {
-        return { a in (a % 2 == 0) ? Try.invoke(constant(a)) : Try.invoke({ throw TryError.illegalState }) }
-    }
-
     func testEquatableLaws() {
         EquatableKLaws<ForTry, Int>.check()
     }

--- a/Tests/BowTests/Data/TryTest.swift
+++ b/Tests/BowTests/Data/TryTest.swift
@@ -50,8 +50,6 @@ class TryTest: XCTestCase {
     }
 
     func testMonoidLaws() {
-        property("Try monoid laws") <- forAll { (a: Int) in
-            return MonoidLaws<Try<Int>>.check(a: Try.success(a))
-        }
+        MonoidLaws<Try<Int>>.check()
     }
 }

--- a/Tests/BowTests/Data/TryTest.swift
+++ b/Tests/BowTests/Data/TryTest.swift
@@ -42,7 +42,7 @@ class TryTest: XCTestCase {
     }
 
     func testFunctorFilterLaws() {
-        FunctorFilterLaws<ForTry>.check(generator: self.generator)
+        FunctorFilterLaws<ForTry>.check()
     }
 
     func testSemigroupLaws() {

--- a/Tests/BowTests/Data/TryTest.swift
+++ b/Tests/BowTests/Data/TryTest.swift
@@ -10,7 +10,7 @@ class TryTest: XCTestCase {
     }
 
     func testEquatableLaws() {
-        EquatableKLaws.check(generator: self.generator)
+        EquatableKLaws<ForTry, Int>.check()
     }
     
     func testFunctorLaws() {

--- a/Tests/BowTests/Data/TryTest.swift
+++ b/Tests/BowTests/Data/TryTest.swift
@@ -46,12 +46,7 @@ class TryTest: XCTestCase {
     }
 
     func testSemigroupLaws() {
-        property("Try semigroup laws") <- forAll { (a: Int, b: Int, c: Int) in
-            return SemigroupLaws<Try<Int>>.check(
-                a: Try.success(a),
-                b: Try.success(b),
-                c: Try.success(c))
-        }
+        SemigroupLaws<Try<Int>>.check()
     }
 
     func testMonoidLaws() {

--- a/Tests/BowTests/Data/TryTest.swift
+++ b/Tests/BowTests/Data/TryTest.swift
@@ -14,7 +14,7 @@ class TryTest: XCTestCase {
     }
     
     func testFunctorLaws() {
-        FunctorLaws<ForTry>.check(generator: self.generator)
+        FunctorLaws<ForTry>.check()
     }
     
     func testApplicativeLaws() {

--- a/Tests/BowTests/Data/TryTest.swift
+++ b/Tests/BowTests/Data/TryTest.swift
@@ -38,7 +38,7 @@ class TryTest: XCTestCase {
     }
     
     func testTraverseLaws() {
-        TraverseLaws<ForTry>.check(generator: self.generator)
+        TraverseLaws<ForTry>.check()
     }
 
     func testFunctorFilterLaws() {

--- a/Tests/BowTests/Data/ValidatedTest.swift
+++ b/Tests/BowTests/Data/ValidatedTest.swift
@@ -34,7 +34,7 @@ class ValidatedTest: XCTestCase {
     }
     
     func testFoldableLaws() {
-        FoldableLaws<ValidatedPartial<Int>>.check(generator: self.generator)
+        FoldableLaws<ValidatedPartial<Int>>.check()
     }
     
     func testApplicativeErrorLaws() {

--- a/Tests/BowTests/Data/ValidatedTest.swift
+++ b/Tests/BowTests/Data/ValidatedTest.swift
@@ -14,7 +14,7 @@ class ValidatedTest: XCTestCase {
     }
     
     func testFunctorLaws() {
-        FunctorLaws<ValidatedPartial<Int>>.check(generator: self.generator)
+        FunctorLaws<ValidatedPartial<Int>>.check()
     }
     
     func testApplicativeLaws() {

--- a/Tests/BowTests/Data/ValidatedTest.swift
+++ b/Tests/BowTests/Data/ValidatedTest.swift
@@ -10,7 +10,7 @@ class ValidatedTest: XCTestCase {
     }
 
     func testEquatableLaws() {
-        EquatableKLaws.check(generator: self.generator)
+        EquatableKLaws<ValidatedPartial<Int>, Int>.check()
     }
     
     func testFunctorLaws() {

--- a/Tests/BowTests/Data/ValidatedTest.swift
+++ b/Tests/BowTests/Data/ValidatedTest.swift
@@ -26,7 +26,7 @@ class ValidatedTest: XCTestCase {
     }
     
     func testSemigroupKLaws() {
-        SemigroupKLaws<ValidatedPartial<Int>>.check(generator: self.generator)
+        SemigroupKLaws<ValidatedPartial<Int>>.check()
     }
 
     func testCustomStringConvertibleLaws() {

--- a/Tests/BowTests/Data/ValidatedTest.swift
+++ b/Tests/BowTests/Data/ValidatedTest.swift
@@ -4,11 +4,6 @@ import SwiftCheck
 import Bow
 
 class ValidatedTest: XCTestCase {
-    
-    var generator: (Int) -> Validated<Int, Int> {
-        return { a in (a % 2 == 0) ? Validated.valid(a) : Validated.invalid(a) }
-    }
-
     func testEquatableLaws() {
         EquatableKLaws<ValidatedPartial<Int>, Int>.check()
     }
@@ -46,36 +41,29 @@ class ValidatedTest: XCTestCase {
     }
     
     func testCheckers() {
-        property("valid and invalid are mutually exclusive") <- forAll { (x: Int) in
-            let input = self.generator(x)
+        property("valid and invalid are mutually exclusive") <- forAll { (input: Validated<Int, Int>) in
             return xor(input.isValid, input.isInvalid)
         }
     }
     
     func testConversionConsistency() {
-        property("Consistency fromOption - toOption") <- forAll { (x: Int?, none: String) in
-            let option = Option<Int>.fromOptional(x)
-            let validated = Validated.fromOption(option, ifNone: constant(none))
-            return validated.toOption() == option
+        property("Consistency fromOption - toOption") <- forAll { (option: Option<Int>, none: String) in
+            return Validated.fromOption(option, ifNone: constant(none)).toOption() == option
         }
         
-        property("Consistency fromEither - toEither") <- forAll { (x: Int) in
-            let either = x % 2 == 0 ? Either.left(x) : Either.right(x)
-            let validated = Validated.fix(Validated.fromEither(either))
-            return validated.toEither() == either
+        property("Consistency fromEither - toEither") <- forAll { (either: Either<Int, Int>) in
+            return Validated.fromEither(either)^.toEither() == either
         }
         
-        property("Consistency fromTry - toList") <- forAll { (x: Int) in
-            let attempt = x % 2 == 0 ? Try.success(x) : Try.failure(TryError.illegalState)
+        property("Consistency fromTry - toList") <- forAll { (attempt: Try<Int>) in
             let validated = Validated<TryError, Int>.fromTry(attempt)
-            return (validated.isValid && validated.toArray() == [x]) ||
+            return (validated.isValid && validated.toArray().count == 1) ||
                     (validated.isInvalid && validated.toArray() == [])
         }
     }
 
     func testSwapIsomorphism() {
-        property("swap twice is equivalent to id") <- forAll { (x : Int) in
-            let input = self.generator(x)
+        property("swap twice is equivalent to id") <- forAll { (input: Validated<Int, Int>) in
             return input.swap().swap() == input
         }
     }

--- a/Tests/BowTests/Data/ValidatedTest.swift
+++ b/Tests/BowTests/Data/ValidatedTest.swift
@@ -42,7 +42,7 @@ class ValidatedTest: XCTestCase {
     }
     
     func testTraverseLaws() {
-        TraverseLaws<ValidatedPartial<Int>>.check(generator: self.generator)
+        TraverseLaws<ValidatedPartial<Int>>.check()
     }
     
     func testCheckers() {

--- a/Tests/BowTests/Data/ValidatedTest.swift
+++ b/Tests/BowTests/Data/ValidatedTest.swift
@@ -1,7 +1,7 @@
 import XCTest
 import SwiftCheck
 @testable import BowLaws
-@testable import Bow
+import Bow
 
 class ValidatedTest: XCTestCase {
     
@@ -30,7 +30,7 @@ class ValidatedTest: XCTestCase {
     }
 
     func testCustomStringConvertibleLaws() {
-        CustomStringConvertibleLaws.check(generator: self.generator)
+        CustomStringConvertibleLaws<Validated<Int, Int>>.check()
     }
     
     func testFoldableLaws() {

--- a/Tests/BowTests/Instances/NumberInstancesTest.swift
+++ b/Tests/BowTests/Instances/NumberInstancesTest.swift
@@ -102,63 +102,43 @@ class NumberInstancesTest: XCTestCase {
     }
     
     func testIntSemigroupLaws() {
-        property("Sum semigroup laws") <- forAll { (a: Int, b: Int, c: Int) in
-            return SemigroupLaws.check(a: a, b: b, c: c)
-        }
+        SemigroupLaws<Int>.check()
     }
     
     func testInt8SemigroupLaws() {
-        property("Sum semigroup laws") <- forAll { (a: Int8, b: Int8, c: Int8) in
-            return SemigroupLaws.check(a: a, b: b, c: c)
-        }
+        SemigroupLaws<Int8>.check()
     }
     
     func testInt16SemigroupLaws() {
-        property("Sum semigroup laws") <- forAll { (a: Int16, b: Int16, c: Int16) in
-            return SemigroupLaws.check(a: a, b: b, c: c)
-        }
+        SemigroupLaws<Int16>.check()
     }
     
     func testInt32SemigroupLaws() {
-        property("Sum semigroup laws") <- forAll { (a: Int32, b: Int32, c: Int32) in
-            return SemigroupLaws.check(a: a, b: b, c: c)
-        }
+        SemigroupLaws<Int32>.check()
     }
     
     func testInt64SemigroupLaws() {
-        property("Sum semigroup laws") <- forAll { (a: Int64, b: Int64, c: Int64) in
-            return SemigroupLaws.check(a: a, b: b, c: c)
-        }
+        SemigroupLaws<Int64>.check()
     }
     
     func testUIntSemigroupLaws() {
-        property("Sum semigroup laws") <- forAll { (a: UInt, b: UInt, c: UInt) in
-            return SemigroupLaws.check(a: a, b: b, c: c)
-        }
+        SemigroupLaws<UInt>.check()
     }
     
     func testUInt8SemigroupLaws() {
-        property("Sum semigroup laws") <- forAll { (a: UInt8, b: UInt8, c: UInt8) in
-            return SemigroupLaws.check(a: a, b: b, c: c)
-        }
+        SemigroupLaws<UInt8>.check()
     }
     
     func testUInt16SemigroupLaws() {
-        property("Sum semigroup laws") <- forAll { (a: UInt16, b: UInt16, c: UInt16) in
-            return SemigroupLaws.check(a: a, b: b, c: c)
-        }
+        SemigroupLaws<UInt16>.check()
     }
     
     func testUInt32SemigroupLaws() {
-        property("Sum semigroup laws") <- forAll { (a: UInt32, b: UInt32, c: UInt32) in
-            return SemigroupLaws.check(a: a, b: b, c: c)
-        }
+        SemigroupLaws<UInt32>.check()
     }
     
     func testUInt64SemigroupLaws() {
-        property("Sum semigroup laws") <- forAll { (a: UInt64, b: UInt64, c: UInt64) in
-            return SemigroupLaws.check(a: a, b: b, c: c)
-        }
+        SemigroupLaws<UInt64>.check()
     }
     
     func testIntMonoidLaws() {

--- a/Tests/BowTests/Instances/NumberInstancesTest.swift
+++ b/Tests/BowTests/Instances/NumberInstancesTest.swift
@@ -142,74 +142,50 @@ class NumberInstancesTest: XCTestCase {
     }
     
     func testIntMonoidLaws() {
-        property("Sum Monoid laws") <- forAll { (a: Int) in
-            return MonoidLaws.check(a: a)
-        }
+        MonoidLaws<Int>.check()
     }
     
     func testInt8MonoidLaws() {
-        property("Sum Monoid laws") <- forAll { (a: Int8) in
-            return MonoidLaws.check(a: a)
-        }
+        MonoidLaws<Int8>.check()
     }
     
     func testInt16MonoidLaws() {
-        property("Sum Monoid laws") <- forAll { (a: Int16) in
-            return MonoidLaws.check(a: a)
-        }
+        MonoidLaws<Int16>.check()
     }
     
     func testInt32MonoidLaws() {
-        property("Sum Monoid laws") <- forAll { (a: Int32) in
-            return MonoidLaws.check(a: a)
-        }
+        MonoidLaws<Int32>.check()
     }
     
     func testInt64MonoidLaws() {
-        property("Sum Monoid laws") <- forAll { (a: Int64) in
-            return MonoidLaws.check(a: a)
-        }
+        MonoidLaws<Int64>.check()
     }
     
     func testUIntMonoidLaws() {
-        property("Sum Monoid laws") <- forAll { (a: UInt) in
-            return MonoidLaws.check(a: a)
-        }
+        MonoidLaws<UInt>.check()
     }
     
     func testUInt8MonoidLaws() {
-        property("Sum Monoid laws") <- forAll { (a: UInt8) in
-            return MonoidLaws.check(a: a)
-        }
+        MonoidLaws<UInt8>.check()
     }
     
     func testUInt16MonoidLaws() {
-        property("Sum Monoid laws") <- forAll { (a: UInt16) in
-            return MonoidLaws.check(a: a)
-        }
+        MonoidLaws<UInt16>.check()
     }
     
     func testUInt32MonoidLaws() {
-        property("Sum Monoid laws") <- forAll { (a: UInt32) in
-            return MonoidLaws.check(a: a)
-        }
+        MonoidLaws<UInt32>.check()
     }
     
     func testUInt64MonoidLaws() {
-        property("Sum Monoid laws") <- forAll { (a: UInt64) in
-            return MonoidLaws.check(a: a)
-        }
+        MonoidLaws<UInt64>.check()
     }
     
     func testFloatMonoidLaws() {
-        property("Sum Monoid laws") <- forAll { (a: Float) in
-            return MonoidLaws.check(a: a)
-        }
+        MonoidLaws<Float>.check()
     }
     
     func testDoubleMonoidLaws() {
-        property("Sum Monoid laws") <- forAll { (a: Double) in
-            return MonoidLaws.check(a: a)
-        }
+        MonoidLaws<Double>.check()
     }
 }

--- a/Tests/BowTests/Instances/NumberInstancesTest.swift
+++ b/Tests/BowTests/Instances/NumberInstancesTest.swift
@@ -1,5 +1,4 @@
 import XCTest
-import SwiftCheck
 @testable import BowLaws
 import Bow
 

--- a/Tests/BowTests/Instances/NumberInstancesTest.swift
+++ b/Tests/BowTests/Instances/NumberInstancesTest.swift
@@ -1,7 +1,7 @@
 import XCTest
 import SwiftCheck
 @testable import BowLaws
-@testable import Bow
+import Bow
 
 class NumberInstancesTest: XCTestCase {
 

--- a/Tests/BowTests/Instances/StringInstancesTest.swift
+++ b/Tests/BowTests/Instances/StringInstancesTest.swift
@@ -1,5 +1,4 @@
 import XCTest
-import SwiftCheck
 @testable import BowLaws
 import Bow
 
@@ -14,8 +13,6 @@ class StringInstancesTest: XCTestCase {
     }
     
     func testMonoidLaws() {
-        property("String concatenation monoid") <- forAll { (a: String) in
-            return MonoidLaws.check(a: a)
-        }
+        MonoidLaws<String>.check()
     }
 }

--- a/Tests/BowTests/Instances/StringInstancesTest.swift
+++ b/Tests/BowTests/Instances/StringInstancesTest.swift
@@ -10,9 +10,7 @@ class StringInstancesTest: XCTestCase {
     }
     
     func testSemigroupLaws() {
-        property("String concatenation semigroup") <- forAll { (a: String, b: String, c: String) in
-            return SemigroupLaws.check(a: a, b: b, c: c)
-        }
+        SemigroupLaws<String>.check()
     }
     
     func testMonoidLaws() {

--- a/Tests/BowTests/Instances/StringInstancesTest.swift
+++ b/Tests/BowTests/Instances/StringInstancesTest.swift
@@ -1,7 +1,7 @@
 import XCTest
 import SwiftCheck
 @testable import BowLaws
-@testable import Bow
+import Bow
 
 class StringInstancesTest: XCTestCase {
     

--- a/Tests/BowTests/Syntax/BooleanFunctionsTest.swift
+++ b/Tests/BowTests/Syntax/BooleanFunctionsTest.swift
@@ -1,6 +1,6 @@
 import XCTest
 import SwiftCheck
-@testable import Bow
+import Bow
 
 class BooleanFunctionsTest: XCTestCase {
     

--- a/Tests/BowTests/Syntax/CurryTest.swift
+++ b/Tests/BowTests/Syntax/CurryTest.swift
@@ -1,6 +1,6 @@
 import XCTest
 import SwiftCheck
-@testable import Bow
+import Bow
 
 class CurryTest: XCTestCase {
     

--- a/Tests/BowTests/Syntax/MemoizationTest.swift
+++ b/Tests/BowTests/Syntax/MemoizationTest.swift
@@ -1,6 +1,6 @@
 import XCTest
 import SwiftCheck
-@testable import Bow
+import Bow
 
 class MemoizationTest: XCTestCase {
 

--- a/Tests/BowTests/Syntax/PartialApplicationTest.swift
+++ b/Tests/BowTests/Syntax/PartialApplicationTest.swift
@@ -1,6 +1,6 @@
 import XCTest
 import SwiftCheck
-@testable import Bow
+import Bow
 
 class PartialApplicationTest: XCTestCase {
     

--- a/Tests/BowTests/Syntax/PredefTest.swift
+++ b/Tests/BowTests/Syntax/PredefTest.swift
@@ -1,6 +1,6 @@
 import XCTest
 import SwiftCheck
-@testable import Bow
+import Bow
 
 class PredefTest : XCTestCase {
     

--- a/Tests/BowTests/Syntax/ReverseTest.swift
+++ b/Tests/BowTests/Syntax/ReverseTest.swift
@@ -1,6 +1,6 @@
 import XCTest
 import SwiftCheck
-@testable import Bow
+import Bow
 
 class ReverseTest: XCTestCase {
 

--- a/Tests/BowTests/Transformers/EitherTTest.swift
+++ b/Tests/BowTests/Transformers/EitherTTest.swift
@@ -11,7 +11,7 @@ class EitherTTest: XCTestCase {
     }
 
     func testEquatableLaws() {
-        EquatableKLaws.check(generator: self.generator)
+        EquatableKLaws<EitherTPartial<ForId, Int>, Int>.check()
     }
     
     func testFunctorLaws() {

--- a/Tests/BowTests/Transformers/EitherTTest.swift
+++ b/Tests/BowTests/Transformers/EitherTTest.swift
@@ -15,7 +15,7 @@ class EitherTTest: XCTestCase {
     }
     
     func testFunctorLaws() {
-        FunctorLaws<EitherTPartial<ForId, Int>>.check(generator: self.generator)
+        FunctorLaws<EitherTPartial<ForId, Int>>.check()
     }
     
     func testApplicativeLaws() {

--- a/Tests/BowTests/Transformers/EitherTTest.swift
+++ b/Tests/BowTests/Transformers/EitherTTest.swift
@@ -4,12 +4,6 @@ import SwiftCheck
 import Bow
 
 class EitherTTest: XCTestCase {
-    var generator: (Int) -> EitherT<ForId, Int, Int> {
-        return { a in a % 2 == 0 ? EitherT.right(a)
-                                 : EitherT.left(a)
-        }
-    }
-
     func testEquatableLaws() {
         EquatableKLaws<EitherTPartial<ForId, Int>, Int>.check()
     }

--- a/Tests/BowTests/Transformers/EitherTTest.swift
+++ b/Tests/BowTests/Transformers/EitherTTest.swift
@@ -1,7 +1,7 @@
 import XCTest
 import SwiftCheck
 @testable import BowLaws
-@testable import Bow
+import Bow
 
 class EitherTTest: XCTestCase {
     var generator: (Int) -> EitherT<ForId, Int, Int> {

--- a/Tests/BowTests/Transformers/EitherTTest.swift
+++ b/Tests/BowTests/Transformers/EitherTTest.swift
@@ -39,7 +39,7 @@ class EitherTTest: XCTestCase {
     }
     
     func testSemigroupKLaws() {
-        SemigroupKLaws<EitherTPartial<ForId, Int>>.check(generator: self.generator)
+        SemigroupKLaws<EitherTPartial<ForId, Int>>.check()
     }
 
     func testOptionTConversion() {

--- a/Tests/BowTests/Transformers/OptionTTest.swift
+++ b/Tests/BowTests/Transformers/OptionTTest.swift
@@ -38,7 +38,7 @@ class OptionTTest: XCTestCase {
     }
     
     func testFunctorFilterLaws() {
-        FunctorFilterLaws<OptionTPartial<ForId>>.check(generator: self.generator)
+        FunctorFilterLaws<OptionTPartial<ForId>>.check()
     }
 
     func testToLeftWithFunctionWithSome() {

--- a/Tests/BowTests/Transformers/OptionTTest.swift
+++ b/Tests/BowTests/Transformers/OptionTTest.swift
@@ -34,7 +34,7 @@ class OptionTTest: XCTestCase {
     }
 
     func testMonoidKLaws() {
-        MonoidKLaws<OptionTPartial<ForId>>.check(generator: self.generator)
+        MonoidKLaws<OptionTPartial<ForId>>.check()
     }
     
     func testFunctorFilterLaws() {

--- a/Tests/BowTests/Transformers/OptionTTest.swift
+++ b/Tests/BowTests/Transformers/OptionTTest.swift
@@ -1,7 +1,7 @@
 import XCTest
 import SwiftCheck
 @testable import BowLaws
-@testable import Bow
+import Bow
 
 class OptionTTest: XCTestCase {
     

--- a/Tests/BowTests/Transformers/OptionTTest.swift
+++ b/Tests/BowTests/Transformers/OptionTTest.swift
@@ -10,7 +10,7 @@ class OptionTTest: XCTestCase {
     }
 
     func testEquatableLaws() {
-        EquatableKLaws.check(generator: self.generator)
+        EquatableKLaws<OptionTPartial<ForId>, Int>.check()
     }
     
     func testFunctorLaws() {

--- a/Tests/BowTests/Transformers/OptionTTest.swift
+++ b/Tests/BowTests/Transformers/OptionTTest.swift
@@ -14,7 +14,7 @@ class OptionTTest: XCTestCase {
     }
     
     func testFunctorLaws() {
-        FunctorLaws<OptionTPartial<ForId>>.check(generator: self.generator)
+        FunctorLaws<OptionTPartial<ForId>>.check()
     }
     
     func testApplicativeLaws() {

--- a/Tests/BowTests/Transformers/OptionTTest.swift
+++ b/Tests/BowTests/Transformers/OptionTTest.swift
@@ -30,7 +30,7 @@ class OptionTTest: XCTestCase {
     }
     
     func testSemigroupKLaws() {
-        SemigroupKLaws<OptionTPartial<ForId>>.check(generator: self.generator)
+        SemigroupKLaws<OptionTPartial<ForId>>.check()
     }
 
     func testMonoidKLaws() {

--- a/Tests/BowTests/Transformers/OptionTTest.swift
+++ b/Tests/BowTests/Transformers/OptionTTest.swift
@@ -4,11 +4,6 @@ import SwiftCheck
 import Bow
 
 class OptionTTest: XCTestCase {
-    
-    var generator: (Int) -> OptionTOf<ForId, Int> {
-        return { a in OptionT<ForId, Int>.pure(a) }
-    }
-
     func testEquatableLaws() {
         EquatableKLaws<OptionTPartial<ForId>, Int>.check()
     }

--- a/Tests/BowTests/Transformers/StateTTest.swift
+++ b/Tests/BowTests/Transformers/StateTTest.swift
@@ -17,7 +17,7 @@ class StateTTest: XCTestCase {
     }
     
     func testFunctorLaws() {
-        FunctorLaws<StateTPartial<ForId, Int>>.check(generator: self.generator)
+        FunctorLaws<StateTPartial<ForId, Int>>.check()
     }
     
     func testApplicativeLaws() {

--- a/Tests/BowTests/Transformers/StateTTest.swift
+++ b/Tests/BowTests/Transformers/StateTTest.swift
@@ -1,5 +1,4 @@
 import XCTest
-import SwiftCheck
 @testable import BowLaws
 import Bow
 
@@ -12,10 +11,6 @@ extension StateTPartial: EquatableK where F: EquatableK & Monad, S == Int {
 }
 
 class StateTTest: XCTestCase {
-    var generator: (Int) -> StateTOf<ForId, Int, Int> {
-        return { a in StateT<ForId, Int, Int>.pure(a) }
-    }
-    
     func testFunctorLaws() {
         FunctorLaws<StateTPartial<ForId, Int>>.check()
     }

--- a/Tests/BowTests/Transformers/StateTTest.swift
+++ b/Tests/BowTests/Transformers/StateTTest.swift
@@ -41,7 +41,7 @@ class StateTTest: XCTestCase {
     }
     
     func testSemigroupKLaws() {
-        SemigroupKLaws<StateTPartial<ForArrayK, Int>>.check(generator: { (a : Int) in StateT<ForArrayK, Int, Int>.pure(a) })
+        SemigroupKLaws<StateTPartial<ForArrayK, Int>>.check()
     }
     
     func testMonadStateLaws() {

--- a/Tests/BowTests/Transformers/StateTTest.swift
+++ b/Tests/BowTests/Transformers/StateTTest.swift
@@ -1,7 +1,7 @@
 import XCTest
 import SwiftCheck
 @testable import BowLaws
-@testable import Bow
+import Bow
 
 extension StateTPartial: EquatableK where F: EquatableK & Monad, S == Int {
     public static func eq<A>(_ lhs: Kind<StateTPartial<F, S>, A>, _ rhs: Kind<StateTPartial<F, S>, A>) -> Bool where A : Equatable {

--- a/Tests/BowTests/Transformers/WriterTTest.swift
+++ b/Tests/BowTests/Transformers/WriterTTest.swift
@@ -29,7 +29,7 @@ class WriterTTest: XCTestCase {
     }
     
     func testMonoidKLaws() {
-        MonoidKLaws<WriterTPartial<ForArrayK, Int>>.check(generator: { (a: Int) in WriterT.pure(a) })
+        MonoidKLaws<WriterTPartial<ForArrayK, Int>>.check()
     }
 
     func testFunctorFilterLaws() {

--- a/Tests/BowTests/Transformers/WriterTTest.swift
+++ b/Tests/BowTests/Transformers/WriterTTest.swift
@@ -25,7 +25,7 @@ class WriterTTest: XCTestCase {
     }
     
     func testSemigroupKLaws() {
-        SemigroupKLaws<WriterTPartial<ForArrayK, Int>>.check(generator: { (a: Int) in WriterT.pure(a) })
+        SemigroupKLaws<WriterTPartial<ForArrayK, Int>>.check()
     }
     
     func testMonoidKLaws() {

--- a/Tests/BowTests/Transformers/WriterTTest.swift
+++ b/Tests/BowTests/Transformers/WriterTTest.swift
@@ -1,7 +1,7 @@
 import XCTest
 import SwiftCheck
 @testable import BowLaws
-@testable import Bow
+import Bow
 
 class WriterTTest: XCTestCase {
     var generator: (Int) -> WriterTOf<ForId, Int, Int> {

--- a/Tests/BowTests/Transformers/WriterTTest.swift
+++ b/Tests/BowTests/Transformers/WriterTTest.swift
@@ -9,7 +9,7 @@ class WriterTTest: XCTestCase {
     }
 
     func testEquatableLaws() {
-        EquatableKLaws.check(generator: self.generator)
+        EquatableKLaws<WriterTPartial<ForId, Int>, Int>.check()
     }
     
     func testFunctorLaws() {

--- a/Tests/BowTests/Transformers/WriterTTest.swift
+++ b/Tests/BowTests/Transformers/WriterTTest.swift
@@ -13,7 +13,7 @@ class WriterTTest: XCTestCase {
     }
     
     func testFunctorLaws() {
-        FunctorLaws<WriterTPartial<ForId, Int>>.check(generator: self.generator)
+        FunctorLaws<WriterTPartial<ForId, Int>>.check()
     }
     
     func testApplicativeLaws() {

--- a/Tests/BowTests/Transformers/WriterTTest.swift
+++ b/Tests/BowTests/Transformers/WriterTTest.swift
@@ -4,10 +4,6 @@ import SwiftCheck
 import Bow
 
 class WriterTTest: XCTestCase {
-    var generator: (Int) -> WriterTOf<ForId, Int, Int> {
-        return { a in WriterT.pure(a) }
-    }
-
     func testEquatableLaws() {
         EquatableKLaws<WriterTPartial<ForId, Int>, Int>.check()
     }
@@ -37,7 +33,7 @@ class WriterTTest: XCTestCase {
     }
 
     func testFunctorFilterLaws() {
-        FunctorFilterLaws<WriterTPartial<ForOption, Int>>.check(generator: { (a : Int) in WriterT.pure(a) })
+        FunctorFilterLaws<WriterTPartial<ForOption, Int>>.check()
     }
     
     func testMonadFilterLaws() {

--- a/Tests/BowTests/Transformers/WriterTTest.swift
+++ b/Tests/BowTests/Transformers/WriterTTest.swift
@@ -37,7 +37,7 @@ class WriterTTest: XCTestCase {
     }
     
     func testMonadFilterLaws() {
-        MonadFilterLaws<WriterTPartial<ForOption, Int>>.check(generator: { (a: Int) in WriterT.pure(a) })
+        MonadFilterLaws<WriterTPartial<ForOption, Int>>.check()
     }
     
     func testMonadWriterLaws() {

--- a/Tests/BowTests/Transformers/WriterTTest.swift
+++ b/Tests/BowTests/Transformers/WriterTTest.swift
@@ -1,5 +1,4 @@
 import XCTest
-import SwiftCheck
 @testable import BowLaws
 import Bow
 


### PR DESCRIPTION
## Goal

The usage of the current Optics module is hindered by the need to write all optics for our data types. This PR adds mechanisms to automatically obtain optics for product and sum types. In particular, the ones that we are able to generate at the moment are Lenses and Optionals, and with a little bit of boilerplate, Prisms.

## Implementation details

The implementation of this feature leverages the introduction of key paths in Swift, which allows us to abstract over fields and let us set/get their values without referencing them explicitly. Protocols `AutoLens`, `AutoOptional` and `AutoPrism` have been introduced to enable this feature in new values.

### Lenses

As an example, consider the following data structures:

```swift
struct Article: AutoLens, AutoOptional {
    var title: String
    var date: Date
    var author: Person
    var keyword: Option<String>
}

struct Person: AutoLens {
    var name: String
    var age: Int
}
```

Notice that fields need to be marked as `var` since the `AutoLens` or `AutoOptional` protocols need to be able to create copies of them and set the new values. One can then access lenses for each field:

```swift
let titleLens: Lens<Article, String> = Article.lens(for: \.title)
let ageLens: Lens<Person, Int> = Person.lens(for: \.age)
```

We can also access nested fields by composing lenses:

```swift
let authorNameLens = Article.lens(for: \.author) + Person.lens(for: \.name)
```

Or even better:

```swift
let authorNameLens = Article.lens(for: \.author.name)
```

### Optionals

Similarly, we can also get `Optional` optics for fields that are defined as `A?` or `Option<A>`:

```swift
let keywordOptional = Article.optional(for: \.keyword)
```

### Prisms

Finally, we can do a similar thing with `Prism` although it involves a bit more boilerplate as sum types do not have syntax similar to key paths or generalized pattern matching. Consider the following example:

```swift
enum GameState: AutoPrism {
    case notStarted
    case inProgress(Board)
    case draw(Board)
    case won(Board, winner: Stone)
}
```

We can get a prism focusing on a case that do not have any associated value like:

```swift
let notStartedPrism: Prism<GameState, ()> = GameState.prism(for: GameState.notStarted)
```

If the case has associated values, then a matching function needs to be provided:

```swift
let inProgressPrism: Prism<GameState, Board> = GameState.prism(for: GameState.inProgress) { state in
    switch state {
    case .inProgress(let board): return board
    default: return nil
    }
}

let wonPrism: Prism<GameState, (Board, Stone)> = GameState.prism(for: GameState.won) { state in
    switch state {
    case .won(let board, let stone): return (board, stone)
    default: return nil
    }
}
```

The matching closure must only match the case of interest to the prism and return a tuple of its associated values, or nil if the match does not succeeds.