### PR TITLE
Missing optics instances

### DIFF
--- a/Bow.xcodeproj/project.pbxproj
+++ b/Bow.xcodeproj/project.pbxproj
@@ -128,6 +128,7 @@
 		112D0CE622BB7E260032F675 /* EitherKOpticsInstances.swift in Sources */ = {isa = PBXBuildFile; fileRef = 112D0CE522BB7E260032F675 /* EitherKOpticsInstances.swift */; };
 		112D0CE822BB7EE20032F675 /* IdOpticsInstances.swift in Sources */ = {isa = PBXBuildFile; fileRef = 112D0CE722BB7EE20032F675 /* IdOpticsInstances.swift */; };
 		112D0CEA22BB7F4D0032F675 /* IorOpticsInstances.swift in Sources */ = {isa = PBXBuildFile; fileRef = 112D0CE922BB7F4D0032F675 /* IorOpticsInstances.swift */; };
+		112D0CEC22BB7FE10032F675 /* ValidatedOpticsInstances.swift in Sources */ = {isa = PBXBuildFile; fileRef = 112D0CEB22BB7FE10032F675 /* ValidatedOpticsInstances.swift */; };
 		113CD8F4219DD82F00730E58 /* RxSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8BA0F367217E2CB100969984 /* RxSwift.framework */; };
 		1166A07A22119F720032CD4E /* EqualityFunctions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1166A07822119E640032CD4E /* EqualityFunctions.swift */; };
 		117DC0CD22AE492700EF65F0 /* Nimble.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8BA0F384217E2D3400969984 /* Nimble.framework */; };
@@ -795,6 +796,7 @@
 		112D0CE522BB7E260032F675 /* EitherKOpticsInstances.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EitherKOpticsInstances.swift; sourceTree = "<group>"; };
 		112D0CE722BB7EE20032F675 /* IdOpticsInstances.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IdOpticsInstances.swift; sourceTree = "<group>"; };
 		112D0CE922BB7F4D0032F675 /* IorOpticsInstances.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IorOpticsInstances.swift; sourceTree = "<group>"; };
+		112D0CEB22BB7FE10032F675 /* ValidatedOpticsInstances.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ValidatedOpticsInstances.swift; sourceTree = "<group>"; };
 		1166A07822119E640032CD4E /* EqualityFunctions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EqualityFunctions.swift; sourceTree = "<group>"; };
 		117DC0D322AE492700EF65F0 /* BowEffectsGenerators.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = BowEffectsGenerators.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		117DC0D422AE492700EF65F0 /* Bow-Effects-Generators-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; name = "Bow-Effects-Generators-Info.plist"; path = "/Users/tomasruizlopez/Development/bow/Bow-Effects-Generators-Info.plist"; sourceTree = "<absolute>"; };
@@ -1902,6 +1904,7 @@
 				8BA0F4C2217E2E9200969984 /* OptionOpticsInstances.swift */,
 				8BA0F4C4217E2E9200969984 /* StringOpticsInstances.swift */,
 				8BA0F4C7217E2E9200969984 /* TryOpticsInstances.swift */,
+				112D0CEB22BB7FE10032F675 /* ValidatedOpticsInstances.swift */,
 			);
 			path = Instances;
 			sourceTree = "<group>";
@@ -3130,6 +3133,7 @@
 				11E71729219D722900B94845 /* Option+Optics.swift in Sources */,
 				11E7172A219D722900B94845 /* NonEmptyArray+Optics.swift in Sources */,
 				1126CA9822B12F8500F840CB /* Tuple4.swift in Sources */,
+				112D0CEC22BB7FE10032F675 /* ValidatedOpticsInstances.swift in Sources */,
 				11E7172B219D722900B94845 /* String+Optics.swift in Sources */,
 				11E4190B22B90FE2009BDFB3 /* AutoGetter.swift in Sources */,
 				11E7172C219D722900B94845 /* Try+Optics.swift in Sources */,

--- a/Bow.xcodeproj/project.pbxproj
+++ b/Bow.xcodeproj/project.pbxproj
@@ -127,6 +127,7 @@
 		112D0CE422BB7CB60032F675 /* ConstOpticsInstances.swift in Sources */ = {isa = PBXBuildFile; fileRef = 112D0CE322BB7CB60032F675 /* ConstOpticsInstances.swift */; };
 		112D0CE622BB7E260032F675 /* EitherKOpticsInstances.swift in Sources */ = {isa = PBXBuildFile; fileRef = 112D0CE522BB7E260032F675 /* EitherKOpticsInstances.swift */; };
 		112D0CE822BB7EE20032F675 /* IdOpticsInstances.swift in Sources */ = {isa = PBXBuildFile; fileRef = 112D0CE722BB7EE20032F675 /* IdOpticsInstances.swift */; };
+		112D0CEA22BB7F4D0032F675 /* IorOpticsInstances.swift in Sources */ = {isa = PBXBuildFile; fileRef = 112D0CE922BB7F4D0032F675 /* IorOpticsInstances.swift */; };
 		113CD8F4219DD82F00730E58 /* RxSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8BA0F367217E2CB100969984 /* RxSwift.framework */; };
 		1166A07A22119F720032CD4E /* EqualityFunctions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1166A07822119E640032CD4E /* EqualityFunctions.swift */; };
 		117DC0CD22AE492700EF65F0 /* Nimble.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8BA0F384217E2D3400969984 /* Nimble.framework */; };
@@ -793,6 +794,7 @@
 		112D0CE322BB7CB60032F675 /* ConstOpticsInstances.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConstOpticsInstances.swift; sourceTree = "<group>"; };
 		112D0CE522BB7E260032F675 /* EitherKOpticsInstances.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EitherKOpticsInstances.swift; sourceTree = "<group>"; };
 		112D0CE722BB7EE20032F675 /* IdOpticsInstances.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IdOpticsInstances.swift; sourceTree = "<group>"; };
+		112D0CE922BB7F4D0032F675 /* IorOpticsInstances.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IorOpticsInstances.swift; sourceTree = "<group>"; };
 		1166A07822119E640032CD4E /* EqualityFunctions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EqualityFunctions.swift; sourceTree = "<group>"; };
 		117DC0D322AE492700EF65F0 /* BowEffectsGenerators.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = BowEffectsGenerators.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		117DC0D422AE492700EF65F0 /* Bow-Effects-Generators-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; name = "Bow-Effects-Generators-Info.plist"; path = "/Users/tomasruizlopez/Development/bow/Bow-Effects-Generators-Info.plist"; sourceTree = "<absolute>"; };
@@ -1895,6 +1897,7 @@
 				112D0CE522BB7E260032F675 /* EitherKOpticsInstances.swift */,
 				8BA0F4C5217E2E9200969984 /* EitherOpticsInstances.swift */,
 				112D0CE722BB7EE20032F675 /* IdOpticsInstances.swift */,
+				112D0CE922BB7F4D0032F675 /* IorOpticsInstances.swift */,
 				8BA0F4C3217E2E9200969984 /* NonEmptyArrayOpticsInstances.swift */,
 				8BA0F4C2217E2E9200969984 /* OptionOpticsInstances.swift */,
 				8BA0F4C4217E2E9200969984 /* StringOpticsInstances.swift */,
@@ -3104,6 +3107,7 @@
 				11E7171D219D722900B94845 /* Traversal.swift in Sources */,
 				11E7171E219D722900B94845 /* At+Optics.swift in Sources */,
 				11E7171F219D722900B94845 /* Each+Optics.swift in Sources */,
+				112D0CEA22BB7F4D0032F675 /* IorOpticsInstances.swift in Sources */,
 				1126CA9A22B1301100F840CB /* Tuple5.swift in Sources */,
 				11E71720219D722900B94845 /* EitherOpticsInstances.swift in Sources */,
 				1126CA8E22B1253D00F840CB /* AutoOptional.swift in Sources */,

--- a/Bow.xcodeproj/project.pbxproj
+++ b/Bow.xcodeproj/project.pbxproj
@@ -125,6 +125,7 @@
 		1126CAA422B132CA00F840CB /* Tuple10.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1126CAA322B132CA00F840CB /* Tuple10.swift */; };
 		112D0CE222BB6FA80032F675 /* ArrayOpticsInstances.swift in Sources */ = {isa = PBXBuildFile; fileRef = 112D0CE122BB6FA80032F675 /* ArrayOpticsInstances.swift */; };
 		112D0CE422BB7CB60032F675 /* ConstOpticsInstances.swift in Sources */ = {isa = PBXBuildFile; fileRef = 112D0CE322BB7CB60032F675 /* ConstOpticsInstances.swift */; };
