### PR TITLE
Documentation for Optics

### DIFF
--- a/contents/Documentation/Documentation.xcworkspace/contents.xcworkspacedata
+++ b/contents/Documentation/Documentation.xcworkspace/contents.xcworkspacedata
@@ -11,6 +11,9 @@
       location = "group:Patterns.playground">
    </FileRef>
    <FileRef
+      location = "group:Optics.playground">
+   </FileRef>
+   <FileRef
       location = "group:Legal.playground">
    </FileRef>
    <FileRef

--- a/contents/Documentation/Optics.playground/Pages/Automatic derivation.xcplaygroundpage/Contents.swift
+++ b/contents/Documentation/Optics.playground/Pages/Automatic derivation.xcplaygroundpage/Contents.swift
@@ -4,8 +4,111 @@
  title: Automatic derivation
  */
 // nef:end
+// nef:begin:hidden
+import Bow
+import BowOptics
+// nef:end
 /*:
  # Automatic derivation of optics
  
- Work in progress.
+ Writing optics for each data type may involve a lot of boilerplate. In some cases, Bow can help you generate the optics for your data types. This page will go through each optic that can be automatically generated for your data types. Nonetheless, you should read the section on *Writing your own optics* to get familiar with each optic and how they are implemented.
+ 
+ As a running example, consider the following data types:
+ */
+enum PublicationState {
+    case draft
+    case published(Date)
+}
+
+struct Article {
+    var title: String
+    var subtitle: String?
+    var state: PublicationState
+    var tags: [String]
+}
+/*:
+ **Note**: If you take a close look, you will notice that each field in `Article` is declared as `var` instead of `let`. This is necessary for the automatic generation of optics. If you don't declare your fields as `var`, you will start getting compilation errors when you try to generate your optics and, unfortunately, the error messages will not be descriptive about this being the reason.
+ 
+ ## Getter
+ 
+ In order to get a `Getter`, we need to make our type conform to the `AutoGetter` protocol:
+ */
+extension Article: AutoGetter {}
+/*:
+ From there, we can use a key path to a field to obtain its associated `Getter`:
+ */
+let titleGetter = Article.getter(for: \.title)
+/*:
+ ## Setter
+ 
+ Similarly, to get a `Setter`, we need to make our type conform to the `AutoSetter` protocol:
+ */
+extension Article: AutoSetter {}
+/*:
+ Using a key path to a field, we can get its associated `Setter`:
+ */
+let titleSetter = Article.setter(for: \.title)
+/*:
+ ## Lens
+ 
+ If we can get a `Getter` and a `Setter`, we can as well get a `Lens`. We need to make our type conform to the `AutoLens` protocol:
+ */
+extension Article: AutoLens {}
+/*:
+ And similarly, using a key path to a field, we can get its associated `Lens`:
+ */
+let titleLens = Article.lens(for: \.title)
+/*:
+ ## Optional
+ 
+ For those fields which may or may not be present, we can create an `Optional` in an automatic way by conforming to `AutoOptional`:
+ */
+extension Article: AutoOptional {}
+/*:
+ And using a key path to an optional field, we can obtain its associated `Optional` optic:
+ */
+let subtitleOptional = Article.optional(for: \.subtitle)
+/*:
+ ## Fold
+ 
+ For fields that are `Array` or `ArrayK` of values, or any structure that is `Foldable`, we can obtain their associated `Fold` automatically by conforming to the `AutoFold` protocol:
+ */
+extension Article: AutoFold {}
+/*:
+ Using a key path to an `Array` or `ArrayK` field, or a field whose type is `Foldable`, we can get its associated `Fold`:
+ */
+let tagsFold = Article.fold(for: \.tags)
+/*:
+ ## Traversal
+ 
+ Similar to `Fold`, for those fields that are `Array` or `ArrayK` of values, or any structure that is `Traverse`, we can obtain their associated `Traversal` automatically by conforming to the `AutoTraversal` protocol:
+ */
+extension Article: AutoTraversal {}
+/*:
+ Using a key path to an `Array` or `ArrayK` field, or a field whose type is `Traverse`, we can get its associated `Traversal`:
+ */
+let tagsTraversal = Article.traversal(for: \.tags)
+/*:
+ ## Prism
+ 
+ The optics above work mainly in product types. For sum types, we can try to derive `Prism` in an automatic manner by conforming to the `AutoPrism` protocol:
+ */
+extension PublicationState: AutoPrism {}
+/*:
+ At this point, there are two possible situations: the case of the enum we want to focus with our prism does not have associated values, or does have them.
+ 
+ If the focus of the `Prism` does not have any associated value, like `PublicationState.draft`, we can obtain it seamlessly:
+ */
+let draftPrism = PublicationState.prism(for: .draft)
+/*:
+ However, if the focus has associated values, we need to provide a bit of help by providing a pattern matching function that extracts the associated values out of the case we are focusing on:
+ */
+let publishedPrism = PublicationState.prism(for: PublicationState.published){ state in
+    guard case let .published(date) = state else { return nil }
+    return date
+}
+/*:
+ ## Summary
+ 
+ Using the `Auto-` protocols let us reduce the boilerplate associated to generating many of the optics, thus making it much easier and more seamless to work with optics.
  */

