### PR TITLE
Add missing instances for some types

### DIFF
--- a/Sources/Bow/Arrow/Function0.swift
+++ b/Sources/Bow/Arrow/Function0.swift
@@ -96,3 +96,17 @@ extension ForFunction0: Comonad {
 
 // MARK: Instance of `Bimonad` for `Function0`
 extension ForFunction0: Bimonad {}
+
+// MARK: Instance of `Semigroup` for `Function0`
+extension Function0: Semigroup where A: Semigroup {
+    public func combine(_ other: Function0<A>) -> Function0<A> {
+        return Function0 { self.invoke().combine(other.invoke()) }
+    }
+}
+
+// MARK: Instance of `Monoid` for `Function0`
+extension Function0: Monoid where A: Monoid {
+    public static func empty() -> Function0<A> {
+        return Function0(constant(A.empty()))
+    }
+}

--- a/Sources/Bow/Data/Either.swift
+++ b/Sources/Bow/Data/Either.swift
@@ -310,3 +310,18 @@ extension EitherPartial: SemigroupK {
         return Either.fix(x).fold(constant(Either.fix(y)), Either.right)
     }
 }
+
+// MARK: Instance of `Semigroup` for `Either`.
+extension Either: Semigroup where A: Semigroup, B: Semigroup {
+    public func combine(_ other: Either<A, B>) -> Either<A, B> {
+        return self.fold({ l1 in other.fold({ l2 in .left(l1.combine(l2)) }, { r2 in .left(l1) }) },
+                         { r1 in other.fold({ l2 in .left(l2) }, { r2 in .right(r1.combine(r2)) }) })
+    }
+}
+
+// MARK: Instance of `Monoid` for `Either`.
+extension Either: Monoid where A: Monoid, B: Monoid {
+    public static func empty() -> Either<A, B> {
+        return .right(B.empty())
+    }
+}

--- a/Sources/Bow/Data/EitherK.swift
+++ b/Sources/Bow/Data/EitherK.swift
@@ -69,7 +69,11 @@ extension EitherKPartial: EquatableK where F: EquatableK, G: EquatableK {
 }
 
 // MARK: Instance of `Invariant` for `EitherK`.
-extension EitherKPartial: Invariant where F: Functor, G: Functor {}
+extension EitherKPartial: Invariant where F: Invariant, G: Invariant {
+    public static func imap<A, B>(_ fa: Kind<EitherKPartial<F, G>, A>, _ f: @escaping (A) -> B, _ g: @escaping (B) -> A) -> Kind<EitherKPartial<F, G>, B> {
+        return EitherK(fa^.run.bimap({ a in a.imap(f, g) }, { b in b.imap(f, g) }))
+    }
+}
 
 // MARK: Instance of `Functor` for `EitherK`.
 extension EitherKPartial: Functor where F: Functor, G: Functor {
@@ -120,5 +124,12 @@ extension EitherKPartial: Traverse where F: Traverse, G: Traverse {
         return cop.run.fold(
             { fa in H.map(fa.traverse(f), { fb in EitherK(Either.left(fb)) })},
             { ga in H.map(ga.traverse(f), { gb in EitherK(Either.right(gb)) })})
+    }
+}
+
+// MARK: Instance of `Contravariant` for `EitherK`
+extension EitherKPartial: Contravariant where F: Contravariant, G: Contravariant {
+    public static func contramap<A, B>(_ fa: Kind<EitherKPartial<F, G>, A>, _ f: @escaping (B) -> A) -> Kind<EitherKPartial<F, G>, B> {
+        return EitherK(fa^.run.bimap({ a in a.contramap(f) }, { b in b.contramap(f) }))
     }
 }

--- a/Sources/Bow/Data/Id.swift
+++ b/Sources/Bow/Data/Id.swift
@@ -121,3 +121,17 @@ extension ForId: Traverse {
         return G.map(f(id.value), Id<B>.init)
     }
 }
