### PR TITLE
New encoding for type classes in Optics

### DIFF
--- a/Bow.xcodeproj/project.pbxproj
+++ b/Bow.xcodeproj/project.pbxproj
@@ -171,7 +171,7 @@
 		11E71726219D722900B94845 /* Either+Optics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BA0F4BD217E2E9200969984 /* Either+Optics.swift */; };
 		11E71727219D722900B94845 /* Id+Optics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BA0F4B6217E2E9200969984 /* Id+Optics.swift */; };
 		11E71728219D722900B94845 /* ArrayK+Optics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BA0F4BB217E2E9200969984 /* ArrayK+Optics.swift */; };
-		11E71729219D722900B94845 /* Maybe+Optics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BA0F4B8217E2E9200969984 /* Maybe+Optics.swift */; };
+		11E71729219D722900B94845 /* Option+Optics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BA0F4B8217E2E9200969984 /* Option+Optics.swift */; };
 		11E7172A219D722900B94845 /* NonEmptyArray+Optics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BA0F4BC217E2E9200969984 /* NonEmptyArray+Optics.swift */; };
 		11E7172B219D722900B94845 /* String+Optics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BA0F4B9217E2E9200969984 /* String+Optics.swift */; };
 		11E7172C219D722900B94845 /* Try+Optics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BA0F4B7217E2E9200969984 /* Try+Optics.swift */; };
@@ -994,7 +994,7 @@
 		8BA0F4B4217E2E9200969984 /* Traversal.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Traversal.swift; sourceTree = "<group>"; };
 		8BA0F4B6217E2E9200969984 /* Id+Optics.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Id+Optics.swift"; sourceTree = "<group>"; };
 		8BA0F4B7217E2E9200969984 /* Try+Optics.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Try+Optics.swift"; sourceTree = "<group>"; };
-		8BA0F4B8217E2E9200969984 /* Maybe+Optics.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Maybe+Optics.swift"; sourceTree = "<group>"; };
+		8BA0F4B8217E2E9200969984 /* Option+Optics.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Option+Optics.swift"; sourceTree = "<group>"; };
 		8BA0F4B9217E2E9200969984 /* String+Optics.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "String+Optics.swift"; sourceTree = "<group>"; };
 		8BA0F4BA217E2E9200969984 /* Validated+Optics.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Validated+Optics.swift"; sourceTree = "<group>"; };
 		8BA0F4BB217E2E9200969984 /* ArrayK+Optics.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ArrayK+Optics.swift"; sourceTree = "<group>"; };
@@ -1850,7 +1850,7 @@
 				8BA0F4BB217E2E9200969984 /* ArrayK+Optics.swift */,
 				8BA0F4BD217E2E9200969984 /* Either+Optics.swift */,
 				8BA0F4B6217E2E9200969984 /* Id+Optics.swift */,
-				8BA0F4B8217E2E9200969984 /* Maybe+Optics.swift */,
+				8BA0F4B8217E2E9200969984 /* Option+Optics.swift */,
 				8BA0F4BC217E2E9200969984 /* NonEmptyArray+Optics.swift */,
 				8BA0F4B9217E2E9200969984 /* String+Optics.swift */,
 				8BA0F4B7217E2E9200969984 /* Try+Optics.swift */,
@@ -3081,7 +3081,7 @@
 				1126CA9622B12EC400F840CB /* Tuple3.swift in Sources */,
 				11E71728219D722900B94845 /* ArrayK+Optics.swift in Sources */,
 				1126CA9E22B1314F00F840CB /* Tuple7.swift in Sources */,
-				11E71729219D722900B94845 /* Maybe+Optics.swift in Sources */,
+				11E71729219D722900B94845 /* Option+Optics.swift in Sources */,
 				11E7172A219D722900B94845 /* NonEmptyArray+Optics.swift in Sources */,
 				1126CA9822B12F8500F840CB /* Tuple4.swift in Sources */,
 				11E7172B219D722900B94845 /* String+Optics.swift in Sources */,

--- a/Bow.xcodeproj/project.pbxproj
+++ b/Bow.xcodeproj/project.pbxproj
@@ -629,6 +629,13 @@
 			remoteGlobalIDString = 11E71817219D81B300B94845;
 			remoteInfo = "Bow-Free";
 		};
+		1186E15422BA4A9D001F8A5D /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = OBJ_1 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 1120978222A7EBC7007F3D9C;
+			remoteInfo = "Bow-Generators";
+		};
 		11D97EC5219EBAA1008FC004 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = OBJ_1 /* Project object */;
@@ -2360,6 +2367,7 @@
 			buildRules = (
 			);
 			dependencies = (
+				1186E15522BA4A9D001F8A5D /* PBXTargetDependency */,
 				11E71806219D7DFB00B94845 /* PBXTargetDependency */,
 				11E7179F219D7D5900B94845 /* PBXTargetDependency */,
 			);
@@ -2807,6 +2815,7 @@
 			);
 			inputPaths = (
 				"$(SRCROOT)/Carthage/Build/iOS/SwiftCheck.framework",
+				"$(SRCROOT)/Carthage/Build/iOS/Nimble.framework",
 			);
 			outputPaths = (
 			);
@@ -3486,6 +3495,11 @@
 			isa = PBXTargetDependency;
 			target = 11E71817219D81B300B94845 /* Bow-Free */;
 			targetProxy = 117DC13322AE56D800EF65F0 /* PBXContainerItemProxy */;
+		};
+		1186E15522BA4A9D001F8A5D /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 1120978222A7EBC7007F3D9C /* Bow-Generators */;
+			targetProxy = 1186E15422BA4A9D001F8A5D /* PBXContainerItemProxy */;
 		};
 		11D97EC4219EBAA1008FC004 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;

--- a/Bow.xcodeproj/project.pbxproj
+++ b/Bow.xcodeproj/project.pbxproj
@@ -139,6 +139,7 @@
 		117DC12922AE563900EF65F0 /* Nimble.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8BA0F384217E2D3400969984 /* Nimble.framework */; };
 		117DC12A22AE563900EF65F0 /* SwiftCheck.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8BA0F385217E2D3400969984 /* SwiftCheck.framework */; };
 		117DC13722AE578A00EF65F0 /* Free+Gen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 117DC13622AE578A00EF65F0 /* Free+Gen.swift */; };
+		1186E15122BA395D001F8A5D /* Index+Optics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1186E14E22BA38CD001F8A5D /* Index+Optics.swift */; };
 		11A435622212C60A000C5E31 /* EquatableLaws.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11A435602212C59F000C5E31 /* EquatableLaws.swift */; };
 		11A4356422131ACC000C5E31 /* BoolInstances.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11A4356322131ACC000C5E31 /* BoolInstances.swift */; };
 		11D36A19223261EC00CBD85F /* Selective.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11D36A18223261EC00CBD85F /* Selective.swift */; };
@@ -788,6 +789,7 @@
 		117DC12F22AE563900EF65F0 /* BowFreeGenerators.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = BowFreeGenerators.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		117DC13022AE563900EF65F0 /* Bow-Free-Generators-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; name = "Bow-Free-Generators-Info.plist"; path = "/Users/tomasruizlopez/Development/bow/Bow-Free-Generators-Info.plist"; sourceTree = "<absolute>"; };
 		117DC13622AE578A00EF65F0 /* Free+Gen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Free+Gen.swift"; sourceTree = "<group>"; };
+		1186E14E22BA38CD001F8A5D /* Index+Optics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Index+Optics.swift"; sourceTree = "<group>"; };
 		11A435602212C59F000C5E31 /* EquatableLaws.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EquatableLaws.swift; sourceTree = "<group>"; };
 		11A4356322131ACC000C5E31 /* BoolInstances.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoolInstances.swift; sourceTree = "<group>"; };
 		11D36A18223261EC00CBD85F /* Selective.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Selective.swift; sourceTree = "<group>"; };
@@ -1888,6 +1890,7 @@
 			children = (
 				8BA0F4D0217E2E9200969984 /* At+Optics.swift */,
 				8BA0F4D1217E2E9200969984 /* Each+Optics.swift */,
+				1186E14E22BA38CD001F8A5D /* Index+Optics.swift */,
 				11E4191022B93596009BDFB3 /* Kind+Optics.swift */,
 			);
 			path = DSL;
@@ -3078,6 +3081,7 @@
 				11E71725219D722900B94845 /* TryOpticsInstances.swift in Sources */,
 				11E71726219D722900B94845 /* Either+Optics.swift in Sources */,
 				11E71727219D722900B94845 /* Id+Optics.swift in Sources */,
+				1186E15122BA395D001F8A5D /* Index+Optics.swift in Sources */,
 				1126CA9622B12EC400F840CB /* Tuple3.swift in Sources */,
 				11E71728219D722900B94845 /* ArrayK+Optics.swift in Sources */,
 				1126CA9E22B1314F00F840CB /* Tuple7.swift in Sources */,

--- a/Bow.xcodeproj/project.pbxproj
+++ b/Bow.xcodeproj/project.pbxproj
@@ -150,6 +150,7 @@
 		11DDCD21217F194B00844D9D /* MemoizationTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11DDCD20217F194B00844D9D /* MemoizationTest.swift */; };
 		11DDCD23217F1E2B00844D9D /* Reverse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11DDCD22217F1E2B00844D9D /* Reverse.swift */; };
 		11DDCD28217F1FC200844D9D /* ReverseTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11DDCD27217F1FC200844D9D /* ReverseTest.swift */; };
+		11E4191222B935AE009BDFB3 /* Kind+Optics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11E4191022B93596009BDFB3 /* Kind+Optics.swift */; };
 		11E71715219D722900B94845 /* BoundSetter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BA0F4B2217E2E9200969984 /* BoundSetter.swift */; };
 		11E71716219D722900B94845 /* Fold.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BA0F4BE217E2E9200969984 /* Fold.swift */; };
 		11E71717219D722900B94845 /* Getter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BA0F4B3217E2E9200969984 /* Getter.swift */; };
@@ -797,6 +798,7 @@
 		11DDCD20217F194B00844D9D /* MemoizationTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemoizationTest.swift; sourceTree = "<group>"; };
 		11DDCD22217F1E2B00844D9D /* Reverse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Reverse.swift; sourceTree = "<group>"; };
 		11DDCD27217F1FC200844D9D /* ReverseTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReverseTest.swift; sourceTree = "<group>"; };
+		11E4191022B93596009BDFB3 /* Kind+Optics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Kind+Optics.swift"; sourceTree = "<group>"; };
 		11E71712219D704F00B94845 /* BowOptics.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = BowOptics.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		11E71713219D705000B94845 /* Bow-Optics-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; name = "Bow-Optics-Info.plist"; path = "/Users/tomasruizlopez/Development/bow/Support Files/Bow-Optics-Info.plist"; sourceTree = "<absolute>"; };
 		11E71802219D7D5900B94845 /* BowOpticsTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = BowOpticsTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -1886,6 +1888,7 @@
 			children = (
 				8BA0F4D0217E2E9200969984 /* At+Optics.swift */,
 				8BA0F4D1217E2E9200969984 /* Each+Optics.swift */,
+				11E4191022B93596009BDFB3 /* Kind+Optics.swift */,
 			);
 			path = DSL;
 			sourceTree = "<group>";
@@ -3084,6 +3087,7 @@
 				11E7172B219D722900B94845 /* String+Optics.swift in Sources */,
 				11E7172C219D722900B94845 /* Try+Optics.swift in Sources */,
 				11E7172D219D722900B94845 /* Validated+Optics.swift in Sources */,
+				11E4191222B935AE009BDFB3 /* Kind+Optics.swift in Sources */,
 				11E7172E219D722900B94845 /* At.swift in Sources */,
 				1126CA8A22B1144200F840CB /* AutoOptics.swift in Sources */,
 				1126CA8C22B115E100F840CB /* AutoLens.swift in Sources */,

--- a/Sources/BowOptics/DSL/At+Optics.swift
+++ b/Sources/BowOptics/DSL/At+Optics.swift
@@ -1,50 +1,50 @@
 import Foundation
 import Bow
 
-//public extension Lens {
-//    func at<AtType, I, T>(_ at: AtType, _ i: I) -> Lens<S, T> where AtType: At, AtType.S == A, AtType.I == I, AtType.A == T {
-//        return (self as! Lens<S, A>) + at.at(i)
-//    }
-//}
-//
-//public extension Iso {
-//    func at<AtType, I, T>(_ at: AtType, _ i: I) -> Lens<S, T> where AtType: At, AtType.S == A, AtType.I == I, AtType.A == T {
-//        return (self as! Iso<S, A>) + at.at(i)
-//    }
-//}
-//
-//public extension Prism {
-//    func at<AtType, I, T>(_ at: AtType, _ i: I) -> Optional<S, T> where AtType: At, AtType.S == A, AtType.I == I, AtType.A == T {
-//        return (self as! Prism<S, A>) + at.at(i)
-//    }
-//}
-//
-//public extension Optional {
-//    func at<AtType, I, T>(_ at: AtType, _ i: I) -> Optional<S, T> where AtType: At, AtType.S == A, AtType.I == I, AtType.A == T {
-//        return (self as! Optional<S, A>) + at.at(i)
-//    }
-//}
-//
-//public extension Getter {
-//    func at<AtType, I, T>(_ at: AtType, _ i: I) -> Getter<S, T> where AtType: At, AtType.S == A, AtType.I == I, AtType.A == T {
-//        return self + at.at(i)
-//    }
-//}
-//
-//public extension Setter {
-//    func at<AtType, I, T>(_ at: AtType, _ i: I) -> Setter<S, T> where AtType: At, AtType.S == A, AtType.I == I, AtType.A == T {
-//        return (self as! Setter<S, A>) + at.at(i)
-//    }
-//}
-//
-//public extension Traversal {
-//    func at<AtType, I, T>(_ at: AtType, _ i: I) -> Traversal<S, T> where AtType: At, AtType.S == A, AtType.I == I, AtType.A == T {
-//        return (self as! Traversal<S, A>) + at.at(i)
-//    }
-//}
-//
-//public extension Fold {
-//    func at<AtType, I, T>(_ at: AtType, _ i: I) -> Fold<S, T> where AtType: At, AtType.S == A, AtType.I == I, AtType.A == T {
-//        return self + at.at(i)
-//    }
-//}
+public extension Lens where A: At {
+    func at(_ i: A.AtIndex) -> Lens<S, A.AtFoci>  {
+        return self.fix + A.at(i)
+    }
+}
+
+public extension Iso where A: At {
+    func at(_ i: A.AtIndex) -> Lens<S, A.AtFoci> {
+        return self.fix + A.at(i)
+    }
+}
+
+public extension Prism where A: At {
+    func at(_ i: A.AtIndex) -> Optional<S, A.AtFoci> {
+        return self.fix + A.at(i)
+    }
+}
+
+public extension Optional where A: At {
+    func at(_ i: A.AtIndex) -> Optional<S, A.AtFoci> {
+        return self.fix + A.at(i)
+    }
+}
+
+public extension Getter where A: At {
+    func at(_ i: A.AtIndex) -> Getter<S, A.AtFoci> {
+        return self + A.at(i)
+    }
+}
+
+public extension Setter where A: At {
+    func at(_ i: A.AtIndex) -> Setter<S, A.AtFoci> {
+        return self.fix + A.at(i)
+    }
+}
+
+public extension Traversal where A: At {
+    func at(_ i: A.AtIndex) -> Traversal<S, A.AtFoci> {
+        return self.fix + A.at(i)
+    }
+}
+
+public extension Fold where A: At {
+    func at(_ i: A.AtIndex) -> Fold<S, A.AtFoci> {
+        return self + A.at(i)
+    }
+}

--- a/Sources/BowOptics/DSL/At+Optics.swift
+++ b/Sources/BowOptics/DSL/At+Optics.swift
@@ -1,50 +1,50 @@
 import Foundation
 import Bow
 
-public extension Lens {
-    func at<AtType, I, T>(_ at: AtType, _ i: I) -> Lens<S, T> where AtType: At, AtType.S == A, AtType.I == I, AtType.A == T {
-        return (self as! Lens<S, A>) + at.at(i)
-    }
-}
-
-public extension Iso {
-    func at<AtType, I, T>(_ at: AtType, _ i: I) -> Lens<S, T> where AtType: At, AtType.S == A, AtType.I == I, AtType.A == T {
-        return (self as! Iso<S, A>) + at.at(i)
-    }
-}
-
-public extension Prism {
-    func at<AtType, I, T>(_ at: AtType, _ i: I) -> Optional<S, T> where AtType: At, AtType.S == A, AtType.I == I, AtType.A == T {
-        return (self as! Prism<S, A>) + at.at(i)
-    }
-}
-
-public extension Optional {
-    func at<AtType, I, T>(_ at: AtType, _ i: I) -> Optional<S, T> where AtType: At, AtType.S == A, AtType.I == I, AtType.A == T {
-        return (self as! Optional<S, A>) + at.at(i)
-    }
-}
-
-public extension Getter {
-    func at<AtType, I, T>(_ at: AtType, _ i: I) -> Getter<S, T> where AtType: At, AtType.S == A, AtType.I == I, AtType.A == T {
-        return self + at.at(i)
-    }
-}
-
-public extension Setter {
-    func at<AtType, I, T>(_ at: AtType, _ i: I) -> Setter<S, T> where AtType: At, AtType.S == A, AtType.I == I, AtType.A == T {
-        return (self as! Setter<S, A>) + at.at(i)
-    }
-}
-
-public extension Traversal {
-    func at<AtType, I, T>(_ at: AtType, _ i: I) -> Traversal<S, T> where AtType: At, AtType.S == A, AtType.I == I, AtType.A == T {
-        return (self as! Traversal<S, A>) + at.at(i)
-    }
-}
-
-public extension Fold {
-    func at<AtType, I, T>(_ at: AtType, _ i: I) -> Fold<S, T> where AtType: At, AtType.S == A, AtType.I == I, AtType.A == T {
-        return self + at.at(i)
-    }
-}
+//public extension Lens {
+//    func at<AtType, I, T>(_ at: AtType, _ i: I) -> Lens<S, T> where AtType: At, AtType.S == A, AtType.I == I, AtType.A == T {
+//        return (self as! Lens<S, A>) + at.at(i)
+//    }
+//}
+//
+//public extension Iso {
+//    func at<AtType, I, T>(_ at: AtType, _ i: I) -> Lens<S, T> where AtType: At, AtType.S == A, AtType.I == I, AtType.A == T {
+//        return (self as! Iso<S, A>) + at.at(i)
+//    }
+//}
+//
+//public extension Prism {
+//    func at<AtType, I, T>(_ at: AtType, _ i: I) -> Optional<S, T> where AtType: At, AtType.S == A, AtType.I == I, AtType.A == T {
+//        return (self as! Prism<S, A>) + at.at(i)
+//    }
+//}
+//
+//public extension Optional {
+//    func at<AtType, I, T>(_ at: AtType, _ i: I) -> Optional<S, T> where AtType: At, AtType.S == A, AtType.I == I, AtType.A == T {
+//        return (self as! Optional<S, A>) + at.at(i)
+//    }
+//}
+//
+//public extension Getter {
+//    func at<AtType, I, T>(_ at: AtType, _ i: I) -> Getter<S, T> where AtType: At, AtType.S == A, AtType.I == I, AtType.A == T {
+//        return self + at.at(i)
+//    }
+//}
+//
+//public extension Setter {
+//    func at<AtType, I, T>(_ at: AtType, _ i: I) -> Setter<S, T> where AtType: At, AtType.S == A, AtType.I == I, AtType.A == T {
+//        return (self as! Setter<S, A>) + at.at(i)
+//    }
+//}
+//
+//public extension Traversal {
+//    func at<AtType, I, T>(_ at: AtType, _ i: I) -> Traversal<S, T> where AtType: At, AtType.S == A, AtType.I == I, AtType.A == T {
+//        return (self as! Traversal<S, A>) + at.at(i)
+//    }
+//}
+//
+//public extension Fold {
+//    func at<AtType, I, T>(_ at: AtType, _ i: I) -> Fold<S, T> where AtType: At, AtType.S == A, AtType.I == I, AtType.A == T {
+//        return self + at.at(i)
+//    }
+//}

--- a/Sources/BowOptics/DSL/Each+Optics.swift
+++ b/Sources/BowOptics/DSL/Each+Optics.swift
@@ -1,44 +1,44 @@
 import Foundation
 import Bow
 
-//public extension Lens {
-//    func every<EachType, T>(_ each : EachType) -> Traversal<S, T> where EachType : Each, EachType.S == A, EachType.A == T {
-//        return (self as! Lens<S, A>) + each.each()
-//    }
-//}
-//
-//public extension Iso {
-//    func every<EachType, T>(_ each : EachType) -> Traversal<S, T> where EachType : Each, EachType.S == A, EachType.A == T {
-//        return (self as! Iso<S, A>) + each.each()
-//    }
-//}
-//
-//public extension Prism {
-//    func every<EachType, T>(_ each : EachType) -> Traversal<S, T> where EachType : Each, EachType.S == A, EachType.A == T {
-//        return (self as! Prism<S, A>) + each.each()
-//    }
-//}
-//
-//public extension Optional {
-//    func every<EachType, T>(_ each : EachType) -> Traversal<S, T> where EachType : Each, EachType.S == A, EachType.A == T {
-//        return (self as! Optional<S, A>) + each.each()
-//    }
-//}
-//
-//public extension Setter {
-//    func every<EachType, T>(_ each : EachType) -> Setter<S, T> where EachType : Each, EachType.S == A, EachType.A == T {
-//        return (self as! Setter<S, A>) + each.each()
-//    }
-//}
-//
-//public extension Traversal {
-//    func every<EachType, T>(_ each : EachType) -> Traversal<S, T> where EachType : Each, EachType.S == A, EachType.A == T {
-//        return (self as! Traversal<S, A>) + each.each()
-//    }
-//}
-//
-//public extension Fold {
-//    func every<EachType, T>(_ each : EachType) -> Fold<S, T> where EachType : Each, EachType.S == A, EachType.A == T {
-//        return self + each.each()
-//    }
-//}
+public extension Lens where A: Each {
+    var every: Traversal<S, A.EachFoci> {
+        return self.fix + A.each
+    }
+}
+
+public extension Iso where A: Each {
+    var every: Traversal<S, A.EachFoci> {
+        return self.fix + A.each
+    }
+}
+
+public extension Prism where A: Each {
+    var every: Traversal<S, A.EachFoci> {
+        return self.fix + A.each
+    }
+}
+
+public extension Optional where A: Each {
+    var every: Traversal<S, A.EachFoci> {
+        return self.fix + A.each
+    }
+}
+
+public extension Setter where A: Each {
+    var every: Setter<S, A.EachFoci> {
+        return self.fix + A.each
+    }
+}
+
+public extension Traversal where A: Each {
+    var every: Traversal<S, A.EachFoci> {
+        return self.fix + A.each
+    }
+}
+
+public extension Fold where A: Each {
+    var every: Fold<S, A.EachFoci> {
+        return self + A.each
+    }
+}