+		112D0CE622BB7E260032F675 /* EitherKOpticsInstances.swift in Sources */ = {isa = PBXBuildFile; fileRef = 112D0CE522BB7E260032F675 /* EitherKOpticsInstances.swift */; };
 		113CD8F4219DD82F00730E58 /* RxSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8BA0F367217E2CB100969984 /* RxSwift.framework */; };
 		1166A07A22119F720032CD4E /* EqualityFunctions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1166A07822119E640032CD4E /* EqualityFunctions.swift */; };
 		117DC0CD22AE492700EF65F0 /* Nimble.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8BA0F384217E2D3400969984 /* Nimble.framework */; };
@@ -789,6 +790,7 @@
 		1126CAA322B132CA00F840CB /* Tuple10.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Tuple10.swift; sourceTree = "<group>"; };
 		112D0CE122BB6FA80032F675 /* ArrayOpticsInstances.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArrayOpticsInstances.swift; sourceTree = "<group>"; };
 		112D0CE322BB7CB60032F675 /* ConstOpticsInstances.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConstOpticsInstances.swift; sourceTree = "<group>"; };
+		112D0CE522BB7E260032F675 /* EitherKOpticsInstances.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EitherKOpticsInstances.swift; sourceTree = "<group>"; };
 		1166A07822119E640032CD4E /* EqualityFunctions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EqualityFunctions.swift; sourceTree = "<group>"; };
 		117DC0D322AE492700EF65F0 /* BowEffectsGenerators.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = BowEffectsGenerators.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		117DC0D422AE492700EF65F0 /* Bow-Effects-Generators-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; name = "Bow-Effects-Generators-Info.plist"; path = "/Users/tomasruizlopez/Development/bow/Bow-Effects-Generators-Info.plist"; sourceTree = "<absolute>"; };
@@ -1888,6 +1890,7 @@
 				8BA0F4C6217E2E9200969984 /* ArrayKOpticsInstances.swift */,
 				112D0CE122BB6FA80032F675 /* ArrayOpticsInstances.swift */,
 				112D0CE322BB7CB60032F675 /* ConstOpticsInstances.swift */,
+				112D0CE522BB7E260032F675 /* EitherKOpticsInstances.swift */,
 				8BA0F4C5217E2E9200969984 /* EitherOpticsInstances.swift */,
 				8BA0F4C3217E2E9200969984 /* NonEmptyArrayOpticsInstances.swift */,
 				8BA0F4C2217E2E9200969984 /* OptionOpticsInstances.swift */,
@@ -3104,6 +3107,7 @@
 				11E71721219D722900B94845 /* ArrayKOpticsInstances.swift in Sources */,
 				11E71722219D722900B94845 /* OptionOpticsInstances.swift in Sources */,
 				11E71723219D722900B94845 /* NonEmptyArrayOpticsInstances.swift in Sources */,
+				112D0CE622BB7E260032F675 /* EitherKOpticsInstances.swift in Sources */,
 				1126CAA222B1324E00F840CB /* Tuple9.swift in Sources */,
 				11E71724219D722900B94845 /* StringOpticsInstances.swift in Sources */,
 				112D0CE222BB6FA80032F675 /* ArrayOpticsInstances.swift in Sources */,

--- a/Bow.xcodeproj/project.pbxproj
+++ b/Bow.xcodeproj/project.pbxproj
@@ -124,6 +124,7 @@
 		1126CAA222B1324E00F840CB /* Tuple9.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1126CAA122B1324E00F840CB /* Tuple9.swift */; };
 		1126CAA422B132CA00F840CB /* Tuple10.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1126CAA322B132CA00F840CB /* Tuple10.swift */; };
 		112D0CE222BB6FA80032F675 /* ArrayOpticsInstances.swift in Sources */ = {isa = PBXBuildFile; fileRef = 112D0CE122BB6FA80032F675 /* ArrayOpticsInstances.swift */; };
+		112D0CE422BB7CB60032F675 /* ConstOpticsInstances.swift in Sources */ = {isa = PBXBuildFile; fileRef = 112D0CE322BB7CB60032F675 /* ConstOpticsInstances.swift */; };
 		113CD8F4219DD82F00730E58 /* RxSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8BA0F367217E2CB100969984 /* RxSwift.framework */; };
 		1166A07A22119F720032CD4E /* EqualityFunctions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1166A07822119E640032CD4E /* EqualityFunctions.swift */; };
 		117DC0CD22AE492700EF65F0 /* Nimble.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8BA0F384217E2D3400969984 /* Nimble.framework */; };
@@ -787,6 +788,7 @@
 		1126CAA122B1324E00F840CB /* Tuple9.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Tuple9.swift; sourceTree = "<group>"; };
 		1126CAA322B132CA00F840CB /* Tuple10.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Tuple10.swift; sourceTree = "<group>"; };
 		112D0CE122BB6FA80032F675 /* ArrayOpticsInstances.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArrayOpticsInstances.swift; sourceTree = "<group>"; };
+		112D0CE322BB7CB60032F675 /* ConstOpticsInstances.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConstOpticsInstances.swift; sourceTree = "<group>"; };
 		1166A07822119E640032CD4E /* EqualityFunctions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EqualityFunctions.swift; sourceTree = "<group>"; };
 		117DC0D322AE492700EF65F0 /* BowEffectsGenerators.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = BowEffectsGenerators.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		117DC0D422AE492700EF65F0 /* Bow-Effects-Generators-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; name = "Bow-Effects-Generators-Info.plist"; path = "/Users/tomasruizlopez/Development/bow/Bow-Effects-Generators-Info.plist"; sourceTree = "<absolute>"; };
@@ -1885,6 +1887,7 @@
 			children = (
 				8BA0F4C6217E2E9200969984 /* ArrayKOpticsInstances.swift */,
 				112D0CE122BB6FA80032F675 /* ArrayOpticsInstances.swift */,
+				112D0CE322BB7CB60032F675 /* ConstOpticsInstances.swift */,
 				8BA0F4C5217E2E9200969984 /* EitherOpticsInstances.swift */,
 				8BA0F4C3217E2E9200969984 /* NonEmptyArrayOpticsInstances.swift */,
 				8BA0F4C2217E2E9200969984 /* OptionOpticsInstances.swift */,
@@ -3091,6 +3094,7 @@
 				11E7171B219D722900B94845 /* Prism.swift in Sources */,
 				11E7171C219D722900B94845 /* Setter.swift in Sources */,
 				1126CA9C22B130B800F840CB /* Tuple6.swift in Sources */,
+				112D0CE422BB7CB60032F675 /* ConstOpticsInstances.swift in Sources */,
 				11E7171D219D722900B94845 /* Traversal.swift in Sources */,
 				11E7171E219D722900B94845 /* At+Optics.swift in Sources */,
 				11E7171F219D722900B94845 /* Each+Optics.swift in Sources */,

--- a/Bow.xcodeproj/project.pbxproj
+++ b/Bow.xcodeproj/project.pbxproj
@@ -129,6 +129,7 @@
 		112D0CE822BB7EE20032F675 /* IdOpticsInstances.swift in Sources */ = {isa = PBXBuildFile; fileRef = 112D0CE722BB7EE20032F675 /* IdOpticsInstances.swift */; };
 		112D0CEA22BB7F4D0032F675 /* IorOpticsInstances.swift in Sources */ = {isa = PBXBuildFile; fileRef = 112D0CE922BB7F4D0032F675 /* IorOpticsInstances.swift */; };
 		112D0CEC22BB7FE10032F675 /* ValidatedOpticsInstances.swift in Sources */ = {isa = PBXBuildFile; fileRef = 112D0CEB22BB7FE10032F675 /* ValidatedOpticsInstances.swift */; };
+		112D0CEE22BB85560032F675 /* Ior+Optics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 112D0CED22BB85560032F675 /* Ior+Optics.swift */; };
 		113CD8F4219DD82F00730E58 /* RxSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8BA0F367217E2CB100969984 /* RxSwift.framework */; };
 		1166A07A22119F720032CD4E /* EqualityFunctions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1166A07822119E640032CD4E /* EqualityFunctions.swift */; };
 		117DC0CD22AE492700EF65F0 /* Nimble.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8BA0F384217E2D3400969984 /* Nimble.framework */; };
