### PR TITLE
Permalinks trailing slash additions

### DIFF
--- a/contents/Documentation/FP concepts.playground/docs/docs/README.md
+++ b/contents/Documentation/FP concepts.playground/docs/docs/README.md
@@ -1,7 +1,7 @@
 ---
 layout: docs
 title: Home
-permalink: /docs
+permalink: /docs/
 ---
 
 # Bow

--- a/contents/Documentation/Legal.playground/docs/docs/README.md
+++ b/contents/Documentation/Legal.playground/docs/docs/README.md
@@ -1,7 +1,7 @@
 ---
 layout: docs
 title: Home
-permalink: /docs
+permalink: /docs/
 ---
 
 # Bow

--- a/contents/Documentation/Patterns.playground/docs/docs/README.md
+++ b/contents/Documentation/Patterns.playground/docs/docs/README.md
@@ -1,7 +1,7 @@
 ---
 layout: docs
 title: Home
-permalink: /docs
+permalink: /docs/
 ---
 
 # Bow

--- a/contents/Home.md
+++ b/contents/Home.md
@@ -1,7 +1,7 @@
 ---
 layout: docs
 title: Home
-permalink: /docs
+permalink: /docs/
 ---
 
 # Bow


### PR DESCRIPTION
## Goal

I'm not sure if this is the way to proceed, or that information is being read from another place through `nef`, but when writing permalinks for Jekyll is better to always write them ending at `/` slash. That way the files/path generated in the end could be navigated through `bow-swift.io/docs` and `bow-swift.io/docs/`. Without it, a path not ending in a slash will give you a 404 😵

Do you think there could be more elsewhere?  Thanks!