--- a/Sources/BowOptics/DSL/Each+Optics.swift
+++ b/Sources/BowOptics/DSL/Each+Optics.swift
@@ -1,44 +1,44 @@
 import Foundation
 import Bow
 
-public extension Lens {
-    func every<EachType, T>(_ each : EachType) -> Traversal<S, T> where EachType : Each, EachType.S == A, EachType.A == T {
-        return (self as! Lens<S, A>) + each.each()
-    }
-}
-
-public extension Iso {
-    func every<EachType, T>(_ each : EachType) -> Traversal<S, T> where EachType : Each, EachType.S == A, EachType.A == T {
-        return (self as! Iso<S, A>) + each.each()
-    }
-}
-
-public extension Prism {
-    func every<EachType, T>(_ each : EachType) -> Traversal<S, T> where EachType : Each, EachType.S == A, EachType.A == T {
-        return (self as! Prism<S, A>) + each.each()
-    }
-}
-
-public extension Optional {
-    func every<EachType, T>(_ each : EachType) -> Traversal<S, T> where EachType : Each, EachType.S == A, EachType.A == T {
-        return (self as! Optional<S, A>) + each.each()
-    }
-}
-
-public extension Setter {
-    func every<EachType, T>(_ each : EachType) -> Setter<S, T> where EachType : Each, EachType.S == A, EachType.A == T {
-        return (self as! Setter<S, A>) + each.each()
-    }
-}
-
-public extension Traversal {
-    func every<EachType, T>(_ each : EachType) -> Traversal<S, T> where EachType : Each, EachType.S == A, EachType.A == T {
-        return (self as! Traversal<S, A>) + each.each()
-    }
-}
-
-public extension Fold {
-    func every<EachType, T>(_ each : EachType) -> Fold<S, T> where EachType : Each, EachType.S == A, EachType.A == T {
-        return self + each.each()
-    }
-}
+//public extension Lens {
+//    func every<EachType, T>(_ each : EachType) -> Traversal<S, T> where EachType : Each, EachType.S == A, EachType.A == T {
+//        return (self as! Lens<S, A>) + each.each()
+//    }
+//}
+//
+//public extension Iso {
+//    func every<EachType, T>(_ each : EachType) -> Traversal<S, T> where EachType : Each, EachType.S == A, EachType.A == T {
+//        return (self as! Iso<S, A>) + each.each()
+//    }
+//}
+//
+//public extension Prism {
+//    func every<EachType, T>(_ each : EachType) -> Traversal<S, T> where EachType : Each, EachType.S == A, EachType.A == T {
+//        return (self as! Prism<S, A>) + each.each()
+//    }
+//}
+//
+//public extension Optional {
+//    func every<EachType, T>(_ each : EachType) -> Traversal<S, T> where EachType : Each, EachType.S == A, EachType.A == T {
+//        return (self as! Optional<S, A>) + each.each()
+//    }
+//}
+//
+//public extension Setter {
+//    func every<EachType, T>(_ each : EachType) -> Setter<S, T> where EachType : Each, EachType.S == A, EachType.A == T {
+//        return (self as! Setter<S, A>) + each.each()
+//    }
+//}
+//
+//public extension Traversal {
+//    func every<EachType, T>(_ each : EachType) -> Traversal<S, T> where EachType : Each, EachType.S == A, EachType.A == T {
+//        return (self as! Traversal<S, A>) + each.each()
+//    }
+//}
+//
+//public extension Fold {
+//    func every<EachType, T>(_ each : EachType) -> Fold<S, T> where EachType : Each, EachType.S == A, EachType.A == T {
+//        return self + each.each()
+//    }
+//}

--- a/Sources/BowOptics/DSL/Index+Optics.swift
+++ b/Sources/BowOptics/DSL/Index+Optics.swift
@@ -1,0 +1,71 @@
+import Bow
+
+public extension Lens where A: Index {
+    func index(_ i: A.IndexType) -> Optional<S, A.IndexFoci> {
+        return self.fix + A.index(i)
+    }
+    
+    subscript(_ i: A.IndexType) -> Optional<S, A.IndexFoci> {
+        return self.index(i)
+    }
+}
+
+public extension Iso where A: Index {
+    func index(_ i: A.IndexType) -> Optional<S, A.IndexFoci> {
+        return self.fix + A.index(i)
+    }
+    
+    subscript(_ i: A.IndexType) -> Optional<S, A.IndexFoci> {
+        return self.index(i)
+    }
+}
+
+public extension Prism where A: Index {
+    func index(_ i: A.IndexType) -> Optional<S, A.IndexFoci> {
+        return self.fix + A.index(i)
+    }
+    
+    subscript(_ i: A.IndexType) -> Optional<S, A.IndexFoci> {
+        return self.index(i)
+    }
+}
+
+public extension Optional where A: Index {
+    func index(_ i: A.IndexType) -> Optional<S, A.IndexFoci> {
+        return self.fix + A.index(i)
+    }
+    
+    subscript(_ i: A.IndexType) -> Optional<S, A.IndexFoci> {
+        return self.index(i)
+    }
+}
+
+public extension Setter where A: Index {
+    func index(_ i: A.IndexType) -> Setter<S, A.IndexFoci> {
+        return self.fix + A.index(i)
+    }
+    
+    subscript(_ i: A.IndexType) -> Setter<S, A.IndexFoci> {
+        return self.index(i)
+    }
+}
+
+public extension Traversal where A: Index {
+    func index(_ i: A.IndexType) -> Traversal<S, A.IndexFoci> {
+        return self.fix + A.index(i)
+    }
+    
+    subscript(_ i: A.IndexType) -> Traversal<S, A.IndexFoci> {
+        return self.index(i)
+    }
+}
+
+public extension Fold where A: Index {
+    func index(_ i: A.IndexType) -> Fold<S, A.IndexFoci> {
+        return self + A.index(i)
+    }
+    
+    subscript(_ i: A.IndexType) -> Fold<S, A.IndexFoci> {
+        return self.index(i)
+    }
+}

--- a/Sources/BowOptics/DSL/Kind+Optics.swift
+++ b/Sources/BowOptics/DSL/Kind+Optics.swift
@@ -2,7 +2,7 @@ import Bow
 
 // MARK: Optics extensions
 public extension Kind where F: Traverse {
-    static func traversalK() -> Traversal<Kind<F, A>, A> {
+    static var traversalK: Traversal<Kind<F, A>, A> {
         return KindTraversal<F, A>()
     }
 }

--- a/Sources/BowOptics/DSL/Kind+Optics.swift
+++ b/Sources/BowOptics/DSL/Kind+Optics.swift
@@ -7,6 +7,12 @@ public extension Kind where F: Traverse {
     }
 }
 