+
+// MARK: Instance of `Semigroup` for `Id`
+extension Id: Semigroup where A: Semigroup {
+    public func combine(_ other: Id<A>) -> Id<A> {
+        return Id(self.value.combine(other.value))
+    }
+}
+
+// MARK: Instance of `Monoid` for `Id`
+extension Id: Monoid where A: Monoid {
+    public static func empty() -> Id<A> {
+        return Id(A.empty())
+    }
+}

--- a/Sources/Bow/Data/Option.swift
+++ b/Sources/Bow/Data/Option.swift
@@ -244,6 +244,13 @@ extension ForOption: TraverseFilter {
     }
 }
 
+// MARK: Instance of `SemigroupK` for `Option`
+extension ForOption: SemigroupK {
+    public static func combineK<A>(_ x: Kind<ForOption, A>, _ y: Kind<ForOption, A>) -> Kind<ForOption, A> {
+        return x^.fold(constant(y), Option.some)
+    }
+}
+
 // MARK: Instance of `Semigroup` for `Option`, provided that `A` has an instance of `Semigroup`.
 extension Option: Semigroup where A: Semigroup {
     public func combine(_ other: Option<A>) -> Option<A> {

--- a/Sources/Bow/Data/Option.swift
+++ b/Sources/Bow/Data/Option.swift
@@ -258,6 +258,9 @@ extension ForOption: MonoidK {
     }
 }
 
+// MARK: Instance of `MonadCombine` for `Option`
+extension ForOption: MonadCombine {}
+
 // MARK: Instance of `Semigroup` for `Option`, provided that `A` has an instance of `Semigroup`.
 extension Option: Semigroup where A: Semigroup {
     public func combine(_ other: Option<A>) -> Option<A> {

--- a/Sources/Bow/Data/Option.swift
+++ b/Sources/Bow/Data/Option.swift
@@ -251,6 +251,13 @@ extension ForOption: SemigroupK {
     }
 }
 
+// MARK: Instance of `MonoidK` for `Option`
+extension ForOption: MonoidK {
+    public static func emptyK<A>() -> Kind<ForOption, A> {
+        return Option.none()
+    }
+}
+
 // MARK: Instance of `Semigroup` for `Option`, provided that `A` has an instance of `Semigroup`.
 extension Option: Semigroup where A: Semigroup {
     public func combine(_ other: Option<A>) -> Option<A> {

--- a/Sources/Bow/Transformers/EitherT.swift
+++ b/Sources/Bow/Transformers/EitherT.swift
@@ -225,3 +225,21 @@ extension EitherTPartial: SemigroupK where F: Monad {
         })
     }
 }
+
+// MARK: Instance of `Foldable` for `EitherT`
+extension EitherTPartial: Foldable where F: Foldable {
+    public static func foldLeft<A, B>(_ fa: Kind<EitherTPartial<F, L>, A>, _ b: B, _ f: @escaping (B, A) -> B) -> B {
+        return fa^.value.foldLeft(b, { bb, either in either.foldLeft(bb, f) })
+    }
+    
+    public static func foldRight<A, B>(_ fa: Kind<EitherTPartial<F, L>, A>, _ b: Eval<B>, _ f: @escaping (A, Eval<B>) -> Eval<B>) -> Eval<B> {
+        return fa^.value.foldRight(b, { either, bb in either.foldRight(bb, f) })
+    }
+}
+
+// MARK: Instance of `Traverse` for `EitherT`
+extension EitherTPartial: Traverse where F: Traverse {
+    public static func traverse<G: Applicative, A, B>(_ fa: Kind<EitherTPartial<F, L>, A>, _ f: @escaping (A) -> Kind<G, B>) -> Kind<G, Kind<EitherTPartial<F, L>, B>> {
+        return fa^.value.traverse { either in either.traverse(f) }.map { x in EitherT(x.map{ b in b^ }) }
+    }
+}

--- a/Sources/Bow/Transformers/OptionT.swift
+++ b/Sources/Bow/Transformers/OptionT.swift
@@ -261,3 +261,16 @@ extension OptionTPartial: MonoidK where F: Monad {
         return OptionT(F.pure(.none()))
     }
 }
