### PR TITLE
Add API reference for utility optics for core data types

### DIFF
--- a/Sources/BowOptics/STD/ArrayK+Optics.swift
+++ b/Sources/BowOptics/STD/ArrayK+Optics.swift
@@ -1,7 +1,11 @@
 import Foundation
 import Bow
 
+// MARK: Optics extensions
 public extension ArrayK {
+    /// Provides a polymorphic Iso between ArrayK and Option of NonEmptyArray.
+    ///
+    /// - Returns: A polymorphic Iso between ArrayK and Option of NonEmptyArray.
     static func toPOptionNEA<B>() -> PIso<ArrayK<A>, ArrayK<B>, Option<NonEmptyArray<A>>, Option<NonEmptyArray<B>>> {
         return PIso<ArrayK<A>, ArrayK<B>, Option<NonEmptyArray<A>>, Option<NonEmptyArray<B>>>(
             get: { nea in nea.isEmpty ?
@@ -12,34 +16,44 @@ public extension ArrayK {
         })
     }
 
+    /// Provides an Iso between ArrayK and Option of NonEmptyArray
     static var toOptionNEA: Iso<ArrayK<A>, Option<NonEmptyArray<A>>> {
         return toPOptionNEA()
     }
     
+    /// Provides an optional to retreieve the first element of an ArrayK
     static var head: Optional<ArrayK<A>, A> {
         return firstOption
     }
     
+    /// Provides an optional to retrieve the tail of an ArrayK
     static var tail: Optional<ArrayK<A>, ArrayK<A>> {
         return tailOption
     }
 }
 
+// MARK: Optics extensions
 public extension Array {
+    /// Provides a polymorphic Iso between Array and ArrayK
+    ///
+    /// - Returns: A polymorphic Iso between Array and ArrayK
     static func toPArrayK<B>() -> PIso<Array<Element>, Array<B>, ArrayK<Element>, ArrayK<B>> {
         return PIso<Array<Element>, Array<B>, ArrayK<Element>, ArrayK<B>>(
             get: ArrayK<Element>.init,
             reverseGet: { arrayK in arrayK.asArray })
     }
 
+    /// Provides an Iso between Array and ArrayK
     static var toArrayK: Iso<Array<Element>, ArrayK<Element>> {
         return toPArrayK()
     }
     
+    /// Provides an Optional to retrieve the first element of an Array
     static var head: Optional<Array<Element>, Element> {
         return firstOption
     }
     
+    /// Provides an Optional to retrieve the tail of an Array.
     static var tail: Optional<Array<Element>, Array<Element>> {
         return tailOption
     }

--- a/Sources/BowOptics/STD/Either+Optics.swift
+++ b/Sources/BowOptics/STD/Either+Optics.swift
@@ -1,17 +1,23 @@
 import Foundation
 import Bow
 
+// MARK: Optics extensions
 public extension Either {
+    /// Provides a polymorphic Iso between Either and Validated.
+    ///
+    /// - Returns: A polymorphic Iso between Either and Validated.
     static func toPValidated<C, D>() -> PIso<Either<A, B>, Either<C, D>, Validated<A, B>, Validated<C, D>> {
         return PIso<Either<A, B>, Either<C, D>, Validated<A, B>, Validated<C, D>>(
             get: { either in either.fold(Validated<A, B>.invalid, Validated<A, B>.valid) },
             reverseGet: { x in x.toEither() })
     }
 
+    /// Provides an Iso between Either and Validated.
     static var toValidated: Iso<Either<A, B>, Validated<A, B>> {
         return toPValidated()
     }
     
+    /// Provides a Prism focused on the left side of an Either.
     static var leftPrism: Prism<Either<A, B>, A> {
         return Prism(
             getOrModify: { either in either.fold(
@@ -20,6 +26,7 @@ public extension Either {
             reverseGet: Either.left)
     }
     
+    /// Provides a Prism focused on the right side of an Either.
     static var rightPrism: Prism<Either<A, B>, B> {
         return Prism(
             getOrModify: { either in either.fold(

--- a/Sources/BowOptics/STD/Id+Optics.swift
+++ b/Sources/BowOptics/STD/Id+Optics.swift
@@ -1,13 +1,18 @@
 import Foundation
 import Bow
 
+// MARK: Optics extensions
 public extension Id {
+    /// Provides a polymorphic Iso between Id and a raw type.
+    ///
+    /// - Returns: A polymorphic Iso between Id and a raw type.
     static func toPValue<B>() -> PIso<Id<A>, Id<B>, A, B> {
         return PIso<Id<A>, Id<B>, A, B>(
             get: { x in x.value },
             reverseGet: Id<B>.init)
     }
 
+    /// Provides an Iso bewteen Id and its wrapped type.
     static var toValue: Iso<Id<A>, A> {
         return toPValue()
     }

--- a/Sources/BowOptics/STD/Ior+Optics.swift
+++ b/Sources/BowOptics/STD/Ior+Optics.swift
@@ -1,6 +1,8 @@
 import Bow
 
+// MARK: Optics extensions
 public extension Ior {
+    /// Provides a prism focused on the left side of this Ior.
     static var leftPrism: Prism<Ior<A, B>, A> {
         return Prism(
             getOrModify: { ior in ior.fold(
@@ -11,6 +13,7 @@ public extension Ior {
             reverseGet: Ior.left)
     }
     
+    /// Provides a prism focused on the right side of this Ior.
     static var rightPrism: Prism<Ior<A, B>, B> {
         return Prism(
             getOrModify: { ior in ior.fold(
@@ -21,6 +24,7 @@ public extension Ior {
             reverseGet: Ior.right)
     }
     
+    /// Provides a prism focused on the both side of this Ior.
     static var bothPrism: Prism<Ior<A, B>, (A, B)> {
         return Prism(
             getOrModify: { ior in ior.fold(

--- a/Sources/BowOptics/STD/NonEmptyArray+Optics.swift
+++ b/Sources/BowOptics/STD/NonEmptyArray+Optics.swift
@@ -1,13 +1,16 @@
 import Foundation
 import Bow
 
+// MARK: Optics extensions
 public extension NonEmptyArray {
+    /// Provides a lens between a NonEmptyArray and its head.
     static var headLens: Lens<NonEmptyArray<A>, A> {
         return Lens<NonEmptyArray<A>, A>(
             get: { x in x.head },
             set: { (nea, newHead) in NonEmptyArray(head: newHead, tail: nea.tail) })
     }
 
+    /// Provides a lens between a NonEmptyArray and its tail.
     static var tailLens: Lens<NonEmptyArray<A>, [A]> {
         return Lens<NonEmptyArray<A>, [A]>(
             get: { x in x.tail },

--- a/Sources/BowOptics/STD/Option+Optics.swift
+++ b/Sources/BowOptics/STD/Option+Optics.swift
@@ -1,18 +1,26 @@
 import Foundation
 import Bow
 
+// MARK: Optics extensions
 public extension Option {
+    /// Provides a polymorphic Iso between Option and Swift Optional.
+    ///
+    /// - Returns: A polymorphic Iso between Option and Swift Optional.
     static func toPOption<B>() -> PIso<Option<A>, Option<B>, A?, B?> {
         return PIso<Option<A>, Option<B>, A?, B?>(
             get: { x in x.toOptional() },
             reverseGet: Option<B>.fromOptional)
     }
 
+    /// Provides an Iso between Option and Swift Optional.
     static var toOption: Iso<Option<A>, A?> {
         return toPOption()
     }
 
-    static func PSomePrism<B>() -> PPrism<Option<A>, Option<B>, A, B> {
+    /// Provides a polymorphic prism focused on the some side of an Option.
+    ///
+    /// - Returns: A polymorphic prism focused on the some side of an Option.
+    static func pSomePrism<B>() -> PPrism<Option<A>, Option<B>, A, B> {
         return PPrism<Option<A>, Option<B>, A, B>(
             getOrModify: { option in
                 option.fold({ Either<Option<B>, A>.left(Option<B>.none()) },
@@ -21,10 +29,12 @@ public extension Option {
             reverseGet: Option<B>.some)
     }
 
+    /// Provides a prism focused on the some side of an Option.
     static var somePrism: Prism<Option<A>, A> {
-        return PSomePrism()
+        return pSomePrism()
     }
 
+    /// Provides a prism focused on the none side of an Option.
     static var nonePrism: Prism<Option<A>, ()> {
         return Prism<Option<A>, ()>(
             getOrModify: { option in
@@ -34,6 +44,9 @@ public extension Option {
             reverseGet: { Option<A>.none() })
     }
 
+    /// Provides a polymorphic Iso between Option and Either.
+    ///
+    /// - Returns: A polymorphic Iso between Option and Either.
     static func toPEither<B>() -> PIso<Option<A>, Option<B>, Either<(), A>, Either<(), B>> {
         return PIso<Option<A>, Option<B>, Either<(), A>, Either<(), B>>(
             get: { option in option.fold({ Either.left(unit) },
@@ -42,6 +55,7 @@ public extension Option {
                                                 { b in Option<B>.some(b) })})
     }
 
+    /// Provides a polymorphic Iso between Option and Either.
     static var toEither: Iso<Option<A>, Either<(), A>> {
         return toPEither()
     }

--- a/Sources/BowOptics/STD/Result+Optics.swift
+++ b/Sources/BowOptics/STD/Result+Optics.swift
@@ -1,7 +1,9 @@
 import Foundation
 import Bow
 
+// MARK: Optics extensions
 public extension Result {
+    /// Provides a prism focused on the success side of a Result.
     static var successPrism: Prism<Result<Success, Failure>, Success> {
         return Prism(
             getOrModify: { result in
@@ -13,6 +15,7 @@ public extension Result {
             reverseGet: Result.success)
     }
     
+    /// Provides a prism focused on the failure side of a Result.
     static var failurePrism: Prism<Result<Success, Failure>, Failure> {
         return Prism(
             getOrModify: { result in
@@ -22,5 +25,17 @@ public extension Result {
                 }
             },
             reverseGet: Result.failure)
+    }
+    
+    /// Provides an Iso between Result and Either.
+    static var toEither: Iso<Result<Success, Failure>, Either<Failure, Success>> {
+        return Iso(get: { x in x.toEither() },
+                   reverseGet: { x in x.toResult() })
+    }
+    
+    /// Provides an Iso between Result and Validated.
+    static var toValidated: Iso<Result<Success, Failure>, Validated<Failure, Success>> {
+        return Iso(get: { x in x.toValidated() },
+                   reverseGet: { x in x.toResult() })
     }
 }

--- a/Sources/BowOptics/STD/String+Optics.swift
+++ b/Sources/BowOptics/STD/String+Optics.swift
@@ -1,13 +1,16 @@
 import Foundation
 import Bow
 
+// MARK: Optics extensions
 public extension String {
+    /// Provides an Iso between String and Array of Character.
     static var toArray: Iso<String, [Character]> {
         return Iso<String, [Character]>(
             get: { str in str.map(id) },
             reverseGet: { characters in String(characters) })
     }
 
+    /// Provides an Iso between String and ArrayK of Character.
     static var toArrayK: Iso<String, ArrayK<Character>> {
         return String.toArray + Array.toArrayK
     }

--- a/Sources/BowOptics/STD/Try+Optics.swift
+++ b/Sources/BowOptics/STD/Try+Optics.swift
@@ -1,7 +1,11 @@
 import Foundation
 import Bow
 
+// MARK: Optics extensions
 public extension Try {
+    /// Provides a polymorphic prism focused on the success side of a Try.
+    ///
+    /// - Returns: A polymorphic prism focused on the success side of a Try.
     static func pSuccessPrism<B>() -> PPrism<Try<A>, Try<B>, A, B> {
         return PPrism<Try<A>, Try<B>, A, B>(
             getOrModify: { aTry in aTry.fold({ e in Either<Try<B>, A>.left(Try<B>.failure(e)) },
@@ -9,10 +13,12 @@ public extension Try {
             reverseGet: Try<B>.success)
     }
     
+    /// Provides a prism focused on the success side of a Try.
     static var successPrism: Prism<Try<A>, A> {
         return pSuccessPrism()
     }
     
+    /// Provides a prism focused on the failure side of a Try.
     static var failurePrism: Prism<Try<A>, Error> {
         return Prism<Try<A>, Error>(
             getOrModify: { aTry in aTry.fold({ e in Either.right(e) },
@@ -20,22 +26,30 @@ public extension Try {
             reverseGet: Try.failure )
     }
     
+    /// Provides a polymorphic Iso between Try and Either.
+    ///
+    /// - Returns: A polymorphic Iso between Try and Either.
     static func toPEither<B>() -> PIso<Try<A>, Try<B>, Either<Error, A>, Either<Error, B>> {
         return PIso<Try<A>, Try<B>, Either<Error, A>, Either<Error, B>>(
             get: { aTry in aTry.fold(Either<Error, A>.left, Either<Error, A>.right) },
             reverseGet: { either in either.fold(Try<B>.failure, Try<B>.success) })
     }
     
+    /// Provides an Iso between Try and Either.
     static var toEither: Iso<Try<A>, Either<Error, A>> {
         return toPEither()
     }
     
+    /// Provides a polymorphic Iso between Try and Validated.
+    ///
+    /// - Returns: A polymorphic Iso between Try and Validated.
     static func toPValidated<B>() -> PIso<Try<A>, Try<B>, Validated<Error, A>, Validated<Error, B>> {
         return PIso<Try<A>, Try<B>, Validated<Error, A>, Validated<Error, B>>(
             get: { aTry in aTry.fold(Validated<Error, A>.invalid, Validated<Error, A>.valid)},
             reverseGet: { validated in validated.fold(Try<B>.failure, Try<B>.success) })
     }
     
+    /// Provides an Iso between Try and Validated.
     static var toValidated: Iso<Try<A>, Validated<Error, A>> {
         return toPValidated()
     }

--- a/Sources/BowOptics/STD/Validated+Optics.swift
+++ b/Sources/BowOptics/STD/Validated+Optics.swift
@@ -1,7 +1,11 @@
 import Foundation
 import Bow
 
+// MARK: Optics extensions
 public extension Validated {
+    /// Provides a polymorphic Iso between Validated and Either.
+    ///
+    /// - Returns: A polymorphic Iso between Validated and Either.
     static func toPEither<E2, B>() -> PIso<Validated<E, A>, Validated<E2, B>, Either<E, A>, Either<E2, B>> {
         return PIso<Validated<E, A>, Validated<E2, B>, Either<E, A>, Either<E2, B>>(
             get: { validated in validated.fold(Either<E, A>.left,
@@ -10,10 +14,14 @@ public extension Validated {
                                                 Validated<E2, B>.valid) })
     }
 
+    /// Provides an Iso between Validated and Either.
     static var toEither: Iso<Validated<E, A>, Either<E, A>> {
         return toPEither()
     }
 
+    /// Provides a polymorphic Iso between Validated and Try.
+    ///
+    /// - Returns: A polymorphic Iso between Validated and Try.
     static func toPTry<B>() -> PIso<Validated<Error, A>, Validated<Error, B>, Try<A>, Try<B>> {
         return PIso<Validated<Error, A>, Validated<Error, B>, Try<A>, Try<B>>(
             get: { validated in validated.fold(Try<A>.failure,
@@ -21,26 +29,35 @@ public extension Validated {
             reverseGet: Validated<Error, B>.fromTry )
     }
 
+    /// Provides an Iso between Validated and Try.
     static var toTry: Iso<Validated<Error, A>, Try<A>> {
         return toPTry()
     }
     
+    /// Provides a polymorphic Prism focused on the valid side of a Validated.
+    ///
+    /// - Returns: A polymorphic Prism focused on the valid side of a Validated.
     static func pValidPrism<B>() -> PPrism<Validated<E, A>, Validated<E, B>, A, B> {
         return PPrism(
             getOrModify: { validated in validated.fold({ e in Either.left(Validated<E, B>.invalid(e)) }, Either.right) },
             reverseGet: Validated<E, B>.valid)
     }
     
+    /// Provides a Prism focused on the valid side of a Validated.
     static var validPrism: Prism<Validated<E, A>, A> {
         return pValidPrism()
     }
     
+    /// Provides a polymorphic Prism focused on the invalid side of a Validated.
+    ///
+    /// - Returns: A polymorphic Prism focused on the invalid side of a Validated.
     static func pInvalidPrism<EE>() -> PPrism<Validated<E, A>, Validated<EE, A>, E, EE> {
         return PPrism(
             getOrModify: { validated in validated.fold(Either.right, { a in Either.left(Validated<EE, A>.valid(a)) } ) },
             reverseGet: Validated<EE, A>.invalid)
     }
     
+    /// Provides a Prism focused on the invalid side of a Validated.
     static var invalidPrism: Prism<Validated<E, A>, E> {
         return pInvalidPrism()
     }


### PR DESCRIPTION
## Related issues

- Closes #362.

## Goal

This PR adds documentation to the API of optics provided for the core data types in Bow.