### PR TITLE
Add Promise

### DIFF
--- a/Bow.xcodeproj/project.pbxproj
+++ b/Bow.xcodeproj/project.pbxproj
@@ -146,6 +146,8 @@
 		114545D9225F935300EA8755 /* (null) in Sources */ = {isa = PBXBuildFile; };
 		114D4EA622C3692600BEE850 /* Ref.swift in Sources */ = {isa = PBXBuildFile; fileRef = 114D4EA522C3692600BEE850 /* Ref.swift */; };
 		114D4EA822C3A18900BEE850 /* Promise.swift in Sources */ = {isa = PBXBuildFile; fileRef = 114D4EA722C3A18900BEE850 /* Promise.swift */; };
+		114D4EAB22C3A2F400BEE850 /* CancelablePromise.swift in Sources */ = {isa = PBXBuildFile; fileRef = 114D4EAA22C3A2F400BEE850 /* CancelablePromise.swift */; };
+		114D4EAD22C3A32900BEE850 /* UncancelablePromise.swift in Sources */ = {isa = PBXBuildFile; fileRef = 114D4EAC22C3A32900BEE850 /* UncancelablePromise.swift */; };
 		1166A07A22119F720032CD4E /* EqualityFunctions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1166A07822119E640032CD4E /* EqualityFunctions.swift */; };
 		117DC0CD22AE492700EF65F0 /* Nimble.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8BA0F384217E2D3400969984 /* Nimble.framework */; };
 		117DC0CE22AE492700EF65F0 /* SwiftCheck.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8BA0F385217E2D3400969984 /* SwiftCheck.framework */; };
@@ -828,6 +830,8 @@
 		112D0CF522BBC17C0032F675 /* AutoTraversal.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoTraversal.swift; sourceTree = "<group>"; };
 		114D4EA522C3692600BEE850 /* Ref.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Ref.swift; sourceTree = "<group>"; };
 		114D4EA722C3A18900BEE850 /* Promise.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Promise.swift; sourceTree = "<group>"; };
+		114D4EAA22C3A2F400BEE850 /* CancelablePromise.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CancelablePromise.swift; sourceTree = "<group>"; };
+		114D4EAC22C3A32900BEE850 /* UncancelablePromise.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UncancelablePromise.swift; sourceTree = "<group>"; };
 		1166A07822119E640032CD4E /* EqualityFunctions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EqualityFunctions.swift; sourceTree = "<group>"; };
 		117DC0D322AE492700EF65F0 /* BowEffectsGenerators.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = BowEffectsGenerators.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		117DC0D422AE492700EF65F0 /* Bow-Effects-Generators-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; name = "Bow-Effects-Generators-Info.plist"; path = "/Users/tomasruizlopez/Development/bow/Bow-Effects-Generators-Info.plist"; sourceTree = "<absolute>"; };
@@ -1507,6 +1511,8 @@
 		114D4EA922C3A2A800BEE850 /* Internal */ = {
 			isa = PBXGroup;
 			children = (
+				114D4EAA22C3A2F400BEE850 /* CancelablePromise.swift */,
+				114D4EAC22C3A32900BEE850 /* UncancelablePromise.swift */,
 			);
 			path = Internal;
 			sourceTree = "<group>";
@@ -3074,6 +3080,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 0;
 			files = (
+				114D4EAD22C3A32900BEE850 /* UncancelablePromise.swift in Sources */,
 				1104BEEA22C25AAF002C3F78 /* Resource.swift in Sources */,
 				114D4EA622C3692600BEE850 /* Ref.swift in Sources */,
 				114D4EA822C3A18900BEE850 /* Promise.swift in Sources */,
@@ -3085,6 +3092,7 @@
 				11229745219DC557006D66C5 /* ConcurrentEffect.swift in Sources */,
 				1104BEE422C22E47002C3F78 /* Bracket.swift in Sources */,
 				1104BEDE22C22DEC002C3F78 /* KindConnection.swift in Sources */,
+				114D4EAB22C3A2F400BEE850 /* CancelablePromise.swift in Sources */,
 				11229746219DC557006D66C5 /* Effect.swift in Sources */,
 				1104BEE822C25869002C3F78 /* UnitDuration+Extension.swift in Sources */,
 				11229747219DC557006D66C5 /* MonadDefer.swift in Sources */,

--- a/Bow.xcodeproj/project.pbxproj
+++ b/Bow.xcodeproj/project.pbxproj
@@ -145,6 +145,7 @@
 		114545D7225F805500EA8755 /* (null) in Sources */ = {isa = PBXBuildFile; };
 		114545D9225F935300EA8755 /* (null) in Sources */ = {isa = PBXBuildFile; };
 		114D4EA622C3692600BEE850 /* Ref.swift in Sources */ = {isa = PBXBuildFile; fileRef = 114D4EA522C3692600BEE850 /* Ref.swift */; };
+		114D4EA822C3A18900BEE850 /* Promise.swift in Sources */ = {isa = PBXBuildFile; fileRef = 114D4EA722C3A18900BEE850 /* Promise.swift */; };
 		1166A07A22119F720032CD4E /* EqualityFunctions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1166A07822119E640032CD4E /* EqualityFunctions.swift */; };
 		117DC0CD22AE492700EF65F0 /* Nimble.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8BA0F384217E2D3400969984 /* Nimble.framework */; };
 		117DC0CE22AE492700EF65F0 /* SwiftCheck.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8BA0F385217E2D3400969984 /* SwiftCheck.framework */; };
