### PR TITLE
Add API reference for optics instances

### DIFF
--- a/Sources/BowOptics/Instances/ArrayKOpticsInstances.swift
+++ b/Sources/BowOptics/Instances/ArrayKOpticsInstances.swift
@@ -8,6 +8,7 @@ public extension ArrayK {
         return Iso(get: id, reverseGet: ArrayK.fix)
     }
     
+    /// Provides a Fold based on the Foldable instance of this type.
     static var fold: Fold<ArrayK<A>, A> {
         return fixIso + foldK
     }

--- a/Sources/BowOptics/Instances/ArrayKOpticsInstances.swift
+++ b/Sources/BowOptics/Instances/ArrayKOpticsInstances.swift
@@ -3,6 +3,7 @@ import Bow
 
 // MARK: Optics extensions
 public extension ArrayK {
+    /// Provides an Iso to go from/to this type to its `Kind` version.
     static var fixIso: Iso<ArrayK<A>, ArrayKOf<A>> {
         return Iso(get: id, reverseGet: ArrayK.fix)
     }

--- a/Sources/BowOptics/Instances/ArrayKOpticsInstances.swift
+++ b/Sources/BowOptics/Instances/ArrayKOpticsInstances.swift
@@ -13,6 +13,7 @@ public extension ArrayK {
         return fixIso + foldK
     }
     
+    /// Provides a Traversal based on the Traverse instance of this type.
     static var traversal: Traversal<ArrayK<A>, A> {
         return fixIso + traversalK
     }

--- a/Sources/BowOptics/Instances/ArrayOpticsInstances.swift
+++ b/Sources/BowOptics/Instances/ArrayOpticsInstances.swift
@@ -3,6 +3,7 @@ import Foundation
 
 // MARK: Optics extensions
 public extension Array {
+    /// Provides a Fold based on the Foldable instance of this type.
     static var fold: Fold<Array<Element>, Element> {
         return Array.toArrayK + ArrayK.fold
     }

--- a/Sources/BowOptics/Instances/ArrayOpticsInstances.swift
+++ b/Sources/BowOptics/Instances/ArrayOpticsInstances.swift
@@ -8,6 +8,7 @@ public extension Array {
         return Array.toArrayK + ArrayK.fold
     }
     
+    /// Provides a Traversal based on the Traverse instance of this type.
     static var traversal: Traversal<Array<Element>, Element> {
         return Array.toArrayK + ArrayK.traversal
     }

--- a/Sources/BowOptics/Instances/ConstOpticsInstances.swift
+++ b/Sources/BowOptics/Instances/ConstOpticsInstances.swift
@@ -12,6 +12,7 @@ public extension Const {
         return fixIso + foldK
     }
     
+    /// Provides a Traversal based on the Traverse instance of this type.
     static var traversal: Traversal<Const<A, T>, T> {
         return fixIso + traversalK
     }

--- a/Sources/BowOptics/Instances/ConstOpticsInstances.swift
+++ b/Sources/BowOptics/Instances/ConstOpticsInstances.swift
@@ -2,6 +2,7 @@ import Bow
 
 // MARK: Optics extensions
 public extension Const {
+    /// Provides an Iso to go from/to this type to its `Kind` version.
     static var fixIso: Iso<Const<A, T>, ConstOf<A, T>> {
         return Iso(get: id, reverseGet: Const.fix)
     }

--- a/Sources/BowOptics/Instances/ConstOpticsInstances.swift
+++ b/Sources/BowOptics/Instances/ConstOpticsInstances.swift
@@ -7,6 +7,7 @@ public extension Const {
         return Iso(get: id, reverseGet: Const.fix)
     }
     
+    /// Provides a Fold based on the Foldable instance of this type.
     static var fold: Fold<Const<A, T>, T> {
         return fixIso + foldK
     }

--- a/Sources/BowOptics/Instances/EitherKOpticsInstances.swift
+++ b/Sources/BowOptics/Instances/EitherKOpticsInstances.swift
@@ -2,6 +2,7 @@ import Bow
 
 // MARK: Optics extensions
 public extension EitherK {
+    /// Provides an Iso to go from/to this type to its `Kind` version.
     static var fixIso: Iso<EitherK<F, G, A>, EitherKOf<F, G, A>> {
         return Iso(get: id, reverseGet: EitherK.fix)
     }

--- a/Sources/BowOptics/Instances/EitherKOpticsInstances.swift
+++ b/Sources/BowOptics/Instances/EitherKOpticsInstances.swift
@@ -16,6 +16,7 @@ public extension EitherK where F: Foldable, G: Foldable {
 }
 
 public extension EitherK where F: Traverse, G: Traverse {
+    /// Provides a Traversal based on the Traverse instance of this type.
     static var traversal: Traversal<EitherK<F, G, A>, A> {
         return fixIso + traversalK
     }

--- a/Sources/BowOptics/Instances/EitherKOpticsInstances.swift
+++ b/Sources/BowOptics/Instances/EitherKOpticsInstances.swift
@@ -9,6 +9,7 @@ public extension EitherK {
 }
 
 public extension EitherK where F: Foldable, G: Foldable {
+    /// Provides a Fold based on the Foldable instance of this type.
     static var fold: Fold<EitherK<F, G, A>, A> {
         return fixIso + foldK
     }

--- a/Sources/BowOptics/Instances/EitherOpticsInstances.swift
+++ b/Sources/BowOptics/Instances/EitherOpticsInstances.swift
@@ -8,6 +8,7 @@ public extension Either {
         return Iso(get: id, reverseGet: Either.fix)
     }
     
+    /// Provides a Fold based on the Foldable instance of this type.
     static var fold: Fold<Either<A, B>, B> {
         return fixIso + foldK
     }

--- a/Sources/BowOptics/Instances/EitherOpticsInstances.swift
+++ b/Sources/BowOptics/Instances/EitherOpticsInstances.swift
@@ -13,6 +13,7 @@ public extension Either {
         return fixIso + foldK
     }
     
+    /// Provides a Traversal based on the Traverse instance of this type.
     static var traversal: Traversal<Either<A, B>, B> {
         return fixIso + traversalK
     }

--- a/Sources/BowOptics/Instances/EitherOpticsInstances.swift
+++ b/Sources/BowOptics/Instances/EitherOpticsInstances.swift
@@ -3,6 +3,7 @@ import Bow
 
 // MARK: Optics extensions
 public extension Either {
+    /// Provides an Iso to go from/to this type to its `Kind` version.
     static var fixIso: Iso<Either<A, B>, EitherOf<A, B>> {
         return Iso(get: id, reverseGet: Either.fix)
     }

--- a/Sources/BowOptics/Instances/IdOpticsInstances.swift
+++ b/Sources/BowOptics/Instances/IdOpticsInstances.swift
@@ -7,6 +7,7 @@ public extension Id {
         return Iso(get: id, reverseGet: Id.fix)
     }
     
+    /// Provides a Fold based on the Foldable instance of this type.
     static var fold: Fold<Id<A>, A> {
         return fixIso + foldK
     }

--- a/Sources/BowOptics/Instances/IdOpticsInstances.swift
+++ b/Sources/BowOptics/Instances/IdOpticsInstances.swift
@@ -2,6 +2,7 @@ import Bow
 
 // MARK: Optics extensions
 public extension Id {
+    /// Provides an Iso to go from/to this type to its `Kind` version.
     static var fixIso: Iso<Id<A>, IdOf<A>> {
         return Iso(get: id, reverseGet: Id.fix)
     }

--- a/Sources/BowOptics/Instances/IdOpticsInstances.swift
+++ b/Sources/BowOptics/Instances/IdOpticsInstances.swift
@@ -12,6 +12,7 @@ public extension Id {
         return fixIso + foldK
     }
     
+    /// Provides a Traversal based on the Traverse instance of this type.
     static var traversal: Traversal<Id<A>, A> {
         return fixIso + traversalK
     }

--- a/Sources/BowOptics/Instances/IorOpticsInstances.swift
+++ b/Sources/BowOptics/Instances/IorOpticsInstances.swift
@@ -2,6 +2,7 @@ import Bow
 
 // MARK: Optics extensions
 public extension Ior {
+    /// Provides an Iso to go from/to this type to its `Kind` version.
     static var fixIso: Iso<Ior<A, B>, IorOf<A, B>> {
         return Iso(get: id, reverseGet: Ior.fix)
     }

--- a/Sources/BowOptics/Instances/IorOpticsInstances.swift
+++ b/Sources/BowOptics/Instances/IorOpticsInstances.swift
@@ -12,6 +12,7 @@ public extension Ior {
         return fixIso + foldK
     }
     
+    /// Provides a Traversal based on the Traverse instance of this type.
     static var traversal: Traversal<Ior<A, B>, B> {
         return fixIso + traversalK
     }

--- a/Sources/BowOptics/Instances/IorOpticsInstances.swift
+++ b/Sources/BowOptics/Instances/IorOpticsInstances.swift
@@ -7,6 +7,7 @@ public extension Ior {
         return Iso(get: id, reverseGet: Ior.fix)
     }
     
+    /// Provides a Fold based on the Foldable instance of this type.
     static var fold: Fold<Ior<A, B>, B> {
         return fixIso + foldK
     }

--- a/Sources/BowOptics/Instances/NonEmptyArrayOpticsInstances.swift
+++ b/Sources/BowOptics/Instances/NonEmptyArrayOpticsInstances.swift
@@ -13,6 +13,7 @@ public extension NonEmptyArray {
         return fixIso + foldK
     }
     
+    /// Provides a Traversal based on the Traverse instance of this type.
     static var traversal: Traversal<NEA<A>, A> {
         return fixIso + traversalK
     }

--- a/Sources/BowOptics/Instances/NonEmptyArrayOpticsInstances.swift
+++ b/Sources/BowOptics/Instances/NonEmptyArrayOpticsInstances.swift
@@ -8,6 +8,7 @@ public extension NonEmptyArray {
         return Iso(get: id, reverseGet: NEA.fix)
     }
     
+    /// Provides a Fold based on the Foldable instance of this type.
     static var fold: Fold<NEA<A>, A> {
         return fixIso + foldK
     }

--- a/Sources/BowOptics/Instances/NonEmptyArrayOpticsInstances.swift
+++ b/Sources/BowOptics/Instances/NonEmptyArrayOpticsInstances.swift
@@ -3,6 +3,7 @@ import Bow
 
 // MARK: Optics extensions
 public extension NonEmptyArray {
+    /// Provides an Iso to go from/to this type to its `Kind` version.
     static var fixIso: Iso<NEA<A>, NonEmptyArrayOf<A>> {
         return Iso(get: id, reverseGet: NEA.fix)
     }

--- a/Sources/BowOptics/Instances/OptionOpticsInstances.swift
+++ b/Sources/BowOptics/Instances/OptionOpticsInstances.swift
@@ -13,6 +13,7 @@ public extension Option {
         return fixIso + foldK
     }
     
+    /// Provides a Traversal based on the Traverse instance of this type.
     static var traversal: Traversal<Option<A>, A> {
         return fixIso + traversalK
     }

--- a/Sources/BowOptics/Instances/OptionOpticsInstances.swift
+++ b/Sources/BowOptics/Instances/OptionOpticsInstances.swift
@@ -8,6 +8,7 @@ public extension Option {
         return Iso(get: id, reverseGet: Option.fix)
     }
     
+    /// Provides a Fold based on the Foldable instance of this type.
     static var fold: Fold<Option<A>, A> {
         return fixIso + foldK
     }

--- a/Sources/BowOptics/Instances/OptionOpticsInstances.swift
+++ b/Sources/BowOptics/Instances/OptionOpticsInstances.swift
@@ -3,6 +3,7 @@ import Bow
 
 // MARK: Optics extensions
 public extension Option {
+    /// Provides an Iso to go from/to this type to its `Kind` version.
     static var fixIso: Iso<Option<A>, OptionOf<A>> {
         return Iso(get: id, reverseGet: Option.fix)
     }

--- a/Sources/BowOptics/Instances/StringOpticsInstances.swift
+++ b/Sources/BowOptics/Instances/StringOpticsInstances.swift
@@ -3,7 +3,7 @@ import Bow
 
 // MARK: Optics extensions
 public extension String {
-    /// Provides an Iso to go from/to this type to its `Kind` version.
+    /// Provides a Traversal based on the Traverse instance of this type.
     static var traversal: Traversal<String, Character> {
         return StringTraversal()
     }

--- a/Sources/BowOptics/Instances/StringOpticsInstances.swift
+++ b/Sources/BowOptics/Instances/StringOpticsInstances.swift
@@ -3,6 +3,7 @@ import Bow
 
 // MARK: Optics extensions
 public extension String {
+    /// Provides an Iso to go from/to this type to its `Kind` version.
     static var traversal: Traversal<String, Character> {
         return StringTraversal()
     }

--- a/Sources/BowOptics/Instances/TryOpticsInstances.swift
+++ b/Sources/BowOptics/Instances/TryOpticsInstances.swift
@@ -13,6 +13,7 @@ public extension Try {
         return fixIso + foldK
     }
     
+    /// Provides a Traversal based on the Traverse instance of this type.
     static var traversal: Traversal<Try<A>, A> {
         return fixIso + traversalK
     }

--- a/Sources/BowOptics/Instances/TryOpticsInstances.swift
+++ b/Sources/BowOptics/Instances/TryOpticsInstances.swift
@@ -3,6 +3,7 @@ import Bow
 
 // MARK: Optics extensions
 public extension Try {
+    /// Provides an Iso to go from/to this type to its `Kind` version.
     static var fixIso: Iso<Try<A>, TryOf<A>> {
         return Iso(get: id, reverseGet: Try.fix)
     }

--- a/Sources/BowOptics/Instances/TryOpticsInstances.swift
+++ b/Sources/BowOptics/Instances/TryOpticsInstances.swift
@@ -8,6 +8,7 @@ public extension Try {
         return Iso(get: id, reverseGet: Try.fix)
     }
     
+    /// Provides a Fold based on the Foldable instance of this type.
     static var fold: Fold<Try<A>, A> {
         return fixIso + foldK
     }

--- a/Sources/BowOptics/Instances/ValidatedOpticsInstances.swift
+++ b/Sources/BowOptics/Instances/ValidatedOpticsInstances.swift
@@ -7,6 +7,7 @@ public extension Validated {
         return Iso(get: id, reverseGet: Validated.fix)
     }
     
+    /// Provides a Fold based on the Foldable instance of this type.
     static var fold: Fold<Validated<E, A>, A> {
         return fixIso + foldK
     }

--- a/Sources/BowOptics/Instances/ValidatedOpticsInstances.swift
+++ b/Sources/BowOptics/Instances/ValidatedOpticsInstances.swift
@@ -12,6 +12,7 @@ public extension Validated {
         return fixIso + foldK
     }
     
+    /// Provides a Traversal based on the Traverse instance of this type.
     static var traversal: Traversal<Validated<E, A>, A> {
         return fixIso + traversalK
     }

--- a/Sources/BowOptics/Instances/ValidatedOpticsInstances.swift
+++ b/Sources/BowOptics/Instances/ValidatedOpticsInstances.swift
@@ -2,6 +2,7 @@ import Bow
 
 // MARK: Optics extensions
 public extension Validated {
+    /// Provides an Iso to go from/to this type to its `Kind` version.
     static var fixIso: Iso<Validated<E, A>, ValidatedOf<E, A>> {
         return Iso(get: id, reverseGet: Validated.fix)
     }


### PR DESCRIPTION
## Related issues

- Closes #360 

## Goal

Add API reference for the instances and default optics for some types in the core module.