@@ -797,6 +798,7 @@
 		112D0CE722BB7EE20032F675 /* IdOpticsInstances.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IdOpticsInstances.swift; sourceTree = "<group>"; };
 		112D0CE922BB7F4D0032F675 /* IorOpticsInstances.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IorOpticsInstances.swift; sourceTree = "<group>"; };
 		112D0CEB22BB7FE10032F675 /* ValidatedOpticsInstances.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ValidatedOpticsInstances.swift; sourceTree = "<group>"; };
+		112D0CED22BB85560032F675 /* Ior+Optics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Ior+Optics.swift"; sourceTree = "<group>"; };
 		1166A07822119E640032CD4E /* EqualityFunctions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EqualityFunctions.swift; sourceTree = "<group>"; };
 		117DC0D322AE492700EF65F0 /* BowEffectsGenerators.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = BowEffectsGenerators.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		117DC0D422AE492700EF65F0 /* Bow-Effects-Generators-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; name = "Bow-Effects-Generators-Info.plist"; path = "/Users/tomasruizlopez/Development/bow/Bow-Effects-Generators-Info.plist"; sourceTree = "<absolute>"; };
@@ -1881,8 +1883,9 @@
 				8BA0F4BB217E2E9200969984 /* ArrayK+Optics.swift */,
 				8BA0F4BD217E2E9200969984 /* Either+Optics.swift */,
 				8BA0F4B6217E2E9200969984 /* Id+Optics.swift */,
-				8BA0F4B8217E2E9200969984 /* Option+Optics.swift */,
+				112D0CED22BB85560032F675 /* Ior+Optics.swift */,
 				8BA0F4BC217E2E9200969984 /* NonEmptyArray+Optics.swift */,
+				8BA0F4B8217E2E9200969984 /* Option+Optics.swift */,
 				8BA0F4B9217E2E9200969984 /* String+Optics.swift */,
 				8BA0F4B7217E2E9200969984 /* Try+Optics.swift */,
 				8BA0F4BA217E2E9200969984 /* Validated+Optics.swift */,
@@ -3145,6 +3148,7 @@
 				1126CA8A22B1144200F840CB /* AutoOptics.swift in Sources */,
 				1126CA8C22B115E100F840CB /* AutoLens.swift in Sources */,
 				11E7172F219D722900B94845 /* Each.swift in Sources */,
+				112D0CEE22BB85560032F675 /* Ior+Optics.swift in Sources */,
 				11E71730219D722900B94845 /* FilterIndex.swift in Sources */,
 				11E71731219D722900B94845 /* Index.swift in Sources */,
 				1126CA9022B1262F00F840CB /* AutoPrism.swift in Sources */,

--- a/Bow.xcodeproj/project.pbxproj
+++ b/Bow.xcodeproj/project.pbxproj
@@ -123,6 +123,7 @@
 		1126CAA022B131DF00F840CB /* Tuple8.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1126CA9F22B131DF00F840CB /* Tuple8.swift */; };
 		1126CAA222B1324E00F840CB /* Tuple9.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1126CAA122B1324E00F840CB /* Tuple9.swift */; };
 		1126CAA422B132CA00F840CB /* Tuple10.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1126CAA322B132CA00F840CB /* Tuple10.swift */; };
+		112D0CE222BB6FA80032F675 /* ArrayOpticsInstances.swift in Sources */ = {isa = PBXBuildFile; fileRef = 112D0CE122BB6FA80032F675 /* ArrayOpticsInstances.swift */; };
 		113CD8F4219DD82F00730E58 /* RxSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8BA0F367217E2CB100969984 /* RxSwift.framework */; };
 		1166A07A22119F720032CD4E /* EqualityFunctions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1166A07822119E640032CD4E /* EqualityFunctions.swift */; };
 		117DC0CD22AE492700EF65F0 /* Nimble.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8BA0F384217E2D3400969984 /* Nimble.framework */; };
@@ -785,6 +786,7 @@
 		1126CA9F22B131DF00F840CB /* Tuple8.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Tuple8.swift; sourceTree = "<group>"; };
 		1126CAA122B1324E00F840CB /* Tuple9.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Tuple9.swift; sourceTree = "<group>"; };
 		1126CAA322B132CA00F840CB /* Tuple10.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Tuple10.swift; sourceTree = "<group>"; };
+		112D0CE122BB6FA80032F675 /* ArrayOpticsInstances.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArrayOpticsInstances.swift; sourceTree = "<group>"; };
 		1166A07822119E640032CD4E /* EqualityFunctions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EqualityFunctions.swift; sourceTree = "<group>"; };
 		117DC0D322AE492700EF65F0 /* BowEffectsGenerators.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = BowEffectsGenerators.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		117DC0D422AE492700EF65F0 /* Bow-Effects-Generators-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; name = "Bow-Effects-Generators-Info.plist"; path = "/Users/tomasruizlopez/Development/bow/Bow-Effects-Generators-Info.plist"; sourceTree = "<absolute>"; };
@@ -1882,9 +1884,10 @@
 			isa = PBXGroup;
 			children = (
 				8BA0F4C6217E2E9200969984 /* ArrayKOpticsInstances.swift */,
+				112D0CE122BB6FA80032F675 /* ArrayOpticsInstances.swift */,
 				8BA0F4C5217E2E9200969984 /* EitherOpticsInstances.swift */,
-				8BA0F4C2217E2E9200969984 /* OptionOpticsInstances.swift */,
 				8BA0F4C3217E2E9200969984 /* NonEmptyArrayOpticsInstances.swift */,
+				8BA0F4C2217E2E9200969984 /* OptionOpticsInstances.swift */,
 				8BA0F4C4217E2E9200969984 /* StringOpticsInstances.swift */,
 				8BA0F4C7217E2E9200969984 /* TryOpticsInstances.swift */,
 			);
@@ -3099,6 +3102,7 @@
 				11E71723219D722900B94845 /* NonEmptyArrayOpticsInstances.swift in Sources */,
 				1126CAA222B1324E00F840CB /* Tuple9.swift in Sources */,
 				11E71724219D722900B94845 /* StringOpticsInstances.swift in Sources */,
+				112D0CE222BB6FA80032F675 /* ArrayOpticsInstances.swift in Sources */,
 				11E71725219D722900B94845 /* TryOpticsInstances.swift in Sources */,
 				1186E15722BA8A77001F8A5D /* Cons.swift in Sources */,
 				11E71726219D722900B94845 /* Either+Optics.swift in Sources */,

--- a/Bow.xcodeproj/project.pbxproj
+++ b/Bow.xcodeproj/project.pbxproj
@@ -130,6 +130,7 @@
 		112D0CEA22BB7F4D0032F675 /* IorOpticsInstances.swift in Sources */ = {isa = PBXBuildFile; fileRef = 112D0CE922BB7F4D0032F675 /* IorOpticsInstances.swift */; };
 		112D0CEC22BB7FE10032F675 /* ValidatedOpticsInstances.swift in Sources */ = {isa = PBXBuildFile; fileRef = 112D0CEB22BB7FE10032F675 /* ValidatedOpticsInstances.swift */; };
 		112D0CEE22BB85560032F675 /* Ior+Optics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 112D0CED22BB85560032F675 /* Ior+Optics.swift */; };
+		112D0CF022BB88F20032F675 /* Result+Optics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 112D0CEF22BB88F20032F675 /* Result+Optics.swift */; };
 		113CD8F4219DD82F00730E58 /* RxSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8BA0F367217E2CB100969984 /* RxSwift.framework */; };
 		1166A07A22119F720032CD4E /* EqualityFunctions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1166A07822119E640032CD4E /* EqualityFunctions.swift */; };
 		117DC0CD22AE492700EF65F0 /* Nimble.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8BA0F384217E2D3400969984 /* Nimble.framework */; };
@@ -799,6 +800,7 @@
 		112D0CE922BB7F4D0032F675 /* IorOpticsInstances.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IorOpticsInstances.swift; sourceTree = "<group>"; };
 		112D0CEB22BB7FE10032F675 /* ValidatedOpticsInstances.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ValidatedOpticsInstances.swift; sourceTree = "<group>"; };
 		112D0CED22BB85560032F675 /* Ior+Optics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Ior+Optics.swift"; sourceTree = "<group>"; };
+		112D0CEF22BB88F20032F675 /* Result+Optics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Result+Optics.swift"; sourceTree = "<group>"; };
 		1166A07822119E640032CD4E /* EqualityFunctions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EqualityFunctions.swift; sourceTree = "<group>"; };
 		117DC0D322AE492700EF65F0 /* BowEffectsGenerators.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = BowEffectsGenerators.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		117DC0D422AE492700EF65F0 /* Bow-Effects-Generators-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; name = "Bow-Effects-Generators-Info.plist"; path = "/Users/tomasruizlopez/Development/bow/Bow-Effects-Generators-Info.plist"; sourceTree = "<absolute>"; };
@@ -1886,6 +1888,7 @@
 				112D0CED22BB85560032F675 /* Ior+Optics.swift */,
 				8BA0F4BC217E2E9200969984 /* NonEmptyArray+Optics.swift */,
 				8BA0F4B8217E2E9200969984 /* Option+Optics.swift */,