+
+// MARK: Instance of `ApplicativeError` for `OptionT`
+extension OptionTPartial: ApplicativeError where F: ApplicativeError {
+    public typealias E = F.E
+    
+    public static func raiseError<A>(_ e: F.E) -> Kind<OptionTPartial<F>, A> {
+        return OptionT(F.raiseError(e))
+    }
+    
+    public static func handleErrorWith<A>(_ fa: Kind<OptionTPartial<F>, A>, _ f: @escaping (F.E) -> Kind<OptionTPartial<F>, A>) -> Kind<OptionTPartial<F>, A> {
+        return OptionT(fa^.value.handleErrorWith { e in f(e)^.value })
+    }
+}

--- a/Sources/Bow/Transformers/OptionT.swift
+++ b/Sources/Bow/Transformers/OptionT.swift
@@ -274,3 +274,31 @@ extension OptionTPartial: ApplicativeError where F: ApplicativeError {
         return OptionT(fa^.value.handleErrorWith { e in f(e)^.value })
     }
 }
+
+// MARK: Instance of `MonadError` for `OptionT`
+extension OptionTPartial: MonadError where F: MonadError {}
+
+// MARK: Instance of `Foldable` for `OptionT`
+extension OptionTPartial: Foldable where F: Foldable {
+    public static func foldLeft<A, B>(_ fa: Kind<OptionTPartial<F>, A>, _ b: B, _ f: @escaping (B, A) -> B) -> B {
+        return fa^.value.foldLeft(b, { bb, option in option.foldLeft(bb, f) })
+    }
+    
+    public static func foldRight<A, B>(_ fa: Kind<OptionTPartial<F>, A>, _ b: Eval<B>, _ f: @escaping (A, Eval<B>) -> Eval<B>) -> Eval<B> {
+        return fa^.value.foldRight(b, { option, bb in option.foldRight(bb, f) })
+    }
+}
+
+// MARK: Instance of `Traverse` for `OptionT`
+extension OptionTPartial: Traverse where F: Traverse {
+    public static func traverse<G: Applicative, A, B>(_ fa: Kind<OptionTPartial<F>, A>, _ f: @escaping (A) -> Kind<G, B>) -> Kind<G, Kind<OptionTPartial<F>, B>> {
+        return fa^.value.traverse { option in option.traverse(f) }.map { x in OptionT(x.map { b in b^ }) }
+    }
+}
+
+// MARK: Instance of `TraverseFilter` for `OptionT`
+extension OptionTPartial: TraverseFilter where F: TraverseFilter {
+    public static func traverseFilter<A, B, G: Applicative>(_ fa: Kind<OptionTPartial<F>, A>, _ f: @escaping (A) -> Kind<G, Kind<ForOption, B>>) -> Kind<G, Kind<OptionTPartial<F>, B>> {
+        return fa^.value.traverseFilter { option in option.traverseFilter(f) }.map { x in OptionT(x.map(Option.some)) }
+    }
+}

--- a/Sources/Bow/Transformers/WriterT.swift
+++ b/Sources/Bow/Transformers/WriterT.swift
@@ -330,3 +330,6 @@ extension WriterTPartial: ApplicativeError where F: MonadError, W: Monoid {
         return WriterT(fa^.value.handleErrorWith { e in f(e)^.value })
     }
 }
+
+// MARK: Instance of `MonadError` for `WriterT`
+extension WriterTPartial: MonadError where F: MonadError, W: Monoid {}

--- a/Sources/Bow/Transformers/WriterT.swift
+++ b/Sources/Bow/Transformers/WriterT.swift
@@ -317,3 +317,16 @@ extension WriterTPartial: MonadWriter where F: Monad, W: Monoid {
         })
     }
 }