+public extension Kind where F: Foldable {
+    static var foldK: Fold<Kind<F, A>, A> {
+        return Fold<A, A>.fromFoldable()
+    }
+}
+
 private class KindTraversal<G: Traverse, A>: Traversal<Kind<G, A>, A> {
     override func modifyF<F: Applicative>(_ s: Kind<G, A>, _ f: @escaping (A) -> Kind<F, A>) -> Kind<F, Kind<G, A>> {
         return s.traverse(f)

--- a/Sources/BowOptics/DSL/Kind+Optics.swift
+++ b/Sources/BowOptics/DSL/Kind+Optics.swift
@@ -9,7 +9,7 @@ public extension Kind where F: Traverse {
 
 public extension Kind where F: Foldable {
     static var foldK: Fold<Kind<F, A>, A> {
-        return Fold<A, A>.fromFoldable()
+        return Fold<Kind<F, A>, A>.fromFoldable()
     }
 }
 

--- a/Sources/BowOptics/DSL/Kind+Optics.swift
+++ b/Sources/BowOptics/DSL/Kind+Optics.swift
@@ -1,0 +1,14 @@
+import Bow
+
+// MARK: Optics extensions
+public extension Kind where F: Traverse {
+    static func traversalK() -> Traversal<Kind<F, A>, A> {
+        return KindTraversal<F, A>()
+    }
+}
+
+private class KindTraversal<G: Traverse, A>: Traversal<Kind<G, A>, A> {
+    override func modifyF<F: Applicative>(_ s: Kind<G, A>, _ f: @escaping (A) -> Kind<F, A>) -> Kind<F, Kind<G, A>> {
+        return s.traverse(f)
+    }
+}

--- a/Sources/BowOptics/Fold.swift
+++ b/Sources/BowOptics/Fold.swift
@@ -6,27 +6,14 @@ public final class FoldPartial<S>: Kind<ForFold, S> {}
 public typealias FoldOf<S, A> = Kind<FoldPartial<S>, A>
 
 open class Fold<S, A>: FoldOf<S, A> {
-
-    public static func identity() -> Fold<A, A> {
-        return Iso<A, A>.identity().asFold()
-    }
-
-    public static func codiagonal() -> Fold<Either<S, S>, S> {
-        return CodiagonalFold<S>()
-    }
-
-    public static func select(_ predicate: @escaping (S) -> Bool) -> Fold<S, S> {
-        return SelectFold<S>(predicate: predicate)
-    }
-
     public static func void() -> Fold<S, A> {
         return Optional<S, A>.void().asFold()
     }
 
-    public static func fromFoldable<F: Foldable>() -> Fold<Kind<F, S>, S> {
+    public static func fromFoldable<F: Foldable>() -> Fold<Kind<F, A>, A> where S: Kind<F, A> {
         return FoldableFold()
     }
-
+    
     public static func +<C>(lhs: Fold<S, A>, rhs: Fold<A, C>) -> Fold<S, C> {
         return lhs.compose(rhs)
     }
@@ -133,6 +120,20 @@ open class Fold<S, A>: FoldOf<S, A> {
 
     public func exists(_ s: S, _ predicate: @escaping (A) -> Bool) -> Bool {
         return find(s, predicate).fold(constant(false), constant(true))
+    }
+}
+
+public extension Fold where S == A {
+    static func identity() -> Fold<S, S> {
+        return Iso<S, S>.identity().asFold()
+    }
+    
+    static func codiagonal() -> Fold<Either<S, S>, S> {
+        return CodiagonalFold<S>()
+    }
+    
+    static func select(_ predicate: @escaping (S) -> Bool) -> Fold<S, S> {
+        return SelectFold<S>(predicate: predicate)
     }
 }
 

--- a/Sources/BowOptics/Getter.swift
+++ b/Sources/BowOptics/Getter.swift
@@ -24,16 +24,6 @@ public class Getter<S, A> : GetterOf<S, A> {
         return lhs.compose(rhs)
     }
     
-    public static func identity() -> Getter<S, S> {
-        return Iso<S, S>.identity().asGetter()
-    }
-    
-    public static func codiagonal() -> Getter<Either<S, S>, S> {
-        return Getter<Either<S, S>, S>(get: { either in
-            either.fold(id, id)
-        })
-    }
-    
     public init(get : @escaping (S) -> A) {
         self.getFunc = get
     }
@@ -107,6 +97,18 @@ public class Getter<S, A> : GetterOf<S, A> {
     
     public func exists(_ s : S, _ predicate : (A) -> Bool) -> Bool {
         return predicate(get(s))
+    }
+}
+
+public extension Getter where S == A {
+    static func identity() -> Getter<S, S> {
+        return Iso<S, S>.identity().asGetter()
+    }
+    
+    static func codiagonal() -> Getter<Either<S, S>, S> {
+        return Getter<Either<S, S>, S>(get: { either in
+            either.fold(id, id)
+        })
     }
 }
 

--- a/Sources/BowOptics/Instances/ArrayKOpticsInstances.swift
+++ b/Sources/BowOptics/Instances/ArrayKOpticsInstances.swift
@@ -2,75 +2,75 @@ import Foundation
 import Bow
 
 public extension ArrayK {
-    static func traversal() -> Traversal<ArrayK<A>, A> {
-        return ArrayKTraversal<A>()
-    }
-
-    static func each() -> EachInstance<A> {
-        return EachInstance<A>()
-    }
-
-    static func index() -> IndexInstance<A> {
-        return IndexInstance<A>()
-    }
-
-    static func filterIndex() -> FilterIndexInstance<A> {
-        return FilterIndexInstance<A>()
-    }
-
-    class EachInstance<E>: Each {
-        public typealias S = ArrayK<E>
-        public typealias A = E
-
-        public func each() -> Traversal<ArrayK<E>, E> {
-            return ArrayK<E>.traversal()
-        }
-    }
-
-    class IndexInstance<E>: Index {
-        public typealias S = ArrayK<E>
-        public typealias I = Int
-        public typealias A = E
-
-        public func index(_ i: Int) -> Optional<ArrayK<E>, E> {
-            return Optional<ArrayK<E>, E>(
-                set: { arrayK, e in
-                    arrayK.asArray.enumerated().map { x in
-                        return (x.offset == i) ? e : x.element
-                        }.k()
-            }, getOrModify: { array in
-                array.getOrNone(i).fold({ Either<ArrayK<E>, E>.left(array) }, Either<ArrayK<E>, E>.right)
-            })
-        }
-    }
-
-    class FilterIndexInstance<E>: FilterIndex {
-        public typealias S = ArrayK<E>
-        public typealias I = Int
-        public typealias A = E
-
-        public func filter(_ predicate: @escaping (Int) -> Bool) -> Traversal<ArrayK<E>, E> {
-            return ArrayKFilterIndexTraversal<E>(predicate: predicate)
-        }
-    }
-
-    private class ArrayKFilterIndexTraversal<A>: Traversal<ArrayK<A>, A> {
-        private let predicate: (Int) -> Bool
-
-        init(predicate : @escaping (Int) -> Bool) {
-            self.predicate = predicate
-        }
-
-        override func modifyF<F: Applicative>(_ s: ArrayK<A>, _ f: @escaping (A) -> Kind<F, A>) -> Kind<F, ArrayK<A>> {
-            return F.map(s.asArray.enumerated().map(id).k().traverse({ x in
-                self.predicate(x.offset) ? f(x.element) : F.pure(x.element)
-            }), ArrayK<A>.fix)
-        }
-    }
-
-    private class ArrayKTraversal<A>: Traversal<ArrayK<A>, A> {
-        override func modifyF<F: Applicative>(_ s: ArrayK<A>, _ f: @escaping (A) -> Kind<F, A>) -> Kind<F, ArrayK<A>>  {
-            return F.map(s.traverse(f), { x in ArrayK<A>.fix(x) })
-        }
-    }
+//    static func traversal() -> Traversal<ArrayK<A>, A> {
+//        return ArrayKTraversal<A>()
+//    }
+//
+//    static func each() -> EachInstance<A> {
+//        return EachInstance<A>()
+//    }
+//
+//    static func index() -> IndexInstance<A> {
+//        return IndexInstance<A>()
+//    }
+//
+//    static func filterIndex() -> FilterIndexInstance<A> {
+//        return FilterIndexInstance<A>()
+//    }
+//
+//    class EachInstance<E>: Each {
+//        public typealias S = ArrayK<E>
+//        public typealias A = E
+//
+//        public func each() -> Traversal<ArrayK<E>, E> {
+//            return ArrayK<E>.traversal()
+//        }
+//    }
+//
+//    class IndexInstance<E>: Index {
+//        public typealias S = ArrayK<E>
+//        public typealias I = Int
+//        public typealias A = E
+//
+//        public func index(_ i: Int) -> Optional<ArrayK<E>, E> {
+//            return Optional<ArrayK<E>, E>(
+//                set: { arrayK, e in
+//                    arrayK.asArray.enumerated().map { x in
+//                        return (x.offset == i) ? e : x.element
+//                        }.k()
+//            }, getOrModify: { array in
+//                array.getOrNone(i).fold({ Either<ArrayK<E>, E>.left(array) }, Either<ArrayK<E>, E>.right)
+//            })
+//        }
+//    }
+//
+//    class FilterIndexInstance<E>: FilterIndex {
+//        public typealias S = ArrayK<E>
+//        public typealias I = Int
+//        public typealias A = E
+//
+//        public func filter(_ predicate: @escaping (Int) -> Bool) -> Traversal<ArrayK<E>, E> {
+//            return ArrayKFilterIndexTraversal<E>(predicate: predicate)
+//        }
+//    }
+//
+//    private class ArrayKFilterIndexTraversal<A>: Traversal<ArrayK<A>, A> {
+//        private let predicate: (Int) -> Bool
+//
+//        init(predicate : @escaping (Int) -> Bool) {
+//            self.predicate = predicate
+//        }
+//
+//        override func modifyF<F: Applicative>(_ s: ArrayK<A>, _ f: @escaping (A) -> Kind<F, A>) -> Kind<F, ArrayK<A>> {
+//            return F.map(s.asArray.enumerated().map(id).k().traverse({ x in
+//                self.predicate(x.offset) ? f(x.element) : F.pure(x.element)
+//            }), ArrayK<A>.fix)
+//        }
+//    }
+//
+//    private class ArrayKTraversal<A>: Traversal<ArrayK<A>, A> {
+//        override func modifyF<F: Applicative>(_ s: ArrayK<A>, _ f: @escaping (A) -> Kind<F, A>) -> Kind<F, ArrayK<A>>  {
+//            return F.map(s.traverse(f), { x in ArrayK<A>.fix(x) })
+//        }
+//    }
 }

--- a/Sources/BowOptics/Instances/ArrayKOpticsInstances.swift
+++ b/Sources/BowOptics/Instances/ArrayKOpticsInstances.swift
@@ -58,6 +58,6 @@ private class ArrayKFilterIndexTraversal<A>: Traversal<ArrayK<A>, A> {
 
 private class ArrayKTraversal<A>: Traversal<ArrayK<A>, A> {
     override func modifyF<F: Applicative>(_ s: ArrayK<A>, _ f: @escaping (A) -> Kind<F, A>) -> Kind<F, ArrayK<A>>  {
-        return F.map(s.traverse(f), { x in ArrayK<A>.fix(x) })
+        return s.traverse(f).map { x in x^ }
     }
 }

--- a/Sources/BowOptics/Instances/ArrayKOpticsInstances.swift
+++ b/Sources/BowOptics/Instances/ArrayKOpticsInstances.swift
@@ -1,76 +1,63 @@
 import Foundation
 import Bow
 
+// MARK: Optics extensions
 public extension ArrayK {
-//    static func traversal() -> Traversal<ArrayK<A>, A> {
-//        return ArrayKTraversal<A>()
-//    }
-//
-//    static func each() -> EachInstance<A> {
-//        return EachInstance<A>()
-//    }
-//
-//    static func index() -> IndexInstance<A> {
-//        return IndexInstance<A>()
-//    }
-//
-//    static func filterIndex() -> FilterIndexInstance<A> {
-//        return FilterIndexInstance<A>()
-//    }
-//
-//    class EachInstance<E>: Each {
-//        public typealias S = ArrayK<E>
-//        public typealias A = E
-//
-//        public func each() -> Traversal<ArrayK<E>, E> {
-//            return ArrayK<E>.traversal()
-//        }
-//    }
-//
-//    class IndexInstance<E>: Index {
-//        public typealias S = ArrayK<E>
-//        public typealias I = Int
-//        public typealias A = E
-//
-//        public func index(_ i: Int) -> Optional<ArrayK<E>, E> {
-//            return Optional<ArrayK<E>, E>(
-//                set: { arrayK, e in
-//                    arrayK.asArray.enumerated().map { x in
-//                        return (x.offset == i) ? e : x.element
-//                        }.k()
-//            }, getOrModify: { array in
-//                array.getOrNone(i).fold({ Either<ArrayK<E>, E>.left(array) }, Either<ArrayK<E>, E>.right)
-//            })
-//        }
-//    }
-//
-//    class FilterIndexInstance<E>: FilterIndex {
-//        public typealias S = ArrayK<E>
-//        public typealias I = Int
-//        public typealias A = E
-//
-//        public func filter(_ predicate: @escaping (Int) -> Bool) -> Traversal<ArrayK<E>, E> {
-//            return ArrayKFilterIndexTraversal<E>(predicate: predicate)
-//        }
-//    }
-//
-//    private class ArrayKFilterIndexTraversal<A>: Traversal<ArrayK<A>, A> {
-//        private let predicate: (Int) -> Bool
-//
-//        init(predicate : @escaping (Int) -> Bool) {
-//            self.predicate = predicate
-//        }
-//
-//        override func modifyF<F: Applicative>(_ s: ArrayK<A>, _ f: @escaping (A) -> Kind<F, A>) -> Kind<F, ArrayK<A>> {
-//            return F.map(s.asArray.enumerated().map(id).k().traverse({ x in
-//                self.predicate(x.offset) ? f(x.element) : F.pure(x.element)
-//            }), ArrayK<A>.fix)
-//        }
-//    }
-//
-//    private class ArrayKTraversal<A>: Traversal<ArrayK<A>, A> {
-//        override func modifyF<F: Applicative>(_ s: ArrayK<A>, _ f: @escaping (A) -> Kind<F, A>) -> Kind<F, ArrayK<A>>  {
-//            return F.map(s.traverse(f), { x in ArrayK<A>.fix(x) })
-//        }
-//    }
+    static func traversal() -> Traversal<ArrayK<A>, A> {
+        return ArrayKTraversal<A>()
+    }
+}
+
+// MARK: Instance of `Each` for `ArrayK`
+extension ArrayK: Each {
+    public typealias EachFoci = A
+    
+    public static var each: Traversal<ArrayK<A>, A> {
+        return ArrayK.traversal()
+    }
+}
+
+// MARK: Instance of `Index` for `ArrayK`
+extension ArrayK: Index {
+    public typealias IndexType = Int
+    public typealias IndexFoci = A
+    
+    public static func index(_ i: Int) -> Optional<ArrayK<A>, A> {
+        return Optional(
+            set: { arrayK, e in
+                arrayK.asArray.enumerated().map { x in (x.offset == i) ? e : x.element }.k()
+        }, getOrModify: { array in
+            array.getOrNone(i).fold({ Either.left(array) }, Either.right)
+        })
+    }
+}
+
+// MARK: Instance of `FilterIndex` for `ArrayK`
+extension ArrayK: FilterIndex {
+    public typealias FilterIndexType = Int
+    public typealias FilterIndexFoci = A
+    
+    public static func filter(_ predicate: @escaping (Int) -> Bool) -> Traversal<ArrayK<A>, A> {
+        return ArrayKFilterIndexTraversal(predicate: predicate)
+    }
+}
+
+private class ArrayKFilterIndexTraversal<A>: Traversal<ArrayK<A>, A> {
+    private let predicate: (Int) -> Bool
+    
+    init(predicate: @escaping (Int) -> Bool) {
+        self.predicate = predicate
+    }
+    
+    override func modifyF<F: Applicative>(_ s: ArrayK<A>, _ f: @escaping (A) -> Kind<F, A>) -> Kind<F, ArrayK<A>> {
+        return F.map(s.asArray.enumerated().map(id).k().traverse({ x in
+            self.predicate(x.offset) ? f(x.element) : F.pure(x.element)
+        }), ArrayK<A>.fix)
+    }
+}
+
+private class ArrayKTraversal<A>: Traversal<ArrayK<A>, A> {
+    override func modifyF<F: Applicative>(_ s: ArrayK<A>, _ f: @escaping (A) -> Kind<F, A>) -> Kind<F, ArrayK<A>>  {
+        return F.map(s.traverse(f), { x in ArrayK<A>.fix(x) })
+    }
 }

--- a/Sources/BowOptics/Instances/EitherOpticsInstances.swift
+++ b/Sources/BowOptics/Instances/EitherOpticsInstances.swift
@@ -2,27 +2,27 @@ import Foundation
 import Bow
 
 public extension Either {
-    static func traversal() -> Traversal<Either<A, B>, B> {
-        return EitherTraversal<A, B>()
-    }
-    
-    static func each() -> EachInstance<A, B> {
-        return EachInstance<A, B>()
-    }
-    
-    private class EitherTraversal<L, R> : Traversal<Either<L, R>, R> {
-        override func modifyF<F: Applicative>(_ s: Either<L, R>, _ f: @escaping (R) -> Kind<F, R>) -> Kind<F, Either<L, R>> {
-            return F.map(s.traverse(f), { x in Either<L, R>.fix(x) })
-        }
-    }
-    
-    class EachInstance<L, R> : Each {
-        public typealias S = Either<L, R>
-        public typealias A = R
-        
-        public func each() -> Traversal<Either<L, R>, R> {
-            return Either<L, R>.traversal()
-        }
-    }
+//    static func traversal() -> Traversal<Either<A, B>, B> {
+//        return EitherTraversal<A, B>()
+//    }
+//    
+//    static func each() -> EachInstance<A, B> {
+//        return EachInstance<A, B>()
+//    }
+//    
+//    private class EitherTraversal<L, R> : Traversal<Either<L, R>, R> {
+//        override func modifyF<F: Applicative>(_ s: Either<L, R>, _ f: @escaping (R) -> Kind<F, R>) -> Kind<F, Either<L, R>> {
+//            return F.map(s.traverse(f), { x in Either<L, R>.fix(x) })
+//        }
+//    }
+//    
+//    class EachInstance<L, R> : Each {
+//        public typealias S = Either<L, R>
+//        public typealias A = R
+//        
+//        public func each() -> Traversal<Either<L, R>, R> {
+//            return Either<L, R>.traversal()
+//        }
+//    }
 }
 

--- a/Sources/BowOptics/Instances/EitherOpticsInstances.swift
+++ b/Sources/BowOptics/Instances/EitherOpticsInstances.swift
@@ -3,8 +3,12 @@ import Bow
 
 // MARK: Optics extensions
 public extension Either {
-    static func traversal() -> Traversal<Either<A, B>, B> {
-        return EitherTraversal<A, B>()
+    static var fixIso: Iso<Either<A, B>, EitherOf<A, B>> {
+        return Iso(get: id, reverseGet: Either.fix)
+    }
+    
+    static var traversal: Traversal<Either<A, B>, B> {
+        return fixIso + traversalK
     }
 }
 
@@ -13,12 +17,6 @@ extension Either: Each {
     public typealias EachFoci = B
     
     public static var each: Traversal<Either<A, B>, B> {
-        return EitherTraversal<A, B>()
-    }
-}
-
-private class EitherTraversal<L, R>: Traversal<Either<L, R>, R> {
-    override func modifyF<F: Applicative>(_ s: Either<L, R>, _ f: @escaping (R) -> Kind<F, R>) -> Kind<F, Either<L, R>> {
-        return s.traverse(f).map { x in x^ }
+        return traversal
     }
 }

--- a/Sources/BowOptics/Instances/EitherOpticsInstances.swift
+++ b/Sources/BowOptics/Instances/EitherOpticsInstances.swift
@@ -1,28 +1,24 @@
 import Foundation
 import Bow
 
+// MARK: Optics extensions
 public extension Either {
-//    static func traversal() -> Traversal<Either<A, B>, B> {
-//        return EitherTraversal<A, B>()
-//    }
-//    
-//    static func each() -> EachInstance<A, B> {
-//        return EachInstance<A, B>()
-//    }
-//    
-//    private class EitherTraversal<L, R> : Traversal<Either<L, R>, R> {
-//        override func modifyF<F: Applicative>(_ s: Either<L, R>, _ f: @escaping (R) -> Kind<F, R>) -> Kind<F, Either<L, R>> {
-//            return F.map(s.traverse(f), { x in Either<L, R>.fix(x) })
-//        }
-//    }
-//    
-//    class EachInstance<L, R> : Each {
-//        public typealias S = Either<L, R>
-//        public typealias A = R
-//        
-//        public func each() -> Traversal<Either<L, R>, R> {
-//            return Either<L, R>.traversal()
-//        }
-//    }
+    static func traversal() -> Traversal<Either<A, B>, B> {
+        return EitherTraversal<A, B>()
+    }
 }
 
+// MARK: Instance of `Each` for `Either`
+extension Either: Each {
+    public typealias EachFoci = B
+    
+    public static var each: Traversal<Either<A, B>, B> {
+        return EitherTraversal<A, B>()
+    }
+}
+
+private class EitherTraversal<L, R>: Traversal<Either<L, R>, R> {
+    override func modifyF<F: Applicative>(_ s: Either<L, R>, _ f: @escaping (R) -> Kind<F, R>) -> Kind<F, Either<L, R>> {
+        return s.traverse(f).map { x in x^ }
+    }
+}

--- a/Sources/BowOptics/Instances/NonEmptyArrayOpticsInstances.swift
+++ b/Sources/BowOptics/Instances/NonEmptyArrayOpticsInstances.swift
@@ -1,77 +1,60 @@
 import Foundation
 import Bow
 
+// MARK: Optics extensions
 public extension NonEmptyArray {
-//    static func traversal() -> Traversal<NonEmptyArray<A>, A> {
-//        return NEATraversal<A>()
-//    }
-//
-//    static func each() -> EachInstance<A> {
-//        return EachInstance<A>()
-//    }
-//
-//    static func filterIndex() -> FilterIndexInstance<A> {
-//        return FilterIndexInstance<A>()
-//    }
-//
-//    static func index() -> IndexInstance<A> {
-//        return IndexInstance<A>()
-//    }
-//
-//    class EachInstance<E>: Each {
-//        public typealias S = NEA<E>
-//        public typealias A = E
-//
-//        public func each() -> Traversal<NonEmptyArray<E>, E> {
-//            return NonEmptyArray<E>.traversal()
-//        }
-//    }
-//
-//    class FilterIndexInstance<E>: FilterIndex {
-//        public typealias S = NEA<E>
-//        public typealias I = Int
-//        public typealias A = E
-//
-//        public func filter(_ predicate: @escaping (Int) -> Bool) -> Traversal<NonEmptyArray<E>, E> {
-//            return NonEmptyArrayFilterIndexTraversal<E>(predicate: predicate)
-//        }
-//    }
-//
-//    class IndexInstance<E>: Index {
-//        public typealias S = NEA<E>
-//        public typealias I = Int
-//        public typealias A = E
-//
-//        public func index(_ i: Int) -> Optional<NonEmptyArray<E>, E> {
-//            return Optional<NEA<E>, E>(
-//                set: { nea, e in NonEmptyArray<E>.fromArrayUnsafe(
-//                    nea.all().enumerated().map { x in
-//                        (x.offset == i) ? x.element : e
-//                })
-//            }, getOrModify: { nea in nea.getOrNone(i).fold({ Either<NEA<E>, E>.left(nea) },
-//                                                           Either<NEA<E>, E>.right) })
-//        }
-//    }
-//}
-//
-//private class NEATraversal<A>: Traversal<NEA<A>, A> {
-//    override func modifyF<F: Applicative>(_ s: NonEmptyArray<A>, _ f: @escaping (A) -> Kind<F, A>) -> Kind<F, NonEmptyArray<A>> {
-//        return F.map(s.traverse(f), NonEmptyArray.fix)
-//    }
-//}
-//
-//private class NonEmptyArrayFilterIndexTraversal<E>: Traversal<NEA<E>, E> {
-//    private let predicate: (Int) -> Bool
-//
-//    init(predicate: @escaping (Int) -> Bool) {
-//        self.predicate = predicate
-//    }
-//
-//    override func modifyF<F: Applicative>(_ s: NonEmptyArray<E>, _ f: @escaping (E) -> Kind<F, E>) -> Kind<F, NonEmptyArray<E>> {
-//        return F.map(
-//            NonEmptyArray.fromArrayUnsafe(s.all().enumerated().map(id))
-//                .traverse({ x in
-//                    self.predicate(x.offset) ? f(x.element) : F.pure(x.element)
-//                }), NonEmptyArray.fix)
-//    }
+    static var fixIso: Iso<NEA<A>, NonEmptyArrayOf<A>> {
+        return Iso(get: id, reverseGet: NEA.fix)
+    }
+    
+    static var traversal: Traversal<NonEmptyArray<A>, A> {
+        return fixIso + traversalK
+    }
+}
+
+// MARK: Instance of `Each` for `NonEmptyArray`
+extension NonEmptyArray: Each {
+    public typealias EachFoci = A
+    
+    public static var each: Traversal<NonEmptyArray<A>, A> {
+        return traversal
+    }
+}
+
+// MARK: Instance of `Index` for `NonEmptyArray`
+extension NonEmptyArray: Index {
+    public typealias IndexType = Int
+    public typealias IndexFoci = A
+    
+    public static func index(_ i: Int) -> Optional<NonEmptyArray<A>, A> {
+        return Optional(
+            set: { nea, e in NEA.fromArrayUnsafe(nea.all().enumerated().map { x in (x.offset == i) ? x.element : e })},
+            getOrModify: { nea in nea.getOrNone(i).fold({ Either.left(nea) }, Either.right) })
+    }
+}
+
+// MARK: Instance of `FilterIndex` for `NonEmptyArray`
+extension NonEmptyArray: FilterIndex {
+    public typealias FilterIndexType = Int
+    public typealias FilterIndexFoci = A
+    
+    public static func filter(_ predicate: @escaping (Int) -> Bool) -> Traversal<NonEmptyArray<A>, A> {
+        return NonEmptyArrayFilterIndexTraversal(predicate: predicate)
+    }
+}
+
+private class NonEmptyArrayFilterIndexTraversal<E>: Traversal<NEA<E>, E> {
+    private let predicate: (Int) -> Bool
+    
+    init(predicate: @escaping (Int) -> Bool) {
+        self.predicate = predicate
+    }
+    
+    override func modifyF<F: Applicative>(_ s: NonEmptyArray<E>, _ f: @escaping (E) -> Kind<F, E>) -> Kind<F, NonEmptyArray<E>> {
+        return F.map(
+            NonEmptyArray.fromArrayUnsafe(s.all().enumerated().map(id))
+                .traverse({ x in
+                    self.predicate(x.offset) ? f(x.element) : F.pure(x.element)
+                }), NonEmptyArray.fix)
+    }
 }

--- a/Sources/BowOptics/Instances/NonEmptyArrayOpticsInstances.swift
+++ b/Sources/BowOptics/Instances/NonEmptyArrayOpticsInstances.swift
@@ -2,76 +2,76 @@ import Foundation
 import Bow
 
 public extension NonEmptyArray {
-    static func traversal() -> Traversal<NonEmptyArray<A>, A> {
-        return NEATraversal<A>()
-    }
-
-    static func each() -> EachInstance<A> {
-        return EachInstance<A>()
-    }
-
-    static func filterIndex() -> FilterIndexInstance<A> {
-        return FilterIndexInstance<A>()
-    }
-
-    static func index() -> IndexInstance<A> {
-        return IndexInstance<A>()
-    }
-
-    class EachInstance<E>: Each {
-        public typealias S = NEA<E>
-        public typealias A = E
-
-        public func each() -> Traversal<NonEmptyArray<E>, E> {
-            return NonEmptyArray<E>.traversal()
-        }
-    }
-
-    class FilterIndexInstance<E>: FilterIndex {
-        public typealias S = NEA<E>
-        public typealias I = Int
-        public typealias A = E
-
-        public func filter(_ predicate: @escaping (Int) -> Bool) -> Traversal<NonEmptyArray<E>, E> {
-            return NonEmptyArrayFilterIndexTraversal<E>(predicate: predicate)
-        }
-    }
-
-    class IndexInstance<E>: Index {
-        public typealias S = NEA<E>
-        public typealias I = Int
-        public typealias A = E
-
-        public func index(_ i: Int) -> Optional<NonEmptyArray<E>, E> {
-            return Optional<NEA<E>, E>(
-                set: { nea, e in NonEmptyArray<E>.fromArrayUnsafe(
-                    nea.all().enumerated().map { x in
-                        (x.offset == i) ? x.element : e
-                })
-            }, getOrModify: { nea in nea.getOrNone(i).fold({ Either<NEA<E>, E>.left(nea) },
-                                                           Either<NEA<E>, E>.right) })
-        }
-    }
-}
-
-private class NEATraversal<A>: Traversal<NEA<A>, A> {
-    override func modifyF<F: Applicative>(_ s: NonEmptyArray<A>, _ f: @escaping (A) -> Kind<F, A>) -> Kind<F, NonEmptyArray<A>> {
-        return F.map(s.traverse(f), NonEmptyArray.fix)
-    }
-}
-
-private class NonEmptyArrayFilterIndexTraversal<E>: Traversal<NEA<E>, E> {
-    private let predicate: (Int) -> Bool
-
-    init(predicate: @escaping (Int) -> Bool) {
-        self.predicate = predicate
-    }
-
-    override func modifyF<F: Applicative>(_ s: NonEmptyArray<E>, _ f: @escaping (E) -> Kind<F, E>) -> Kind<F, NonEmptyArray<E>> {
-        return F.map(
-            NonEmptyArray.fromArrayUnsafe(s.all().enumerated().map(id))
-                .traverse({ x in
-                    self.predicate(x.offset) ? f(x.element) : F.pure(x.element)
-                }), NonEmptyArray.fix)
-    }
+//    static func traversal() -> Traversal<NonEmptyArray<A>, A> {
+//        return NEATraversal<A>()
+//    }
+//
+//    static func each() -> EachInstance<A> {
+//        return EachInstance<A>()
+//    }
+//
+//    static func filterIndex() -> FilterIndexInstance<A> {
+//        return FilterIndexInstance<A>()
+//    }
+//
+//    static func index() -> IndexInstance<A> {
+//        return IndexInstance<A>()
+//    }
+//
+//    class EachInstance<E>: Each {
+//        public typealias S = NEA<E>
+//        public typealias A = E
+//
+//        public func each() -> Traversal<NonEmptyArray<E>, E> {
+//            return NonEmptyArray<E>.traversal()
+//        }
+//    }
+//
+//    class FilterIndexInstance<E>: FilterIndex {
+//        public typealias S = NEA<E>
+//        public typealias I = Int
+//        public typealias A = E
+//
+//        public func filter(_ predicate: @escaping (Int) -> Bool) -> Traversal<NonEmptyArray<E>, E> {
+//            return NonEmptyArrayFilterIndexTraversal<E>(predicate: predicate)
+//        }
+//    }
+//
+//    class IndexInstance<E>: Index {
+//        public typealias S = NEA<E>
+//        public typealias I = Int
+//        public typealias A = E
+//
+//        public func index(_ i: Int) -> Optional<NonEmptyArray<E>, E> {
+//            return Optional<NEA<E>, E>(
+//                set: { nea, e in NonEmptyArray<E>.fromArrayUnsafe(
+//                    nea.all().enumerated().map { x in
+//                        (x.offset == i) ? x.element : e
+//                })
+//            }, getOrModify: { nea in nea.getOrNone(i).fold({ Either<NEA<E>, E>.left(nea) },
+//                                                           Either<NEA<E>, E>.right) })
+//        }
+//    }
+//}
+//
+//private class NEATraversal<A>: Traversal<NEA<A>, A> {
+//    override func modifyF<F: Applicative>(_ s: NonEmptyArray<A>, _ f: @escaping (A) -> Kind<F, A>) -> Kind<F, NonEmptyArray<A>> {
+//        return F.map(s.traverse(f), NonEmptyArray.fix)
+//    }
+//}
+//
+//private class NonEmptyArrayFilterIndexTraversal<E>: Traversal<NEA<E>, E> {
+//    private let predicate: (Int) -> Bool
+//
+//    init(predicate: @escaping (Int) -> Bool) {
+//        self.predicate = predicate
+//    }
+//
+//    override func modifyF<F: Applicative>(_ s: NonEmptyArray<E>, _ f: @escaping (E) -> Kind<F, E>) -> Kind<F, NonEmptyArray<E>> {
+//        return F.map(
+//            NonEmptyArray.fromArrayUnsafe(s.all().enumerated().map(id))
+//                .traverse({ x in
+//                    self.predicate(x.offset) ? f(x.element) : F.pure(x.element)
+//                }), NonEmptyArray.fix)
+//    }
 }

--- a/Sources/BowOptics/Instances/OptionOpticsInstances.swift
+++ b/Sources/BowOptics/Instances/OptionOpticsInstances.swift
@@ -1,28 +1,24 @@
 import Foundation
 import Bow
 
+// MARK: Optics extensions
 public extension Option {
-//    static func traversal() -> Traversal<OptionOf<A>, A> {
-//        return OptionTraversal<A>()
-//    }
-//
-//    static func each() -> EachInstance<A> {
-//        return EachInstance<A>()
-//    }
-//
-//    private class OptionTraversal<A> : Traversal<OptionOf<A>, A> {
-//        override func modifyF<F: Applicative>(_ s: OptionOf<A>, _ f: @escaping (A) -> Kind<F, A>) -> Kind<F, OptionOf<A>> {
-//            return s.traverse(f)
-//        }
-//    }
-//
-//    class EachInstance<E> : Each {
-//        public typealias S = OptionOf<E>
-//        public typealias A = E
-//
-//        public func each() -> Traversal<OptionOf<E>, E> {
-//            return Option<E>.traversal()
-//        }
-//    }
+    static func traversal() -> Traversal<Option<A>, A> {
+        return OptionTraversal<A>()
+    }
 }
 
+// MARK: Instance of `Each` for `Option`
+extension Option: Each {
+    public typealias EachFoci = A
+    
+    public static var each: Traversal<Option<A>, A> {
+        return OptionTraversal<A>()
+    }
+}
+
+private class OptionTraversal<A>: Traversal<Option<A>, A> {
+    override func modifyF<F: Applicative>(_ s: Option<A>, _ f: @escaping (A) -> Kind<F, A>) -> Kind<F, Option<A>> {
+        return s.traverse(f).map { x in x^ }
+    }
+}

--- a/Sources/BowOptics/Instances/OptionOpticsInstances.swift
+++ b/Sources/BowOptics/Instances/OptionOpticsInstances.swift
@@ -2,27 +2,27 @@ import Foundation
 import Bow
 
 public extension Option {
-    static func traversal() -> Traversal<OptionOf<A>, A> {
-        return OptionTraversal<A>()
-    }
-
-    static func each() -> EachInstance<A> {
-        return EachInstance<A>()
-    }
-
-    private class OptionTraversal<A> : Traversal<OptionOf<A>, A> {
-        override func modifyF<F: Applicative>(_ s: OptionOf<A>, _ f: @escaping (A) -> Kind<F, A>) -> Kind<F, OptionOf<A>> {
-            return s.traverse(f)
-        }
-    }
-
-    class EachInstance<E> : Each {
-        public typealias S = OptionOf<E>
-        public typealias A = E
-
-        public func each() -> Traversal<OptionOf<E>, E> {
-            return Option<E>.traversal()
-        }
-    }
+//    static func traversal() -> Traversal<OptionOf<A>, A> {
+//        return OptionTraversal<A>()
+//    }
+//
+//    static func each() -> EachInstance<A> {
+//        return EachInstance<A>()
+//    }
+//
+//    private class OptionTraversal<A> : Traversal<OptionOf<A>, A> {
+//        override func modifyF<F: Applicative>(_ s: OptionOf<A>, _ f: @escaping (A) -> Kind<F, A>) -> Kind<F, OptionOf<A>> {
+//            return s.traverse(f)
+//        }
+//    }
+//
+//    class EachInstance<E> : Each {
+//        public typealias S = OptionOf<E>
+//        public typealias A = E
+//
+//        public func each() -> Traversal<OptionOf<E>, E> {
+//            return Option<E>.traversal()
+//        }
+//    }
 }
 

--- a/Sources/BowOptics/Instances/OptionOpticsInstances.swift
+++ b/Sources/BowOptics/Instances/OptionOpticsInstances.swift
@@ -3,8 +3,12 @@ import Bow
 
 // MARK: Optics extensions
 public extension Option {
-    static func traversal() -> Traversal<Option<A>, A> {
-        return OptionTraversal<A>()
+    static var fixIso: Iso<Option<A>, OptionOf<A>> {
+        return Iso(get: id, reverseGet: Option.fix)
+    }
+    
+    static var traversal: Traversal<Option<A>, A> {
+        return fixIso + traversalK
     }
 }
 
@@ -13,12 +17,6 @@ extension Option: Each {
     public typealias EachFoci = A
     
     public static var each: Traversal<Option<A>, A> {
-        return OptionTraversal<A>()
-    }
-}
-
-private class OptionTraversal<A>: Traversal<Option<A>, A> {
-    override func modifyF<F: Applicative>(_ s: Option<A>, _ f: @escaping (A) -> Kind<F, A>) -> Kind<F, Option<A>> {
-        return s.traverse(f).map { x in x^ }
+        return traversal
     }
 }

--- a/Sources/BowOptics/Instances/StringOpticsInstances.swift
+++ b/Sources/BowOptics/Instances/StringOpticsInstances.swift
@@ -1,29 +1,26 @@
 import Foundation
 import Bow
 
+// MARK: Optics extensions
 public extension String {
-//    static func traversal() -> Traversal<String, Character> {
-//        return StringTraversal()
-//    }
-//
-//    static func each() -> EachInstance {
-//        return EachInstance()
-//    }
-//
-//    private class StringTraversal: Traversal<String, Character> {
-//        override func modifyF<F: Applicative>(_ s: String, _ f: @escaping (Character) -> Kind<F, Character>) -> Kind<F, String> {
-//            return F.map(s.map(id).k().traverse(f), { x in
-//                String(ArrayK.fix(x).asArray)
-//            })
-//        }
-//    }
-//
-//    class EachInstance : Each {
-//        public typealias S = String
-//        public typealias A = Character
-//
-//        public func each() -> Traversal<String, Character> {
-//            return String.traversal()
-//        }
-//    }
+    static var traversal: Traversal<String, Character> {
+        return StringTraversal()
+    }
+}
+
+// MARK: Instance of `Each` for String
+extension String: Each {
+    public typealias EachFoci = Character
+    
+    public static var each: Traversal<String, Character> {
+        return traversal
+    }
+}
+
+private class StringTraversal: Traversal<String, Character> {
+    override func modifyF<F: Applicative>(_ s: String, _ f: @escaping (Character) -> Kind<F, Character>) -> Kind<F, String> {
+        return F.map(s.map(id).k().traverse(f), { x in
+            String(ArrayK.fix(x).asArray)
+        })
+    }
 }

--- a/Sources/BowOptics/Instances/StringOpticsInstances.swift
+++ b/Sources/BowOptics/Instances/StringOpticsInstances.swift
@@ -2,28 +2,28 @@ import Foundation
 import Bow
 
 public extension String {
-    static func traversal() -> Traversal<String, Character> {
-        return StringTraversal()
-    }
-
-    static func each() -> EachInstance {
-        return EachInstance()
-    }
-
-    private class StringTraversal: Traversal<String, Character> {
-        override func modifyF<F: Applicative>(_ s: String, _ f: @escaping (Character) -> Kind<F, Character>) -> Kind<F, String> {
-            return F.map(s.map(id).k().traverse(f), { x in
-                String(ArrayK.fix(x).asArray)
-            })
-        }
-    }
-
-    class EachInstance : Each {
-        public typealias S = String
-        public typealias A = Character
-
-        public func each() -> Traversal<String, Character> {
-            return String.traversal()
-        }
-    }
+//    static func traversal() -> Traversal<String, Character> {
+//        return StringTraversal()
+//    }
+//
+//    static func each() -> EachInstance {
+//        return EachInstance()
+//    }
+//
+//    private class StringTraversal: Traversal<String, Character> {
+//        override func modifyF<F: Applicative>(_ s: String, _ f: @escaping (Character) -> Kind<F, Character>) -> Kind<F, String> {
+//            return F.map(s.map(id).k().traverse(f), { x in
+//                String(ArrayK.fix(x).asArray)
+//            })
+//        }
+//    }
+//
+//    class EachInstance : Each {
+//        public typealias S = String
+//        public typealias A = Character
+//
+//        public func each() -> Traversal<String, Character> {
+//            return String.traversal()
+//        }
+//    }
 }

--- a/Sources/BowOptics/Instances/TryOpticsInstances.swift
+++ b/Sources/BowOptics/Instances/TryOpticsInstances.swift
@@ -1,27 +1,22 @@
 import Foundation
 import Bow
 
+// MARK: Optics extensions
 public extension Try {
-//    static func traversal() -> Traversal<TryOf<A>, A> {
-//        return TryTraversal<A>()
-//    }
-//    
-//    static func each() -> TryEach<A> {
-//        return TryEach<A>()
-//    }
-//    
-//    private class TryTraversal<A>: Traversal<TryOf<A>, A> {
-//        override func modifyF<F: Applicative>(_ s: Kind<ForTry, A>, _ f: @escaping (A) -> Kind<F, A>) -> Kind<F, Kind<ForTry, A>> {
-//            return s.traverse(f)
-//        }
-//    }
-//    
-//    class TryEach<E> : Each {
-//        public typealias S = TryOf<E>
-//        public typealias A = E
-//        
-//        public func each() -> Traversal<TryOf<E>, E> {
-//            return Try<E>.traversal()
-//        }
-//    }
+    static var fixIso: Iso<Try<A>, TryOf<A>> {
+        return Iso(get: id, reverseGet: Try.fix)
+    }
+    
+    static var traversal: Traversal<Try<A>, A> {
+        return fixIso + traversalK
+    }
+}
+
+// MARK: Instance of `Each` for `Try`
+extension Try: Each {
+    public typealias EachFoci = A
+    
+    public static var each: PTraversal<Try<A>, Try<A>, A, A> {
+        return traversal
+    }
 }

--- a/Sources/BowOptics/Instances/TryOpticsInstances.swift
+++ b/Sources/BowOptics/Instances/TryOpticsInstances.swift
@@ -2,26 +2,26 @@ import Foundation
 import Bow
 
 public extension Try {
-    static func traversal() -> Traversal<TryOf<A>, A> {
-        return TryTraversal<A>()
-    }
-    
-    static func each() -> TryEach<A> {
-        return TryEach<A>()
-    }
-    
-    private class TryTraversal<A>: Traversal<TryOf<A>, A> {
-        override func modifyF<F: Applicative>(_ s: Kind<ForTry, A>, _ f: @escaping (A) -> Kind<F, A>) -> Kind<F, Kind<ForTry, A>> {
-            return s.traverse(f)
-        }
-    }
-    
-    class TryEach<E> : Each {
-        public typealias S = TryOf<E>
-        public typealias A = E
-        
-        public func each() -> Traversal<TryOf<E>, E> {
-            return Try<E>.traversal()
-        }
-    }
+//    static func traversal() -> Traversal<TryOf<A>, A> {
+//        return TryTraversal<A>()
+//    }
+//    
+//    static func each() -> TryEach<A> {
+//        return TryEach<A>()
+//    }
+//    
+//    private class TryTraversal<A>: Traversal<TryOf<A>, A> {
+//        override func modifyF<F: Applicative>(_ s: Kind<ForTry, A>, _ f: @escaping (A) -> Kind<F, A>) -> Kind<F, Kind<ForTry, A>> {
+//            return s.traverse(f)
+//        }
+//    }
+//    
+//    class TryEach<E> : Each {
+//        public typealias S = TryOf<E>
+//        public typealias A = E
+//        
+//        public func each() -> Traversal<TryOf<E>, E> {
+//            return Try<E>.traversal()
+//        }
+//    }
 }

--- a/Sources/BowOptics/Iso.swift
+++ b/Sources/BowOptics/Iso.swift
@@ -222,3 +222,9 @@ private class IsoTraversal<S, T, A, B>: PTraversal<S, T, A, B> {
         return F.map(f(iso.get(s)), iso.reverseGet)
     }
 }
+
+extension Iso {
+    internal var fix: Iso<S, A> {
+        return self as! Iso<S, A>
+    }
+}

--- a/Sources/BowOptics/Lens.swift
+++ b/Sources/BowOptics/Lens.swift
@@ -197,3 +197,9 @@ private class LensTraversal<S, T, A, B> : PTraversal<S, T, A, B> {
         return F.map(f(self.lens.get(s)), { b in self.lens.set(s, b)})
     }
 }
+
+extension Lens {
+    internal var fix: Lens<S, A> {
+        return self as! Lens<S, A>
+    }
+}

--- a/Sources/BowOptics/Lens.swift
+++ b/Sources/BowOptics/Lens.swift
@@ -45,16 +45,6 @@ public class PLens<S, T, A, B> : PLensOf<S, T, A, B> {
         return lhs.compose(rhs)
     }
     
-    public static func identity() -> Lens<S, S> {
-        return Iso<S, S>.identity().asLens()
-    }
-    
-    public static func codiagonal() -> Lens<Either<S, S>, S> {
-        return Lens<Either<S, S>, S>(
-            get: { ess in ess.fold(id, id) },
-            set: { ess, s in ess.bimap(constant(s), constant(s)) })
-    }
-    
     public init(get : @escaping (S) -> A, set : @escaping (S, B) -> T) {
         self.getFunc = get
         self.setFunc = set
@@ -171,6 +161,18 @@ public class PLens<S, T, A, B> : PLensOf<S, T, A, B> {
     
     public func exists(_ s : S, _ predicate : (A) -> Bool) -> Bool {
         return predicate(get(s))
+    }
+}
+
+public extension Lens where S == A {
+    static func identity() -> Lens<S, S> {
+        return Iso<S, S>.identity().asLens()
+    }
+    
+    static func codiagonal() -> Lens<Either<S, S>, S> {
+        return Lens<Either<S, S>, S>(
+            get: { ess in ess.fold(id, id) },
+            set: { ess, s in ess.bimap(constant(s), constant(s)) })
     }
 }
 

--- a/Sources/BowOptics/Optional.swift
+++ b/Sources/BowOptics/Optional.swift
@@ -216,3 +216,9 @@ private class OptionalTraversal<S, T, A, B> : PTraversal<S, T, A, B> {
         return self.optional.modifyF(s, f)
     }
 }
+
+extension Optional {
+    internal var fix: Optional<S, A> {
+        return self as! Optional<S, A>
+    }
+}

--- a/Sources/BowOptics/Optional.swift
+++ b/Sources/BowOptics/Optional.swift
@@ -45,16 +45,6 @@ public class POptional<S, T, A, B> : POptionalOf<S, T, A, B> {
         return lhs.compose(rhs)
     }
     
-    public static func identity() -> Optional<S, S> {
-        return Iso<S, S>.identity().asOptional()
-    }
-    
-    public static func codiagonal() -> Optional<Either<S, S>, S> {
-        return Optional<Either<S, S>, S>(
-            set: { ess, s in ess.bimap(constant(s), constant(s)) },
-            getOrModify: { ess in ess.fold(Either.right, Either.right) })
-    }
-    
     public static func void() -> Optional<S, A> {
         return Optional(set: { s, _ in s }, getOrModify: { s in Either<S, A>.left(s) })
     }
@@ -190,6 +180,18 @@ public class POptional<S, T, A, B> : POptionalOf<S, T, A, B> {
     
     public func asTraversal() -> PTraversal<S, T, A, B> {
         return OptionalTraversal(optional: self)
+    }
+}
+
+public extension Optional where S == A {
+    static func identity() -> Optional<S, S> {
+        return Iso<S, S>.identity().asOptional()
+    }
+    
+    static func codiagonal() -> Optional<Either<S, S>, S> {
+        return Optional<Either<S, S>, S>(
+            set: { ess, s in ess.bimap(constant(s), constant(s)) },
+            getOrModify: { ess in ess.fold(Either.right, Either.right) })
     }
 }
 

--- a/Sources/BowOptics/Prism.swift
+++ b/Sources/BowOptics/Prism.swift
@@ -238,3 +238,9 @@ private class PrismTraversal<S, T, A, B> : PTraversal<S, T, A, B> {
                   { a in F.map(f(a), prism.reverseGet) })
     }
 }
+
+extension Prism {
+    internal var fix: Prism<S, A> {
+        return self as! Prism<S, A>
+    }
+}

--- a/Sources/BowOptics/Prism.swift
+++ b/Sources/BowOptics/Prism.swift
@@ -41,10 +41,6 @@ public class PPrism<S, T, A, B> : PPrismOf<S, T, A, B> {
         return lhs.compose(rhs)
     }
 
-    public static func identity() -> Prism<S, S> {
-        return Iso<S, S>.identity().asPrism()
-    }
-
     public init(getOrModify : @escaping (S) -> Either<T, A>, reverseGet : @escaping (B) -> T) {
         self.getOrModifyFunc = getOrModify
         self.reverseGetFunc = reverseGet
@@ -203,6 +199,12 @@ public class PPrism<S, T, A, B> : PPrismOf<S, T, A, B> {
 
     public func asTraversal() -> PTraversal<S, T, A, B> {
         return PrismTraversal(prism: self)
+    }
+}
+
+public extension Prism where S == A {
+    static func identity() -> Prism<S, S> {
+        return Iso<S, S>.identity().asPrism()
     }
 }
 

--- a/Sources/BowOptics/STD/ArrayK+Optics.swift
+++ b/Sources/BowOptics/STD/ArrayK+Optics.swift
@@ -12,7 +12,7 @@ public extension ArrayK {
         })
     }
 
-    static func toOptionNEA() -> Iso<ArrayK<A>, Option<NonEmptyArray<A>>> {
+    static var toOptionNEA: Iso<ArrayK<A>, Option<NonEmptyArray<A>>> {
         return toPOptionNEA()
     }
 }
@@ -24,7 +24,7 @@ public extension Array {
             reverseGet: { arrayK in arrayK.asArray })
     }
 
-    static func toArrayK() -> Iso<Array<Element>, ArrayK<Element>> {
+    static var toArrayK: Iso<Array<Element>, ArrayK<Element>> {
         return toPArrayK()
     }
 }

--- a/Sources/BowOptics/STD/Either+Optics.swift
+++ b/Sources/BowOptics/STD/Either+Optics.swift
@@ -8,7 +8,7 @@ public extension Either {
             reverseGet: { x in x.toEither() })
     }
 
-    static func toValidated() -> Iso<Either<A, B>, Validated<A, B>> {
+    static var toValidated: Iso<Either<A, B>, Validated<A, B>> {
         return toPValidated()
     }
 }

--- a/Sources/BowOptics/STD/Id+Optics.swift
+++ b/Sources/BowOptics/STD/Id+Optics.swift
@@ -8,7 +8,7 @@ public extension Id {
             reverseGet: Id<B>.init)
     }
 