+				112D0CEF22BB88F20032F675 /* Result+Optics.swift */,
 				8BA0F4B9217E2E9200969984 /* String+Optics.swift */,
 				8BA0F4B7217E2E9200969984 /* Try+Optics.swift */,
 				8BA0F4BA217E2E9200969984 /* Validated+Optics.swift */,
@@ -3147,6 +3150,7 @@
 				11E7172E219D722900B94845 /* At.swift in Sources */,
 				1126CA8A22B1144200F840CB /* AutoOptics.swift in Sources */,
 				1126CA8C22B115E100F840CB /* AutoLens.swift in Sources */,
+				112D0CF022BB88F20032F675 /* Result+Optics.swift in Sources */,
 				11E7172F219D722900B94845 /* Each.swift in Sources */,
 				112D0CEE22BB85560032F675 /* Ior+Optics.swift in Sources */,
 				11E71730219D722900B94845 /* FilterIndex.swift in Sources */,

--- a/Bow.xcodeproj/project.pbxproj
+++ b/Bow.xcodeproj/project.pbxproj
@@ -140,6 +140,7 @@
 		117DC12A22AE563900EF65F0 /* SwiftCheck.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8BA0F385217E2D3400969984 /* SwiftCheck.framework */; };
 		117DC13722AE578A00EF65F0 /* Free+Gen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 117DC13622AE578A00EF65F0 /* Free+Gen.swift */; };
 		1186E15122BA395D001F8A5D /* Index+Optics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1186E14E22BA38CD001F8A5D /* Index+Optics.swift */; };
+		1186E15722BA8A77001F8A5D /* Cons.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1186E15622BA8A77001F8A5D /* Cons.swift */; };
 		11A435622212C60A000C5E31 /* EquatableLaws.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11A435602212C59F000C5E31 /* EquatableLaws.swift */; };
 		11A4356422131ACC000C5E31 /* BoolInstances.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11A4356322131ACC000C5E31 /* BoolInstances.swift */; };
 		11D36A19223261EC00CBD85F /* Selective.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11D36A18223261EC00CBD85F /* Selective.swift */; };
@@ -151,9 +152,9 @@
 		11DDCD21217F194B00844D9D /* MemoizationTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11DDCD20217F194B00844D9D /* MemoizationTest.swift */; };
 		11DDCD23217F1E2B00844D9D /* Reverse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11DDCD22217F1E2B00844D9D /* Reverse.swift */; };
 		11DDCD28217F1FC200844D9D /* ReverseTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11DDCD27217F1FC200844D9D /* ReverseTest.swift */; };
-		11E4191222B935AE009BDFB3 /* Kind+Optics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11E4191022B93596009BDFB3 /* Kind+Optics.swift */; };
 		11E4190B22B90FE2009BDFB3 /* AutoGetter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11E4190A22B90FE2009BDFB3 /* AutoGetter.swift */; };
 		11E4190F22B91169009BDFB3 /* AutoSetter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11E4190E22B91169009BDFB3 /* AutoSetter.swift */; };
+		11E4191222B935AE009BDFB3 /* Kind+Optics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11E4191022B93596009BDFB3 /* Kind+Optics.swift */; };
 		11E71715219D722900B94845 /* BoundSetter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BA0F4B2217E2E9200969984 /* BoundSetter.swift */; };
 		11E71716219D722900B94845 /* Fold.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BA0F4BE217E2E9200969984 /* Fold.swift */; };
 		11E71717219D722900B94845 /* Getter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BA0F4B3217E2E9200969984 /* Getter.swift */; };
@@ -799,6 +800,7 @@
 		117DC13022AE563900EF65F0 /* Bow-Free-Generators-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; name = "Bow-Free-Generators-Info.plist"; path = "/Users/tomasruizlopez/Development/bow/Bow-Free-Generators-Info.plist"; sourceTree = "<absolute>"; };
 		117DC13622AE578A00EF65F0 /* Free+Gen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Free+Gen.swift"; sourceTree = "<group>"; };
 		1186E14E22BA38CD001F8A5D /* Index+Optics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Index+Optics.swift"; sourceTree = "<group>"; };
+		1186E15622BA8A77001F8A5D /* Cons.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Cons.swift; sourceTree = "<group>"; };
 		11A435602212C59F000C5E31 /* EquatableLaws.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EquatableLaws.swift; sourceTree = "<group>"; };
 		11A4356322131ACC000C5E31 /* BoolInstances.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoolInstances.swift; sourceTree = "<group>"; };
 		11D36A18223261EC00CBD85F /* Selective.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Selective.swift; sourceTree = "<group>"; };
@@ -809,9 +811,9 @@
 		11DDCD20217F194B00844D9D /* MemoizationTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemoizationTest.swift; sourceTree = "<group>"; };
 		11DDCD22217F1E2B00844D9D /* Reverse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Reverse.swift; sourceTree = "<group>"; };
 		11DDCD27217F1FC200844D9D /* ReverseTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReverseTest.swift; sourceTree = "<group>"; };
-		11E4191022B93596009BDFB3 /* Kind+Optics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Kind+Optics.swift"; sourceTree = "<group>"; };
 		11E4190A22B90FE2009BDFB3 /* AutoGetter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoGetter.swift; sourceTree = "<group>"; };
 		11E4190E22B91169009BDFB3 /* AutoSetter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoSetter.swift; sourceTree = "<group>"; };
+		11E4191022B93596009BDFB3 /* Kind+Optics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Kind+Optics.swift"; sourceTree = "<group>"; };
 		11E71712219D704F00B94845 /* BowOptics.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = BowOptics.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		11E71713219D705000B94845 /* Bow-Optics-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; name = "Bow-Optics-Info.plist"; path = "/Users/tomasruizlopez/Development/bow/Support Files/Bow-Optics-Info.plist"; sourceTree = "<absolute>"; };
 		11E71802219D7D5900B94845 /* BowOpticsTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = BowOpticsTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -1891,6 +1893,7 @@
 			isa = PBXGroup;
 			children = (
 				8BA0F4CE217E2E9200969984 /* At.swift */,
+				1186E15622BA8A77001F8A5D /* Cons.swift */,
 				8BA0F4CB217E2E9200969984 /* Each.swift */,
 				8BA0F4CD217E2E9200969984 /* FilterIndex.swift */,
 				8BA0F4CC217E2E9200969984 /* Index.swift */,
@@ -3094,6 +3097,7 @@
 				1126CAA222B1324E00F840CB /* Tuple9.swift in Sources */,
 				11E71724219D722900B94845 /* StringOpticsInstances.swift in Sources */,
 				11E71725219D722900B94845 /* TryOpticsInstances.swift in Sources */,
+				1186E15722BA8A77001F8A5D /* Cons.swift in Sources */,
 				11E71726219D722900B94845 /* Either+Optics.swift in Sources */,
 				11E71727219D722900B94845 /* Id+Optics.swift in Sources */,
 				1186E15122BA395D001F8A5D /* Index+Optics.swift in Sources */,

--- a/Bow.xcodeproj/project.pbxproj
+++ b/Bow.xcodeproj/project.pbxproj
@@ -141,6 +141,7 @@
 		117DC13722AE578A00EF65F0 /* Free+Gen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 117DC13622AE578A00EF65F0 /* Free+Gen.swift */; };
 		1186E15122BA395D001F8A5D /* Index+Optics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1186E14E22BA38CD001F8A5D /* Index+Optics.swift */; };
 		1186E15722BA8A77001F8A5D /* Cons.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1186E15622BA8A77001F8A5D /* Cons.swift */; };
+		1186E15922BA8ECA001F8A5D /* Snoc.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1186E15822BA8ECA001F8A5D /* Snoc.swift */; };
 		11A435622212C60A000C5E31 /* EquatableLaws.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11A435602212C59F000C5E31 /* EquatableLaws.swift */; };
 		11A4356422131ACC000C5E31 /* BoolInstances.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11A4356322131ACC000C5E31 /* BoolInstances.swift */; };
 		11D36A19223261EC00CBD85F /* Selective.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11D36A18223261EC00CBD85F /* Selective.swift */; };