@@ -826,6 +827,7 @@
 		112D0CF322BBC0390032F675 /* AutoFold.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoFold.swift; sourceTree = "<group>"; };
 		112D0CF522BBC17C0032F675 /* AutoTraversal.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoTraversal.swift; sourceTree = "<group>"; };
 		114D4EA522C3692600BEE850 /* Ref.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Ref.swift; sourceTree = "<group>"; };
+		114D4EA722C3A18900BEE850 /* Promise.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Promise.swift; sourceTree = "<group>"; };
 		1166A07822119E640032CD4E /* EqualityFunctions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EqualityFunctions.swift; sourceTree = "<group>"; };
 		117DC0D322AE492700EF65F0 /* BowEffectsGenerators.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = BowEffectsGenerators.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		117DC0D422AE492700EF65F0 /* Bow-Effects-Generators-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; name = "Bow-Effects-Generators-Info.plist"; path = "/Users/tomasruizlopez/Development/bow/Bow-Effects-Generators-Info.plist"; sourceTree = "<absolute>"; };
@@ -1291,12 +1293,14 @@
 		1104BED322C22DD2002C3F78 /* Data */ = {
 			isa = PBXGroup;
 			children = (
+				114D4EA922C3A2A800BEE850 /* Internal */,
 				1104BED522C22DD2002C3F78 /* Atomic.swift */,
 				1104BED722C22DD2002C3F78 /* Fiber.swift */,
 				1104BED422C22DD2002C3F78 /* IO.swift */,
 				1104BED622C22DD2002C3F78 /* KindConnection.swift */,
 				1104BEE922C25AAF002C3F78 /* Resource.swift */,
 				114D4EA522C3692600BEE850 /* Ref.swift */,
+				114D4EA722C3A18900BEE850 /* Promise.swift */,
 			);
 			path = Data;
 			sourceTree = "<group>";
@@ -1498,6 +1502,13 @@
 				1126CAA322B132CA00F840CB /* Tuple10.swift */,
 			);
 			path = Tuple;
+			sourceTree = "<group>";
+		};
+		114D4EA922C3A2A800BEE850 /* Internal */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = Internal;
 			sourceTree = "<group>";
 		};
 		117DC0D522AE499E00EF65F0 /* BowEffectsGenerators */ = {
@@ -3065,6 +3076,7 @@
 			files = (
 				1104BEEA22C25AAF002C3F78 /* Resource.swift in Sources */,
 				114D4EA622C3692600BEE850 /* Ref.swift in Sources */,
+				114D4EA822C3A18900BEE850 /* Promise.swift in Sources */,
 				1104BEDC22C22DEC002C3F78 /* IO.swift in Sources */,
 				1104BEDF22C22DEC002C3F78 /* Fiber.swift in Sources */,
 				1104BEDD22C22DEC002C3F78 /* Atomic.swift in Sources */,

--- a/Bow.xcodeproj/project.pbxproj
+++ b/Bow.xcodeproj/project.pbxproj
@@ -148,6 +148,8 @@
 		114D4EA822C3A18900BEE850 /* Promise.swift in Sources */ = {isa = PBXBuildFile; fileRef = 114D4EA722C3A18900BEE850 /* Promise.swift */; };
 		114D4EAB22C3A2F400BEE850 /* CancelablePromise.swift in Sources */ = {isa = PBXBuildFile; fileRef = 114D4EAA22C3A2F400BEE850 /* CancelablePromise.swift */; };
 		114D4EAD22C3A32900BEE850 /* UncancelablePromise.swift in Sources */ = {isa = PBXBuildFile; fileRef = 114D4EAC22C3A32900BEE850 /* UncancelablePromise.swift */; };
+		114D4EAF22C3A4DA00BEE850 /* Token.swift in Sources */ = {isa = PBXBuildFile; fileRef = 114D4EAE22C3A4DA00BEE850 /* Token.swift */; };
+		114D4EB122C3A97500BEE850 /* Dictionary+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 114D4EB022C3A97500BEE850 /* Dictionary+Extensions.swift */; };
 		1166A07A22119F720032CD4E /* EqualityFunctions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1166A07822119E640032CD4E /* EqualityFunctions.swift */; };
 		117DC0CD22AE492700EF65F0 /* Nimble.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8BA0F384217E2D3400969984 /* Nimble.framework */; };
 		117DC0CE22AE492700EF65F0 /* SwiftCheck.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8BA0F385217E2D3400969984 /* SwiftCheck.framework */; };