+
+// MARK: Instance of `ApplicativeError` for `WriterT`
+extension WriterTPartial: ApplicativeError where F: MonadError, W: Monoid {
+    public typealias E = F.E
+    
+    public static func raiseError<A>(_ e: F.E) -> Kind<WriterTPartial<F, W>, A> {
+        return WriterT(F.raiseError(e))
+    }
+    
+    public static func handleErrorWith<A>(_ fa: Kind<WriterTPartial<F, W>, A>, _ f: @escaping (F.E) -> Kind<WriterTPartial<F, W>, A>) -> Kind<WriterTPartial<F, W>, A> {
+        return WriterT(fa^.value.handleErrorWith { e in f(e)^.value })
+    }
+}

--- a/Tests/BowTests/Arrow/Function0Test.swift
+++ b/Tests/BowTests/Arrow/Function0Test.swift
@@ -30,4 +30,12 @@ class Function0Test: XCTestCase {
     func testBimonadLaws() {
         BimonadLaws<ForFunction0>.check()
     }
+    
+    func testSemigroupLaws() {
+        SemigroupLaws<Function0<String>>.check()
+    }
+    
+    func testMonoidLaws() {
+        MonoidLaws<Function0<String>>.check()
+    }
 }

--- a/Tests/BowTests/Data/EitherKTest.swift
+++ b/Tests/BowTests/Data/EitherKTest.swift
@@ -1,6 +1,8 @@
 import XCTest
 @testable import BowLaws
 import Bow
