### PR TITLE
fix permalink for main page

### DIFF
--- a/contents/Home.md
+++ b/contents/Home.md
@@ -1,7 +1,7 @@
 ---
 layout: docs
 title: Home
-permalink: /docs
+permalink: /docs/
 ---
 
 # Bow

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,3 +1,0 @@
----
-layout: home
----


### PR DESCRIPTION
## Goal

This fix the permalink for Jekyll in `main page` - That way the files/path generated in the end could be navigated through `bow-swift.io/docs` and `bow-swift.io/docs/`. Without it, a path not ending in a slash will give you a 404 😵 