@@ -832,6 +834,8 @@
 		114D4EA722C3A18900BEE850 /* Promise.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Promise.swift; sourceTree = "<group>"; };
 		114D4EAA22C3A2F400BEE850 /* CancelablePromise.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CancelablePromise.swift; sourceTree = "<group>"; };
 		114D4EAC22C3A32900BEE850 /* UncancelablePromise.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UncancelablePromise.swift; sourceTree = "<group>"; };
+		114D4EAE22C3A4DA00BEE850 /* Token.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Token.swift; sourceTree = "<group>"; };
+		114D4EB022C3A97500BEE850 /* Dictionary+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Dictionary+Extensions.swift"; sourceTree = "<group>"; };
 		1166A07822119E640032CD4E /* EqualityFunctions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EqualityFunctions.swift; sourceTree = "<group>"; };
 		117DC0D322AE492700EF65F0 /* BowEffectsGenerators.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = BowEffectsGenerators.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		117DC0D422AE492700EF65F0 /* Bow-Effects-Generators-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; name = "Bow-Effects-Generators-Info.plist"; path = "/Users/tomasruizlopez/Development/bow/Bow-Effects-Generators-Info.plist"; sourceTree = "<absolute>"; };
@@ -1512,6 +1516,8 @@
 			isa = PBXGroup;
 			children = (
 				114D4EAA22C3A2F400BEE850 /* CancelablePromise.swift */,
+				114D4EB022C3A97500BEE850 /* Dictionary+Extensions.swift */,
+				114D4EAE22C3A4DA00BEE850 /* Token.swift */,
 				114D4EAC22C3A32900BEE850 /* UncancelablePromise.swift */,
 			);
 			path = Internal;
@@ -3088,7 +3094,9 @@
 				1104BEDF22C22DEC002C3F78 /* Fiber.swift in Sources */,
 				1104BEDD22C22DEC002C3F78 /* Atomic.swift in Sources */,
 				11229744219DC557006D66C5 /* Async.swift in Sources */,
+				114D4EB122C3A97500BEE850 /* Dictionary+Extensions.swift in Sources */,
 				1104BEE322C22E47002C3F78 /* UnsafeRun.swift in Sources */,
+				114D4EAF22C3A4DA00BEE850 /* Token.swift in Sources */,
 				11229745219DC557006D66C5 /* ConcurrentEffect.swift in Sources */,
 				1104BEE422C22E47002C3F78 /* Bracket.swift in Sources */,
 				1104BEDE22C22DEC002C3F78 /* KindConnection.swift in Sources */,

--- a/Bow.xcodeproj/project.pbxproj
+++ b/Bow.xcodeproj/project.pbxproj
@@ -150,6 +150,7 @@
 		114D4EAD22C3A32900BEE850 /* UncancelablePromise.swift in Sources */ = {isa = PBXBuildFile; fileRef = 114D4EAC22C3A32900BEE850 /* UncancelablePromise.swift */; };
 		114D4EAF22C3A4DA00BEE850 /* Token.swift in Sources */ = {isa = PBXBuildFile; fileRef = 114D4EAE22C3A4DA00BEE850 /* Token.swift */; };
 		114D4EB122C3A97500BEE850 /* Dictionary+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 114D4EB022C3A97500BEE850 /* Dictionary+Extensions.swift */; };