@@ -801,6 +802,7 @@
 		117DC13622AE578A00EF65F0 /* Free+Gen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Free+Gen.swift"; sourceTree = "<group>"; };
 		1186E14E22BA38CD001F8A5D /* Index+Optics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Index+Optics.swift"; sourceTree = "<group>"; };
 		1186E15622BA8A77001F8A5D /* Cons.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Cons.swift; sourceTree = "<group>"; };
+		1186E15822BA8ECA001F8A5D /* Snoc.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Snoc.swift; sourceTree = "<group>"; };
 		11A435602212C59F000C5E31 /* EquatableLaws.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EquatableLaws.swift; sourceTree = "<group>"; };
 		11A4356322131ACC000C5E31 /* BoolInstances.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoolInstances.swift; sourceTree = "<group>"; };
 		11D36A18223261EC00CBD85F /* Selective.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Selective.swift; sourceTree = "<group>"; };
@@ -1897,6 +1899,7 @@
 				8BA0F4CB217E2E9200969984 /* Each.swift */,
 				8BA0F4CD217E2E9200969984 /* FilterIndex.swift */,
 				8BA0F4CC217E2E9200969984 /* Index.swift */,
+				1186E15822BA8ECA001F8A5D /* Snoc.swift */,
 			);
 			path = Typeclasses;
 			sourceTree = "<group>";
@@ -3113,6 +3116,7 @@
 				11E4190F22B91169009BDFB3 /* AutoSetter.swift in Sources */,
 				11E7172D219D722900B94845 /* Validated+Optics.swift in Sources */,
 				11E4191222B935AE009BDFB3 /* Kind+Optics.swift in Sources */,
+				1186E15922BA8ECA001F8A5D /* Snoc.swift in Sources */,
 				11E7172E219D722900B94845 /* At.swift in Sources */,
 				1126CA8A22B1144200F840CB /* AutoOptics.swift in Sources */,
 				1126CA8C22B115E100F840CB /* AutoLens.swift in Sources */,

--- a/Bow.xcodeproj/project.pbxproj
+++ b/Bow.xcodeproj/project.pbxproj
@@ -126,6 +126,7 @@
 		112D0CE222BB6FA80032F675 /* ArrayOpticsInstances.swift in Sources */ = {isa = PBXBuildFile; fileRef = 112D0CE122BB6FA80032F675 /* ArrayOpticsInstances.swift */; };
 		112D0CE422BB7CB60032F675 /* ConstOpticsInstances.swift in Sources */ = {isa = PBXBuildFile; fileRef = 112D0CE322BB7CB60032F675 /* ConstOpticsInstances.swift */; };
 		112D0CE622BB7E260032F675 /* EitherKOpticsInstances.swift in Sources */ = {isa = PBXBuildFile; fileRef = 112D0CE522BB7E260032F675 /* EitherKOpticsInstances.swift */; };
+		112D0CE822BB7EE20032F675 /* IdOpticsInstances.swift in Sources */ = {isa = PBXBuildFile; fileRef = 112D0CE722BB7EE20032F675 /* IdOpticsInstances.swift */; };
 		113CD8F4219DD82F00730E58 /* RxSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8BA0F367217E2CB100969984 /* RxSwift.framework */; };
 		1166A07A22119F720032CD4E /* EqualityFunctions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1166A07822119E640032CD4E /* EqualityFunctions.swift */; };
 		117DC0CD22AE492700EF65F0 /* Nimble.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8BA0F384217E2D3400969984 /* Nimble.framework */; };
@@ -791,6 +792,7 @@
 		112D0CE122BB6FA80032F675 /* ArrayOpticsInstances.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArrayOpticsInstances.swift; sourceTree = "<group>"; };
 		112D0CE322BB7CB60032F675 /* ConstOpticsInstances.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConstOpticsInstances.swift; sourceTree = "<group>"; };
 		112D0CE522BB7E260032F675 /* EitherKOpticsInstances.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EitherKOpticsInstances.swift; sourceTree = "<group>"; };
+		112D0CE722BB7EE20032F675 /* IdOpticsInstances.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IdOpticsInstances.swift; sourceTree = "<group>"; };
 		1166A07822119E640032CD4E /* EqualityFunctions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EqualityFunctions.swift; sourceTree = "<group>"; };
 		117DC0D322AE492700EF65F0 /* BowEffectsGenerators.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = BowEffectsGenerators.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		117DC0D422AE492700EF65F0 /* Bow-Effects-Generators-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; name = "Bow-Effects-Generators-Info.plist"; path = "/Users/tomasruizlopez/Development/bow/Bow-Effects-Generators-Info.plist"; sourceTree = "<absolute>"; };
@@ -1892,6 +1894,7 @@
 				112D0CE322BB7CB60032F675 /* ConstOpticsInstances.swift */,
 				112D0CE522BB7E260032F675 /* EitherKOpticsInstances.swift */,
 				8BA0F4C5217E2E9200969984 /* EitherOpticsInstances.swift */,
+				112D0CE722BB7EE20032F675 /* IdOpticsInstances.swift */,
 				8BA0F4C3217E2E9200969984 /* NonEmptyArrayOpticsInstances.swift */,
 				8BA0F4C2217E2E9200969984 /* OptionOpticsInstances.swift */,
 				8BA0F4C4217E2E9200969984 /* StringOpticsInstances.swift */,
@@ -3110,6 +3113,7 @@
 				112D0CE622BB7E260032F675 /* EitherKOpticsInstances.swift in Sources */,
 				1126CAA222B1324E00F840CB /* Tuple9.swift in Sources */,
 				11E71724219D722900B94845 /* StringOpticsInstances.swift in Sources */,
+				112D0CE822BB7EE20032F675 /* IdOpticsInstances.swift in Sources */,
 				112D0CE222BB6FA80032F675 /* ArrayOpticsInstances.swift in Sources */,
 				11E71725219D722900B94845 /* TryOpticsInstances.swift in Sources */,
 				1186E15722BA8A77001F8A5D /* Cons.swift in Sources */,

