### PR TITLE
Automatic derivation of Getter, Setter and BoundSetter

### DIFF
--- a/Bow.xcodeproj/project.pbxproj
+++ b/Bow.xcodeproj/project.pbxproj
@@ -151,6 +151,7 @@
 		11DDCD23217F1E2B00844D9D /* Reverse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11DDCD22217F1E2B00844D9D /* Reverse.swift */; };
 		11DDCD28217F1FC200844D9D /* ReverseTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11DDCD27217F1FC200844D9D /* ReverseTest.swift */; };
 		11E4190B22B90FE2009BDFB3 /* AutoGetter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11E4190A22B90FE2009BDFB3 /* AutoGetter.swift */; };
+		11E4190F22B91169009BDFB3 /* AutoSetter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11E4190E22B91169009BDFB3 /* AutoSetter.swift */; };
 		11E71715219D722900B94845 /* BoundSetter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BA0F4B2217E2E9200969984 /* BoundSetter.swift */; };
 		11E71716219D722900B94845 /* Fold.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BA0F4BE217E2E9200969984 /* Fold.swift */; };
 		11E71717219D722900B94845 /* Getter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BA0F4B3217E2E9200969984 /* Getter.swift */; };
@@ -799,6 +800,7 @@
 		11DDCD22217F1E2B00844D9D /* Reverse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Reverse.swift; sourceTree = "<group>"; };
 		11DDCD27217F1FC200844D9D /* ReverseTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReverseTest.swift; sourceTree = "<group>"; };
 		11E4190A22B90FE2009BDFB3 /* AutoGetter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoGetter.swift; sourceTree = "<group>"; };
+		11E4190E22B91169009BDFB3 /* AutoSetter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoSetter.swift; sourceTree = "<group>"; };
 		11E71712219D704F00B94845 /* BowOptics.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = BowOptics.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		11E71713219D705000B94845 /* Bow-Optics-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; name = "Bow-Optics-Info.plist"; path = "/Users/tomasruizlopez/Development/bow/Support Files/Bow-Optics-Info.plist"; sourceTree = "<absolute>"; };
 		11E71802219D7D5900B94845 /* BowOpticsTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = BowOpticsTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -1389,6 +1391,7 @@
 				1126CA8922B1144200F840CB /* AutoOptics.swift */,
 				1126CA8D22B1253D00F840CB /* AutoOptional.swift */,
 				1126CA8F22B1262F00F840CB /* AutoPrism.swift */,
+				11E4190E22B91169009BDFB3 /* AutoSetter.swift */,
 			);
 			path = Auto;
 			sourceTree = "<group>";
@@ -3087,6 +3090,7 @@
 				11E7172B219D722900B94845 /* String+Optics.swift in Sources */,
 				11E4190B22B90FE2009BDFB3 /* AutoGetter.swift in Sources */,
 				11E7172C219D722900B94845 /* Try+Optics.swift in Sources */,
+				11E4190F22B91169009BDFB3 /* AutoSetter.swift in Sources */,
 				11E7172D219D722900B94845 /* Validated+Optics.swift in Sources */,
 				11E7172E219D722900B94845 /* At.swift in Sources */,
 				1126CA8A22B1144200F840CB /* AutoOptics.swift in Sources */,

--- a/Bow.xcodeproj/project.pbxproj
+++ b/Bow.xcodeproj/project.pbxproj
@@ -150,6 +150,7 @@
 		11DDCD21217F194B00844D9D /* MemoizationTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11DDCD20217F194B00844D9D /* MemoizationTest.swift */; };
 		11DDCD23217F1E2B00844D9D /* Reverse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11DDCD22217F1E2B00844D9D /* Reverse.swift */; };
 		11DDCD28217F1FC200844D9D /* ReverseTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11DDCD27217F1FC200844D9D /* ReverseTest.swift */; };
+		11E4190B22B90FE2009BDFB3 /* AutoGetter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11E4190A22B90FE2009BDFB3 /* AutoGetter.swift */; };
 		11E71715219D722900B94845 /* BoundSetter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BA0F4B2217E2E9200969984 /* BoundSetter.swift */; };
 		11E71716219D722900B94845 /* Fold.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BA0F4BE217E2E9200969984 /* Fold.swift */; };
 		11E71717219D722900B94845 /* Getter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BA0F4B3217E2E9200969984 /* Getter.swift */; };