+		114D4EB322C3C31000BEE850 /* UnsafePromise.swift in Sources */ = {isa = PBXBuildFile; fileRef = 114D4EB222C3C31000BEE850 /* UnsafePromise.swift */; };
 		1166A07A22119F720032CD4E /* EqualityFunctions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1166A07822119E640032CD4E /* EqualityFunctions.swift */; };
 		117DC0CD22AE492700EF65F0 /* Nimble.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8BA0F384217E2D3400969984 /* Nimble.framework */; };
 		117DC0CE22AE492700EF65F0 /* SwiftCheck.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8BA0F385217E2D3400969984 /* SwiftCheck.framework */; };
@@ -836,6 +837,7 @@
 		114D4EAC22C3A32900BEE850 /* UncancelablePromise.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UncancelablePromise.swift; sourceTree = "<group>"; };
 		114D4EAE22C3A4DA00BEE850 /* Token.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Token.swift; sourceTree = "<group>"; };
 		114D4EB022C3A97500BEE850 /* Dictionary+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Dictionary+Extensions.swift"; sourceTree = "<group>"; };
+		114D4EB222C3C31000BEE850 /* UnsafePromise.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnsafePromise.swift; sourceTree = "<group>"; };
 		1166A07822119E640032CD4E /* EqualityFunctions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EqualityFunctions.swift; sourceTree = "<group>"; };
 		117DC0D322AE492700EF65F0 /* BowEffectsGenerators.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = BowEffectsGenerators.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		117DC0D422AE492700EF65F0 /* Bow-Effects-Generators-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; name = "Bow-Effects-Generators-Info.plist"; path = "/Users/tomasruizlopez/Development/bow/Bow-Effects-Generators-Info.plist"; sourceTree = "<absolute>"; };
@@ -1519,6 +1521,7 @@
 				114D4EB022C3A97500BEE850 /* Dictionary+Extensions.swift */,
 				114D4EAE22C3A4DA00BEE850 /* Token.swift */,
 				114D4EAC22C3A32900BEE850 /* UncancelablePromise.swift */,
+				114D4EB222C3C31000BEE850 /* UnsafePromise.swift */,
 			);
 			path = Internal;
 			sourceTree = "<group>";
@@ -3089,6 +3092,7 @@
 				114D4EAD22C3A32900BEE850 /* UncancelablePromise.swift in Sources */,
 				1104BEEA22C25AAF002C3F78 /* Resource.swift in Sources */,
 				114D4EA622C3692600BEE850 /* Ref.swift in Sources */,
+				114D4EB322C3C31000BEE850 /* UnsafePromise.swift in Sources */,
 				114D4EA822C3A18900BEE850 /* Promise.swift in Sources */,
 				1104BEDC22C22DEC002C3F78 /* IO.swift in Sources */,
 				1104BEDF22C22DEC002C3F78 /* Fiber.swift in Sources */,

--- a/Sources/BowEffects/Data/Atomic.swift
+++ b/Sources/BowEffects/Data/Atomic.swift
@@ -11,17 +11,14 @@ final class Atomic<A> {
         get {
             return queue.sync { self._value }
         }
+        set {
+            self._value = newValue
+        }
     }
 
     func mutate(_ transform: (inout A) -> ()) {
         queue.sync {
             transform(&self._value)
-        }
-    }
-    
-    func set(_ newValue: A) {
-        queue.sync {
-            self._value = newValue
         }
     }
 

--- a/Sources/BowEffects/Data/Internal/CancelablePromise.swift
+++ b/Sources/BowEffects/Data/Internal/CancelablePromise.swift
@@ -1,0 +1,5 @@
+import Bow
+
+internal class CancelablePromise<F: Concurrent, A>: Promise<F, A> {
+    
+}

--- a/Sources/BowEffects/Data/Internal/CancelablePromise.swift
+++ b/Sources/BowEffects/Data/Internal/CancelablePromise.swift
@@ -1,5 +1,156 @@
 import Bow
+import Foundation
 