--- a/Sources/Bow/Data/ArrayK.swift
+++ b/Sources/Bow/Data/ArrayK.swift
@@ -19,6 +19,26 @@ public final class ArrayK<A>: ArrayKOf<A> {
     public static func +(lhs: ArrayK<A>, rhs: ArrayK<A>) -> ArrayK<A> {
         return ArrayK(lhs.array + rhs.array)
     }
+    
+    /// Prepends an element to an array.
+    ///
+    /// - Parameters:
+    ///   - lhs: Element to prepend.
+    ///   - rhs: Array.
+    /// - Returns: An array containing the prepended element at the head and the other array as the tail.
+    public static func +(lhs: A, rhs: ArrayK<A>) -> ArrayK<A> {
+        return ArrayK(lhs) + rhs
+    }
+    
+    /// Appends an element to an array.
+    ///
+    /// - Parameters:
+    ///   - lhs: Array.
+    ///   - rhs: Element to append.
+    /// - Returns: An array containing all elements of the first array and the appended element as the last element.
+    public static func +(lhs: ArrayK<A>, rhs: A) -> ArrayK<A> {
+        return lhs + ArrayK(rhs)
+    }
 
     /// Safe downcast.
     ///
@@ -51,10 +71,16 @@ public final class ArrayK<A>: ArrayKOf<A> {
     ///
     /// - Returns: An optional value containing the first element of the array, if present.
     public func firstOrNone() -> Option<A> {
-        if let first = asArray.first { return Option.some(first) }
-        return Option.none()
+        return asArray.first.toOption()
     }
 
+    /// Obtains the last element of this array, or `Option.none` if it is empty.
+    ///
+    /// - Returns: An optional value containing the first element of the array, if present.
+    public func lastOrNone() -> Option<A> {
+        return asArray.last.toOption()
+    }
+    
     /// Obtains the element in the position passed as an argument, if any.
     ///
     /// - Parameter i: Index of the element to obtain.
@@ -72,6 +98,20 @@ public final class ArrayK<A>: ArrayKOf<A> {
     /// - Parameter index: Index of the element to obtain.
     public subscript(index: Int) -> Option<A> {
         return getOrNone(index)
+    }
+    
+    /// Drops the first element of this array.
+    ///
+    /// - Returns: A new array that contains all elements but the first.
+    public func dropFirst() -> ArrayK<A> {
+        return ArrayK(Array(asArray.dropFirst()))
+    }
+    
+    /// Drops the last element of this array.
+    ///
+    /// - Returns: A new array that contains all elements but the last.
+    public func dropLast() -> ArrayK<A> {
+        return ArrayK(Array(asArray.dropLast()))
     }
 }
 

--- a/Sources/BowOptics/Instances/ArrayKOpticsInstances.swift
+++ b/Sources/BowOptics/Instances/ArrayKOpticsInstances.swift
@@ -7,6 +7,10 @@ public extension ArrayK {
         return Iso(get: id, reverseGet: ArrayK.fix)
     }
     
+    static var fold: Fold<ArrayK<A>, A> {
+        return fixIso + foldK
+    }
+    
     static var traversal: Traversal<ArrayK<A>, A> {
         return fixIso + traversalK
     }

--- a/Sources/BowOptics/Instances/ArrayKOpticsInstances.swift
+++ b/Sources/BowOptics/Instances/ArrayKOpticsInstances.swift
@@ -45,6 +45,32 @@ extension ArrayK: FilterIndex {
     }
 }
 
+// MARK: Instance of `Cons` for `ArrayK`
+extension ArrayK: Cons {
+    public typealias First = A
+    
+    public static var cons: Prism<ArrayK<A>, (A, ArrayK<A>)> {
+        return Prism(
+            getOrModify: { array in array.firstOrNone().fold(
+                { .left(array) },
+                { head in .right((head, array.dropFirst())) }) },
+            reverseGet: { x in x.0 + x.1 })
+    }
+}
+
+// MARK: Instance of `Snoc` for `ArrayK`
+extension ArrayK: Snoc {
+    public typealias Last = A
+    
+    public static var snoc: Prism<ArrayK<A>, (ArrayK<A>, A)> {
+        return Prism(
+            getOrModify: { array in array.lastOrNone().fold(
+                { .left(array) },
+                { last in .right((array.dropLast(), last)) }) },
+            reverseGet: { x in x.0 + x.1 })
+    }
+}
+
 private class ArrayKFilterIndexTraversal<A>: Traversal<ArrayK<A>, A> {
     private let predicate: (Int) -> Bool
     

--- a/Sources/BowOptics/Instances/ArrayOpticsInstances.swift
+++ b/Sources/BowOptics/Instances/ArrayOpticsInstances.swift
@@ -1,0 +1,56 @@
+import Bow
+import Foundation
+
+// MARK: Optics extensions
+public extension Array {
+    static var traversal: Traversal<Array<Element>, Element> {
+        return Array.toArrayK + ArrayK<Element>.traversal
+    }
+}
+
+// MARK: Instance of `Each` for Array
+extension Array: Each {
+    public typealias EachFoci = Element
+    
+    public static var each: Traversal<Array<Element>, Element> {
+        return traversal
+    }
+}
+
+// MARK: Instance of `Index` for Array
+extension Array: Index {
+    public typealias IndexType = Int
+    public typealias IndexFoci = Element
+    
+    public static func index(_ i: Int) -> Optional<Array<Element>, Element> {
+        return ArrayK<Element>.index(i, iso: toArrayK)
+    }
+}
+
+// MARK: Instance of `FilterIndex` for Array
+extension Array: FilterIndex {
+    public typealias FilterIndexType = Int
+    public typealias FilterIndexFoci = Element
+    
+    public static func filter(_ predicate: @escaping (Int) -> Bool) -> Traversal<Array<Element>, Element> {
+        return ArrayK<Element>.filter(predicate, iso: toArrayK)
+    }
+}
+
+// MARK: Instance of `Cons` for Array
+extension Array: Cons {
+    public typealias First = Element
+    
+    public static var cons: Prism<Array<Element>, (Element, Array<Element>)> {
+        return ArrayK<Element>.cons(toArrayK)
+    }
+}
+
+// MARK: Instance of `Snoc` for Array
+extension Array: Snoc {
+    public typealias Last = Element
+    
+    public static var snoc: Prism<Array<Element>, (Array<Element>, Element)> {
+        return ArrayK<Element>.snoc(toArrayK)
+    }
+}

--- a/Sources/BowOptics/Instances/ArrayOpticsInstances.swift
+++ b/Sources/BowOptics/Instances/ArrayOpticsInstances.swift
@@ -3,8 +3,12 @@ import Foundation
 
 // MARK: Optics extensions
 public extension Array {
+    static var fold: Fold<Array<Element>, Element> {
+        return Array.toArrayK + ArrayK.fold
+    }
+    
     static var traversal: Traversal<Array<Element>, Element> {
-        return Array.toArrayK + ArrayK<Element>.traversal
+        return Array.toArrayK + ArrayK.traversal
     }
 }
 

--- a/Sources/BowOptics/Instances/ConstOpticsInstances.swift
+++ b/Sources/BowOptics/Instances/ConstOpticsInstances.swift
@@ -14,3 +14,12 @@ public extension Const {
         return fixIso + traversalK
     }
 }
+
+// MARK: Instance of `Each` for `Const`
+extension Const: Each {
+    public typealias EachFoci = T
+    
+    public static var each: Traversal<Const<A, T>, T> {
+        return traversal
+    }
+}

--- a/Sources/BowOptics/Instances/ConstOpticsInstances.swift
+++ b/Sources/BowOptics/Instances/ConstOpticsInstances.swift
@@ -6,6 +6,10 @@ public extension Const {
         return Iso(get: id, reverseGet: Const.fix)
     }
     
+    static var fold: Fold<Const<A, T>, T> {
+        return fixIso + foldK
+    }
+    
     static var traversal: Traversal<Const<A, T>, T> {
         return fixIso + traversalK
     }

--- a/Sources/BowOptics/Instances/ConstOpticsInstances.swift
+++ b/Sources/BowOptics/Instances/ConstOpticsInstances.swift
@@ -1,0 +1,12 @@
+import Bow
+
+// MARK: Optics extensions
+public extension Const {
+    static var fixIso: Iso<Const<A, T>, ConstOf<A, T>> {
+        return Iso(get: id, reverseGet: Const.fix)
+    }
+    
+    static var traversal: Traversal<Const<A, T>, T> {
+        return fixIso + traversalK
+    }
+}

--- a/Sources/BowOptics/Instances/EitherKOpticsInstances.swift
+++ b/Sources/BowOptics/Instances/EitherKOpticsInstances.swift
@@ -1,0 +1,14 @@
+import Bow
+
+// MARK: Optics extensions
+public extension EitherK {
+    static var fixIso: Iso<EitherK<F, G, A>, EitherKOf<F, G, A>> {
+        return Iso(get: id, reverseGet: EitherK.fix)
+    }
+}
+
+public extension EitherK where F: Traverse, G: Traverse {
+    static var traversal: Traversal<EitherK<F, G, A>, A> {
+        return fixIso + traversalK
+    }
+}

--- a/Sources/BowOptics/Instances/EitherKOpticsInstances.swift
+++ b/Sources/BowOptics/Instances/EitherKOpticsInstances.swift
@@ -7,6 +7,12 @@ public extension EitherK {
     }
 }
 
+public extension EitherK where F: Foldable, G: Foldable {
+    static var fold: Fold<EitherK<F, G, A>, A> {
+        return fixIso + foldK
+    }
+}
+
 public extension EitherK where F: Traverse, G: Traverse {
     static var traversal: Traversal<EitherK<F, G, A>, A> {
         return fixIso + traversalK

--- a/Sources/BowOptics/Instances/EitherKOpticsInstances.swift
+++ b/Sources/BowOptics/Instances/EitherKOpticsInstances.swift
@@ -18,3 +18,12 @@ public extension EitherK where F: Traverse, G: Traverse {
         return fixIso + traversalK
     }
 }
+
+// MARK: Instance of `Each` for `EitherK`
+extension EitherK: Each where F: Traverse, G: Traverse {
+    public typealias EachFoci = A
+    
+    public static var each: Traversal<EitherK<F, G, A>, A> {
+        return traversal
+    }
+}

--- a/Sources/BowOptics/Instances/EitherOpticsInstances.swift
+++ b/Sources/BowOptics/Instances/EitherOpticsInstances.swift
@@ -7,6 +7,10 @@ public extension Either {
         return Iso(get: id, reverseGet: Either.fix)
     }
     
+    static var fold: Fold<Either<A, B>, B> {
+        return fixIso + foldK
+    }
+    
     static var traversal: Traversal<Either<A, B>, B> {
         return fixIso + traversalK
     }

--- a/Sources/BowOptics/Instances/IdOpticsInstances.swift
+++ b/Sources/BowOptics/Instances/IdOpticsInstances.swift
@@ -6,6 +6,10 @@ public extension Id {
         return Iso(get: id, reverseGet: Id.fix)
     }
     
+    static var fold: Fold<Id<A>, A> {
+        return fixIso + foldK
+    }
+    
     static var traversal: Traversal<Id<A>, A> {
         return fixIso + traversalK
     }

--- a/Sources/BowOptics/Instances/IdOpticsInstances.swift
+++ b/Sources/BowOptics/Instances/IdOpticsInstances.swift
@@ -14,3 +14,12 @@ public extension Id {
         return fixIso + traversalK
     }
 }