--- a/contents/Documentation/Optics.playground/Pages/Automatic derivation.xcplaygroundpage/Contents.swift
+++ b/contents/Documentation/Optics.playground/Pages/Automatic derivation.xcplaygroundpage/Contents.swift
@@ -1,0 +1,11 @@
+// nef:begin:header
+/*
+ layout: docs
+ title: Automatic derivation
+ */
+// nef:end
+/*:
+ # Automatic derivation of optics
+ 
+ Work in progress.
+ */

--- a/contents/Documentation/Optics.playground/Pages/Automatic derivation.xcplaygroundpage/Contents.swift
+++ b/contents/Documentation/Optics.playground/Pages/Automatic derivation.xcplaygroundpage/Contents.swift
@@ -103,7 +103,7 @@ let draftPrism = PublicationState.prism(for: .draft)
 /*:
  However, if the focus has associated values, we need to provide a bit of help by providing a pattern matching function that extracts the associated values out of the case we are focusing on:
  */
-let publishedPrism = PublicationState.prism(for: PublicationState.published){ state in
+let publishedPrism = PublicationState.prism(for: PublicationState.published) { state in
     guard case let .published(date) = state else { return nil }
     return date
 }

--- a/contents/Documentation/Optics.playground/Pages/Composition.xcplaygroundpage/Contents.swift
+++ b/contents/Documentation/Optics.playground/Pages/Composition.xcplaygroundpage/Contents.swift
@@ -4,8 +4,102 @@
  title: Composition
  */
 // nef:end
+// nef:begin:hidden
+import Bow
+import BowOptics
+// nef:end
 /*:
  # Composition
  
- Work in progress.
+ Optics can compose to create more powerful optics and access deeply nested data structures in an seamless manner. The result of the composition of the 8 pairs of optics that are included in Bow is shown in the following table. Notice that not all combinations are possible for composition, and that some times the resulting optic is not the same as the optics that were composed.
+ 
+ |               | **Iso**   | **Lens**  | **Prism** | **Optional** | **Getter** | **Setter** | **Fold** | **Traversal** |
+ | ------------- | --------- | --------- | --------- | ------------ | ---------- | ---------- | -------- | ------------- |
+ | **Iso**       | Iso       | Lens      | Prism     | Optional     | Getter     | Setter     | Fold     | Traversal     |
+ | **Lens**      | Lens      | Lens      | Optional  | Optional     | Getter     | Setter     | Fold     | Traversal     |
+ | **Prism**     | Prism     | Optional  | Prism     | Optional     | 🚫         | Setter     | Fold     | Traversal     |
+ | **Optional**  | Optional  | Optional  | Optional  | Optional     | Fold       | Setter     | Fold     | Traversal     |
+ | **Getter**    | Getter    | Getter    | 🚫        | 🚫           | Getter     | 🚫         | Fold     | 🚫            |
+ | **Setter**    | Setter    | Setter    | Setter    | Setter       | 🚫         | Setter     | 🚫       | Setter        |
+ | **Fold**      | Fold      | Fold      | Fold      | Fold         | Fold       | 🚫         | Fold     | Fold          |
+ | **Traversal** | Traversal | Traversal | Traversal | Traversal    | Fold       | Setter     | Fold     | Traversal     |
+ 
+ Each optic can be composed using its instance method `compose`, which is overloaded to accept all possible combinations with other optics. Besides, for the sake of simplicity, operator `+` can also be used to compose any two optics.
+ 
+ ## Example of composition: N-ary Tree
+ 
+ An N-ary tree is a tree where each node can have any number of branches. We can model it like:
+ */
+enum NTree<A> {
+    case leaf(A)
+    indirect case node(A, branches: NEA<NTree<A>>)
+}
+/*:
+ That is, we can have a leaf with an associated value, or a node with an associated value and a `NonEmptyArray` of branches (it must have at least one, otherwise it would be a leaf).
+ 
+ Let's imagine that we would like to combine all values of the nodes at level `m`. Stop for a moment and think how you would do it without optics. It does not have a trivial solution, right? Let's see if we can leverage the power of optics to do this.
+ 
+ We can start by trying to access the branches of a node. Since `NTree` is a sum type, the optic that we need to use is a Prism. We can use `AutoPrism` to get the `Prism` for the node side of the `NTree`:
+ */
+extension NTree: AutoPrism {}
+
+func nodePrism<A>() -> Prism<NTree<A>, (A, NEA<NTree<A>>)> {
+    return NTree.prism(for: NTree.node) { tree in
+        guard case let .node(value, branches: branches) = tree else { return nil }
+        return (value, branches)
+    }
+}
+/*:
+ `nodePrism` gives us a `Prism` to look into a `NTree` and get a pair of `(A, NEA<NTree<A>>)`, but we are only interested in the branches part. Given we have a tuple, we would need an optic that lets us focus on one of the components of a tuple.
+ 
+ Fortunately, Bow already provides these utilities. In particular, given that tuples are product types, it seems we would need a `Lens` to focus on the second component of the tuple. To do so, we can get the `Lens` from `Tuple2._1`. There are utilities like this from `Tuple2` to `Tuple10`, to focus on every component of the tuples.
+ 
+ Then, we can compose the previous `Prism` with this `Lens` to get an `Optional` (see table above) that focuses only on the branches of a node:
+ */
+func branchesOptional<A>() -> Optional<NTree<A>, NEA<NTree<A>>> {
+    return nodePrism() + Tuple2._1
+}
+/*:
+ Now, we would like to be able to traverse each individual branch and modify them in isolation. This would give us a way of visiting the branches under the first level of the tree. If we look into the focus of the `branchesOptional` we can see that it is a `NonEmptyArray`, which already has a `Traversal` to visit each element. Therefore, if we compose them, we can get a `Traversal` with foci in each node of the first level under the provided node:
+ */
+func levelTraversal<A>() -> Traversal<NTree<A>, NTree<A>> {
+    return branchesOptional() + NEA.traversal
+}
+/*:
+ Looking at `levelTraversal` we can see that its source and focus types match. That means we can compose with itself in order to go further down in the tree structure, level by level. We can write a function that gets us a `Traversal` focused on the nodes of the `m` level, just by composing the `levelTraversal` with itself `m` times:
+ */
+func level<A>(_ m: UInt) -> Traversal<NTree<A>, NTree<A>> {
+    guard m > 0 else { return Traversal.identity }
+    return (0 ..< m)
+        .map { _ in levelTraversal() }
+        .reduce(Traversal.identity, +)
+}
+/*:
+ In the function above, if `m` is 0, we return `Traversal.identity`, which is a `Traversal` that focuses on the source itself, corresponding to visiting level 0 of the tree. Otherwise, we create `m` instances of the `levelTraversal` and combine them all into a single one, to get a `Traversal` that focuses on nodes at level `m`.
+ 
+ We wanted to combine values of the nodes at level `m`. First, we would need to extract the values out of the `NTrees`. Since all cases in `NTree` have a value, we can write a custom `Getter` to do this:
+ */
+func valueGetter<A>() -> Getter<NTree<A>, A> {
+    return Getter(get: { state in
+        switch state {
+        case .leaf(let value), .node(let value, branches: _): return value
+        }
+    })
+}
+/*:
+ We can convert the `Traversal` to a `Fold` using the `asFold` property. We can get a `Fold` to combine values at level `m` as:
+ */
+func levelFold<A>(_ m: UInt) -> Fold<NTree<A>, A> {
+    return level(m).asFold + valueGetter()
+}
+/*:
+ Finally, if we get a tree whose values have an instance of `Monoid`, we can combine all its values at level `m` by:
+ */
+func combineValues<A: Monoid>(of tree: NTree<A>, at level: UInt) -> A {
+    return levelFold(level).combineAll(tree)
+}
+/*:
+ ## Summary
+ 
+ With this example we have seen how we can use auto-generated, custom and library-provided optics, to build more complex ones that help us perfom a complicated task in an easy and seamless manner.
  */

--- a/contents/Documentation/Optics.playground/Pages/Composition.xcplaygroundpage/Contents.swift
+++ b/contents/Documentation/Optics.playground/Pages/Composition.xcplaygroundpage/Contents.swift
@@ -1,0 +1,11 @@
+// nef:begin:header
+/*
+ layout: docs
+ title: Composition
+ */
+// nef:end
+/*:
+ # Composition
+ 
+ Work in progress.
+ */

--- a/contents/Documentation/Optics.playground/Pages/Overview.xcplaygroundpage/Contents.swift
+++ b/contents/Documentation/Optics.playground/Pages/Overview.xcplaygroundpage/Contents.swift
@@ -5,7 +5,50 @@
  */
 // nef:end
 /*:
- # Credits
+ # Overview
  
- Work in progress.
+ {:.beginner}
+ beginner
+ 
+ The optics module in Bow provides several utilities to work with immutable data structures. It enables easy access to getting, setting and modifying deeply nested data structure without the burden of making explicit copies of the involved values.
+ 
+ In order to use the module, you just need to import it:
+ */
+import BowOptics
+/*:
+ This module includes multiple facilities to work with immutable nested data structures:
+ 
+ - Optics: it includes several data types that let us work with different types of structures.
+ - Type classes: several abstractions are provided to generalize operations of accessing data structures internals.
+ - Automatic generation: in some cases, the library is able to automatically provide certain optics for some data types, so that you do not need to write them.
+ 
+ ## Optics
+ 
+ The provided optics operate on two type arguments that are typically named `S` and `A`, which correspond to the source (the whole structure we have) and the focus (the part we want to obtain or modify). The following table summarizes the individual optics that are provided in `BowOptics`:
+ 
+ | Optic     | Description |
+ | --------- | ----------- |
+ | Iso       | A lossless invertible optic defining an isomorphism between two types |
+ | Getter    | An optic that can focus into a structure and get its focus |
+ | Setter    | An optic that can focus into a structure and set or modify its focus |
+ | Lens      | An optic that can focus into a structure and get, set or modify its focus |
+ | Optional  | An optic whose focus is optional and can get, set or modify it |
+ | Prism     | An optic whose focus is present under certain circumstances and can get, set or modify it |
+ | Fold      | An optic that can have multiple foci and is able to fold them into a single value |
+ | Traversal | An optic that can have multiple foci and get, set or modify them |
+
+ Besides, the optics provided in this module are able to operate polymorphically. In this case, their name is prepended by a `P` (e.g. `PIso`, `PLens` or `PPrism`) and have two additional type parameters: `T`, the modified source, and `B`, the modified focus. This means those optics can operate on structures that change the type of the source or the focus (usually parametrically polymorphic types).
+ 
+ ## Type classes
+ 
+ These are the provided type classes in the `BowOptics` module:
+ 
+ | Type class  | Description |
+ | ----------- | ----------- |
+ | Cons        | Splits a structure into its first element and the rest |
+ | Snoc        | Splits a structure into a prefix with all elements but the last, and the last |
+ | At          | Provides a Lens at a given index |
+ | Index       | Provides an Optional at a given index |
+ | FilterIndex | Provides a Traversal of elements whose index fulfils a predicate |
+ | Each        | Provides a Traversal that can focus into a structure to see all foci |
  */

--- a/contents/Documentation/Optics.playground/Pages/Overview.xcplaygroundpage/Contents.swift
+++ b/contents/Documentation/Optics.playground/Pages/Overview.xcplaygroundpage/Contents.swift
@@ -1,0 +1,11 @@
+// nef:begin:header
+/*
+ layout: docs
+ title: Overview
+ */
+// nef:end
+/*:
+ # Credits
+ 
+ Work in progress.
+ */

--- a/contents/Documentation/Optics.playground/Pages/Overview.xcplaygroundpage/Contents.swift
+++ b/contents/Documentation/Optics.playground/Pages/Overview.xcplaygroundpage/Contents.swift
@@ -33,7 +33,7 @@ import BowOptics
  | Setter    | An optic that can focus into a structure and set or modify its focus |
  | Lens      | An optic that can focus into a structure and get, set or modify its focus |
  | Optional  | An optic whose focus is optional and can get, set or modify it |
- | Prism     | An optic whose focus is present under certain circumstances and can get, set or modify it |
+ | Prism     | An optic whose focus is present only in some cases (of a sum type) and can get, set or modify it |
  | Fold      | An optic that can have multiple foci and is able to fold them into a single value |
  | Traversal | An optic that can have multiple foci and get, set or modify them |
 

--- a/contents/Documentation/Optics.playground/Pages/Writing your own optics.xcplaygroundpage/Contents.swift
+++ b/contents/Documentation/Optics.playground/Pages/Writing your own optics.xcplaygroundpage/Contents.swift
@@ -1,0 +1,11 @@
+// nef:begin:header
+/*
+ layout: docs
+ title: Writing your own optics
+ */
+// nef:end
+/*:
+ # Writing your own optics
+ 
+ Work in progress.
+ */

--- a/contents/Documentation/Optics.playground/Pages/Writing your own optics.xcplaygroundpage/Contents.swift
+++ b/contents/Documentation/Optics.playground/Pages/Writing your own optics.xcplaygroundpage/Contents.swift
@@ -7,5 +7,131 @@
 /*:
  # Writing your own optics
  
- Work in progress.
+ {:.beginner}
+ beginner
+ 
+ In order to work with optics, you need to create them for your specific data type. Consider the following data types:
  */
+// nef:begin:hidden
+import Bow
+import BowOptics
+// nef:end
+enum PublicationState {
+    case draft
+    case published(Date)
+}
+
+struct Article {
+    let title: String
+    let subtitle: Option<String>
+    let state: PublicationState
+    let tags: [String]
+}
+/*:
+ In the following sections, we will describe how to create each of the optics for those types, where they are applicable.
+ 
+ ## Iso
+ 
+ `Iso<S, A>` represents an isomorphism between types `S` and `A`. That means we can transform from an `S` to an `A` and back to `S` with a pair of functions, and we will get the original value. Similarly, we can start with an `A`, transform it to an `S` and back to an `A` without losing information. This does not mean `S` and `A` are equal, but it implies their structures are equivalent.
+ 
+ An example of an `Iso` can be found in product types. In our running example, `Article` is a product type composed of a `String`, an optional `String`, a `PublicationState` and an `Array` of `String`. But we could also represent the same information using a tuple of 4 elements, and we would be able to get a tuple from an article, and vice versa. That is, we can build an `Iso<Article, (String, Option<String>, PublicationState, [String])>.
+ 
+ To do so, we need a pair of functions. To go from tuple to `Article`, we can use `Article.init`, since the types in the tuple are already in the same order the initializer expects them. To go from `Article` to tuple we need to destructure the `Article`:
+ */
+func toTuple(_ article: Article) -> (String, Option<String>, PublicationState, [String]) {
+    return (article.title, article.subtitle, article.state, article.tags)
+}
+/*:
+ With this function, creating an `Iso` between these types is as easy as:
+ */
+let iso = Iso<Article, (String, Option<String>, PublicationState, [String])>(get: toTuple, reverseGet: Article.init)
+/*:
+ The `Iso` initializer expects two functions: `get`, to go from `S` to `A`, and `reverseGet` to go from `A` to `S`, which is exactly what our two functions are doing.
+ 
+ ## Getter
+ 
+ `Getter<S, A>` allows us to get a value `A` out of a structure `S`. For instance, we can make a `Getter` to extract the `title` of an `Article`. In that case, we need to make a `Getter<Article, String>`:
+ */
+let titleGetter = Getter<Article, String>(get: { article in article.title })
+/*:
+ ## Setter
+ 
+ Similarly, a `Setter<S, A>` allows us to set a new value of type `A` or modify the existing one in a structure `S`. Since we are dealing with immutable data structures, that involves making a copy of the structure that changes the focused value. We can add the following method to `Article` in order to get copies with modified fields seamlessly:
+ */
+extension Article {
+    func copy(withTitle title: String? = nil,
+              withSubtitle subtitle: Option<String>? = nil,
+              withState state: PublicationState? = nil,
+              withTags tags: [String]? = nil) -> Article {
+        return Article(title: title ?? self.title,
+                       subtitle: subtitle ?? self.subtitle,
+                       state: state ?? self.state,
+                       tags: tags ?? self.tags)
+    }
+}
+/*:
+ This copy method provides multiple overloads to make a copy of the receiver object and modify only certain fields. If an argument is passed, the copy will have it; otherwise, the current value of the object is taken.
+ 
+ Using this, let's proceed to write a `Setter` for the title of an `Article`. To create a `Setter`, we can pass two closures that specify how an article is modified with a function `f` that modifies its title, and how to set a new title for an article. We can write a `Setter<Article, String>`:
+ */
+let titleSetter = Setter<Article, String>(
+    modify: { article, f in article.copy(withTitle: f(article.title)) },
+    set: { article, newTitle in article.copy(withTitle: newTitle) })
+/*:
+ ## Lens
+ 
+ If we combine the power of `Getter` and `Setter` into a single optic, we have a `Lens`. A `Lens<S, A>` is an optic that lets us get, set or modify a value `A` out of a structure `S`.
+ 
+ We can provide a Lens to get/set the title of an `Article` by providing these two functions:
+ */
+let titleLens = Lens<Article, String>(
+    get: { article in article.title },
+    set: { article, newTitle in article.copy(withTitle: newTitle) })
+/*:
+ ## Optional
+ 
+ In the previous optics, title is always present in an `Article`. However, if we focus on its subtitle, we can see it is an `Option<String>`. We can still write a `Lens` whose focus is `Option<String>`, but for the sake of composition, it would be better to remove that optionality.
+ 
+ To do so, we can use the `Optional<S, A>`, which lets us focus on a value `A` that may be absent in a structure `S`, just like the case of the article subtitle. An `Optional` needs two functions to be initialized. The setter function just needs to make a copy of the article with the new value. The getter function is a bit trickier. It returns an `Either`; if the focus is present in the structure, it returns an `Either.right` containing it; otherwise, it returns an `Either.left` with the original article.
+ */
+let subtitleOptional = Optional<Article, String>(
+    set: { article, newSubtitle in article.copy(withSubtitle: .some(newSubtitle)) },
+    getOrModify: { article in article.subtitle.fold({ Either.left(article) }, Either.right) })
+/*:
+ ## Prism
+ 
+ All the optics above work for product types. When it comes to sum types, we need to use `Prism`. `Prism<S, A>` is an optic that lets us focus on a value `A` that is present under certain circumstances in the structure `S`.
+ 
+ Sum types in Swift are usually represented by `enum`, so focusing on one of the cases does not guarantee that it is always going to be there.
+ 
+ As an example, consider the `PublicationState` described above. If we want to focus on the published side and get the `Date` of publication, we need to create a `Prism<PublicationState, Date>`. As usual, we need two functions. The getter lets us get `Either` the date (`right`, if we received a `PublicationState` that is in the state we are focusing) or the original state (`left`, if we are in another case of the `PublicationState`). The other function lets us build a state from a given `Date`.
+ */
+let publishedPrism = Prism<PublicationState, Date>(
+    getOrModify: { state in
+        guard case let .published(date) = state else {
+            return Either.left(state)
+        }
+        return Either.right(date)
+    }, reverseGet: PublicationState.published)
+/*:
+ ## Fold
+ 
+ The optics presented so far have only one focus. Is it possible to have multiple foci? The `Fold` and `Traversal` optics have 0 to n foci.
+ 
+ `Fold` is a generalization of `Foldable`. `Fold<S, A>` describes an optic that can focus on several `A` values in a structure `S` and can transform and fold them into a summary value.
+ 
+ This is usually the case of fields that contain collections of elements and we want to focus on them individually. In the case of `Article`, if we write a `Lens` for the tags, it lets us focus on all tags as a whole, not on each individual tag.
+ */
+let tagsLens = Lens<Article, [String]>(
+    get: { article in article.tags },
+    set: { article, newTags in article.copy(withTags: newTags) })
+/*:
+ We can get a `Fold<Article, String>` that lets us have foci to each individual tag. In this case, we can leverage an existing `Fold<[A], A>`; i.e. for any array, it gives us a `Fold` to focus on each item of the array. It is available in `Array<Element>.fold`. With that, we can compose it with the `tagsLens` to get a `Fold`:
+ */
+let tagsFold: Fold<Article, String> = tagsLens + Array<String>.fold
+/*:
+ ## Traversal
+ 
+ Finally, `Traversal` is a generalization of `Traverse`. `Traversal<S, A>` lets us focus on multiple `A` values in a structure `S` to get, set or modify them. Like in the case for `Fold`, it is useful for fields that contain collections of elements. Likeways, there is a `Traversal<[A], A>` available for any array in `Array<Element>.traversal`. With that, we can compose it with the `tagsLens` to get a `Traversal`:
+ */
+let tagsTraversal: Traversal<Article, String> = tagsLens + Array<String>.traversal

--- a/contents/Documentation/Optics.playground/contents.xcplayground
+++ b/contents/Documentation/Optics.playground/contents.xcplayground
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<playground version='6.0' target-platform='macos' display-mode='raw'>
+    <pages>
+        <page name='Overview'/>
+        <page name='Writing your own optics'/>
+        <page name='Automatic derivation'/>
+        <page name='Composition'/>
+    </pages>
+</playground>

--- a/contents/Documentation/Optics.playground/playground.xcworkspace/contents.xcworkspacedata
+++ b/contents/Documentation/Optics.playground/playground.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>


### PR DESCRIPTION
## Goal

Add documentation about how to use optics. This PR includes 4 pages for the microsite:

- **Overview**: contains a description of the optics module and reference tables with the optics and type classes provided in the module.
- **Writing your own optics**: contains an explanation with a running example about how to write each of the provided optics.
- **Automatic derivation**: presents the same example as above, but showing how the library has mechanisms to derive automatically all optics.
- **Composition**: contains a table describing all possible compositions between different optics, and an example to apply all the techniques present in the module.