-internal class CancelablePromise<F: Concurrent, A>: Promise<F, A> {
+internal class CancelablePromise<F: Concurrent, A: Equatable>: Promise<F, A> where F.E: Equatable & PromiseError {
+    private let state = Atomic<PromiseState<F.E, A>>(.pending(joiners: [:]))
     
+    override func get() -> Kind<F, A> {
+        return F.defer {
+            switch self.state.value {
+            case let .complete(value: value): return F.pure(value)
+            case .pending: return F.cancelable { callback in
+                let id = self.unsafeRegister(callback)
+                return F.delay { self.unregister(id) }
+            }
+            case let .error(error): return F.raiseError(error)
+            }
+        }
+    }
+    
+    override func tryGet() -> Kind<F, Option<A>> {
+        return F.delay {
+            let current = self.state.value
+            switch current {
+            case let .complete(value: a): return .some(a)
+            default: return .none()
+            }
+        }
+    }
+    
+    override func complete(_ a: A) -> Kind<F, ()> {
+        return tryComplete(a).flatMap { didComplete in
+            if didComplete {
+                return F.pure(())
+            } else {
+                return F.raiseError(F.E.alreadyFulfilled)
+            }
+        }
+    }
+    
+    override func tryComplete(_ a: A) -> Kind<F, Bool> {
+        return F.defer { self.unsafeTryComplete(a) }
+    }
+    
+    override func error<E: Error>(_ e: E) -> Kind<F, ()> {
+        return tryError(e).flatMap { didError in
+            if didError {
+                return F.pure(())
+            } else {
+                return F.raiseError(F.E.alreadyFulfilled)
+            }
+        }
+    }
+    
+    override func tryError<E: Error>(_ e: E) -> Kind<F, Bool> {
+        if let error = e as? F.E {
+            return F.defer { self.unsafeTryError(error) }
+        } else {
+            return F.pure(false)
+        }
+    }
+    
+    private func unsafeTryComplete(_ a: A) -> Kind<F, Bool> {
+        let current = state.value
+        switch current {
+        case let .pending(joiners: joiners):
+            if state.compare(current, andSet: .complete(value: a)) {
+                if !joiners.values.isEmpty {
+                    return callAll(joiners.arrayValues, with: .right(a)).map { _ in true }
+                } else {
+                    return F.pure(true)
+                }
+            } else {
+                return unsafeTryComplete(a)
+            }
+        default:
+            return F.pure(false)
+        }
+    }
+    
+    private func unsafeTryError(_ error: F.E) -> Kind<F, Bool> {
+        let current = state.value
+        switch current {
+        case let .pending(joiners: joiners):
+            if state.compare(current, andSet: .error(error)) {
+                if !joiners.values.isEmpty {
+                    return callAll(joiners.arrayValues, with: .left(error)).map { _ in true }
+                } else {
+                    return F.pure(true)
+                }
+            } else {
+                return unsafeTryError(error)
+            }
+        default:
+            return F.pure(false)
+        }
+    }
+    
+    private func unsafeRegister(_ callback: @escaping (Either<F.E, A>) -> ()) -> Token {
+        let id = Token()
+        if let result = register(id, callback) {
+            callback(result)
+        }
+        return id
+    }
+    
+    private func register(_ id: Token, _ callback: @escaping (Either<F.E, A>) -> ()) -> Either<F.E, A>? {
+        let current = state.value
+        switch current {
+        case let .complete(value: value): return .right(value)
+        case let .pending(joiners: joiners):
+            let updated = PromiseState.pending(joiners: joiners + (id, callback))
+            return !state.compare(current, andSet: updated) ? register(id, callback) : nil
+        case let .error(error): return .left(error)
+        }
+    }
+    
+    private func unregister(_ id: Token) {
+        let current = state.value
+        switch current {
+        case let .pending(joiners: joiners):
+            let updated = PromiseState<F.E, A>.pending(joiners: joiners - id)
+            return !state.compare(current, andSet: updated) ? unregister(id) : ()
+        default: return
+        }
+    }
+    
+    private func callAll(_ array: [(Either<F.E, A>) -> ()], with value: Either<F.E, A>) -> Kind<F, ()> {
+        let queue = DispatchQueue(label: "CancelablePromise")
+        let fold = array.k().foldLeft(Option<Kind<F, Fiber<F, ()>>>.none()) { acc, callback in
+            let task = queue.startFiber(F.delay { callback(value) })
+            return acc.map { x in x.flatMap { _ in task } }^.orElse(.some(task))
+        }
+        return fold.map { x in x.map { _ in () } }^.getOrElse(F.pure(()))
+    }
+}
+
+private enum PromiseState<E, A> {
+    case pending(joiners: [Token: (Either<E, A>) -> ()])
+    case complete(value: A)
+    case error(E)
+}
+
+extension PromiseState: Equatable where A: Equatable, E: Equatable {
+    static func == (lhs: PromiseState<E, A>, rhs: PromiseState<E, A>) -> Bool {
+        switch (lhs, rhs) {
+        case let (.pending(joiners: j1), .pending(joiners: j2)): return sameKeys(j1, j2)
+        case let (.complete(value: v1), .complete(value: v2)): return v1 == v2
+        case let (.error(e1), .error(e2)): return e1 == e2
+        default: return false
+        }
+    }
+    
+    private static func sameKeys<K: Hashable, V>(_ lhs: [K: V], _ rhs: [K: V]) -> Bool {
+        return lhs.keys == rhs.keys
+    }
 }

--- a/Sources/BowEffects/Data/Internal/Dictionary+Extensions.swift
+++ b/Sources/BowEffects/Data/Internal/Dictionary+Extensions.swift
@@ -1,0 +1,19 @@
+import Foundation
+
+func -<K: Hashable, V>(lhs: Dictionary<K, V>, rhs: K) -> Dictionary<K, V> {
+    var copy = lhs
+    copy.removeValue(forKey: rhs)
+    return copy
+}
+
+func +<K: Hashable, V>(lhs: Dictionary<K, V>, rhs: (K, V)) -> Dictionary<K, V> {
+    var copy = lhs
+    copy[rhs.0] = rhs.1
+    return copy
+}
+
+extension Dictionary {
+    var arrayValues: [Value] {
+        return self.map { x in x.value }
+    }
+}

--- a/Sources/BowEffects/Data/Internal/Dictionary+Extensions.swift
+++ b/Sources/BowEffects/Data/Internal/Dictionary+Extensions.swift
@@ -14,6 +14,6 @@ func +<K: Hashable, V>(lhs: Dictionary<K, V>, rhs: (K, V)) -> Dictionary<K, V> {
 
 extension Dictionary {
     var arrayValues: [Value] {
-        return self.map { x in x.value }
+        return Array(values)
     }
 }

--- a/Sources/BowEffects/Data/Internal/Token.swift
+++ b/Sources/BowEffects/Data/Internal/Token.swift
@@ -1,0 +1,23 @@
+import Foundation
+
+internal class Token {
+    private let id: Double = Date().timeIntervalSince1970
+}
+
+extension Token: Hashable {
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(id)
+    }
+}
+
+extension Token: Equatable {}
+
+func ==(lhs: Token, rhs: Token) -> Bool {
+    return lhs === rhs
+}
+
+extension Token: CustomStringConvertible {
+    var description: String {
+        return "Token(\(hashValue))"
+    }
+}

--- a/Sources/BowEffects/Data/Internal/UncancelablePromise.swift
+++ b/Sources/BowEffects/Data/Internal/UncancelablePromise.swift
@@ -1,0 +1,5 @@
+import Bow
+
+internal class UncancelablePromise<F: Async, A>: Promise<F, A> {
+    
+}

--- a/Sources/BowEffects/Data/Internal/UncancelablePromise.swift
+++ b/Sources/BowEffects/Data/Internal/UncancelablePromise.swift
@@ -1,5 +1,116 @@
 import Bow
 
-internal class UncancelablePromise<F: Async, A>: Promise<F, A> {
+internal class UncancelablePromise<F: Async, A: Equatable>: Promise<F, A> where F.E: Equatable & PromiseError {
+    private let state = Atomic<PromiseState<F.E, A>>(.pending(joiners: []))
     
+    override func get() -> Kind<F, A> {
+        return F.async { callback in
+            if let result = self.register(callback) {
+                callback(result)
+            }
+        }
+    }
+    
+    override func tryGet() -> Kind<F, Option<A>> {
+        let oldState = state.value
+        switch oldState {
+        case let .complete(value: value): return F.pure(.some(value))
+        default:
+            return F.pure(.none())
+        }
+    }
+    
+    override func complete(_ a: A) -> Kind<F, ()> {
+        return tryComplete(a).flatMap { didComplete in
+            if didComplete {
+                return F.pure(())
+            } else {
+                return F.raiseError(F.E.alreadyFulfilled)
+            }
+        }
+    }
+    
+    override func tryComplete(_ a: A) -> Kind<F, Bool> {
+        return F.defer { self.unsafeTryComplete(a) }
+    }
+    
+    override func error<E: Error>(_ e: E) -> Kind<F, ()> {
+        return tryError(e).flatMap { didError in
+            if didError {
+                return F.pure(())
+            } else {
+                return F.raiseError(F.E.alreadyFulfilled)
+            }
+        }
+    }
+    
+    override func tryError<E: Error>(_ e: E) -> Kind<F, Bool> {
+        if let error = e as? F.E {
+            return F.defer { self.unsafeTryError(error) }
+        } else {
+            return F.pure(false)
+        }
+    }
+    
+    private func register(_ callback: @escaping (Either<F.E, A>) -> ()) -> Either<F.E, A>? {
+        let current = state.value
+        switch current {
+        case let .complete(value: value): return .right(value)
+        case let .pending(joiners: joiners):
+            let updated = PromiseState<F.E, A>.pending(joiners: joiners + [callback])
+            if !state.compare(current, andSet: updated) {
+                return register(callback)
+            } else {
+                return nil
+            }
+        case let .error(error): return .left(error)
+        }
+    }
+    
+    private func unsafeTryComplete(_ a: A) -> Kind<F, Bool> {
+        return unsafeTry(.complete(value: a), .right(a))
+    }
+    
+    private func unsafeTryError(_ e: F.E) -> Kind<F, Bool> {
+        return unsafeTry(.error(e), .left(e))
+    }
+    
+    private func unsafeTry(_ newState: PromiseState<F.E, A>, _ result: Either<F.E, A>) -> Kind<F, Bool> {
+        let current = state.value
+        switch current {
+        case let .pending(joiners: joiners):
+            if state.compare(current, andSet: newState) {
+                return F.delay {
+                    joiners.forEach { joiner in joiner(result) }
+                    return true
+                }
+            } else {
+                return F.pure(true)
+            }
+        default:
+            return F.pure(false)
+        }
+    }
+}
+
+private enum PromiseState<E, A> {
+    case pending(joiners: [(Either<E, A>) -> ()])
+    case complete(value: A)
+    case error(E)
+}
+
+extension PromiseState: Equatable where E: Equatable, A: Equatable {
+    static func == (lhs: PromiseState<E, A>, rhs: PromiseState<E, A>) -> Bool {
+        switch (lhs, rhs) {
+        case let (.pending(joiners: j1), .pending(joiners: j2)):
+            if j1.count == j2.count {
+                return zip(j1, j2).map { x in "\(String(describing: x.0))" == "\(String(describing: x.1))" }.reduce(true, and)
+            } else {
+                return false
+            }
+        case let (.complete(value: v1), .complete(value: v2)): return v1 == v2
+        case let (.error(e1), .error(e2)): return e1 == e2
+        default: return false
+        }
+    }
 }

--- a/Sources/BowEffects/Data/Internal/UnsafePromise.swift
+++ b/Sources/BowEffects/Data/Internal/UnsafePromise.swift
@@ -1,0 +1,62 @@
+import Bow
+
+internal class UnsafePromise<E: Equatable, A: Equatable> {
+    private let state = Atomic(PromiseState<E, A>.empty)
+    
+    func get(_ callback: @escaping (Either<E, A>) -> ()) {
+        func go() {
+            let oldState = state.value
+            switch oldState {
+            case .empty:
+                return !state.compare(oldState, andSet: .waiting(joiners: [callback])) ? go() : ()
+            case let .waiting(joiners: joiners):
+                return !state.compare(oldState, andSet: .waiting(joiners: joiners + [callback])) ? go() : ()
+            case let .full(result):
+                return callback(result)
+            }
+        }
+        
+        return go()
+    }
+    
+    func complete(_ value: Either<E, A>) throws {
+        func go() throws {
+            let oldState = state.value
+            switch oldState {
+            case .empty:
+                return !state.compare(oldState, andSet: .full(value)) ? try go() : ()
+            case let .waiting(joiners: joiners):
+                if state.compare(oldState, andSet: .full(value)) {
+                    joiners.forEach { joiner in joiner(value) }
+                } else {
+                    try go()
+                }
+            case .full:
+                throw UnsafePromiseError.alreadyFulfilled
+            }
+        }
+        
+        return try go()
+    }
+}
+
+internal enum UnsafePromiseError: Error {
+    case alreadyFulfilled
+}
+
+private enum PromiseState<E, A> {
+    case empty
+    case waiting(joiners: [(Either<E, A>) -> ()])
+    case full(Either<E, A>)
+}
+
+extension PromiseState: Equatable where A: Equatable, E: Equatable {
+    static func == (lhs: PromiseState<E, A>, rhs: PromiseState<E, A>) -> Bool {
+        switch (lhs, rhs) {
+        case (.empty, .empty): return true
+        case let (.full(r1), .full(r2)): return r1 == r2
+        default:
+            return false
+        }
+    }
+}

--- a/Sources/BowEffects/Data/Promise.swift
+++ b/Sources/BowEffects/Data/Promise.swift
@@ -40,7 +40,7 @@ public extension Promise where F: Concurrent, A: Equatable, F.E: Equatable & Pro
     }
 }
 