+
+// MARK: Instance of `Each` for `Id`
+extension Id: Each {
+    public typealias EachFoci = A
+    
+    public static var each: Traversal<Id<A>, A> {
+        return traversal
+    }
+}

--- a/Sources/BowOptics/Instances/IdOpticsInstances.swift
+++ b/Sources/BowOptics/Instances/IdOpticsInstances.swift
@@ -1,0 +1,12 @@
+import Bow
+
+// MARK: Optics extensions
+public extension Id {
+    static var fixIso: Iso<Id<A>, IdOf<A>> {
+        return Iso(get: id, reverseGet: Id.fix)
+    }
+    
+    static var traversal: Traversal<Id<A>, A> {
+        return fixIso + traversalK
+    }
+}

--- a/Sources/BowOptics/Instances/IorOpticsInstances.swift
+++ b/Sources/BowOptics/Instances/IorOpticsInstances.swift
@@ -6,6 +6,10 @@ public extension Ior {
         return Iso(get: id, reverseGet: Ior.fix)
     }
     
+    static var fold: Fold<Ior<A, B>, B> {
+        return fixIso + foldK
+    }
+    
     static var traversal: Traversal<Ior<A, B>, B> {
         return fixIso + traversalK
     }

--- a/Sources/BowOptics/Instances/IorOpticsInstances.swift
+++ b/Sources/BowOptics/Instances/IorOpticsInstances.swift
@@ -1,0 +1,12 @@
+import Bow
+
+// MARK: Optics extensions
+public extension Ior {
+    static var fixIso: Iso<Ior<A, B>, IorOf<A, B>> {
+        return Iso(get: id, reverseGet: Ior.fix)
+    }
+    
+    static var traversal: Traversal<Ior<A, B>, B> {
+        return fixIso + traversalK
+    }
+}

--- a/Sources/BowOptics/Instances/IorOpticsInstances.swift
+++ b/Sources/BowOptics/Instances/IorOpticsInstances.swift
@@ -14,3 +14,12 @@ public extension Ior {
         return fixIso + traversalK
     }
 }
+
+// MARK: Instance of `Each` for `Ior`
+extension Ior: Each {
+    public typealias EachFoci = B
+    
+    public static var each: Traversal<Ior<A, B>, B> {
+        return traversal
+    }
+}

--- a/Sources/BowOptics/Instances/NonEmptyArrayOpticsInstances.swift
+++ b/Sources/BowOptics/Instances/NonEmptyArrayOpticsInstances.swift
@@ -7,7 +7,11 @@ public extension NonEmptyArray {
         return Iso(get: id, reverseGet: NEA.fix)
     }
     
-    static var traversal: Traversal<NonEmptyArray<A>, A> {
+    static var fold: Fold<NEA<A>, A> {
+        return fixIso + foldK
+    }
+    
+    static var traversal: Traversal<NEA<A>, A> {
         return fixIso + traversalK
     }
 }

--- a/Sources/BowOptics/Instances/OptionOpticsInstances.swift
+++ b/Sources/BowOptics/Instances/OptionOpticsInstances.swift
@@ -7,6 +7,10 @@ public extension Option {
         return Iso(get: id, reverseGet: Option.fix)
     }
     
+    static var fold: Fold<Option<A>, A> {
+        return fixIso + foldK
+    }
+    
     static var traversal: Traversal<Option<A>, A> {
         return fixIso + traversalK
     }

--- a/Sources/BowOptics/Instances/StringOpticsInstances.swift
+++ b/Sources/BowOptics/Instances/StringOpticsInstances.swift
@@ -17,6 +17,44 @@ extension String: Each {
     }
 }
 