@@ -797,6 +798,7 @@
 		11DDCD20217F194B00844D9D /* MemoizationTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemoizationTest.swift; sourceTree = "<group>"; };
 		11DDCD22217F1E2B00844D9D /* Reverse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Reverse.swift; sourceTree = "<group>"; };
 		11DDCD27217F1FC200844D9D /* ReverseTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReverseTest.swift; sourceTree = "<group>"; };
+		11E4190A22B90FE2009BDFB3 /* AutoGetter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoGetter.swift; sourceTree = "<group>"; };
 		11E71712219D704F00B94845 /* BowOptics.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = BowOptics.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		11E71713219D705000B94845 /* Bow-Optics-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; name = "Bow-Optics-Info.plist"; path = "/Users/tomasruizlopez/Development/bow/Support Files/Bow-Optics-Info.plist"; sourceTree = "<absolute>"; };
 		11E71802219D7D5900B94845 /* BowOpticsTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = BowOpticsTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -1382,6 +1384,7 @@
 		1126CA8822B1139B00F840CB /* Auto */ = {
 			isa = PBXGroup;
 			children = (
+				11E4190A22B90FE2009BDFB3 /* AutoGetter.swift */,
 				1126CA8B22B115E100F840CB /* AutoLens.swift */,
 				1126CA8922B1144200F840CB /* AutoOptics.swift */,
 				1126CA8D22B1253D00F840CB /* AutoOptional.swift */,
@@ -3082,6 +3085,7 @@
 				11E7172A219D722900B94845 /* NonEmptyArray+Optics.swift in Sources */,
 				1126CA9822B12F8500F840CB /* Tuple4.swift in Sources */,
 				11E7172B219D722900B94845 /* String+Optics.swift in Sources */,
+				11E4190B22B90FE2009BDFB3 /* AutoGetter.swift in Sources */,
 				11E7172C219D722900B94845 /* Try+Optics.swift in Sources */,
 				11E7172D219D722900B94845 /* Validated+Optics.swift in Sources */,
 				11E7172E219D722900B94845 /* At.swift in Sources */,

--- a/Sources/BowOptics/Auto/AutoGetter.swift
+++ b/Sources/BowOptics/Auto/AutoGetter.swift
@@ -1,0 +1,12 @@
+/// Protocol for automatic derivation of Getter optics
+public protocol AutoGetter: AutoOptics {}
+
+public extension AutoGetter {
+    /// Generates a Getter for the field given by the key path.
+    ///
+    /// - Parameter path: Key path of the field.
+    /// - Returns: A Getter optic focused on the provided field.
+    static func getter<T>(for path: KeyPath<Self, T>) -> Getter<Self, T> {
+        return Getter(get: { whole in whole[keyPath: path] })
+    }
+}

--- a/Sources/BowOptics/Auto/AutoSetter.swift
+++ b/Sources/BowOptics/Auto/AutoSetter.swift
@@ -1,0 +1,35 @@
+/// Protocol for automatic derivation of Setter
+public protocol AutoSetter: AutoOptics {}
+
+public extension AutoSetter {
+    /// Generates a Setter for the provided field.
+    ///
+    /// - Parameter path: Key path for the field.
+    /// - Returns: A Setter that focuses on the provided field.
+    static func setter<T>(for path: WritableKeyPath<Self, T>) -> Setter<Self, T> {
+        return Setter<Self, T>(modify: { (whole, f) in
+            whole.copy(with: f(whole[keyPath: path]), for: path)
+        }, set: { whole, part in
+            whole.copy(with: part, for: path)
+        })
+    }
+    
+    /// Generates a BoundSetter for the provided field on a specific value.
+    ///
+    /// - Parameters:
+    ///   - path: Key path for the field.
+    ///   - value: Value to bind the setter to.
+    /// - Returns: A BoundSetter that focuses on the provided field on the specific value.
+    static func boundSetter<T>(for path: WritableKeyPath<Self, T>, onValue value: Self) -> BoundSetter<Self, T> {
+        return value.boundSetter(for: path)
+    }
+    
+    /// Generates a BoundSetter for the provided field on this value.
+    ///
+    /// - Parameter path: Key path for the field.
+    /// - Returns: A BoundSetter that focuses on the provided field.
+    func boundSetter<T>(for path: WritableKeyPath<Self, T>) -> BoundSetter<Self, T> {
+        return BoundSetter(value: self, setter: Self.setter(for: path))
+    }
+}
+


### PR DESCRIPTION
## Goal

Following the work done in #341, three new optics are automatically derived using the same techniques described in such PR. The three new optics that we are able to derive are `Getter`, `Setter` and `BoundSetter`. They can be seen as specializations of the work done for `Lens`.

## Implementation details

Given the following type:

```swift
struct Person {
  var name: String
  var age: Int
}
```

We can get `Getter` and `Setter` as:

```swift
let nameGetter = Person.getter(for: \.name)
let ageSetter = Person.setter(for: \.age)
```

In the case of `BoundSetter`, we need to provide a specific value:

```swift
let person = Person(name: "Tomás", age: 32)
let ageBoundSetter = Person.boundSetter(for: \.age, onValue: person)
// Or alternatively
let ageBoundSetter2 = person.boundSetter(for: \.age)
```