-public extension Promise where F: Async {
+public extension Promise where F: Async, A: Equatable, F.E: Equatable & PromiseError {
     static var uncancelable: Kind<F, Promise<F, A>> {
         return F.delay { UncancelablePromise<F, A>() }
     }

--- a/Sources/BowEffects/Data/Promise.swift
+++ b/Sources/BowEffects/Data/Promise.swift
@@ -26,11 +26,11 @@ public class Promise<F, A> {
     }
 }
 
-public enum PromiseError: Error {
-    case alreadyFulfilled
+public protocol PromiseError {
+    static var alreadyFulfilled: Self { get }
 }
 
-public extension Promise where F: Concurrent {
+public extension Promise where F: Concurrent, A: Equatable, F.E: Equatable & PromiseError {
     static var cancelable: Kind<F, Promise<F, A>> {
         return F.delay { CancelablePromise<F, A>() }
     }

--- a/Sources/BowEffects/Data/Promise.swift
+++ b/Sources/BowEffects/Data/Promise.swift
@@ -1,0 +1,31 @@
+import Bow
+
+public class Promise<F, A> {
+    public func get() -> Kind<F, A> {
+        fatalError("get must be implemented in subclasses")
+    }
+    
+    public func tryGet() -> Kind<F, Option<A>> {
+        fatalError("tryGet must be implemented in subclasses")
+    }
+    
+    public func complete(_ a: A) -> Kind<F, ()> {
+        fatalError("complete must be implemented in subclasses")
+    }
+    
+    public func tryComplete(_ a: A) -> Kind<F, Bool> {
+        fatalError("tryComplete must be implemented in subclasses")
+    }
+    
+    public func error<E: Error>(_ e: E) -> Kind<F, ()> {
+        fatalError("error must be implemented in subclasses")
+    }
+    
+    public func tryError<E: Error>(_ e: E) -> Kind<F, Bool> {
+        fatalError("tryError must be implemented in subclasses")
+    }
+}
+
+public enum PromiseError: Error {
+    case alreadyFulfilled
+}

--- a/Sources/BowEffects/Data/Promise.swift
+++ b/Sources/BowEffects/Data/Promise.swift
@@ -29,3 +29,23 @@ public class Promise<F, A> {
 public enum PromiseError: Error {
     case alreadyFulfilled
 }
+
+public extension Promise where F: Concurrent {
+    static var cancelable: Kind<F, Promise<F, A>> {
+        return F.delay { CancelablePromise<F, A>() }
+    }
+    
+    static var unsafeCancelable: Promise<F, A> {
+        return CancelablePromise<F, A>()
+    }
+}
+
+public extension Promise where F: Async {
+    static var uncancelable: Kind<F, Promise<F, A>> {
+        return F.delay { UncancelablePromise<F, A>() }
+    }
+    
+    static var unsafeUncancelable: Promise<F, A> {
+        return UncancelablePromise<F, A>()
+    }
+}

--- a/Sources/BowEffects/Data/Ref.swift
+++ b/Sources/BowEffects/Data/Ref.swift
@@ -68,7 +68,7 @@ private class MonadDeferRef<F: MonadDefer, A: Equatable>: Ref<F, A> {
     }
     
     override func set(_ a: A) -> Kind<F, ()> {
-        return F.delay { self.atomic.set(a) }
+        return F.delay { self.atomic.value = a }
     }
     
     override func getAndSet(_ a: A) -> Kind<F, A> {


### PR DESCRIPTION
## Related issues

- Closes #268 

## Goal

Add `Promise` concurrency primitive. There are two concrete implementations: `CancelablePromise` and `UncancelablePromise`. There is an unsafe implementation `UnsafePromise`. A protocol `PromiseError` to describe errors that can be thrown from a `Promise` is also included.