-    static func toValue() -> Iso<Id<A>, A> {
+    static var toValue: Iso<Id<A>, A> {
         return toPValue()
     }
 }

--- a/Sources/BowOptics/STD/NonEmptyArray+Optics.swift
+++ b/Sources/BowOptics/STD/NonEmptyArray+Optics.swift
@@ -2,13 +2,13 @@ import Foundation
 import Bow
 
 public extension NonEmptyArray {
-    static func head() -> Lens<NonEmptyArray<A>, A> {
+    static var headLens: Lens<NonEmptyArray<A>, A> {
         return Lens<NonEmptyArray<A>, A>(
             get: { x in x.head },
             set: { (nea, newHead) in NonEmptyArray(head: newHead, tail: nea.tail) })
     }
 
-    static func tail() -> Lens<NonEmptyArray<A>, [A]> {
+    static var tailLens: Lens<NonEmptyArray<A>, [A]> {
         return Lens<NonEmptyArray<A>, [A]>(
             get: { x in x.tail },
             set: { (nea, newTail) in NonEmptyArray(head: nea.head, tail: newTail) })

--- a/Sources/BowOptics/STD/Option+Optics.swift
+++ b/Sources/BowOptics/STD/Option+Optics.swift
@@ -8,7 +8,7 @@ public extension Option {
             reverseGet: Option<B>.fromOptional)
     }
 
-    static func toOption() -> Iso<Option<A>, A?> {
+    static var toOption: Iso<Option<A>, A?> {
         return toPOption()
     }
 
@@ -21,11 +21,11 @@ public extension Option {
             reverseGet: Option<B>.some)
     }
 
-    static func somePrism() -> Prism<Option<A>, A> {
+    static var somePrism: Prism<Option<A>, A> {
         return PSomePrism()
     }
 
-    static func nonePrism() -> Prism<Option<A>, ()> {
+    static var nonePrism: Prism<Option<A>, ()> {
         return Prism<Option<A>, ()>(
             getOrModify: { option in
                 option.fold({ Either<Option<A>, ()>.right(unit) },
@@ -42,7 +42,7 @@ public extension Option {
                                                 { b in Option<B>.some(b) })})
     }
 
-    static func toEither() -> Iso<Option<A>, Either<(), A>> {
+    static var toEither: Iso<Option<A>, Either<(), A>> {
         return toPEither()
     }
 }

--- a/Sources/BowOptics/STD/String+Optics.swift
+++ b/Sources/BowOptics/STD/String+Optics.swift
@@ -2,13 +2,13 @@ import Foundation
 import Bow
 
 public extension String {
-    static func toArray() -> Iso<String, [Character]> {
+    static var toArray: Iso<String, [Character]> {
         return Iso<String, [Character]>(
             get: { str in str.map(id) },
             reverseGet: { characters in String(characters) })
     }
 
-    static func toArrayK() -> Iso<String, ArrayK<Character>> {
-        return String.toArray() + Array.toArrayK()
+    static var toArrayK: Iso<String, ArrayK<Character>> {
+        return String.toArray + Array.toArrayK
     }
 }

--- a/Sources/BowOptics/STD/Try+Optics.swift
+++ b/Sources/BowOptics/STD/Try+Optics.swift
@@ -9,11 +9,11 @@ public extension Try {
             reverseGet: Try<B>.success)
     }
     
-    static func successPrism() -> Prism<Try<A>, A> {
+    static var successPrism: Prism<Try<A>, A> {
         return pSuccessPrism()
     }
     
-    static func failurePrism() -> Prism<Try<A>, Error> {
+    static var failurePrism: Prism<Try<A>, Error> {
         return Prism<Try<A>, Error>(
             getOrModify: { aTry in aTry.fold({ e in Either.right(e) },
                                              { a in Either.left(Try.success(a)) }) },
@@ -26,7 +26,7 @@ public extension Try {
             reverseGet: { either in either.fold(Try<B>.failure, Try<B>.success) })
     }
     
-    static func toEither() -> Iso<Try<A>, Either<Error, A>> {
+    static var toEither: Iso<Try<A>, Either<Error, A>> {
         return toPEither()
     }
     
@@ -36,7 +36,7 @@ public extension Try {
             reverseGet: { validated in validated.fold(Try<B>.failure, Try<B>.success) })
     }
     
-    static func toValidated() -> Iso<Try<A>, Validated<Error, A>> {
+    static var toValidated: Iso<Try<A>, Validated<Error, A>> {
         return toPValidated()
     }
 }

--- a/Sources/BowOptics/STD/Validated+Optics.swift
+++ b/Sources/BowOptics/STD/Validated+Optics.swift
@@ -10,7 +10,7 @@ public extension Validated {
                                                 Validated<E2, B>.valid) })
     }
 
-    static func toEither() -> Iso<Validated<E, A>, Either<E, A>> {
+    static var toEither: Iso<Validated<E, A>, Either<E, A>> {
         return toPEither()
     }
 
@@ -21,7 +21,7 @@ public extension Validated {
             reverseGet: Validated<Error, B>.fromTry )
     }
 
-    static func toTry() -> Iso<Validated<Error, A>, Try<A>> {
+    static var toTry: Iso<Validated<Error, A>, Try<A>> {
         return toPTry()
     }
 }

--- a/Sources/BowOptics/Setter.swift
+++ b/Sources/BowOptics/Setter.swift
@@ -37,15 +37,7 @@ public class PSetter<S, T, A, B> : PSetterOf<S, T, A, B> {
         return lhs.compose(rhs)
     }
     
-    public static func identity() -> Setter<S, S> {
-        return Iso<S, S>.identity().asSetter()
-    }
-    
-    public static func codiagonal() -> Setter<Either<S, S>, S> {
-        return Setter<Either<S, S>, S>(modify: { f in { ss in ss.bimap(f, f) } })
-    }
-    
-    public static func fromFunctor<F: Functor>() -> PSetter<Kind<F, A>, Kind<F, B>, A, B> {
+    public static func fromFunctor<F: Functor>() -> PSetter<Kind<F, A>, Kind<F, B>, A, B> where S: Kind<F, A>, T: Kind<F, B> {
         return PSetter<Kind<F, A>, Kind<F, B>, A, B>(modify: { f in
             { fs in F.map(fs, f) }
         })
@@ -107,6 +99,16 @@ public class PSetter<S, T, A, B> : PSetterOf<S, T, A, B> {
     
     public func compose<C, D>(_ other : PTraversal<A, B, C, D>) -> PSetter<S, T, C, D> {
         return self.compose(other.asSetter())
+    }
+}
+
+public extension Setter where S == A {
+    static func identity() -> Setter<S, S> {
+        return Iso<S, S>.identity().asSetter()
+    }
+    
+    static func codiagonal() -> Setter<Either<S, S>, S> {
+        return Setter<Either<S, S>, S>(modify: { f in { ss in ss.bimap(f, f) } })
     }
 }
 

--- a/Sources/BowOptics/Setter.swift
+++ b/Sources/BowOptics/Setter.swift
@@ -109,3 +109,9 @@ public class PSetter<S, T, A, B> : PSetterOf<S, T, A, B> {
         return self.compose(other.asSetter())
     }
 }
+
+extension Setter {
+    internal var fix: Setter<S, A> {
+        return self as! Setter<S, A>
+    }
+}

--- a/Sources/BowOptics/Traversal.swift
+++ b/Sources/BowOptics/Traversal.swift
@@ -15,20 +15,12 @@ open class PTraversal<S, T, A, B>: PTraversalOf<S, T, A, B> {
     open func modifyF<F: Applicative>(_ s: S, _ f: @escaping (A) -> Kind<F, B>) -> Kind<F, T> {
         fatalError("modifyF must be implemented in subclasses")
     }
-
-    public static func identity() -> Traversal<S, S> {
-        return Iso<S, S>.identity().asTraversal()
-    }
-    
-    public static func codiagonal() -> Traversal<Either<S, S>, S> {
-        return CodiagonalTraversal()
-    }
     
     public static func void() -> Traversal<S, A> {
         return Optional<S, A>.void().asTraversal()
     }
     
-    public static func fromTraverse<T: Traverse>() -> PTraversal<Kind<T, A>, Kind<T, B>, A, B> {
+    public static func fromTraverse<F: Traverse>() -> PTraversal<Kind<F, A>, Kind<F, B>, A, B> where S: Kind<F, A>, T: Kind<F, B> {
         return TraverseTraversal()
     }
     
@@ -268,6 +260,16 @@ open class PTraversal<S, T, A, B>: PTraversalOf<S, T, A, B> {
     
     public func forall(_ s : S, _ predicate : @escaping (A) -> Bool) -> Bool {
         return foldMap(s, predicate)
+    }
+}
+
+public extension Traversal where S == A {
+    static func identity() -> Traversal<S, S> {
+        return Iso<S, S>.identity().asTraversal()
+    }
+    
+    static func codiagonal() -> Traversal<Either<S, S>, S> {
+        return CodiagonalTraversal()
     }
 }
 

--- a/Sources/BowOptics/Traversal.swift
+++ b/Sources/BowOptics/Traversal.swift
@@ -612,3 +612,9 @@ private class ComposeTraversal<S, T, A, B, C, D> : PTraversal<S, T, C, D> {
         })
     }
 }
+
+extension Traversal {
+    internal var fix: Traversal<S, A> {
+        return self as! Traversal<S, A>
+    }
+}

--- a/Sources/BowOptics/Typeclasses/At.swift
+++ b/Sources/BowOptics/Typeclasses/At.swift
@@ -2,37 +2,36 @@ import Foundation
 import Bow
 
 public protocol At {
-    associatedtype S
-    associatedtype I
-    associatedtype A
+    associatedtype AtIndex
+    associatedtype AtFoci
 
-    func at(_ i: I) -> Lens<S, A>
+    static func at(_ i: AtIndex) -> Lens<Self, AtFoci>
 }
 
-public extension At {
-    static func at<AtType>(_ at: AtType, _ i: I) -> Lens<S, A> where AtType: At, AtType.S == S, AtType.I == I, AtType.A == A {
-        return at.at(i)
-    }
-
-    static func fromIso<U, AtType>(_ at: AtType, _ iso: Iso<S, U>) -> AtFromIso<S, I, A, U, AtType> where AtType: At, AtType.S == U, AtType.I == I, AtType.A == A {
-        return AtFromIso(at: at, iso: iso)
-    }
-}
-
-public class AtFromIso<M, N, O, P, AtType>: At where AtType: At, AtType.S == P, AtType.I == N, AtType.A == O {
-    public typealias S = M
-    public typealias I = N
-    public typealias A = O
-
-    private let atInstance: AtType
-    private let iso: Iso<M, P>
-
-    public init(at: AtType, iso: Iso<M, P>) {
-        self.atInstance = at
-        self.iso = iso
-    }
-
-    public func at(_ i: N) -> Lens<M, O> {
-        return iso + atInstance.at(i)
-    }
-}
+//public extension At {
+//    static func at<AtType>(_ at: AtType, _ i: I) -> Lens<S, A> where AtType: At, AtType.S == S, AtType.I == I, AtType.A == A {
+//        return at.at(i)
+//    }
+//
+//    static func fromIso<U, AtType>(_ at: AtType, _ iso: Iso<S, U>) -> AtFromIso<S, I, A, U, AtType> where AtType: At, AtType.S == U, AtType.I == I, AtType.A == A {
+//        return AtFromIso(at: at, iso: iso)
+//    }
+//}
+//
+//public class AtFromIso<M, N, O, P, AtType>: At where AtType: At, AtType.S == P, AtType.I == N, AtType.A == O {
+//    public typealias S = M
+//    public typealias I = N
+//    public typealias A = O
+//
+//    private let atInstance: AtType
+//    private let iso: Iso<M, P>
+//
+//    public init(at: AtType, iso: Iso<M, P>) {
+//        self.atInstance = at
+//        self.iso = iso
+//    }
+//
+//    public func at(_ i: N) -> Lens<M, O> {
+//        return iso + atInstance.at(i)
+//    }
+//}

--- a/Sources/BowOptics/Typeclasses/At.swift
+++ b/Sources/BowOptics/Typeclasses/At.swift
@@ -8,30 +8,20 @@ public protocol At {
     static func at(_ i: AtIndex) -> Lens<Self, AtFoci>
 }
 
-//public extension At {
-//    static func at<AtType>(_ at: AtType, _ i: I) -> Lens<S, A> where AtType: At, AtType.S == S, AtType.I == I, AtType.A == A {
-//        return at.at(i)
-//    }
-//
-//    static func fromIso<U, AtType>(_ at: AtType, _ iso: Iso<S, U>) -> AtFromIso<S, I, A, U, AtType> where AtType: At, AtType.S == U, AtType.I == I, AtType.A == A {
-//        return AtFromIso(at: at, iso: iso)
-//    }
-//}
-//
-//public class AtFromIso<M, N, O, P, AtType>: At where AtType: At, AtType.S == P, AtType.I == N, AtType.A == O {
-//    public typealias S = M
-//    public typealias I = N
-//    public typealias A = O
-//
-//    private let atInstance: AtType
-//    private let iso: Iso<M, P>
-//
-//    public init(at: AtType, iso: Iso<M, P>) {
-//        self.atInstance = at
-//        self.iso = iso
-//    }
-//
-//    public func at(_ i: N) -> Lens<M, O> {
-//        return iso + atInstance.at(i)
-//    }
-//}
+public extension At {
+    func remove<A>(_ i: AtIndex) -> Self where AtFoci == Option<A> {
+        return Self.at(i).set(self, .none())
+    }
+    
+    func remove<A>(_ i: AtIndex) -> Self where AtFoci == A? {
+        return Self.at(i).set(self, nil)
+    }
+    
+    static func at<B>(_ i: AtIndex, iso: Iso<AtFoci, B>) -> Lens<Self, B> {
+        return Self.at(i) + iso
+    }
+    
+    static func at<B>(_ i: AtIndex, iso: Iso<B, Self>) -> Lens<B, AtFoci> {
+        return iso + Self.at(i)
+    }
+}

--- a/Sources/BowOptics/Typeclasses/Each.swift
+++ b/Sources/BowOptics/Typeclasses/Each.swift
@@ -7,42 +7,12 @@ public protocol Each {
     static var each: Traversal<Self, EachFoci> { get }
 }
 
-//public extension Each {
-//    static func fromIso<B, EachIn>(_ each : EachIn, _ iso : Iso<S, A>) -> EachFromIso<S, B, A, EachIn> where EachIn : Each, EachIn.S == A, EachIn.A == B {
-//        return EachFromIso<S, B, A, EachIn>(each : each, iso : iso)
-//    }
-//}
-//
-//public extension Each where S: Traverse {
-//    static func from() -> EachFromTraverse<S, A>  {
-//        return EachFromTraverse<S, A>()
-//    }
-//}
-//
-//public class EachFromIso<M, N, O, EachIn> : Each where EachIn : Each, EachIn.S == O, EachIn.A == N {
-//    public typealias S = M
-//    public typealias A = N
-//
-//    private let eachObject : EachIn
-//    private let iso : Iso<S, O>
-//
-//    public init(each eachObject : EachIn, iso : Iso<S, O>) {
-//        self.eachObject = eachObject
-//        self.iso = iso
-//    }
-//
-//    public func each() -> Traversal<M, N> {
-//        return iso + eachObject.each()
-//    }
-//}
-//
-//public class EachFromTraverse<M: Traverse, N>: Each {
-//    public typealias S = Kind<M, N>
-//    public typealias A = N
-//
-//    public init() {}
-//
-//    public func each() -> Traversal<Kind<M, N>, N> {
-//        return Traversal<S, A>.fromTraverse()
-//    }
-//}
+public extension Each {
+    static func each<B>(_ iso: Iso<B, Self>) -> Traversal<B, EachFoci> {
+        return iso + each
+    }
+    
+    static func each<B>(_ iso: Iso<EachFoci, B>) -> Traversal<Self, B> {
+        return each + iso
+    }
+}

--- a/Sources/BowOptics/Typeclasses/Each.swift
+++ b/Sources/BowOptics/Typeclasses/Each.swift
@@ -2,48 +2,47 @@ import Foundation
 import Bow
 
 public protocol Each {
-    associatedtype S
-    associatedtype A
+    associatedtype EachFoci
 
-    func each() -> Traversal<S, A>
+    static var each: Traversal<Self, EachFoci> { get }
 }
 
-public extension Each {
-    static func fromIso<B, EachIn>(_ each : EachIn, _ iso : Iso<S, A>) -> EachFromIso<S, B, A, EachIn> where EachIn : Each, EachIn.S == A, EachIn.A == B {
-        return EachFromIso<S, B, A, EachIn>(each : each, iso : iso)
-    }
-}
-
-public extension Each where S: Traverse {
-    static func from() -> EachFromTraverse<S, A>  {
-        return EachFromTraverse<S, A>()
-    }
-}
-
-public class EachFromIso<M, N, O, EachIn> : Each where EachIn : Each, EachIn.S == O, EachIn.A == N {
-    public typealias S = M
-    public typealias A = N
-
-    private let eachObject : EachIn
-    private let iso : Iso<S, O>
-
-    public init(each eachObject : EachIn, iso : Iso<S, O>) {
-        self.eachObject = eachObject
-        self.iso = iso
-    }
-
-    public func each() -> Traversal<M, N> {
-        return iso + eachObject.each()
-    }
-}
-
-public class EachFromTraverse<M: Traverse, N>: Each {
-    public typealias S = Kind<M, N>
-    public typealias A = N
-
-    public init() {}
-
-    public func each() -> Traversal<Kind<M, N>, N> {
-        return Traversal<S, A>.fromTraverse()
-    }
-}
+//public extension Each {
+//    static func fromIso<B, EachIn>(_ each : EachIn, _ iso : Iso<S, A>) -> EachFromIso<S, B, A, EachIn> where EachIn : Each, EachIn.S == A, EachIn.A == B {
+//        return EachFromIso<S, B, A, EachIn>(each : each, iso : iso)
+//    }
+//}
+//
+//public extension Each where S: Traverse {
+//    static func from() -> EachFromTraverse<S, A>  {
+//        return EachFromTraverse<S, A>()
+//    }
+//}
+//
+//public class EachFromIso<M, N, O, EachIn> : Each where EachIn : Each, EachIn.S == O, EachIn.A == N {
+//    public typealias S = M
+//    public typealias A = N
+//
+//    private let eachObject : EachIn
+//    private let iso : Iso<S, O>
+//
+//    public init(each eachObject : EachIn, iso : Iso<S, O>) {
+//        self.eachObject = eachObject
+//        self.iso = iso
+//    }
+//
+//    public func each() -> Traversal<M, N> {
+//        return iso + eachObject.each()
+//    }
+//}
+//
+//public class EachFromTraverse<M: Traverse, N>: Each {
+//    public typealias S = Kind<M, N>
+//    public typealias A = N
+//
+//    public init() {}
+//
+//    public func each() -> Traversal<Kind<M, N>, N> {
+//        return Traversal<S, A>.fromTraverse()
+//    }
+//}

--- a/Sources/BowOptics/Typeclasses/FilterIndex.swift
+++ b/Sources/BowOptics/Typeclasses/FilterIndex.swift
@@ -8,71 +8,32 @@ public protocol FilterIndex {
     static func filter(_ predicate: @escaping (FilterIndexType) -> Bool) -> Traversal<Self, FilterIndexFoci>
 }
 
-//public extension FilterIndex {
-//    static func filterIndex<FilterIdx>(_ fi: FilterIdx, _ predicate: @escaping (I) -> Bool) -> Traversal<S, A> where FilterIdx: FilterIndex, FilterIdx.S == S, FilterIdx.I == I, FilterIdx.A == A {
-//        return fi.filter(predicate)
-//    }
-//
-//    static func fromIso<FilterIdx, B>(_ fi: FilterIdx, _ iso: Iso<S, A>) -> FilterIndexFromIso<S, I, B, A, FilterIdx> where FilterIdx: FilterIndex, FilterIdx.S == A, FilterIdx.I == I, FilterIdx.A == B {
-//        return FilterIndexFromIso<S, I, B, A, FilterIdx>(filterIndex: fi, iso: iso)
-//    }
-//
-//}
-//
-//extension FilterIndex where S: Traverse {
-//    public static func from(zipWithIndex: @escaping (Kind<S, A>) -> Kind<S, (A, Int)>) -> FilterIndexFromTraverse<S, A> {
-//        return FilterIndexFromTraverse(zipWithIndex: zipWithIndex)
-//    }
-//}
-//
-//public class FilterIndexFromIso<M, N, O, P, FilterIdx>: FilterIndex where FilterIdx: FilterIndex, FilterIdx.S == P, FilterIdx.I == N, FilterIdx.A == O {
-//    public typealias S = M
-//    public typealias I = N
-//    public typealias A = O
-//
-//    private let filterIndex: FilterIdx
-//    private let iso: Iso<M, P>
-//
-//    public init(filterIndex: FilterIdx, iso: Iso<M, P>) {
-//        self.filterIndex = filterIndex
-//        self.iso = iso
-//    }
-//
-//    public func filter(_ predicate: @escaping (N) -> Bool) -> Traversal<M, O> {
-//        return iso + filterIndex.filter(predicate)
-//    }
-//}
-//
-//public class FilterIndexFromTraverse<M: Traverse, N>: FilterIndex {
-//    public typealias S = Kind<M, N>
-//    public typealias I = Int
-//    public typealias A = N
-//
-//    private let zipWithIndex: (Kind<M, N>) -> Kind<M, (N, Int)>
-//
-//    public init(zipWithIndex: @escaping (Kind<M, N>) -> Kind<M, (N, Int)>) {
-//        self.zipWithIndex = zipWithIndex
-//    }
-//
-//    public func filter(_ predicate: @escaping (Int) -> Bool) -> Traversal<Kind<M, N>, N> {
-//        return FilterIndexFromTraverseTraversal(
-//            zipWithIndex: zipWithIndex,
-//            predicate: predicate)
-//    }
-//}
-//
-//private class FilterIndexFromTraverseTraversal<S: Traverse, A>: Traversal<Kind<S, A>, A> {
-//    private let zipWithIndex: (Kind<S, A>) -> Kind<S, (A, Int)>
-//    private let predicate: (Int) -> Bool
-//
-//    init(zipWithIndex: @escaping (Kind<S, A>) -> Kind<S, (A, Int)>, predicate: @escaping (Int) -> Bool) {
-//        self.zipWithIndex = zipWithIndex
-//        self.predicate = predicate
-//    }
-//
-//    override func modifyF<F: Applicative>(_ s: Kind<S, A>, _ f: @escaping (A) -> Kind<F, A>) -> Kind<F, Kind<S, A>> {
-//        return S.traverse(zipWithIndex(s), { x in
-//            self.predicate(x.1) ? f(x.0): F.pure(x.0)
-//        })
-//    }
-//}
+public extension FilterIndex {
+    static func filter<B>(_ predicate: @escaping (FilterIndexType) -> Bool, iso: Iso<B, Self>) -> Traversal<B, FilterIndexFoci> {
+        return iso + filter(predicate)
+    }
+    
+    static func filter<B>(_ predicate: @escaping (FilterIndexType) -> Bool, iso: Iso<FilterIndexFoci, B>) -> Traversal<Self, B> {
+        return filter(predicate) + iso
+    }
+    
+    static func filter<F: Traverse, A>(_ predicate: @escaping (FilterIndexType) -> Bool, zipWithIndex: @escaping (Kind<F, A>) -> Kind<F, (A, FilterIndexType)>) -> Traversal<Kind<F, A>, A> where Self: Kind<F, A>, A == FilterIndexFoci {
+        return FilterIndexFromTraverseTraversal(zipWithIndex: zipWithIndex, predicate: predicate)
+    }
+}
+
+private class FilterIndexFromTraverseTraversal<S: Traverse, A, I>: Traversal<Kind<S, A>, A> {
+    private let zipWithIndex: (Kind<S, A>) -> Kind<S, (A, I)>
+    private let predicate: (I) -> Bool
+
+    init(zipWithIndex: @escaping (Kind<S, A>) -> Kind<S, (A, I)>, predicate: @escaping (I) -> Bool) {
+        self.zipWithIndex = zipWithIndex
+        self.predicate = predicate
+    }
+
+    override func modifyF<F: Applicative>(_ s: Kind<S, A>, _ f: @escaping (A) -> Kind<F, A>) -> Kind<F, Kind<S, A>> {
+        return S.traverse(zipWithIndex(s), { x in
+            self.predicate(x.1) ? f(x.0): F.pure(x.0)
+        })
+    }
+}

--- a/Sources/BowOptics/Typeclasses/FilterIndex.swift
+++ b/Sources/BowOptics/Typeclasses/FilterIndex.swift
@@ -2,78 +2,77 @@ import Foundation
 import Bow
 
 public protocol FilterIndex {
-    associatedtype S
-    associatedtype I
-    associatedtype A
+    associatedtype FilterIndexType
+    associatedtype FilterIndexFoci
 
-    func filter(_ predicate: @escaping (I) -> Bool) -> Traversal<S, A>
+    static func filter(_ predicate: @escaping (FilterIndexType) -> Bool) -> Traversal<Self, FilterIndexFoci>
 }
 
-public extension FilterIndex {
-    static func filterIndex<FilterIdx>(_ fi: FilterIdx, _ predicate: @escaping (I) -> Bool) -> Traversal<S, A> where FilterIdx: FilterIndex, FilterIdx.S == S, FilterIdx.I == I, FilterIdx.A == A {
-        return fi.filter(predicate)
-    }
-
-    static func fromIso<FilterIdx, B>(_ fi: FilterIdx, _ iso: Iso<S, A>) -> FilterIndexFromIso<S, I, B, A, FilterIdx> where FilterIdx: FilterIndex, FilterIdx.S == A, FilterIdx.I == I, FilterIdx.A == B {
-        return FilterIndexFromIso<S, I, B, A, FilterIdx>(filterIndex: fi, iso: iso)
-    }
-
-}
-
-extension FilterIndex where S: Traverse {
-    public static func from(zipWithIndex: @escaping (Kind<S, A>) -> Kind<S, (A, Int)>) -> FilterIndexFromTraverse<S, A> {
-        return FilterIndexFromTraverse(zipWithIndex: zipWithIndex)
-    }
-}
-
-public class FilterIndexFromIso<M, N, O, P, FilterIdx>: FilterIndex where FilterIdx: FilterIndex, FilterIdx.S == P, FilterIdx.I == N, FilterIdx.A == O {
-    public typealias S = M
-    public typealias I = N
-    public typealias A = O
-
-    private let filterIndex: FilterIdx
-    private let iso: Iso<M, P>
-
-    public init(filterIndex: FilterIdx, iso: Iso<M, P>) {
-        self.filterIndex = filterIndex
-        self.iso = iso
-    }
-
-    public func filter(_ predicate: @escaping (N) -> Bool) -> Traversal<M, O> {
-        return iso + filterIndex.filter(predicate)
-    }
-}
-
-public class FilterIndexFromTraverse<M: Traverse, N>: FilterIndex {
-    public typealias S = Kind<M, N>
-    public typealias I = Int
-    public typealias A = N
-
-    private let zipWithIndex: (Kind<M, N>) -> Kind<M, (N, Int)>
-
-    public init(zipWithIndex: @escaping (Kind<M, N>) -> Kind<M, (N, Int)>) {
-        self.zipWithIndex = zipWithIndex
-    }
-
-    public func filter(_ predicate: @escaping (Int) -> Bool) -> Traversal<Kind<M, N>, N> {
-        return FilterIndexFromTraverseTraversal(
-            zipWithIndex: zipWithIndex,
-            predicate: predicate)
-    }
-}
-
-private class FilterIndexFromTraverseTraversal<S: Traverse, A>: Traversal<Kind<S, A>, A> {
-    private let zipWithIndex: (Kind<S, A>) -> Kind<S, (A, Int)>
-    private let predicate: (Int) -> Bool
-
-    init(zipWithIndex: @escaping (Kind<S, A>) -> Kind<S, (A, Int)>, predicate: @escaping (Int) -> Bool) {
-        self.zipWithIndex = zipWithIndex
-        self.predicate = predicate
-    }
-
-    override func modifyF<F: Applicative>(_ s: Kind<S, A>, _ f: @escaping (A) -> Kind<F, A>) -> Kind<F, Kind<S, A>> {
-        return S.traverse(zipWithIndex(s), { x in
-            self.predicate(x.1) ? f(x.0): F.pure(x.0)
-        })
-    }
-}
+//public extension FilterIndex {
+//    static func filterIndex<FilterIdx>(_ fi: FilterIdx, _ predicate: @escaping (I) -> Bool) -> Traversal<S, A> where FilterIdx: FilterIndex, FilterIdx.S == S, FilterIdx.I == I, FilterIdx.A == A {
+//        return fi.filter(predicate)
+//    }
+//
+//    static func fromIso<FilterIdx, B>(_ fi: FilterIdx, _ iso: Iso<S, A>) -> FilterIndexFromIso<S, I, B, A, FilterIdx> where FilterIdx: FilterIndex, FilterIdx.S == A, FilterIdx.I == I, FilterIdx.A == B {
+//        return FilterIndexFromIso<S, I, B, A, FilterIdx>(filterIndex: fi, iso: iso)
+//    }
+//
+//}
+//
+//extension FilterIndex where S: Traverse {
+//    public static func from(zipWithIndex: @escaping (Kind<S, A>) -> Kind<S, (A, Int)>) -> FilterIndexFromTraverse<S, A> {
+//        return FilterIndexFromTraverse(zipWithIndex: zipWithIndex)
+//    }
+//}
+//
+//public class FilterIndexFromIso<M, N, O, P, FilterIdx>: FilterIndex where FilterIdx: FilterIndex, FilterIdx.S == P, FilterIdx.I == N, FilterIdx.A == O {
+//    public typealias S = M
+//    public typealias I = N
+//    public typealias A = O
+//
+//    private let filterIndex: FilterIdx
+//    private let iso: Iso<M, P>
+//
+//    public init(filterIndex: FilterIdx, iso: Iso<M, P>) {
+//        self.filterIndex = filterIndex
+//        self.iso = iso
+//    }
+//
+//    public func filter(_ predicate: @escaping (N) -> Bool) -> Traversal<M, O> {
+//        return iso + filterIndex.filter(predicate)
+//    }
+//}
+//
+//public class FilterIndexFromTraverse<M: Traverse, N>: FilterIndex {
+//    public typealias S = Kind<M, N>
+//    public typealias I = Int
+//    public typealias A = N
+//
+//    private let zipWithIndex: (Kind<M, N>) -> Kind<M, (N, Int)>
+//
+//    public init(zipWithIndex: @escaping (Kind<M, N>) -> Kind<M, (N, Int)>) {
+//        self.zipWithIndex = zipWithIndex
+//    }
+//
+//    public func filter(_ predicate: @escaping (Int) -> Bool) -> Traversal<Kind<M, N>, N> {
+//        return FilterIndexFromTraverseTraversal(
+//            zipWithIndex: zipWithIndex,
+//            predicate: predicate)
+//    }
+//}
+//
+//private class FilterIndexFromTraverseTraversal<S: Traverse, A>: Traversal<Kind<S, A>, A> {
+//    private let zipWithIndex: (Kind<S, A>) -> Kind<S, (A, Int)>
+//    private let predicate: (Int) -> Bool
+//
+//    init(zipWithIndex: @escaping (Kind<S, A>) -> Kind<S, (A, Int)>, predicate: @escaping (Int) -> Bool) {
+//        self.zipWithIndex = zipWithIndex
+//        self.predicate = predicate
+//    }
+//
+//    override func modifyF<F: Applicative>(_ s: Kind<S, A>, _ f: @escaping (A) -> Kind<F, A>) -> Kind<F, Kind<S, A>> {
+//        return S.traverse(zipWithIndex(s), { x in
+//            self.predicate(x.1) ? f(x.0): F.pure(x.0)
+//        })
+//    }
+//}

--- a/Sources/BowOptics/Typeclasses/Index.swift
+++ b/Sources/BowOptics/Typeclasses/Index.swift
@@ -2,37 +2,36 @@ import Foundation
 import Bow
 
 public protocol Index {
-    associatedtype S
-    associatedtype I
-    associatedtype A
+    associatedtype IndexType
+    associatedtype IndexFoci
 
-    func index(_ i: I) -> Optional<S, A>
+    static func index(_ i: IndexType) -> Optional<Self, IndexFoci>
 }
 
-public extension Index {
-    static func index<Idx>(_ idx: Idx, _ i: I) -> Optional<S, A> where Idx: Index, Idx.S == S, Idx.I == I, Idx.A == A {
-        return idx.index(i)
-    }
-
-    static func fromIso<Idx, B>(_ idx: Idx, _ iso: Iso<S, A>) -> IndexFromIso<S, I, B, A, Idx> where Idx: Index, Idx.S == A, Idx.I == I, Idx.A == B {
-        return IndexFromIso(index: idx, iso: iso)
-    }
-}
-
-public class IndexFromIso<M, N, O, P, Idx>: Index where Idx: Index, Idx.S == P, Idx.I == N, Idx.A == O {
-    public typealias S = M
-    public typealias I = N
-    public typealias A = O
-
-    private let idx: Idx
-    private let iso: Iso<M, P>
-
-    public init(index: Idx, iso: Iso<M, P>) {
-        self.idx = index
-        self.iso = iso
-    }
-
-    public func index(_ i: N) -> Optional<M, O> {
-        return iso + idx.index(i)
-    }
-}
+//public extension Index {
+//    static func index<Idx>(_ idx: Idx, _ i: I) -> Optional<S, A> where Idx: Index, Idx.S == S, Idx.I == I, Idx.A == A {
+//        return idx.index(i)
+//    }
+//
+//    static func fromIso<Idx, B>(_ idx: Idx, _ iso: Iso<S, A>) -> IndexFromIso<S, I, B, A, Idx> where Idx: Index, Idx.S == A, Idx.I == I, Idx.A == B {
+//        return IndexFromIso(index: idx, iso: iso)
+//    }
+//}
+//
+//public class IndexFromIso<M, N, O, P, Idx>: Index where Idx: Index, Idx.S == P, Idx.I == N, Idx.A == O {
+//    public typealias S = M
+//    public typealias I = N
+//    public typealias A = O
+//
+//    private let idx: Idx
+//    private let iso: Iso<M, P>
+//
+//    public init(index: Idx, iso: Iso<M, P>) {
+//        self.idx = index
+//        self.iso = iso
+//    }
+//
+//    public func index(_ i: N) -> Optional<M, O> {
+//        return iso + idx.index(i)
+//    }
+//}

--- a/Sources/BowOptics/Typeclasses/Index.swift
+++ b/Sources/BowOptics/Typeclasses/Index.swift
@@ -8,30 +8,12 @@ public protocol Index {
     static func index(_ i: IndexType) -> Optional<Self, IndexFoci>
 }
 
-//public extension Index {
-//    static func index<Idx>(_ idx: Idx, _ i: I) -> Optional<S, A> where Idx: Index, Idx.S == S, Idx.I == I, Idx.A == A {
-//        return idx.index(i)
-//    }
-//
-//    static func fromIso<Idx, B>(_ idx: Idx, _ iso: Iso<S, A>) -> IndexFromIso<S, I, B, A, Idx> where Idx: Index, Idx.S == A, Idx.I == I, Idx.A == B {
-//        return IndexFromIso(index: idx, iso: iso)
-//    }
-//}
-//
-//public class IndexFromIso<M, N, O, P, Idx>: Index where Idx: Index, Idx.S == P, Idx.I == N, Idx.A == O {
-//    public typealias S = M
-//    public typealias I = N
-//    public typealias A = O
-//
-//    private let idx: Idx
-//    private let iso: Iso<M, P>
-//
-//    public init(index: Idx, iso: Iso<M, P>) {
-//        self.idx = index
-//        self.iso = iso
-//    }
-//
-//    public func index(_ i: N) -> Optional<M, O> {
-//        return iso + idx.index(i)
-//    }
-//}
+public extension Index {
+    static func index<B>(_ i: IndexType, iso: Iso<B, Self>) -> Optional<B, IndexFoci> {
+        return iso + index(i)
+    }
+    
+    static func index<B>(_ i: IndexType, iso: Iso<IndexFoci, B>) -> Optional<Self, B> {
+        return index(i) + iso
+    }
+}

--- a/Tests/BowOpticsTests/FoldTest.swift
+++ b/Tests/BowOpticsTests/FoldTest.swift
@@ -7,16 +7,16 @@ class FoldTest: XCTestCase {
     let nonEmptyListGen = Array<Int>.arbitrary.suchThat({ array in array.count > 0 })
 
     func intFold<F: Foldable>() -> Fold<Kind<F, Int>, Int> {
-        return Fold<Int, Int>.fromFoldable()
+        return Fold<Kind<F, Int>, Int>.fromFoldable()
     }
 
     func stringFold<F: Foldable>() -> Fold<Kind<F, String>, String> {
-        return Fold<String, String>.fromFoldable()
+        return Fold<Kind<F, String>, String>.fromFoldable()
     }
 
     func testFoldProperties() {
         property("Fold select an array that contains one") <- forAll(self.nonEmptyListGen) { (array: Array<Int>) in
-            let select = Fold<Array<Int>, Int>.select({ array in array.contains(1) })
+            let select = Fold<Array<Int>, Array<Int>>.select({ array in array.contains(1) })
             return select.getAll(array).asArray.first == (array.contains(1) ? array : nil)
         }
         

--- a/Tests/BowOpticsTests/FoldTest.swift
+++ b/Tests/BowOpticsTests/FoldTest.swift
@@ -1,95 +1,85 @@
 import XCTest
 import SwiftCheck
-@testable import Bow
-@testable import BowOptics
+import Bow
+import BowOptics
 
 class FoldTest: XCTestCase {
-    let nonEmptyListGen = Array<Int>.arbitrary.suchThat({ array in array.count > 0 })
-
-    func intFold<F: Foldable>() -> Fold<Kind<F, Int>, Int> {
-        return Fold<Kind<F, Int>, Int>.fromFoldable()
-    }
-
-    func stringFold<F: Foldable>() -> Fold<Kind<F, String>, String> {
-        return Fold<Kind<F, String>, String>.fromFoldable()
-    }
-
     func testFoldProperties() {
-        property("Fold select an array that contains one") <- forAll(self.nonEmptyListGen) { (array: Array<Int>) in
+        property("Fold select an array that contains one") <- forAll { (array: NEA<Int>) in
             let select = Fold<Array<Int>, Array<Int>>.select({ array in array.contains(1) })
-            return select.getAll(array).asArray.first == (array.contains(1) ? array : nil)
+            return select.getAll(array.all()).asArray.first == (array.contains(element: 1) ? array.all() : nil)
         }
         
-        property("Folding an array of ints") <- forAll { (array: Array<Int>) in
-            return self.intFold().fold(array.k()) == array.reduce(0, +)
+        property("Folding an array of ints") <- forAll { (array: ArrayK<Int>) in
+            return ArrayK<Int>.foldK.fold(array) == array.asArray.reduce(0, +)
         }
         
-        property("Folding an array is equivalent to combineAll") <- forAll { (array: Array<Int>) in
-            return self.intFold().combineAll(array.k()) == array.reduce(0, +)
+        property("Folding an array is equivalent to combineAll") <- forAll { (array: ArrayK<Int>) in
+            return ArrayK<Int>.foldK.combineAll(array) == array.asArray.reduce(0, +)
         }
         
-        property("Folding and mapping an array of strings") <- forAll { (array: Array<Int>) in
-            return self.stringFold().foldMap(array.map(String.init).k(), { s in Int(s)! }) == array.reduce(0, +)
+        property("Folding and mapping an array of strings") <- forAll { (array: ArrayK<Int>) in
+            return ArrayK<String>.foldK.foldMap(array.map(String.init)^, { s in Int(s)! }) == array^.asArray.reduce(0, +)
         }
         
-        property("Get all targets") <- forAll { (array: Array<Int>) in
-            return self.intFold().getAll(array.k()) == array.k()
+        property("Get all targets") <- forAll { (array: ArrayK<Int>) in
+            return ArrayK<Int>.foldK.getAll(array) == array
         }
         
-        property("Get size of the fold") <- forAll { (array: Array<Int>) in
-            return self.intFold().size(array.k()) == array.count
+        property("Get size of the fold") <- forAll { (array: ArrayK<Int>) in
+            return ArrayK<Int>.foldK.size(array) == array.count
         }
         
-        property("Find first element matching predicate") <- forAll { (array: Array<Int>) in
-            return self.intFold().find(array.k(), { x in x > 10 }) ==
-                Option.fromOptional(array.filter{ x in x > 10 }.first)
+        property("Find first element matching predicate") <- forAll { (array: ArrayK<Int>) in
+            return ArrayK<Int>.foldK.find(array, { x in x > 10 }) ==
+                array.asArray.filter{ x in x > 10 }.first.toOption()
         }
         
-        property("Checking existence of a target") <- forAll(self.nonEmptyListGen, Bool.arbitrary) { (array: Array<Int>, predicate: Bool) in
-            return self.intFold().exists(array.k(), constant(predicate)) == predicate
+        property("Checking existence of a target") <- forAll { (array: ArrayK<Int>, predicate: Bool) in
+            return ArrayK<Int>.foldK.exists(array, constant(predicate)) == predicate || array.isEmpty
         }
         
-        property("Check if all targets match the predicate") <- forAll { (array : Array<Int>) in
-            return self.intFold().forAll(array.k(), { x in x % 2 == 0 }) ==
-                array.map { x in x % 2 == 0 }.reduce(true, and)
+        property("Check if all targets match the predicate") <- forAll { (array: ArrayK<Int>) in
+            return ArrayK<Int>.foldK.forAll(array, { x in x % 2 == 0 }) ==
+                array.asArray.map { x in x % 2 == 0 }.reduce(true, and)
         }
         
-        property("Check if there is no target") <- forAll { (array: Array<Int>) in
-            return self.intFold().isEmpty(array.k()) == array.isEmpty
+        property("Check if there is no target") <- forAll { (array: ArrayK<Int>) in
+            return ArrayK<Int>.foldK.isEmpty(array) == array.isEmpty
         }
         
-        property("Check if there is a target") <- forAll { (array: Array<Int>) in
-            return self.intFold().nonEmpty(array.k()) == !array.isEmpty
+        property("Check if there is a target") <- forAll { (array: ArrayK<Int>) in
+            return ArrayK<Int>.foldK.nonEmpty(array) == !array.isEmpty
         }
     }
     
     func testFoldComposition() {
-        property("Fold + Fold::identity") <- forAll { (array: Array<Int>) in
-            return (self.intFold() + Fold<Int, Int>.identity()).getAll(array.k()).asArray == self.intFold().getAll(array.k()).asArray
+        property("Fold + Fold::identity") <- forAll { (array: ArrayK<Int>) in
+            return (ArrayK<Int>.foldK + Fold<Int, Int>.identity()).getAll(array) == ArrayK<Int>.foldK.getAll(array)
         }
         
-        property("Fold + Iso::identity") <- forAll { (array: Array<Int>) in
-            return (self.intFold() + Iso<Int, Int>.identity()).getAll(array.k()).asArray == self.intFold().getAll(array.k()).asArray
+        property("Fold + Iso::identity") <- forAll { (array: ArrayK<Int>) in
+            return (ArrayK<Int>.foldK + Iso<Int, Int>.identity()).getAll(array) == ArrayK<Int>.foldK.getAll(array)
         }
         
-        property("Fold + Lens::identity") <- forAll { (array: Array<Int>) in
-            return (self.intFold() + Lens<Int, Int>.identity()).getAll(array.k()).asArray == self.intFold().getAll(array.k()).asArray
+        property("Fold + Lens::identity") <- forAll { (array: ArrayK<Int>) in
+            return (ArrayK<Int>.foldK + Lens<Int, Int>.identity()).getAll(array) == ArrayK<Int>.foldK.getAll(array)
         }
         
-        property("Fold + Prism::identity") <- forAll { (array: Array<Int>) in
-            return (self.intFold() + Prism<Int, Int>.identity()).getAll(array.k()).asArray == self.intFold().getAll(array.k()).asArray
+        property("Fold + Prism::identity") <- forAll { (array: ArrayK<Int>) in
+            return (ArrayK<Int>.foldK + Prism<Int, Int>.identity()).getAll(array) == ArrayK<Int>.foldK.getAll(array)
         }
         
-        property("Fold + Getter::identity") <- forAll { (array: Array<Int>) in
-            return (self.intFold() + Getter<Int, Int>.identity()).getAll(array.k()).asArray == self.intFold().getAll(array.k()).asArray
+        property("Fold + Getter::identity") <- forAll { (array: ArrayK<Int>) in
+            return (ArrayK<Int>.foldK + Getter<Int, Int>.identity()).getAll(array) == ArrayK<Int>.foldK.getAll(array)
         }
         
-        property("Fold + Optional::identity") <- forAll { (array: Array<Int>) in
-            return (self.intFold() + BowOptics.Optional<Int, Int>.identity()).getAll(array.k()).asArray == self.intFold().getAll(array.k()).asArray
+        property("Fold + Optional::identity") <- forAll { (array: ArrayK<Int>) in
+            return (ArrayK<Int>.foldK + BowOptics.Optional<Int, Int>.identity()).getAll(array) == ArrayK<Int>.foldK.getAll(array)
         }
         
-        property("Fold + Traversal::identity") <- forAll { (array: Array<Int>) in
-            return (self.intFold() + Traversal<Int, Int>.identity()).getAll(array.k()).asArray == self.intFold().getAll(array.k()).asArray
+        property("Fold + Traversal::identity") <- forAll { (array: ArrayK<Int>) in
+            return (ArrayK<Int>.foldK + Traversal<Int, Int>.identity()).getAll(array) == ArrayK<Int>.foldK.getAll(array)
         }
     }
 }

--- a/Tests/BowOpticsTests/GetterTest.swift
+++ b/Tests/BowOpticsTests/GetterTest.swift
@@ -1,7 +1,7 @@
 import XCTest
 import SwiftCheck
-@testable import Bow
-@testable import BowOptics
+import Bow
+import BowOptics
 
 class GetterTest : XCTestCase {
     func testGetterAsFold() {
@@ -39,11 +39,11 @@ class GetterTest : XCTestCase {
     }
     
     func testGetterProperties() {
-        property("Getting the target should yield the exact value") <- forAll { (value : String) in
+        property("Getting the target should yield the exact value") <- forAll { (value: String) in
             return tokenGetter.get(Token(value: value)) == value
         }
         
-        property("Finding a target using a predicate within a Getter should be wrapped in the correct Option result") <- forAll { (token : Token, predicate : Bool) in
+        property("Finding a target using a predicate within a Getter should be wrapped in the correct Option result") <- forAll { (token: Token, predicate : Bool) in
             return tokenGetter.find(token, constant(predicate)).fold(constant(false), constant(true)) == predicate
         }
         
@@ -51,12 +51,12 @@ class GetterTest : XCTestCase {
             return tokenGetter.exists(token, constant(predicate)) == predicate
         }
         
-        property("Zipping two Getters should yield a tuple of the targets") <- forAll { (value : String) in
+        property("Zipping two Getters should yield a tuple of the targets") <- forAll { (value: String) in
             let zippedGetter = lengthGetter.zip(upperGetter)
             return zippedGetter.get(value) == (value.count, value.uppercased())
         }
         
-        property("Joining two Getters together with the same target should yield the same result") <- forAll { (value : String) in
+        property("Joining two Getters together with the same target should yield the same result") <- forAll { (value: String) in
             let userTokenStringGetter = userGetter + tokenGetter
             let joinedGetter = tokenGetter.choice(userTokenStringGetter)
             let token = Token(value: value)
@@ -64,28 +64,28 @@ class GetterTest : XCTestCase {
             return joinedGetter.get(Either.left(token)) == joinedGetter.get(Either.right(user))
         }
         
-        property("Pairing two disjoint Getters should yield a pair of their results") <- forAll { (token : Token, user : User) in
+        property("Pairing two disjoint Getters should yield a pair of their results") <- forAll { (token: Token, user: User) in
             let splitGetter = tokenGetter.split(userGetter)
             return splitGetter.get((token, user)) == (token.value, user.token)
         }
         
-        property("Creating a first pair with a type should result in the target to value") <- forAll { (token : Token, value : Int) in
+        property("Creating a first pair with a type should result in the target to value") <- forAll { (token: Token, value: Int) in
             let first: Getter<(Token, Int), (String, Int)> = tokenGetter.first()
             return first.get((token, value)) == (token.value, value)
         }
         
-        property("Creating a second pair with a type should result in the value to target") <- forAll { (token : Token, value : Int) in
+        property("Creating a second pair with a type should result in the value to target") <- forAll { (token: Token, value: Int) in
             let second: Getter<(Int, Token), (Int, String)> = tokenGetter.second()
             return second.get((value, token)) == (value, token.value)
         }
         
-        property("Creating a left with a type should result in the sum of value and target") <- forAll { (token : Token, value : Int) in
+        property("Creating a left with a type should result in the sum of value and target") <- forAll { (token: Token, value: Int) in
             let left: Getter<Either<Token, Int>, Either<String, Int>> = tokenGetter.left()
             return left.get(Either.left(token)) == Either.left(tokenIso.get(token)) &&
                 left.get(Either.right(value)) == Either.right(value)
         }
         
-        property("Creating a right with a type should result in the sum of target and value") <- forAll { (token : Token, value : Int) in
+        property("Creating a right with a type should result in the sum of target and value") <- forAll { (token: Token, value: Int) in
             let right: Getter<Either<Int, Token>, Either<Int, String>> = tokenGetter.right()
             return right.get(Either.right(token)) == Either.right(tokenIso.get(token)) &&
                 right.get(Either.left(value)) == Either.left(value)
@@ -93,19 +93,19 @@ class GetterTest : XCTestCase {
     }
     
     func testGetterComposition() {
-        property("Getter + Iso::identity") <- forAll { (token : Token) in
+        property("Getter + Iso::identity") <- forAll { (token: Token) in
             return (tokenGetter + Iso<String, String>.identity()).get(token) == tokenGetter.get(token)
         }
         
-        property("Getter + Lens::identity") <- forAll { (token : Token) in
+        property("Getter + Lens::identity") <- forAll { (token: Token) in
             return (tokenGetter + Lens<String, String>.identity()).get(token) == tokenGetter.get(token)
         }
         
-        property("Getter + Getter::identity") <- forAll { (token : Token) in
+        property("Getter + Getter::identity") <- forAll { (token: Token) in
             return (tokenGetter + Getter<String, String>.identity()).get(token) == tokenGetter.get(token)
         }
         
-        property("Getter + Fold::identity") <- forAll { (token : Token) in
+        property("Getter + Fold::identity") <- forAll { (token: Token) in
             return (tokenGetter + Fold<String, String>.identity()).getAll(token).asArray == [tokenGetter.get(token)]
         }
     }

--- a/Tests/BowOpticsTests/IsoTest.swift
+++ b/Tests/BowOpticsTests/IsoTest.swift
@@ -1,7 +1,7 @@
 import XCTest
 import SwiftCheck
-@testable import Bow
-@testable import BowOptics
+import Bow
+import BowOptics
 
 class IsoTest: XCTestCase {
     
@@ -22,151 +22,151 @@ class IsoTest: XCTestCase {
     }
     
     func testSetterLaws() {
-        SetterLaws.check(setter: tokenIso.asSetter(), generatorA: Token.arbitrary)
+        SetterLaws.check(setter: tokenIso.asSetter())
     }
     
     func testTraversalLaws() {
-        TraversalLaws.check(traversal: tokenIso.asTraversal(), generatorA: Token.arbitrary)
+        TraversalLaws.check(traversal: tokenIso.asTraversal())
     }
     
     func testIsoAsFold() {
-        property("Iso as Fold: size") <- forAll { (token : Token) in
+        property("Iso as Fold: size") <- forAll { (token: Token) in
             return tokenIso.asFold().size(token) == 1
         }
         
-        property("Iso as Fold: nonEmpty") <- forAll { (token : Token) in
+        property("Iso as Fold: nonEmpty") <- forAll { (token: Token) in
             return tokenIso.asFold().nonEmpty(token)
         }
         
-        property("Iso as Fold: isEmpty") <- forAll { (token : Token) in
+        property("Iso as Fold: isEmpty") <- forAll { (token: Token) in
             return !tokenIso.asFold().isEmpty(token)
         }
         
-        property("Iso as Fold: getAll") <- forAll { (token : Token) in
+        property("Iso as Fold: getAll") <- forAll { (token: Token) in
             return tokenIso.asFold().getAll(token) == ArrayK.pure(token.value)
         }
         
-        property("Iso as Fold: combineAll") <- forAll { (token : Token) in
+        property("Iso as Fold: combineAll") <- forAll { (token: Token) in
             return tokenIso.asFold().combineAll(token) == token.value
         }
         
-        property("Iso as Fold: fold") <- forAll { (token : Token) in
+        property("Iso as Fold: fold") <- forAll { (token: Token) in
             return tokenIso.asFold().fold(token) == token.value
         }
         
-        property("Iso as Fold: headOption") <- forAll { (token : Token) in
+        property("Iso as Fold: headOption") <- forAll { (token: Token) in
             return tokenIso.asFold().headOption(token) == Option.some(token.value)
         }
         
-        property("Iso as Fold: lastOption") <- forAll { (token : Token) in
+        property("Iso as Fold: lastOption") <- forAll { (token: Token) in
             return tokenIso.asFold().lastOption(token) == Option.some(token.value)
         }
     }
     
     func testIsoAsGetter() {
-        property("Iso as Getter: get") <- forAll { (token : Token) in
+        property("Iso as Getter: get") <- forAll { (token: Token) in
             return tokenIso.asGetter().get(token) == tokenGetter.get(token)
         }
         
-        property("Iso as Getter: find") <- forAll { (token : Token, predicate : ArrowOf<String, Bool>) in
+        property("Iso as Getter: find") <- forAll { (token: Token, predicate: ArrowOf<String, Bool>) in
             return tokenIso.asGetter().find(token, predicate.getArrow) == tokenGetter.find(token, predicate.getArrow)
         }
         
-        property("Iso as Getter: exists") <- forAll { (token : Token, predicate : ArrowOf<String, Bool>) in
+        property("Iso as Getter: exists") <- forAll { (token: Token, predicate: ArrowOf<String, Bool>) in
             return tokenIso.asGetter().find(token, predicate.getArrow) ==
                 tokenGetter.find(token, predicate.getArrow)
         }
     }
     
     func testIsoProperties() {
-        property("Lifting a function should yield the same value as not yielding") <- forAll { (token : Token, value : String) in
+        property("Lifting a function should yield the same value as not yielding") <- forAll { (token: Token, value: String) in
             return tokenIso.modify(token, constant(value)) == tokenIso.lift(constant(value))(token)
         }
         
-        property("Lifting a function as a functior should yield the same value as not yielding") <- forAll { (token : Token, value : String) in
+        property("Lifting a function as a functior should yield the same value as not yielding") <- forAll { (token: Token, value: String) in
             return tokenIso.modifyF(token, constant(Option.some(value))) ==
                 tokenIso.liftF(constant(Option.some(value)))(token)
         }
         
-        property("Creating a first pair with a type should result in the target to value") <- forAll { (token : Token, value : Int) in
+        property("Creating a first pair with a type should result in the target to value") <- forAll { (token: Token, value: Int) in
             let first : Iso<(Token, Int), (String, Int)> = tokenIso.first()
             return first.get((token, value)) == (tokenIso.get(token), value)
         }
         
-        property("Creating a second pair with a type should result in the value to target") <- forAll { (token : Token, value : Int) in
+        property("Creating a second pair with a type should result in the value to target") <- forAll { (token: Token, value: Int) in
             let second : Iso<(Int, Token), (Int, String)> = tokenIso.second()
             return second.get((value, token)) == (value, tokenIso.get(token))
         }
         
-        property("Creating a left with a type should result in the sum of value and target") <- forAll { (token : Token, value : Int) in
+        property("Creating a left with a type should result in the sum of value and target") <- forAll { (token: Token, value: Int) in
             let left : Iso<Either<Token, Int>, Either<String, Int>> = tokenIso.left()
             return left.get(Either.left(token)) == Either.left(tokenIso.get(token)) &&
                 left.get(Either.right(value)) == Either.right(value)
         }
         
-        property("Creating a right with a type should result in the sum of target and value") <- forAll { (token : Token, value : Int) in
+        property("Creating a right with a type should result in the sum of target and value") <- forAll { (token: Token, value: Int) in
             let right : Iso<Either<Int, Token>, Either<Int, String>> = tokenIso.right()
             return right.get(Either.right(token)) == Either.right(tokenIso.get(token)) &&
                 right.get(Either.left(value)) == Either.left(value)
         }
         
-        property("Finding a target using a predicate within an Iso should be wrapped in the correct option result") <- forAll { (predicate : Bool) in
+        property("Finding a target using a predicate within an Iso should be wrapped in the correct option result") <- forAll { (predicate: Bool) in
             return tokenIso.find(Token(value: "Any value"), constant(predicate)).fold(constant(false), constant(true)) == predicate
         }
         
-        property("Checking existence predicate over the target should result in the same result as predicate") <- forAll { (predicate : Bool) in
+        property("Checking existence predicate over the target should result in the same result as predicate") <- forAll { (predicate: Bool) in
             return tokenIso.exists(Token(value: "Any value"), constant(predicate)) == predicate
         }
         
-        property("Pairing two disjoint isos together") <- forAll { (tokenValue : String) in
+        property("Pairing two disjoint isos together") <- forAll { (tokenValue: String) in
             let token = Token(value: tokenValue)
             let user = User(token: token)
             let joinedIso = tokenIso.split(userIso)
             return joinedIso.get((token, user)) == (tokenValue, token)
         }
         
-        property("Composing isos should result in an iso of the first iso's value to the second's target") <- forAll { (tokenValue : String) in
+        property("Composing isos should result in an iso of the first iso's value to the second's target") <- forAll { (tokenValue: String) in
             let composedIso = userIso + tokenIso
             let token = Token(value: tokenValue)
             let user = User(token: token)
             return composedIso.get(user) == tokenValue
         }
         
-        property("Reverse isomorphism") <- forAll { (token : Token) in
+        property("Reverse isomorphism") <- forAll { (token: Token) in
             return tokenIso.reverse().reverse().get(token) == tokenIso.get(token)
         }
     }
     
     func testIsoComposition() {
-        property("Iso + Iso::identity") <- forAll { (token : Token) in
+        property("Iso + Iso::identity") <- forAll { (token: Token) in
             return (tokenIso + Iso<String, String>.identity()).get(token) == tokenIso.get(token)
         }
         
-        property("Iso + Lens::identity") <- forAll { (token : Token) in
+        property("Iso + Lens::identity") <- forAll { (token: Token) in
             return (tokenIso + Lens<String, String>.identity()).get(token) == tokenIso.get(token)
         }
         
-        property("Iso + Prism::identity") <- forAll { (token : Token) in
+        property("Iso + Prism::identity") <- forAll { (token: Token) in
             return (tokenIso + Prism<String, String>.identity()).getOption(token).getOrElse("") == tokenIso.get(token)
         }
         
-        property("Iso + Getter::identity") <- forAll { (token : Token) in
+        property("Iso + Getter::identity") <- forAll { (token: Token) in
             return (tokenIso + Getter<String, String>.identity()).get(token) == tokenIso.get(token)
         }
         
-        property("Iso + Setter::identity") <- forAll { (token : Token) in
+        property("Iso + Setter::identity") <- forAll { (token: Token) in
             return (tokenIso + Setter<String, String>.identity()).set(token, "Any") == tokenIso.set("Any")
         }
         
-        property("Iso + Optional::identity") <- forAll { (token : Token) in
+        property("Iso + Optional::identity") <- forAll { (token: Token) in
             return (tokenIso + BowOptics.Optional<String, String>.identity()).getOption(token).getOrElse("") == tokenIso.get(token)
         }
         
-        property("Iso + Fold::identity") <- forAll { (token : Token) in
+        property("Iso + Fold::identity") <- forAll { (token: Token) in
             return (tokenIso + Fold<String, String>.identity()).getAll(token).asArray == [tokenIso.get(token)]
         }
         
-        property("Iso + Traversal::identity") <- forAll { (token : Token) in
+        property("Iso + Traversal::identity") <- forAll { (token: Token) in
             return (tokenIso + Traversal<String, String>.identity()).getAll(token).asArray == [tokenIso.get(token)]
         }
     }

--- a/Tests/BowOpticsTests/Laws/IsoLaws.swift
+++ b/Tests/BowOpticsTests/Laws/IsoLaws.swift
@@ -1,6 +1,6 @@
 import SwiftCheck
-@testable import Bow
-@testable import BowOptics
+import Bow
+import BowOptics
 
 class IsoLaws<A: Equatable & Arbitrary, B: Equatable & Arbitrary & CoArbitrary & Hashable & Monoid> {
     

--- a/Tests/BowOpticsTests/Laws/LensLaws.swift
+++ b/Tests/BowOpticsTests/Laws/LensLaws.swift
@@ -1,9 +1,10 @@
 import SwiftCheck
-@testable import Bow
-@testable import BowOptics
+import Bow
+import BowOptics
 
 class LensLaws<A: Equatable & Arbitrary, B: Equatable & Arbitrary & CoArbitrary & Hashable & Monoid> {
-    static func check(lens : Lens<A, B>) {
+    
+    static func check(lens: Lens<A, B>) {
         getSet(lens)
         setGet(lens)
         setIdempotent(lens)

--- a/Tests/BowOpticsTests/Laws/OptionalLaws.swift
+++ b/Tests/BowOpticsTests/Laws/OptionalLaws.swift
@@ -1,10 +1,10 @@
 import SwiftCheck
-@testable import Bow
-@testable import BowOptics
+import Bow
+import BowOptics
 
 class OptionalLaws<A: Equatable & Arbitrary, B: Equatable & Arbitrary & CoArbitrary & Hashable> {
     
-    static func check(optional : BowOptics.Optional<A, B>) {
+    static func check(optional: BowOptics.Optional<A, B>) {
         getOptionSet(optional)
         setGetOption(optional)
         setIdempotent(optional)

--- a/Tests/BowOpticsTests/Laws/PrismLaws.swift
+++ b/Tests/BowOpticsTests/Laws/PrismLaws.swift
@@ -1,10 +1,10 @@
 import SwiftCheck
-@testable import Bow
-@testable import BowOptics
+import Bow
+import BowOptics
 
 class PrismLaws<A: Arbitrary & Equatable, B: Arbitrary & CoArbitrary & Hashable & Equatable> {
     
-    static func check(prism : Prism<A, B>) {
+    static func check(prism: Prism<A, B>) {
         partialRoundTripOneWay(prism)
         roundTripOtherWay(prism)
         modifyId(prism)

--- a/Tests/BowOpticsTests/Laws/SetterLaws.swift
+++ b/Tests/BowOpticsTests/Laws/SetterLaws.swift
@@ -1,40 +1,36 @@
 import SwiftCheck
-@testable import Bow
-@testable import BowOptics
+import Bow
+import BowOptics
 
-class SetterLaws<A: Equatable, B: Equatable & Arbitrary & CoArbitrary & Hashable> {
+class SetterLaws<A: Equatable & Arbitrary, B: Equatable & Arbitrary & CoArbitrary & Hashable> {
     
-    static func check(setter: Setter<A, B>, generatorA: Gen<A>) {
-        setIdempotent(setter, generatorA)
-        modifyId(setter, generatorA)
-        composeModify(setter, generatorA)
-        consistentSetModify(setter, generatorA)
+    static func check(setter: Setter<A, B>) {
+        setIdempotent(setter)
+        modifyId(setter)
+        composeModify(setter)
+        consistentSetModify(setter)
     }
     
-    private static func setIdempotent(_ setter: Setter<A, B>, _ generatorA : Gen<A>) {
-        property("Set idempotent") <- forAll { (b: B) in
-            let a = generatorA.generate
+    private static func setIdempotent(_ setter: Setter<A, B>) {
+        property("Set idempotent") <- forAll { (a: A, b: B) in
             return setter.set(setter.set(a, b), b) == setter.set(a, b)
         }
     }
     
-    private static func modifyId(_ setter: Setter<A, B>, _ generatorA: Gen<A>) {
-        property("Modify id") <- forAll { (_: Int) in
-            let a = generatorA.generate
+    private static func modifyId(_ setter: Setter<A, B>) {
+        property("Modify id") <- forAll { (a: A) in
             return setter.modify(a, id) == a
         }
     }
     
-    private static func composeModify(_ setter: Setter<A, B>, _ generatorA : Gen<A>) {
-        property("Compose modify") <- forAll { (f: ArrowOf<B, B>, g: ArrowOf<B, B>) in
-            let a = generatorA.generate
+    private static func composeModify(_ setter: Setter<A, B>) {
+        property("Compose modify") <- forAll { (a: A, f: ArrowOf<B, B>, g: ArrowOf<B, B>) in
             return setter.modify(setter.modify(a, f.getArrow), g.getArrow) == setter.modify(a, g.getArrow <<< f.getArrow)
         }
     }
     
-    private static func consistentSetModify(_ setter: Setter<A, B>, _ generatorA : Gen<A>) {
-        property("Consistent set - modify") <- forAll { (b: B) in
-            let a = generatorA.generate
+    private static func consistentSetModify(_ setter: Setter<A, B>) {
+        property("Consistent set - modify") <- forAll { (a: A, b: B) in
             return setter.set(a, b) == setter.modify(a, constant(b))
         }
     }

--- a/Tests/BowOpticsTests/Laws/TraversalLaws.swift
+++ b/Tests/BowOpticsTests/Laws/TraversalLaws.swift
@@ -1,48 +1,43 @@
 import SwiftCheck
-@testable import Bow
-@testable import BowOptics
+import Bow
+import BowOptics
 
-class TraversalLaws<A: Equatable, B: Equatable & Arbitrary & CoArbitrary & Hashable> {
+class TraversalLaws<A: Equatable & Arbitrary, B: Equatable & Arbitrary & CoArbitrary & Hashable> {
     
-    static func check(traversal: Traversal<A, B>, generatorA: Gen<A>) {
-        headOption(traversal, generatorA)
-        modifyGetAll(traversal, generatorA)
-        setIdempotent(traversal, generatorA)
-        modifyIdentity(traversal, generatorA)
-        composeModify(traversal, generatorA)
+    static func check(traversal: Traversal<A, B>) {
+        headOption(traversal)
+        modifyGetAll(traversal)
+        setIdempotent(traversal)
+        modifyIdentity(traversal)
+        composeModify(traversal)
     }
     
-    private static func headOption(_ traversal: Traversal<A, B>, _ generatorA: Gen<A>) {
-        property("headOption") <- forAll { (_ : Int) in
-            let a = generatorA.generate
+    private static func headOption(_ traversal: Traversal<A, B>) {
+        property("headOption") <- forAll { (a: A) in
             return traversal.headOption(a) == traversal.getAll(a).firstOrNone()
         }
     }
     
-    private static func modifyGetAll(_ traversal: Traversal<A, B>, _ generatorA: Gen<A>) {
-        property("modifyGetAll") <- forAll { (f : ArrowOf<B, B>) in
-            let a = generatorA.generate
+    private static func modifyGetAll(_ traversal: Traversal<A, B>) {
+        property("modifyGetAll") <- forAll { (a: A, f: ArrowOf<B, B>) in
             return traversal.getAll(traversal.modify(a, f.getArrow)) == traversal.getAll(a).map(f.getArrow)
         }
     }
     
-    private static func setIdempotent(_ traversal: Traversal<A, B>, _ generatorA: Gen<A>) {
-        property("setIdempotent") <- forAll { (b : B) in
-            let a = generatorA.generate
+    private static func setIdempotent(_ traversal: Traversal<A, B>) {
+        property("setIdempotent") <- forAll { (a: A, b: B) in
             return traversal.set(traversal.set(a, b), b) == traversal.set(a, b)
         }
     }
     
-    private static func modifyIdentity(_ traversal: Traversal<A, B>, _ generatorA: Gen<A>) {
-        property("modifyIdentity") <- forAll { (_ : Int) in
-            let a = generatorA.generate
+    private static func modifyIdentity(_ traversal: Traversal<A, B>) {
+        property("modifyIdentity") <- forAll { (a: A) in
             return traversal.modify(a, id) == a
         }
     }
     
-    private static func composeModify(_ traversal: Traversal<A, B>, _ generatorA: Gen<A>) {
-        property("composeModify") <- forAll { (f : ArrowOf<B, B>, g : ArrowOf<B, B>) in
-            let a = generatorA.generate
+    private static func composeModify(_ traversal: Traversal<A, B>) {
+        property("composeModify") <- forAll { (a: A, f: ArrowOf<B, B>, g: ArrowOf<B, B>) in
             return traversal.modify(traversal.modify(a, f.getArrow), g.getArrow) == traversal.modify(a, g.getArrow <<< f.getArrow)
         }
     }

--- a/Tests/BowOpticsTests/LensTest.swift
+++ b/Tests/BowOpticsTests/LensTest.swift
@@ -1,7 +1,7 @@
 import XCTest
 import SwiftCheck
-@testable import Bow
-@testable import BowOptics
+import Bow
+import BowOptics
 
 class LensTest: XCTestCase {
     
@@ -14,78 +14,78 @@ class LensTest: XCTestCase {
     }
     
     func testSetterLaws() {
-        SetterLaws.check(setter: tokenLens.asSetter(), generatorA: Token.arbitrary)
+        SetterLaws.check(setter: tokenLens.asSetter())
     }
     
     func testTraversalLaws() {
-        TraversalLaws.check(traversal: tokenLens.asTraversal(), generatorA: Token.arbitrary)
+        TraversalLaws.check(traversal: tokenLens.asTraversal())
     }
     
     func testLensAsFold() {
-        property("Lens as Fold: size") <- forAll { (token : Token) in
+        property("Lens as Fold: size") <- forAll { (token: Token) in
             return tokenLens.asFold().size(token) == 1
         }
         
-        property("Lens as Fold: nonEmpty") <- forAll { (token : Token) in
+        property("Lens as Fold: nonEmpty") <- forAll { (token: Token) in
             return tokenLens.asFold().nonEmpty(token)
         }
         
-        property("Lens as Fold: isEmpty") <- forAll { (token : Token) in
+        property("Lens as Fold: isEmpty") <- forAll { (token: Token) in
             return !tokenLens.asFold().isEmpty(token)
         }
         
-        property("Lens as Fold: getAll") <- forAll { (token : Token) in
+        property("Lens as Fold: getAll") <- forAll { (token: Token) in
             return tokenLens.asFold().getAll(token) == ArrayK.pure(token.value)
         }
         
-        property("Lens as Fold: combineAll") <- forAll { (token : Token) in
+        property("Lens as Fold: combineAll") <- forAll { (token: Token) in
             return tokenLens.asFold().combineAll(token) == token.value
         }
         
-        property("Lens as Fold: headOption") <- forAll { (token : Token) in
+        property("Lens as Fold: headOption") <- forAll { (token: Token) in
             return tokenLens.asFold().headOption(token) == Option.some(token.value)
         }
         
-        property("Lens as Fold: lastOption") <- forAll { (token : Token) in
+        property("Lens as Fold: lastOption") <- forAll { (token: Token) in
             return tokenLens.asFold().lastOption(token) == Option.some(token.value)
         }
     }
     
     func testLensAsGetter() {
-        property("Lens as Getter: get") <- forAll { (token : Token) in
+        property("Lens as Getter: get") <- forAll { (token: Token) in
             return tokenLens.asGetter().get(token) == tokenGetter.get(token)
         }
         
-        property("Lens as Getter: find") <- forAll { (token : Token, predicate : ArrowOf<String, Bool>) in
+        property("Lens as Getter: find") <- forAll { (token: Token, predicate: ArrowOf<String, Bool>) in
             return tokenLens.asGetter().find(token, predicate.getArrow) ==
                 tokenGetter.find(token, predicate.getArrow)
         }
         
-        property("Lens as Getter: exists") <- forAll { (token : Token, predicate : ArrowOf<String, Bool>) in
+        property("Lens as Getter: exists") <- forAll { (token: Token, predicate: ArrowOf<String, Bool>) in
             return tokenLens.asGetter().exists(token, predicate.getArrow) ==
                 tokenGetter.exists(token, predicate.getArrow)
         }
     }
     
     func testLensProperties() {
-        property("Lifting a function should yield the same result as not yielding") <- forAll { (token : Token, value : String) in
+        property("Lifting a function should yield the same result as not yielding") <- forAll { (token: Token, value: String) in
             return tokenLens.set(token, value) == tokenLens.lift(constant(value))(token)
         }
         
-        property("Lifting a function as a functor should yield the same result as not yielding") <- forAll { (token : Token, value : String) in
+        property("Lifting a function as a functor should yield the same result as not yielding") <- forAll { (token: Token, value: String) in
             return tokenLens.modifyF(token, constant(Option.some(value))) ==
                 tokenLens.liftF(constant(Option.some(value)))(token)
         }
         
-        property("Finding a target using a predicate within a Lens should be wrapped in the correct option result") <- forAll { (predicate : Bool) in
+        property("Finding a target using a predicate within a Lens should be wrapped in the correct option result") <- forAll { (predicate: Bool) in
             return tokenLens.find(Token(value: "Any value"), constant(predicate)).fold(constant(false), constant(true)) == predicate
         }
         
-        property("Checking existence predicate over the target should result in same result as predicate") <- forAll { (predicate : Bool) in
+        property("Checking existence predicate over the target should result in same result as predicate") <- forAll { (predicate: Bool) in
             return tokenLens.exists(Token(value: "Any value"), constant(predicate)) == predicate
         }
         
-        property("Joining two lenses with the same target should yield same result") <- forAll { (tokenValue : String) in
+        property("Joining two lenses with the same target should yield same result") <- forAll { (tokenValue: String) in
             let token = Token(value: tokenValue)
             let user = User(token: token)
             let userTokenStringLens = userLens + tokenLens
@@ -93,52 +93,52 @@ class LensTest: XCTestCase {
             return joinedLens.get(Either.left(token)) == joinedLens.get(Either.right(user))
         }
         
-        property("Pairing two disjoint lenses should yield a pair of their results") <- forAll { (token : Token, user : User) in
+        property("Pairing two disjoint lenses should yield a pair of their results") <- forAll { (token: Token, user: User) in
             let split = userLens.split(tokenLens)
             return split.get((user, token)) == (user.token, token.value)
         }
         
-        property("Creating a first pair with a type should result in the target to value") <- forAll { (token : Token, value : Int) in
-            let first : Lens<(Token, Int), (String, Int)> = tokenLens.first()
+        property("Creating a first pair with a type should result in the target to value") <- forAll { (token: Token, value: Int) in
+            let first: Lens<(Token, Int), (String, Int)> = tokenLens.first()
             return first.get((token, value)) == (token.value, value)
         }
         
-        property("Creating a second pair with a type should result in the value to target") <- forAll { (token : Token, value : Int) in
-            let second : Lens<(Int, Token), (Int, String)> = tokenLens.second()
+        property("Creating a second pair with a type should result in the value to target") <- forAll { (token: Token, value: Int) in
+            let second: Lens<(Int, Token), (Int, String)> = tokenLens.second()
             return second.get((value, token)) == (value, token.value)
         }
     }
     
     func testLensComposition() {
-        property("Lens + Lens::identity") <- forAll { (token : Token) in
+        property("Lens + Lens::identity") <- forAll { (token: Token) in
             return (tokenLens + Lens<String, String>.identity()).get(token) == tokenLens.get(token)
         }
         
-        property("Lens + Iso::identity") <- forAll { (token : Token) in
+        property("Lens + Iso::identity") <- forAll { (token: Token) in
             return (tokenLens + Iso<String, String>.identity()).get(token) == tokenLens.get(token)
         }
         
-        property("Lens + Getter::identity") <- forAll { (token : Token) in
+        property("Lens + Getter::identity") <- forAll { (token: Token) in
             return (tokenLens + Getter<String, String>.identity()).get(token) == tokenLens.get(token)
         }
         
-        property("Lens + Prism::identity") <- forAll { (token : Token) in
+        property("Lens + Prism::identity") <- forAll { (token: Token) in
             return (tokenLens + Prism<String, String>.identity()).getOption(token).getOrElse("") == tokenLens.get(token)
         }
         
-        property("Lens + Optional::identity") <- forAll { (token : Token) in
+        property("Lens + Optional::identity") <- forAll { (token: Token) in
             return (tokenLens + BowOptics.Optional<String, String>.identity()).getOption(token).getOrElse("") == tokenLens.get(token)
         }
         
-        property("Lens + Setter::identity") <- forAll { (token : Token, value : String) in
+        property("Lens + Setter::identity") <- forAll { (token: Token, value: String) in
             return (tokenLens + Setter<String, String>.identity()).set(token, value) == tokenLens.set(token, value)
         }
         
-        property("Lens + Fold::identity") <- forAll { (token : Token) in
+        property("Lens + Fold::identity") <- forAll { (token: Token) in
             return (tokenLens + Fold<String, String>.identity()).getAll(token).asArray == [tokenLens.get(token)]
         }
         
-        property("Lens + Traversal::identity") <- forAll { (token : Token) in
+        property("Lens + Traversal::identity") <- forAll { (token: Token) in
             return (tokenLens + Traversal<String, String>.identity()).getAll(token).asArray == [tokenLens.get(token)]
         }
     }

--- a/Tests/BowOpticsTests/OptionalTest.swift
+++ b/Tests/BowOpticsTests/OptionalTest.swift
@@ -1,7 +1,7 @@
 import XCTest
 import SwiftCheck
-@testable import Bow
-@testable import BowOptics
+import Bow
+import BowOptics
 
 class OptionalTest: XCTestCase {
 
@@ -10,11 +10,11 @@ class OptionalTest: XCTestCase {
     }
 
     func testSetterLaws() {
-        SetterLaws.check(setter: BowOptics.Optional<String, String>.identity().asSetter(), generatorA: String.arbitrary)
+        SetterLaws.check(setter: BowOptics.Optional<String, String>.identity().asSetter())
     }
 
     func testTraversalLaws() {
-        TraversalLaws.check(traversal: BowOptics.Optional<String, String>.identity().asTraversal(), generatorA: String.arbitrary)
+        TraversalLaws.check(traversal: BowOptics.Optional<String, String>.identity().asTraversal())
     }
 
     func testOptionalAsFold() {

--- a/Tests/BowOpticsTests/PrismTest.swift
+++ b/Tests/BowOpticsTests/PrismTest.swift
@@ -1,7 +1,7 @@
 import XCTest
 import SwiftCheck
-@testable import Bow
-@testable import BowOptics
+import Bow
+import BowOptics
 
 class PrismTest: XCTestCase {
     
@@ -10,7 +10,7 @@ class PrismTest: XCTestCase {
     }
     
     func testSetterLaws() {
-        SetterLaws.check(setter: stringPrism.asSetter(), generatorA: String.arbitrary)
+        SetterLaws.check(setter: stringPrism.asSetter())
     }
     
     func testOptionalLaws() {
@@ -18,105 +18,105 @@ class PrismTest: XCTestCase {
     }
     
     func testTraversalLaws() {
-        TraversalLaws.check(traversal: stringPrism.asTraversal(), generatorA: String.arbitrary)
+        TraversalLaws.check(traversal: stringPrism.asTraversal())
     }
     
     func testPrismAsFold() {
-        property("Prism as Fold: size") <- forAll { (sum : SumType) in
+        property("Prism as Fold: size") <- forAll { (sum: SumType) in
             return sumPrism.asFold().size(sum) == Option.fix(sumPrism.getOption(sum).map(constant(1))).getOrElse(0)
         }
         
-        property("Prism as Fold: nonEmpty") <- forAll { (sum : SumType) in
+        property("Prism as Fold: nonEmpty") <- forAll { (sum: SumType) in
             return sumPrism.asFold().nonEmpty(sum) == sumPrism.getOption(sum).isDefined
         }
         
-        property("Prism as Fold: isEmpty") <- forAll { (sum : SumType) in
+        property("Prism as Fold: isEmpty") <- forAll { (sum: SumType) in
             return sumPrism.asFold().isEmpty(sum) == sumPrism.getOption(sum).isEmpty
         }
         
-        property("Prism as Fold: getAll") <- forAll { (sum : SumType) in
+        property("Prism as Fold: getAll") <- forAll { (sum: SumType) in
             return sumPrism.asFold().getAll(sum) == sumPrism.getOption(sum).toArray().k()
         }
         
-        property("Prism as Fold: combineAll") <- forAll { (sum : SumType) in
+        property("Prism as Fold: combineAll") <- forAll { (sum: SumType) in
             return sumPrism.asFold().combineAll(sum) == sumPrism.getOption(sum).fold(constant(String.empty()), id)
         }
         
-        property("Prism as Fold: fold") <- forAll { (sum : SumType) in
+        property("Prism as Fold: fold") <- forAll { (sum: SumType) in
             return sumPrism.asFold().fold(sum) == sumPrism.getOption(sum).fold(constant(String.empty()), id)
         }
         
-        property("Prism as Fold: headOption") <- forAll { (sum : SumType) in
+        property("Prism as Fold: headOption") <- forAll { (sum: SumType) in
             return sumPrism.asFold().headOption(sum) == sumPrism.getOption(sum)
         }
         
-        property("Prism as Fold: lastOption") <- forAll { (sum : SumType) in
+        property("Prism as Fold: lastOption") <- forAll { (sum: SumType) in
             return sumPrism.asFold().lastOption(sum) == sumPrism.getOption(sum)
         }
     }
     
-    let sumAGen : Gen<SumType> = String.arbitrary.map(SumType.a)
+    let sumAGen: Gen<SumType> = String.arbitrary.map(SumType.a)
     
     func testPrismProperties() {
-        property("Joining two prisms with the same target should yield the same result") <- forAll { (sum : SumType) in
+        property("Joining two prisms with the same target should yield the same result") <- forAll { (sum: SumType) in
             return (sumPrism + stringPrism).getOption(sum) == sumPrism.getOption(sum).flatMap(stringPrism.getOption)
         }
 
-        property("Checking if a prism exists with a target") <- forAll { (a : SumType, b : SumType) in
+        property("Checking if a prism exists with a target") <- forAll { (a: SumType, b: SumType) in
             return Prism<SumType, SumType>.only(a).isEmpty(b) == (a == b)
         }
         
-        property("Checking if there is no target") <- forAll { (sum : SumType) in
+        property("Checking if there is no target") <- forAll { (sum: SumType) in
             return sumPrism.isEmpty(sum) == !sum.isA
         }
         
-        property("Checking if a target exists") <- forAll { (sum : SumType) in
+        property("Checking if a target exists") <- forAll { (sum: SumType) in
             return sumPrism.nonEmpty(sum) == sum.isA
         }
         
-        property("Setting a target on a prism should set the correct target") <- forAll(self.sumAGen, String.arbitrary) { (sum : SumType, str : String) in
+        property("Setting a target on a prism should set the correct target") <- forAll(self.sumAGen, String.arbitrary) { (sum: SumType, str: String) in
             return sumPrism.setOption(sum, str) == Option.some(SumType.a(str))
         }
         
-        property("Finding a target using a predicate within a Prism should be wrapped in the correct option result") <- forAll { (sum : SumType, predicate : Bool) in
+        property("Finding a target using a predicate within a Prism should be wrapped in the correct option result") <- forAll { (sum: SumType, predicate: Bool) in
             return sumPrism.find(sum, constant(predicate)).fold(constant(false), constant(true)) == (predicate && sum.isA)
         }
         
-        property("Checking existence predicate over the target should result in same result as predicate") <- forAll { (sum : SumType, predicate : Bool) in
+        property("Checking existence predicate over the target should result in same result as predicate") <- forAll { (sum: SumType, predicate: Bool) in
             return sumPrism.exists(sum, constant(predicate)) == (predicate && sum.isA)
         }
         
-        property("Checking satisfaction of predicate over the target should result in opposite result as predicate") <- forAll { (sum : SumType, predicate : Bool) in
+        property("Checking satisfaction of predicate over the target should result in opposite result as predicate") <- forAll { (sum: SumType, predicate: Bool) in
             return sumPrism.all(sum, constant(predicate)) == (predicate || !sum.isA)
         }
     }
     
     func testPrismComposition() {
-        property("Prism + Prism::identity") <- forAll { (sum : SumType, def: String) in
+        property("Prism + Prism::identity") <- forAll { (sum: SumType, def: String) in
             return (sumPrism + Prism<String, String>.identity()).getOption(sum).getOrElse(def) == sumPrism.getOption(sum).getOrElse(def)
         }
         
-        property("Prism + Iso::identity") <- forAll { (sum : SumType, def: String) in
+        property("Prism + Iso::identity") <- forAll { (sum: SumType, def: String) in
             return (sumPrism + Iso<String, String>.identity()).getOption(sum).getOrElse(def) == sumPrism.getOption(sum).getOrElse(def)
         }
         
-        property("Prism + Lens::identity") <- forAll { (sum : SumType, def: String) in
+        property("Prism + Lens::identity") <- forAll { (sum: SumType, def: String) in
             return (sumPrism + Lens<String, String>.identity()).getOption(sum).getOrElse(def) == sumPrism.getOption(sum).getOrElse(def)
         }
         
-        property("Prism + Optional::identity") <- forAll { (sum : SumType, def: String) in
+        property("Prism + Optional::identity") <- forAll { (sum: SumType, def: String) in
             return (sumPrism + BowOptics.Optional<String, String>.identity()).getOption(sum).getOrElse(def) == sumPrism.getOption(sum).getOrElse(def)
         }
         
-        property("Prism + Fold::identity") <- forAll { (sum : SumType) in
+        property("Prism + Fold::identity") <- forAll { (sum: SumType) in
             return (sumPrism + Fold<String, String>.identity()).getAll(sum).asArray == sumPrism.getOption(sum).fold(constant([]), { a in [a] })
         }
         
-        property("Prism + Traversal::identity") <- forAll { (sum : SumType) in
+        property("Prism + Traversal::identity") <- forAll { (sum: SumType) in
             return (sumPrism + Traversal<String, String>.identity()).getAll(sum).asArray == sumPrism.getOption(sum).fold(constant([]), { a in [a] })
         }
         
-        property("Prism + Setter::identity") <- forAll { (sum : SumType, def: String) in
+        property("Prism + Setter::identity") <- forAll { (sum: SumType, def: String) in
             return (sumPrism + Setter<String, String>.identity()).set(sum, def) == sumPrism.set(sum, def)
         }
     }

--- a/Tests/BowOpticsTests/SetterTest.swift
+++ b/Tests/BowOpticsTests/SetterTest.swift
@@ -1,17 +1,17 @@
 import XCTest
 import SwiftCheck
-@testable import Bow
-@testable import BowOptics
+import Bow
+import BowOptics
 
 class SetterTest: XCTestCase {
     
     func testSetterLaws() {
-        SetterLaws.check(setter: tokenSetter, generatorA: Token.arbitrary)
-        SetterLaws.check(setter: Setter<String, String>.identity(), generatorA: String.arbitrary)
+        SetterLaws.check(setter: tokenSetter)
+        SetterLaws.check(setter: Setter<String, String>.identity())
     }
     
     func testSetterProperties() {
-        property("Joining two Setters together with same target should yield same result") <- forAll { (value : String) in
+        property("Joining two Setters together with same target should yield same result") <- forAll { (value: String) in
             let userTokenStringSetter = userSetter + tokenSetter
             let joinedSetter = tokenSetter.choice(userTokenStringSetter)
             let oldValue = "Old value"
@@ -20,33 +20,33 @@ class SetterTest: XCTestCase {
             return joinedSetter.set(Either.left(token), value).swap().getOrElse(Token(value: "Wrong value")).value == joinedSetter.set(Either.right(user), value).getOrElse(User(token: Token(value: "Wrong value"))).token.value
         }
         
-        property("Lifting a function should yield the same result as direct modify") <- forAll { (token : Token, value : String) in
+        property("Lifting a function should yield the same result as direct modify") <- forAll { (token: Token, value: String) in
             return tokenSetter.modify(token, constant(value)) == tokenSetter.lift(constant(value))(token)
         }
     }
     
     func testSetterComposition() {
-        property("Setter + Setter::identity") <- forAll { (token : Token, value : String) in
+        property("Setter + Setter::identity") <- forAll { (token: Token, value: String) in
             return (tokenSetter + Setter<String, String>.identity()).set(token, value) == tokenSetter.set(token, value)
         }
         
-        property("Setter + Iso::identity") <- forAll { (token : Token, value : String) in
+        property("Setter + Iso::identity") <- forAll { (token: Token, value: String) in
             return (tokenSetter + Iso<String, String>.identity()).set(token, value) == tokenSetter.set(token, value)
         }
         
-        property("Setter + Lens::identity") <- forAll { (token : Token, value : String) in
+        property("Setter + Lens::identity") <- forAll { (token: Token, value: String) in
             return (tokenSetter + Lens<String, String>.identity()).set(token, value) == tokenSetter.set(token, value)
         }
         
-        property("Setter + Prism::identity") <- forAll { (token : Token, value : String) in
+        property("Setter + Prism::identity") <- forAll { (token: Token, value: String) in
             return (tokenSetter + Prism<String, String>.identity()).set(token, value) == tokenSetter.set(token, value)
         }
         
-        property("Setter + Optional::identity") <- forAll { (token : Token, value : String) in
+        property("Setter + Optional::identity") <- forAll { (token: Token, value: String) in
             return (tokenSetter + BowOptics.Optional<String, String>.identity()).set(token, value) == tokenSetter.set(token, value)
         }
         
-        property("Setter + Traversal::identity") <- forAll { (token : Token, value : String) in
+        property("Setter + Traversal::identity") <- forAll { (token: Token, value: String) in
             return (tokenSetter + Traversal<String, String>.identity()).set(token, value) == tokenSetter.set(token, value)
         }
     }

--- a/Tests/BowOpticsTests/TestDomain.swift
+++ b/Tests/BowOpticsTests/TestDomain.swift
@@ -1,7 +1,7 @@
 import Foundation
 import SwiftCheck
-@testable import Bow
-@testable import BowOptics
+import Bow
+import BowOptics
 
 struct Token {
     let value : String

--- a/Tests/BowOpticsTests/TraversalTest.swift
+++ b/Tests/BowOpticsTests/TraversalTest.swift
@@ -7,7 +7,7 @@ class TraversalTest: XCTestCase {
     let arrayKGen: Gen<ArrayKOf<Int>> = Array<Int>.arbitrary.map{ array in array.k() }
 
     func arrayKTraversal<F: Traverse>() -> Traversal<Kind<F, Int>, Int>{
-        return Traversal<Int, Int>.fromTraverse()
+        return Traversal<Kind<F, Int>, Int>.fromTraverse()
     }
 
     func testTraversalLaws() {

--- a/Tests/BowOpticsTests/TraversalTest.swift
+++ b/Tests/BowOpticsTests/TraversalTest.swift
@@ -1,114 +1,113 @@
 import XCTest
 import SwiftCheck
-@testable import Bow
-@testable import BowOptics
+import Bow
+import BowGenerators
+import BowOptics
 
 class TraversalTest: XCTestCase {
-    let arrayKGen: Gen<ArrayKOf<Int>> = Array<Int>.arbitrary.map{ array in array.k() }
-
-    func arrayKTraversal<F: Traverse>() -> Traversal<Kind<F, Int>, Int>{
-        return Traversal<Kind<F, Int>, Int>.fromTraverse()
-    }
-
     func testTraversalLaws() {
-        TraversalLaws.check(traversal: arrayKTraversal(),
-                            generatorA: arrayKGen)
+        TraversalLaws<ArrayK<Int>, Int>.check(traversal: ArrayK<Int>.traversal)
     }
 
     func testSetterLaws() {
-        SetterLaws.check(setter: arrayKTraversal().asSetter(),
-                         generatorA: arrayKGen)
+        SetterLaws.check(setter: ArrayK<Int>.traversal.asSetter())
     }
 
     func testTraversalAsFold() {
-        property("Traversal as Fold: size") <- forAll { (array: Array<Int>) in
-            return self.arrayKTraversal().asFold().size(array.k()) == array.count
+        property("Traversal as Fold: size") <- forAll { (array: ArrayK<Int>) in
+            return ArrayK<Int>.traversal.asFold().size(array) == array.count
         }
 
-        property("Traversal as Fold: nonEmpty") <- forAll { (array: Array<Int>) in
-            return self.arrayKTraversal().asFold().nonEmpty(array.k()) == !array.isEmpty
+        property("Traversal as Fold: nonEmpty") <- forAll { (array: ArrayK<Int>) in
+            return ArrayK<Int>.traversal.asFold().nonEmpty(array) == !array.isEmpty
         }
 
-        property("Traversal as Fold: isEmpty") <- forAll { (array: Array<Int>) in
-            return self.arrayKTraversal().asFold().isEmpty(array.k()) == array.isEmpty
+        property("Traversal as Fold: isEmpty") <- forAll { (array: ArrayK<Int>) in
+            return ArrayK<Int>.traversal.asFold().isEmpty(array) == array.isEmpty
         }
 
-        property("Traversal as Fold: getAll") <- forAll { (array: Array<Int>) in
-            return self.arrayKTraversal().asFold().getAll(array.k()) ==
-                array.k()
+        property("Traversal as Fold: getAll") <- forAll { (array: ArrayK<Int>) in
+            return ArrayK<Int>.traversal.asFold().getAll(array) == array
         }
 
-        property("Traversal as Fold: combineAll") <- forAll { (array: Array<Int>) in
-            return self.arrayKTraversal().asFold().combineAll(array.k()) == array.reduce(0, +)
+        property("Traversal as Fold: combineAll") <- forAll { (array: ArrayK<Int>) in
+            return ArrayK<Int>.traversal.asFold().combineAll(array) == array.asArray.reduce(0, +)
         }
 
-        property("Traversal as Fold: fold") <- forAll { (array: Array<Int>) in
-            return self.arrayKTraversal().asFold().combineAll(array.k()) == array.reduce(0, +)
+        property("Traversal as Fold: fold") <- forAll { (array: ArrayK<Int>) in
+            return ArrayK<Int>.traversal.asFold().combineAll(array) == array.asArray.reduce(0, +)
         }
 
-        property("Traversal as Fold: headOption") <- forAll { (array: Array<Int>) in
-            return self.arrayKTraversal().asFold().headOption(array.k()) ==
-                Option.fromOptional(array.first)
+        property("Traversal as Fold: headOption") <- forAll { (array: ArrayK<Int>) in
+            return ArrayK<Int>.traversal.asFold().headOption(array) ==
+                array.firstOrNone()
         }
 
-        property("Traversal as Fold: lastOption") <- forAll { (array: Array<Int>) in
-            return self.arrayKTraversal().asFold().lastOption(array.k()) ==
-                Option.fromOptional(array.last)
+        property("Traversal as Fold: lastOption") <- forAll { (array: ArrayK<Int>) in
+            return ArrayK<Int>.traversal.asFold().lastOption(array) ==
+                array.asArray.last.toOption()
         }
     }
 
     func testTraversalProperties() {
-        property("Getting all targets of a traversal") <- forAll { (array: Array<Int>) in
-            return self.arrayKTraversal().getAll(array.k()) == array.k()
+        property("Getting all targets of a traversal") <- forAll { (array: ArrayK<Int>) in
+            return ArrayK<Int>.traversal.getAll(array) == array
         }
 
-        property("Folding all the values from a traversal") <- forAll { (array: Array<Int>) in
-            return self.arrayKTraversal().fold(array.k()) ==
-                array.reduce(0, +)
+        property("Folding all the values from a traversal") <- forAll { (array: ArrayK<Int>) in
+            return ArrayK<Int>.traversal.fold(array) ==
+                array.asArray.reduce(0, +)
         }
 
-        property("Combining all the values from a traversal") <- forAll { (array: Array<Int>) in
-            return self.arrayKTraversal().fold(array.k()) ==
-                array.reduce(0, +)
+        property("Combining all the values from a traversal") <- forAll { (array: ArrayK<Int>) in
+            return ArrayK<Int>.traversal.fold(array) ==
+                array.asArray.reduce(0, +)
         }
 
-        property("Find a target in a traversal") <- forAll { (array: Array<Int>) in
-            return self.arrayKTraversal().find(array.k(), { x in x > 10 }) ==
-                Option.fromOptional(array.filter { x in x > 10 }.first)
+        property("Find a target in a traversal") <- forAll { (array: ArrayK<Int>) in
+            return ArrayK<Int>.traversal.find(array, { x in x > 10 }) ==
+                array.asArray.filter { x in x > 10 }.first.toOption()
         }
 
-        property("Size of a traversal") <- forAll { (array: Array<Int>) in
-            return self.arrayKTraversal().size(array.k()) == array.count
+        property("Size of a traversal") <- forAll { (array: ArrayK<Int>) in
+            return ArrayK<Int>.traversal.size(array) == array.count
         }
     }
 
     func testTraversalComposition() {
-        property("Traversal + Traversal::identity") <- forAll { (array: Array<Int>) in
-            return (self.arrayKTraversal() + Traversal<Int, Int>.identity()).getAll(array.k()).asArray == self.arrayKTraversal().getAll(array.k()).asArray
+        property("Traversal + Traversal::identity") <- forAll { (array: ArrayK<Int>) in
+            return (ArrayK<Int>.traversal + Traversal<Int, Int>.identity()).getAll(array) ==
+                ArrayK<Int>.traversal.getAll(array)
         }
 
-        property("Traversal + Iso::identity") <- forAll { (array: Array<Int>) in
-            return (self.arrayKTraversal() + Iso<Int, Int>.identity()).getAll(array.k()).asArray == self.arrayKTraversal().getAll(array.k()).asArray
+        property("Traversal + Iso::identity") <- forAll { (array: ArrayK<Int>) in
+            return (ArrayK<Int>.traversal + Iso<Int, Int>.identity()).getAll(array) ==
+                ArrayK<Int>.traversal.getAll(array)
         }
 
-        property("Traversal + Lens::identity") <- forAll { (array: Array<Int>) in
-            return (self.arrayKTraversal() + Lens<Int, Int>.identity()).getAll(array.k()).asArray == self.arrayKTraversal().getAll(array.k()).asArray
+        property("Traversal + Lens::identity") <- forAll { (array: ArrayK<Int>) in
+            return (ArrayK<Int>.traversal + Lens<Int, Int>.identity()).getAll(array) ==
+                ArrayK<Int>.traversal.getAll(array)
         }
 
-        property("Traversal + Prism::identity") <- forAll { (array: Array<Int>) in
-            return (self.arrayKTraversal() + Prism<Int, Int>.identity()).getAll(array.k()).asArray == self.arrayKTraversal().getAll(array.k()).asArray
+        property("Traversal + Prism::identity") <- forAll { (array: ArrayK<Int>) in
+            return (ArrayK<Int>.traversal + Prism<Int, Int>.identity()).getAll(array) ==
+                ArrayK<Int>.traversal.getAll(array)
         }
 
-        property("Traversal + Optional::identity") <- forAll { (array: Array<Int>) in
-            return (self.arrayKTraversal() + BowOptics.Optional<Int, Int>.identity()).getAll(array.k()).asArray == self.arrayKTraversal().getAll(array.k()).asArray
+        property("Traversal + Optional::identity") <- forAll { (array: ArrayK<Int>) in
+            return (ArrayK<Int>.traversal + BowOptics.Optional<Int, Int>.identity()).getAll(array) ==
+                ArrayK<Int>.traversal.getAll(array)
         }
 
-        property("Traversal + Setter::identity") <- forAll { (array: Array<Int>, value: Int) in
-            return (self.arrayKTraversal() + Setter<Int, Int>.identity()).set(array.k(), value) == self.arrayKTraversal().set(array.k(), value)
+        property("Traversal + Setter::identity") <- forAll { (array: ArrayK<Int>, value: Int) in
+            return (ArrayK<Int>.traversal + Setter<Int, Int>.identity()).set(array, value) ==
+                ArrayK<Int>.traversal.set(array, value)
         }
 
-        property("Traversal + Fold::identity") <- forAll { (array: Array<Int>) in
-            return (self.arrayKTraversal() + Fold<Int, Int>.identity()).getAll(array.k()).asArray == self.arrayKTraversal().getAll(array.k()).asArray
+        property("Traversal + Fold::identity") <- forAll { (array: ArrayK<Int>) in
+            return (ArrayK<Int>.traversal + Fold<Int, Int>.identity()).getAll(array) ==
+                ArrayK<Int>.traversal.getAll(array)
         }
     }
 }


### PR DESCRIPTION
## Goal

Similar to what we previously achieved in #136 in the core module, this PR aims to re-encode the type classes in the Optics module so that their instances are resolved automatically by the compiler. As a side consequence, instances are much easier to write and functions making use of them are much easier to read. An important amount of boilerplate code is also removed.