+import BowGenerators
+import SwiftCheck
 
 class EitherKTest: XCTestCase {
     func testEquatableLaws() {

--- a/Tests/BowTests/Data/EitherTest.swift
+++ b/Tests/BowTests/Data/EitherTest.swift
@@ -48,6 +48,14 @@ class EitherTest: XCTestCase {
         TraverseLaws<EitherPartial<Int>>.check()
     }
     
+    func testSemigroupLaws() {
+        SemigroupLaws<Either<Int, Int>>.check()
+    }
+    
+    func testMonoidLaws() {
+        MonoidLaws<Either<Int, Int>>.check()
+    }
+    
     func testCheckers() {
         let left = Either<String, Int>.left("Hello")
         let right = Either<String, Int>.right(5)

--- a/Tests/BowTests/Data/IdTest.swift
+++ b/Tests/BowTests/Data/IdTest.swift
@@ -42,4 +42,12 @@ class IdTest: XCTestCase {
     func testTraverseLaws() {
         TraverseLaws<ForId>.check()
     }
+    
+    func testSemigroupLaws() {
+        SemigroupLaws<Id<Int>>.check()
+    }
+    
+    func testMonoidLaws() {
+        MonoidLaws<Id<Int>>.check()
+    }
 }

--- a/Tests/BowTests/Data/OptionTest.swift
+++ b/Tests/BowTests/Data/OptionTest.swift
@@ -36,6 +36,10 @@ class OptionTest: XCTestCase {
         SemigroupKLaws<ForOption>.check()
     }
     
+    func testMonoidKLaws() {
+        MonoidKLaws<ForOption>.check()
+    }
+    
     func testFunctorFilterLaws() {
         FunctorFilterLaws<ForOption>.check()
     }

--- a/Tests/BowTests/Data/OptionTest.swift
+++ b/Tests/BowTests/Data/OptionTest.swift
@@ -32,6 +32,10 @@ class OptionTest: XCTestCase {
         MonoidLaws<Option<Int>>.check()
     }
     
+    func testSemigroupKLaws() {
+        SemigroupKLaws<ForOption>.check()
+    }
+    
     func testFunctorFilterLaws() {
         FunctorFilterLaws<ForOption>.check()
     }

--- a/Tests/BowTests/Data/OptionTest.swift
+++ b/Tests/BowTests/Data/OptionTest.swift
@@ -64,6 +64,10 @@ class OptionTest: XCTestCase {
         TraverseFilterLaws<ForOption>.check()
     }
     
+    func testMonadCombineLaws() {
+        MonadCombineLaws<ForOption>.check()
+    }
+    
     func testFromToOption() {
         property("fromOption - toOption isomorphism") <- forAll { (x: Int?, option: Option<Int>) in
             return Option.fromOptional(x).toOptional() == x &&

--- a/Tests/BowTests/Transformers/EitherTTest.swift
+++ b/Tests/BowTests/Transformers/EitherTTest.swift
@@ -35,6 +35,14 @@ class EitherTTest: XCTestCase {
     func testSemigroupKLaws() {
         SemigroupKLaws<EitherTPartial<ForId, Int>>.check()
     }
+    
+    func testFoldableLaws() {
+        FoldableLaws<EitherTPartial<ForId, Int>>.check()
+    }
+    
+    func testTraverseLaws() {
+        TraverseLaws<EitherTPartial<ForId, Int>>.check()
+    }
 
     func testOptionTConversion() {
         property("Left converted to none") <- forAll { (x: Int) in

--- a/Tests/BowTests/Transformers/OptionTTest.swift
+++ b/Tests/BowTests/Transformers/OptionTTest.swift
@@ -39,7 +39,23 @@ class OptionTTest: XCTestCase {
     func testApplicativeErrorLaws() {
         ApplicativeErrorLaws<OptionTPartial<EitherPartial<CategoryError>>>.check()
     }
+    
+    func testMonadErrorLaws() {
+        MonadErrorLaws<OptionTPartial<EitherPartial<CategoryError>>>.check()
+    }
+    
+    func testFoldableLaws() {
+        FoldableLaws<OptionTPartial<ForId>>.check()
+    }
+    
+    func testTraverseLaws() {
+        TraverseLaws<OptionTPartial<ForId>>.check()
+    }
 
+    func testTraverseFilterLaws() {
+        TraverseFilterLaws<OptionTPartial<ConstPartial<Int>>>.check()
+    }
+    
     func testToLeftWithFunctionWithSome() {
         property("toLeft for .some should build a correct EitherT") <- forAll { (a: Int, b: String) in
             let optionT = OptionT<ForId, Int>.fromOption(.some(a))

--- a/Tests/BowTests/Transformers/OptionTTest.swift
+++ b/Tests/BowTests/Transformers/OptionTTest.swift
@@ -35,6 +35,10 @@ class OptionTTest: XCTestCase {
     func testFunctorFilterLaws() {
         FunctorFilterLaws<OptionTPartial<ForId>>.check()
     }
+    
+    func testApplicativeErrorLaws() {
+        ApplicativeErrorLaws<OptionTPartial<EitherPartial<CategoryError>>>.check()
+    }
 
     func testToLeftWithFunctionWithSome() {
         property("toLeft for .some should build a correct EitherT") <- forAll { (a: Int, b: String) in

--- a/Tests/BowTests/Transformers/WriterTTest.swift
+++ b/Tests/BowTests/Transformers/WriterTTest.swift
@@ -46,4 +46,8 @@ class WriterTTest: XCTestCase {
     func testApplicativeErrorLaws() {
         ApplicativeErrorLaws<WriterTPartial<EitherPartial<CategoryError>, Int>>.check()
     }
+    
+    func testMonadErrorLaws() {
+        MonadErrorLaws<WriterTPartial<EitherPartial<CategoryError>, Int>>.check()
+    }
 }

--- a/Tests/BowTests/Transformers/WriterTTest.swift
+++ b/Tests/BowTests/Transformers/WriterTTest.swift
@@ -42,4 +42,8 @@ class WriterTTest: XCTestCase {
     func testMonadWriterLaws() {
         MonadWriterLaws<WriterTPartial<ForId, Int>>.check()
     }
+    
+    func testApplicativeErrorLaws() {
+        ApplicativeErrorLaws<WriterTPartial<EitherPartial<CategoryError>, Int>>.check()
+    }
 }


### PR DESCRIPTION
## Related issues

- Closes #228
- Closes #228
- Closes #231
- Closes #249 
- Closes #250
- Closes #255
- Closes #261
- Closes #265

## Goal

Implement conformances to some type classes for several types in the core module that didn't have them respect to their Arrow counterpart.