+// MARK: Instance of `Index` for String
+extension String: Index {
+    public typealias IndexType = Int
+    public typealias IndexFoci = Character
+    
+    public static func index(_ i: Int) -> Optional<String, Character> {
+        return Array<Character>.index(i, iso: String.toArray)
+    }
+}
+
+// MARK: Instance of `FilterIndex` for String
+extension String: FilterIndex {
+    public typealias FilterIndexType = Int
+    public typealias FilterIndexFoci = Character
+    
+    public static func filter(_ predicate: @escaping (Int) -> Bool) -> Traversal<String, Character> {
+        return Array<Character>.filter(predicate, iso: String.toArray)
+    }
+}
+
+// MARK: Instance of `Cons` for String
+extension String: Cons {
+    public typealias First = Character
+    
+    public static var cons: Prism<String, (Character, String)> {
+        return Array<Character>.cons(String.toArray)
+    }
+}
+
+// MARK: Instace of `Snoc` for String
+extension String: Snoc {
+    public typealias Last = Character
+    
+    public static var snoc: Prism<String, (String, Character)> {
+        return Array<Character>.snoc(String.toArray)
+    }
+}
+
 private class StringTraversal: Traversal<String, Character> {
     override func modifyF<F: Applicative>(_ s: String, _ f: @escaping (Character) -> Kind<F, Character>) -> Kind<F, String> {
         return F.map(s.map(id).k().traverse(f), { x in

--- a/Sources/BowOptics/Instances/TryOpticsInstances.swift
+++ b/Sources/BowOptics/Instances/TryOpticsInstances.swift
@@ -7,6 +7,10 @@ public extension Try {
         return Iso(get: id, reverseGet: Try.fix)
     }
     
+    static var fold: Fold<Try<A>, A> {
+        return fixIso + foldK
+    }
+    
     static var traversal: Traversal<Try<A>, A> {
         return fixIso + traversalK
     }

--- a/Sources/BowOptics/Instances/ValidatedOpticsInstances.swift
+++ b/Sources/BowOptics/Instances/ValidatedOpticsInstances.swift
@@ -14,3 +14,12 @@ public extension Validated {
         return fixIso + traversalK
     }
 }
+
+// MARK: Instance of `Each` for `Validated`
+extension Validated: Each {
+    public typealias EachFoci = A
+    
+    public static var each: Traversal<Validated<E, A>, A> {
+        return traversal
+    }
+}

--- a/Sources/BowOptics/Instances/ValidatedOpticsInstances.swift
+++ b/Sources/BowOptics/Instances/ValidatedOpticsInstances.swift
@@ -1,0 +1,12 @@
+import Bow
+
+// MARK: Optics extensions
+public extension Validated {
+    static var fixIso: Iso<Validated<E, A>, ValidatedOf<E, A>> {
+        return Iso(get: id, reverseGet: Validated.fix)
+    }
+    
+    static var traversal: Traversal<Validated<E, A>, A> {
+        return fixIso + traversalK
+    }
+}

--- a/Sources/BowOptics/Instances/ValidatedOpticsInstances.swift
+++ b/Sources/BowOptics/Instances/ValidatedOpticsInstances.swift
@@ -6,6 +6,10 @@ public extension Validated {
         return Iso(get: id, reverseGet: Validated.fix)
     }
     
+    static var fold: Fold<Validated<E, A>, A> {
+        return fixIso + foldK
+    }
+    
     static var traversal: Traversal<Validated<E, A>, A> {
         return fixIso + traversalK
     }

--- a/Sources/BowOptics/STD/ArrayK+Optics.swift
+++ b/Sources/BowOptics/STD/ArrayK+Optics.swift
@@ -15,6 +15,14 @@ public extension ArrayK {
     static var toOptionNEA: Iso<ArrayK<A>, Option<NonEmptyArray<A>>> {
         return toPOptionNEA()
     }
+    
+    static var head: Optional<ArrayK<A>, A> {
+        return firstOption
+    }
+    
+    static var tail: Optional<ArrayK<A>, ArrayK<A>> {
+        return tailOption
+    }
 }
 
 public extension Array {

--- a/Sources/BowOptics/STD/ArrayK+Optics.swift
+++ b/Sources/BowOptics/STD/ArrayK+Optics.swift
@@ -27,4 +27,12 @@ public extension Array {
     static var toArrayK: Iso<Array<Element>, ArrayK<Element>> {
         return toPArrayK()
     }
+    
+    static var head: Optional<Array<Element>, Element> {
+        return firstOption
+    }
+    
+    static var tail: Optional<Array<Element>, Array<Element>> {
+        return tailOption
+    }
 }

--- a/Sources/BowOptics/STD/Either+Optics.swift
+++ b/Sources/BowOptics/STD/Either+Optics.swift
@@ -11,4 +11,20 @@ public extension Either {
     static var toValidated: Iso<Either<A, B>, Validated<A, B>> {
         return toPValidated()
     }
+    
+    static var leftPrism: Prism<Either<A, B>, A> {
+        return Prism(
+            getOrModify: { either in either.fold(
+                Either<Either<A, B>, A>.right,
+                { b in Either<Either<A, B>, A>.left(.right(b)) }) },
+            reverseGet: Either.left)
+    }
+    
+    static var rightPrism: Prism<Either<A, B>, B> {
+        return Prism(
+            getOrModify: { either in either.fold(
+                { a in Either<Either<A, B>, B>.left(.left(a)) },
+                Either<Either<A, B>, B>.right) },
+            reverseGet: Either.right)
+    }
 }

--- a/Sources/BowOptics/STD/Ior+Optics.swift
+++ b/Sources/BowOptics/STD/Ior+Optics.swift
@@ -1,0 +1,33 @@
+import Bow
+
+public extension Ior {
+    static var leftPrism: Prism<Ior<A, B>, A> {
+        return Prism(
+            getOrModify: { ior in ior.fold(
+                Either.right,
+                { b in Either.left(.right(b)) },
+                { a, b in Either.left(.both(a, b)) })
+            },
+            reverseGet: Ior.left)
+    }
+    
+    static var rightPrism: Prism<Ior<A, B>, B> {
+        return Prism(
+            getOrModify: { ior in ior.fold(
+                { a in Either.left(.left(a)) },
+                Either.right,
+                { a, b in Either.left(.both(a, b)) })
+            },
+            reverseGet: Ior.right)
+    }
+    
+    static var bothPrism: Prism<Ior<A, B>, (A, B)> {
+        return Prism(
+            getOrModify: { ior in ior.fold(
+                { a in Either.left(.left(a)) },
+                { b in Either.left(.right(b)) },
+                { a, b in Either.right((a, b)) })
+            },
+            reverseGet: { x in Ior.both(x.0, x.1) })
+    }
+}

--- a/Sources/BowOptics/STD/Result+Optics.swift
+++ b/Sources/BowOptics/STD/Result+Optics.swift
@@ -1,0 +1,26 @@
+import Foundation
+import Bow
+
+public extension Result {
+    static var successPrism: Prism<Result<Success, Failure>, Success> {
+        return Prism(
+            getOrModify: { result in
+                switch result {
+                case let .success(s): return Either.right(s)
+                case let .failure(e): return Either.left(.failure(e))
+                }
+            },
+            reverseGet: Result.success)
+    }
+    
+    static var failurePrism: Prism<Result<Success, Failure>, Failure> {
+        return Prism(
+            getOrModify: { result in
+                switch result {
+                case let .success(s): return Either.left(.success(s))
+                case let .failure(e): return Either.right(e)
+                }
+            },
+            reverseGet: Result.failure)
+    }
+}

--- a/Sources/BowOptics/STD/Validated+Optics.swift
+++ b/Sources/BowOptics/STD/Validated+Optics.swift
@@ -24,4 +24,24 @@ public extension Validated {
     static var toTry: Iso<Validated<Error, A>, Try<A>> {
         return toPTry()
     }
+    
+    static func pValidPrism<B>() -> PPrism<Validated<E, A>, Validated<E, B>, A, B> {
+        return PPrism(
+            getOrModify: { validated in validated.fold({ e in Either.left(Validated<E, B>.invalid(e)) }, Either.right) },
+            reverseGet: Validated<E, B>.valid)
+    }
+    
+    static var validPrism: Prism<Validated<E, A>, A> {
+        return pValidPrism()
+    }
+    
+    static func pInvalidPrism<EE>() -> PPrism<Validated<E, A>, Validated<EE, A>, E, EE> {
+        return PPrism(
+            getOrModify: { validated in validated.fold(Either.right, { a in Either.left(Validated<EE, A>.valid(a)) } ) },
+            reverseGet: Validated<EE, A>.invalid)
+    }
+    
+    static var invalidPrism: Prism<Validated<E, A>, E> {
+        return pInvalidPrism()
+    }
 }

--- a/Sources/BowOptics/Typeclasses/At.swift
+++ b/Sources/BowOptics/Typeclasses/At.swift
@@ -1,4 +1,3 @@
-import Foundation
 import Bow
 
 public protocol At {

--- a/Sources/BowOptics/Typeclasses/Cons.swift
+++ b/Sources/BowOptics/Typeclasses/Cons.swift
@@ -1,0 +1,33 @@
+import Bow
+
+public protocol Cons {
+    associatedtype First
+    
+    static var cons: Prism<Self, (First, Self)> { get }
+}
+
+public extension Cons {
+    static var firstOption: Optional<Self, First> {
+        return cons + Tuple2._0
+    }
+    
+    static var tailOption: Optional<Self, Self> {
+        return cons + Tuple2._1
+    }
+    
+    static func cons<B>(_ iso: Iso<B, Self>) -> Prism<B, (First, B)> {
+        return iso + cons + iso.reverse().second()
+    }
+    
+    static func cons<B>(_ iso: Iso<First, B>) -> Prism<Self, (B, Self)> {
+        return cons + iso.first()
+    }
+    
+    func prepend(_ a: First) -> Self {
+        return Self.cons.reverseGet((a, self))
+    }
+    
+    var uncons: Option<(First, Self)> {
+        return Self.cons.getOption(self)
+    }
+}

--- a/Sources/BowOptics/Typeclasses/Each.swift
+++ b/Sources/BowOptics/Typeclasses/Each.swift
@@ -1,6 +1,3 @@
-import Foundation
-import Bow
-
 public protocol Each {
     associatedtype EachFoci
 

--- a/Sources/BowOptics/Typeclasses/FilterIndex.swift
+++ b/Sources/BowOptics/Typeclasses/FilterIndex.swift
@@ -1,4 +1,3 @@
-import Foundation
 import Bow
 
 public protocol FilterIndex {

--- a/Sources/BowOptics/Typeclasses/Index.swift
+++ b/Sources/BowOptics/Typeclasses/Index.swift
@@ -1,6 +1,3 @@
-import Foundation
-import Bow
-
 public protocol Index {
     associatedtype IndexType
     associatedtype IndexFoci

--- a/Sources/BowOptics/Typeclasses/Snoc.swift
+++ b/Sources/BowOptics/Typeclasses/Snoc.swift
@@ -1,0 +1,37 @@
+import Bow
+
+public protocol Snoc {
+    associatedtype Last
+    
+    static var snoc: Prism<Self, (Self, Last)> { get }
+}
+
+public extension Snoc {
+    static var initialOption: Optional<Self, Self> {
+        return snoc + Tuple2._0
+    }
+    
+    static var lastOption: Optional<Self, Last> {
+        return snoc + Tuple2._1
+    }
+    
+    static func snoc<B>(_ iso: Iso<B, Self>) -> Prism<B, (B, Last)> {
+        return iso + snoc + iso.reverse().first()
+    }
+    
+    static func snoc<B>(_ iso: Iso<Last, B>) -> Prism<Self, (Self, B)> {
+        return snoc + iso.second()
+    }
+    
+    var initial: Option<Self> {
+        return Self.initialOption.getOption(self)
+    }
+    
+    func append(_ a: Last) -> Self {
+        return Self.snoc.reverseGet((self, a))
+    }
+    
+    var unsnoc: Option<(Self, Last)> {
+        return Self.snoc.getOption(self)
+    }
+}


### PR DESCRIPTION
## Related issues

- Closes #311 
- Closes #306
- Closes #309

## Goal

Adds several missing instances for optics type classes for some of the core types. In addition, this PR adds traversals and folds to types in the core package that support `Traverse` and `Foldable`. Finally, prisms to access each case in `Either`,`Ior`, `Validated` and `Result` have been added.
