### PR TITLE
Add API reference for Coproducts

### DIFF
--- a/Sources/BowGeneric/Coproduct10.swift
+++ b/Sources/BowGeneric/Coproduct10.swift
@@ -1,8 +1,12 @@
 import Bow
 
+/// Witness for the `Coproduct10` data type. To be used in simulated Higher Kinded Types.
 public final class ForCoproduct10 {}
+
+/// Higher Kinded Type alias to improve readability over `Kind10`.
 public typealias Coproduct10Of<A, B, C, D, E, F, G, H, I, J> = Kind10<ForCoproduct10, A, B, C, D, E, F, G, H, I, J>
 
+/// Represents a sum type of 10 different types.
 public final class Coproduct10<A, B, C, D, E, F, G, H, I, J>: Coproduct10Of<A, B, C, D, E, F, G, H, I, J> {
     private let cop: Cop10<A, B, C, D, E, F, G, H, I, J>
 
@@ -10,46 +14,100 @@ public final class Coproduct10<A, B, C, D, E, F, G, H, I, J>: Coproduct10Of<A, B
         self.cop = cop
     }
 
+    /// Creates an instance of a coproduct providing a value of the first type.
+    ///
+    /// - Parameter a: Value of the first type of the coproduct.
+    /// - Returns: A coproduct with a value of the first type.
     public static func first(_ a: A) -> Coproduct10<A, B, C, D, E, F, G, H, I, J> {
         return Coproduct10(.first(a))
     }
 
+    /// Creates an instance of a coproduct providing a value of the second type.
+    ///
+    /// - Parameter b: Value of the second type of the coproduct.
+    /// - Returns: A coproduct with a value of the second type.
     public static func second(_ b: B) -> Coproduct10<A, B, C, D, E, F, G, H, I, J> {
         return Coproduct10(.second(b))
     }
 
+    /// Creates an instance of a coproduct providing a value of the third type.
+    ///
+    /// - Parameter c: Value of the third type of the coproduct.
+    /// - Returns: A coproduct with a value of the third type.
     public static func third(_ c: C) -> Coproduct10<A, B, C, D, E, F, G, H, I, J> {
         return Coproduct10(.third(c))
     }
 
+    /// Creates an instance of a coproduct providing a value of the fourth type.
+    ///
+    /// - Parameter d: Value of the fourth type of the coproduct.
+    /// - Returns: A coproduct with a value of the fourth type.
     public static func fourth(_ d: D) -> Coproduct10<A, B, C, D, E, F, G, H, I, J> {
         return Coproduct10(.fourth(d))
     }
 
+    /// Creates an instance of a coproduct providing a value of the fifth type.
+    ///
+    /// - Parameter e: Value of the fifth type of the coproduct.
+    /// - Returns: A coproduct with a value of the fifth type.
     public static func fifth(_ e: E) -> Coproduct10<A, B, C, D, E, F, G, H, I, J> {
         return Coproduct10(.fifth(e))
     }
 
+    /// Creates an instance of a coproduct providing a value of the sixth type.
+    ///
+    /// - Parameter f: Value of the sixth type of the coproduct.
+    /// - Returns: A coproduct with a value of the sixth type.
     public static func sixth(_ f: F) -> Coproduct10<A, B, C, D, E, F, G, H, I, J> {
         return Coproduct10(.sixth(f))
     }
 
+    /// Creates an instance of a coproduct providing a value of the seventh type.
+    ///
+    /// - Parameter g: Value of the seventh type of the coproduct.
+    /// - Returns: A coproduct with a value of the seventh type.
     public static func seventh(_ g: G) -> Coproduct10<A, B, C, D, E, F, G, H, I, J> {
         return Coproduct10(.seventh(g))
     }
 
+    /// Creates an instance of a coproduct providing a value of the eighth type.
+    ///
+    /// - Parameter h: Value of the eighth type of the coproduct.
+    /// - Returns: A coproduct with a value of the eighth type.
     public static func eighth(_ h: H) -> Coproduct10<A, B, C, D, E, F, G, H, I, J> {
         return Coproduct10(.eighth(h))
     }
 
+    /// Creates an instance of a coproduct providing a value of the ninth type.
+    ///
+    /// - Parameter i: Value of the ninth type of the coproduct.
+    /// - Returns: A coproduct with a value of the ninth type.
     public static func ninth(_ i: I) -> Coproduct10<A, B, C, D, E, F, G, H, I, J> {
         return Coproduct10(.ninth(i))
     }
 
+    /// Creates an instance of a coproduct providing a value of the tenth type.
+    ///
+    /// - Parameter j: Value of the tenth type of the coproduct.
+    /// - Returns: A coproduct with a value of the tenth type.
     public static func tenth(_ j: J) -> Coproduct10<A, B, C, D, E, F, G, H, I, J> {
         return Coproduct10(.tenth(j))
     }
 
+    /// Applies a function depending on the content of the coproduct.
+    ///
+    /// - Parameters:
+    ///   - fa: Function to apply with a value of the first type.
+    ///   - fb: Function to apply with a value of the second type.
+    ///   - fc: Function to apply with a value of the third type.
+    ///   - fd: Function to apply with a value of the fourth type.
+    ///   - fe: Function to apply with a value of the fifth type.
+    ///   - ff: Function to apply with a value of the sixth type.
+    ///   - fg: Function to apply with a value of the seventh type.
+    ///   - fh: Function to apply with a value of the eighth type.
+    ///   - fi: Function to apply with a value of the ninth type.
+    ///   - fj: Function to apply with a value of the tenth type.
+    /// - Returns: A value resulting of the application of the corresponding function based on the content of the coproduct.
     public func fold<Z>(_ fa: (A) -> Z,
                         _ fb: (B) -> Z,
                         _ fc: (C) -> Z,
@@ -74,42 +132,52 @@ public final class Coproduct10<A, B, C, D, E, F, G, H, I, J>: Coproduct10Of<A, B
         }
     }
 
+    /// Retrieves the value of the first type, if present.
     public var first: Option<A> {
         return fold(Option.some, constant(Option.none()), constant(Option.none()), constant(Option.none()), constant(Option.none()), constant(Option.none()), constant(Option.none()), constant(Option.none()), constant(Option.none()), constant(Option.none()))
     }
 
+    /// Retrieves the value of the second type, if present.
     public var second: Option<B> {
         return fold(constant(Option.none()), Option.some, constant(Option.none()), constant(Option.none()), constant(Option.none()), constant(Option.none()), constant(Option.none()), constant(Option.none()), constant(Option.none()), constant(Option.none()))
     }
 
+    /// Retrieves the value of the third type, if present.
     public var third: Option<C> {
         return fold(constant(Option.none()), constant(Option.none()), Option.some, constant(Option.none()), constant(Option.none()), constant(Option.none()), constant(Option.none()), constant(Option.none()), constant(Option.none()), constant(Option.none()))
     }
 
+    /// Retrieves the value of the fourth type, if present.
     public var fourth: Option<D> {
         return fold(constant(Option.none()), constant(Option.none()), constant(Option.none()), Option.some, constant(Option.none()), constant(Option.none()), constant(Option.none()), constant(Option.none()), constant(Option.none()), constant(Option.none()))
     }
 
+    /// Retrieves the value of the fifth type, if present.
     public var fifth: Option<E> {
         return fold(constant(Option.none()), constant(Option.none()), constant(Option.none()), constant(Option.none()), Option.some, constant(Option.none()), constant(Option.none()), constant(Option.none()), constant(Option.none()), constant(Option.none()))
     }
 
+    /// Retrieves the value of the sixth type, if present.
     public var sixth: Option<F> {
         return fold(constant(Option.none()), constant(Option.none()), constant(Option.none()), constant(Option.none()), constant(Option.none()), Option.some, constant(Option.none()), constant(Option.none()), constant(Option.none()), constant(Option.none()))
     }
 
+    /// Retrieves the value of the seventh type, if present.
     public var seventh: Option<G> {
         return fold(constant(Option.none()), constant(Option.none()), constant(Option.none()), constant(Option.none()), constant(Option.none()), constant(Option.none()), Option.some, constant(Option.none()), constant(Option.none()), constant(Option.none()))
     }
 
+    /// Retrieves the value of the eighth type, if present.
     public var eighth: Option<H> {
         return fold(constant(Option.none()), constant(Option.none()), constant(Option.none()), constant(Option.none()), constant(Option.none()), constant(Option.none()), constant(Option.none()), Option.some, constant(Option.none()), constant(Option.none()))
     }
 
+    /// Retrieves the value of the ninth type, if present.
     public var ninth: Option<I> {
         return fold(constant(Option.none()), constant(Option.none()), constant(Option.none()), constant(Option.none()), constant(Option.none()), constant(Option.none()), constant(Option.none()), constant(Option.none()), Option.some, constant(Option.none()))
     }
 
+    /// Retrieves the value of the tenth type, if present.
     public var tenth: Option<J> {
         return fold(constant(Option.none()), constant(Option.none()), constant(Option.none()), constant(Option.none()), constant(Option.none()), constant(Option.none()), constant(Option.none()), constant(Option.none()), constant(Option.none()), Option.some)
     }

--- a/Sources/BowGeneric/Coproduct2.swift
+++ b/Sources/BowGeneric/Coproduct2.swift
@@ -1,8 +1,12 @@
 import Bow
 
+/// Witness for the `Coproduct2` data type. To be used in simulated Higher Kinded Types.
 public final class ForCoproduct2 {}
+
+/// Higher Kinded Type alias to improve readability over `Kind2`.
 public typealias Coproduct2Of<A, B> = Kind2<ForCoproduct2, A, B>
 
+/// Represents a sum type of 2 different types.
 public final class Coproduct2<A, B>: Coproduct2Of<A, B> {
     private let cop: Cop2<A, B>
 
@@ -10,15 +14,28 @@ public final class Coproduct2<A, B>: Coproduct2Of<A, B> {
         self.cop = cop
     }
 
+    /// Creates an instance of a coproduct providing a value of the first type.
+    ///
+    /// - Parameter a: Value of the first type of the coproduct.
+    /// - Returns: A coproduct with a value of the first type.
     public static func first(_ a: A) -> Coproduct2<A, B> {
         return Coproduct2(.first(a))
     }
 
+    /// Creates an instance of a coproduct providing a value of the second type.
+    ///
+    /// - Parameter b: Value of the second type of the coproduct.
+    /// - Returns: A coproduct with a value of the second type.
     public static func second(_ b: B) -> Coproduct2<A, B> {
         return Coproduct2(.second(b))
     }
 
-
+    /// Applies a function depending on the content of the coproduct.
+    ///
+    /// - Parameters:
+    ///   - fa: Function to apply with a value of the first type.
+    ///   - fb: Function to apply with a value of the second type.
+    /// - Returns: A value resulting of the application of the corresponding function based on the content of the coproduct.
     public func fold<Z>(_ fa: (A) -> Z,
                         _ fb: (B) -> Z) -> Z {
         switch cop {
@@ -27,10 +44,12 @@ public final class Coproduct2<A, B>: Coproduct2Of<A, B> {
         }
     }
 
+    /// Retrieves the value of the first type, if present.
     public var first: Option<A> {
         return fold(Option.some, constant(Option.none()))
     }
 
+    /// Retrieves the value of the second type, if present.
     public var second: Option<B> {
         return fold(constant(Option.none()), Option.some)
     }

--- a/Sources/BowGeneric/Coproduct3.swift
+++ b/Sources/BowGeneric/Coproduct3.swift
@@ -1,8 +1,12 @@
 import Bow
 
+/// Witness for the `Coproduct3` data type. To be used in simulated Higher Kinded Types.
 public final class ForCoproduct3 {}
+
+/// Higher Kinded Type alias to improve readability over `Kind3`.
 public typealias Coproduct3Of<A, B, C> = Kind3<ForCoproduct3, A, B, C>
 
+/// Represents a sum type of 3 different types.
 public final class Coproduct3<A, B, C>: Coproduct3Of<A, B, C> {
     private let cop: Cop3<A, B, C>
 
@@ -10,18 +14,37 @@ public final class Coproduct3<A, B, C>: Coproduct3Of<A, B, C> {
         self.cop = cop
     }
 
+    /// Creates an instance of a coproduct providing a value of the first type.
+    ///
+    /// - Parameter a: Value of the first type of the coproduct.
+    /// - Returns: A coproduct with a value of the first type.
     public static func first(_ a: A) -> Coproduct3<A, B, C> {
         return Coproduct3(.first(a))
     }
 
+    /// Creates an instance of a coproduct providing a value of the second type.
+    ///
+    /// - Parameter b: Value of the second type of the coproduct.
+    /// - Returns: A coproduct with a value of the second type.
     public static func second(_ b: B) -> Coproduct3<A, B, C> {
         return Coproduct3(.second(b))
     }
 
+    /// Creates an instance of a coproduct providing a value of the third type.
+    ///
+    /// - Parameter c: Value of the third type of the coproduct.
+    /// - Returns: A coproduct with a value of the third type.
     public static func third(_ c: C) -> Coproduct3<A, B, C> {
         return Coproduct3(.third(c))
     }
 
+    /// Applies a function depending on the content of the coproduct.
+    ///
+    /// - Parameters:
+    ///   - fa: Function to apply with a value of the first type.
+    ///   - fb: Function to apply with a value of the second type.
+    ///   - fc: Function to apply with a value of the third type.
+    /// - Returns: A value resulting of the application of the corresponding function based on the content of the coproduct.
     public func fold<Z>(_ fa: (A) -> Z,
                         _ fb: (B) -> Z,
                         _ fc: (C) -> Z) -> Z {
@@ -32,14 +55,17 @@ public final class Coproduct3<A, B, C>: Coproduct3Of<A, B, C> {
         }
     }
 
+    /// Retrieves the value of the first type, if present.
     public var first: Option<A> {
         return fold(Option.some, constant(Option.none()), constant(Option.none()))
     }
 
+    /// Retrieves the value of the second type, if present.
     public var second: Option<B> {
         return fold(constant(Option.none()), Option.some, constant(Option.none()))
     }
 
+    /// Retrieves the value of the third type, if present.
     public var third: Option<C> {
         return fold(constant(Option.none()), constant(Option.none()), Option.some)
     }

--- a/Sources/BowGeneric/Coproduct4.swift
+++ b/Sources/BowGeneric/Coproduct4.swift
@@ -1,8 +1,12 @@
 import Bow
 
+/// Witness for the `Coproduct4` data type. To be used in simulated Higher Kinded Types.
 public final class ForCoproduct4 {}
+
+/// Higher Kinded Type alias to improve readability over `Kind4`.
 public typealias Coproduct4Of<A, B, C, D> = Kind4<ForCoproduct4, A, B, C, D>
 
+/// Represents a sum type of 4 different types.
 public final class Coproduct4<A, B, C, D>: Coproduct4Of<A, B, C, D> {
     private let cop: Cop4<A, B, C, D>
 
@@ -10,22 +14,46 @@ public final class Coproduct4<A, B, C, D>: Coproduct4Of<A, B, C, D> {
         self.cop = cop
     }
 
+    /// Creates an instance of a coproduct providing a value of the first type.
+    ///
+    /// - Parameter a: Value of the first type of the coproduct.
+    /// - Returns: A coproduct with a value of the first type.
     public static func first(_ a: A) -> Coproduct4<A, B, C, D> {
         return Coproduct4(.first(a))
     }
 
+    /// Creates an instance of a coproduct providing a value of the second type.
+    ///
+    /// - Parameter b: Value of the second type of the coproduct.
+    /// - Returns: A coproduct with a value of the second type.
     public static func second(_ b: B) -> Coproduct4<A, B, C, D> {
         return Coproduct4(.second(b))
     }
 
+    /// Creates an instance of a coproduct providing a value of the third type.
+    ///
+    /// - Parameter c: Value of the third type of the coproduct.
+    /// - Returns: A coproduct with a value of the third type.
     public static func third(_ c: C) -> Coproduct4<A, B, C, D> {
         return Coproduct4(.third(c))
     }
 
+    /// Creates an instance of a coproduct providing a value of the fourth type.
+    ///
+    /// - Parameter d: Value of the fourth type of the coproduct.
+    /// - Returns: A coproduct with a value of the fourth type.
     public static func fourth(_ d: D) -> Coproduct4<A, B, C, D> {
         return Coproduct4(.fourth(d))
     }
 
+    /// Applies a function depending on the content of the coproduct.
+    ///
+    /// - Parameters:
+    ///   - fa: Function to apply with a value of the first type.
+    ///   - fb: Function to apply with a value of the second type.
+    ///   - fc: Function to apply with a value of the third type.
+    ///   - fd: Function to apply with a value of the fourth type.
+    /// - Returns: A value resulting of the application of the corresponding function based on the content of the coproduct.
     public func fold<Z>(_ fa: (A) -> Z,
                         _ fb: (B) -> Z,
                         _ fc: (C) -> Z,
@@ -38,18 +66,22 @@ public final class Coproduct4<A, B, C, D>: Coproduct4Of<A, B, C, D> {
         }
     }
 
+    /// Retrieves the value of the first type, if present.
     public var first: Option<A> {
         return fold(Option.some, constant(Option.none()), constant(Option.none()), constant(Option.none()))
     }
 
+    /// Retrieves the value of the second type, if present.
     public var second: Option<B> {
         return fold(constant(Option.none()), Option.some, constant(Option.none()), constant(Option.none()))
     }
 
+    /// Retrieves the value of the third type, if present.
     public var third: Option<C> {
         return fold(constant(Option.none()), constant(Option.none()), Option.some, constant(Option.none()))
     }
 
+    /// Retrieves the value of the fourth type, if present.
     public var fourth: Option<D> {
         return fold(constant(Option.none()), constant(Option.none()), constant(Option.none()), Option.some)
     }

--- a/Sources/BowGeneric/Coproduct5.swift
+++ b/Sources/BowGeneric/Coproduct5.swift
@@ -1,8 +1,12 @@
 import Bow
 
+/// Witness for the `Coproduct5` data type. To be used in simulated Higher Kinded Types.
 public final class ForCoproduct5 {}
+
+/// Higher Kinded Type alias to improve readability over `Kind5`.
 public typealias Coproduct5Of<A, B, C, D, E> = Kind5<ForCoproduct5, A, B, C, D, E>
 
+/// Represents a sum type of 5 different types.
 public final class Coproduct5<A, B, C, D, E>: Coproduct5Of<A, B, C, D, E> {
     private let cop: Cop5<A, B, C, D, E>
 
@@ -10,26 +14,55 @@ public final class Coproduct5<A, B, C, D, E>: Coproduct5Of<A, B, C, D, E> {
         self.cop = cop
     }
 
+    /// Creates an instance of a coproduct providing a value of the first type.
+    ///
+    /// - Parameter a: Value of the first type of the coproduct.
+    /// - Returns: A coproduct with a value of the first type.
     public static func first(_ a: A) -> Coproduct5<A, B, C, D, E> {
         return Coproduct5(.first(a))
     }
 
+    /// Creates an instance of a coproduct providing a value of the second type.
+    ///
+    /// - Parameter b: Value of the second type of the coproduct.
+    /// - Returns: A coproduct with a value of the second type.
     public static func second(_ b: B) -> Coproduct5<A, B, C, D, E> {
         return Coproduct5(.second(b))
     }
 
+    /// Creates an instance of a coproduct providing a value of the third type.
+    ///
+    /// - Parameter c: Value of the third type of the coproduct.
+    /// - Returns: A coproduct with a value of the third type.
     public static func third(_ c: C) -> Coproduct5<A, B, C, D, E> {
         return Coproduct5(.third(c))
     }
 
+    /// Creates an instance of a coproduct providing a value of the fourth type.
+    ///
+    /// - Parameter d: Value of the fourth type of the coproduct.
+    /// - Returns: A coproduct with a value of the fourth type.
     public static func fourth(_ d: D) -> Coproduct5<A, B, C, D, E> {
         return Coproduct5(.fourth(d))
     }
 
+    /// Creates an instance of a coproduct providing a value of the fifth type.
+    ///
+    /// - Parameter e: Value of the fifth type of the coproduct.
+    /// - Returns: A coproduct with a value of the fifth type.
     public static func fifth(_ e: E) -> Coproduct5<A, B, C, D, E> {
         return Coproduct5(.fifth(e))
     }
 
+    /// Applies a function depending on the content of the coproduct.
+    ///
+    /// - Parameters:
+    ///   - fa: Function to apply with a value of the first type.
+    ///   - fb: Function to apply with a value of the second type.
+    ///   - fc: Function to apply with a value of the third type.
+    ///   - fd: Function to apply with a value of the fourth type.
+    ///   - fe: Function to apply with a value of the fifth type.
+    /// - Returns: A value resulting of the application of the corresponding function based on the content of the coproduct.
     public func fold<Z>(_ fa: (A) -> Z,
                         _ fb: (B) -> Z,
                         _ fc: (C) -> Z,
@@ -44,22 +77,27 @@ public final class Coproduct5<A, B, C, D, E>: Coproduct5Of<A, B, C, D, E> {
         }
     }
 
+    /// Retrieves the value of the first type, if present.
     public var first: Option<A> {
         return fold(Option.some, constant(Option.none()), constant(Option.none()), constant(Option.none()), constant(Option.none()))
     }
 
+    /// Retrieves the value of the second type, if present.
     public var second: Option<B> {
         return fold(constant(Option.none()), Option.some, constant(Option.none()), constant(Option.none()), constant(Option.none()))
     }
 
+    /// Retrieves the value of the third type, if present.
     public var third: Option<C> {
         return fold(constant(Option.none()), constant(Option.none()), Option.some, constant(Option.none()), constant(Option.none()))
     }
 
+    /// Retrieves the value of the fourth type, if present.
     public var fourth: Option<D> {
         return fold(constant(Option.none()), constant(Option.none()), constant(Option.none()), Option.some, constant(Option.none()))
     }
 
+    /// Retrieves the value of the fifth type, if present.
     public var fifth: Option<E> {
         return fold(constant(Option.none()), constant(Option.none()), constant(Option.none()), constant(Option.none()), Option.some)
     }

--- a/Sources/BowGeneric/Coproduct6.swift
+++ b/Sources/BowGeneric/Coproduct6.swift
@@ -1,8 +1,12 @@
 import Bow
 
+/// Witness for the `Coproduct6` data type. To be used in simulated Higher Kinded Types.
 public final class ForCoproduct6 {}
+
+/// Higher Kinded Type alias to improve readability over `Kind6`.
 public typealias Coproduct6Of<A, B, C, D, E, F> = Kind6<ForCoproduct6, A, B, C, D, E, F>
 
+/// Represents a sum type of 6 different types.
 public final class Coproduct6<A, B, C, D, E, F>: Coproduct6Of<A, B, C, D, E, F> {
     private let cop: Cop6<A, B, C, D, E, F>
 
@@ -10,30 +14,64 @@ public final class Coproduct6<A, B, C, D, E, F>: Coproduct6Of<A, B, C, D, E, F> 
         self.cop = cop
     }
 
+    /// Creates an instance of a coproduct providing a value of the first type.
+    ///
+    /// - Parameter a: Value of the first type of the coproduct.
+    /// - Returns: A coproduct with a value of the first type.
     public static func first(_ a: A) -> Coproduct6<A, B, C, D, E, F> {
         return Coproduct6(.first(a))
     }
 
+    /// Creates an instance of a coproduct providing a value of the second type.
+    ///
+    /// - Parameter b: Value of the second type of the coproduct.
+    /// - Returns: A coproduct with a value of the second type.
     public static func second(_ b: B) -> Coproduct6<A, B, C, D, E, F> {
         return Coproduct6(.second(b))
     }
 
+    /// Creates an instance of a coproduct providing a value of the third type.
+    ///
+    /// - Parameter c: Value of the third type of the coproduct.
+    /// - Returns: A coproduct with a value of the third type.
     public static func third(_ c: C) -> Coproduct6<A, B, C, D, E, F> {
         return Coproduct6(.third(c))
     }
 
+    /// Creates an instance of a coproduct providing a value of the fourth type.
+    ///
+    /// - Parameter d: Value of the fourth type of the coproduct.
+    /// - Returns: A coproduct with a value of the fourth type.
     public static func fourth(_ d: D) -> Coproduct6<A, B, C, D, E, F> {
         return Coproduct6(.fourth(d))
     }
 
+    /// Creates an instance of a coproduct providing a value of the fifth type.
+    ///
+    /// - Parameter e: Value of the fifth type of the coproduct.
+    /// - Returns: A coproduct with a value of the fifth type.
     public static func fifth(_ e: E) -> Coproduct6<A, B, C, D, E, F> {
         return Coproduct6(.fifth(e))
     }
 
+    /// Creates an instance of a coproduct providing a value of the sixth type.
+    ///
+    /// - Parameter f: Value of the sixth type of the coproduct.
+    /// - Returns: A coproduct with a value of the sixth type.
     public static func sixth(_ f: F) -> Coproduct6<A, B, C, D, E, F> {
         return Coproduct6(.sixth(f))
     }
 
+    /// Applies a function depending on the content of the coproduct.
+    ///
+    /// - Parameters:
+    ///   - fa: Function to apply with a value of the first type.
+    ///   - fb: Function to apply with a value of the second type.
+    ///   - fc: Function to apply with a value of the third type.
+    ///   - fd: Function to apply with a value of the fourth type.
+    ///   - fe: Function to apply with a value of the fifth type.
+    ///   - ff: Function to apply with a value of the sixth type.
+    /// - Returns: A value resulting of the application of the corresponding function based on the content of the coproduct.
     public func fold<Z>(_ fa: (A) -> Z,
                         _ fb: (B) -> Z,
                         _ fc: (C) -> Z,
@@ -50,26 +88,32 @@ public final class Coproduct6<A, B, C, D, E, F>: Coproduct6Of<A, B, C, D, E, F> 
         }
     }
 
+    /// Retrieves the value of the first type, if present.
     public var first: Option<A> {
         return fold(Option.some, constant(Option.none()), constant(Option.none()), constant(Option.none()), constant(Option.none()), constant(Option.none()))
     }
 
+    /// Retrieves the value of the second type, if present.
     public var second: Option<B> {
         return fold(constant(Option.none()), Option.some, constant(Option.none()), constant(Option.none()), constant(Option.none()), constant(Option.none()))
     }
 
+    /// Retrieves the value of the third type, if present.
     public var third: Option<C> {
         return fold(constant(Option.none()), constant(Option.none()), Option.some, constant(Option.none()), constant(Option.none()), constant(Option.none()))
     }
 
+    /// Retrieves the value of the fourth type, if present.
     public var fourth: Option<D> {
         return fold(constant(Option.none()), constant(Option.none()), constant(Option.none()), Option.some, constant(Option.none()), constant(Option.none()))
     }
 
+    /// Retrieves the value of the fifth type, if present.
     public var fifth: Option<E> {
         return fold(constant(Option.none()), constant(Option.none()), constant(Option.none()), constant(Option.none()), Option.some, constant(Option.none()))
     }
 
+    /// Retrieves the value of the sixth type, if present.
     public var sixth: Option<F> {
         return fold(constant(Option.none()), constant(Option.none()), constant(Option.none()), constant(Option.none()), constant(Option.none()), Option.some)
     }

--- a/Sources/BowGeneric/Coproduct7.swift
+++ b/Sources/BowGeneric/Coproduct7.swift
@@ -1,8 +1,12 @@
 import Bow
 
+/// Witness for the `Coproduct7` data type. To be used in simulated Higher Kinded Types.
 public final class ForCoproduct7 {}
+
+/// Higher Kinded Type alias to improve readability over `Kind7`.
 public typealias Coproduct7Of<A, B, C, D, E, F, G> = Kind7<ForCoproduct7, A, B, C, D, E, F, G>
 
+/// Represents a sum type of 7 different types.
 public final class Coproduct7<A, B, C, D, E, F, G>: Coproduct7Of<A, B, C, D, E, F, G> {
     private let cop: Cop7<A, B, C, D, E, F, G>
 
@@ -10,34 +14,73 @@ public final class Coproduct7<A, B, C, D, E, F, G>: Coproduct7Of<A, B, C, D, E, 
         self.cop = cop
     }
 
+    /// Creates an instance of a coproduct providing a value of the first type.
+    ///
+    /// - Parameter a: Value of the first type of the coproduct.
+    /// - Returns: A coproduct with a value of the first type.
     public static func first(_ a: A) -> Coproduct7<A, B, C, D, E, F, G> {
         return Coproduct7(.first(a))
     }
 
+    /// Creates an instance of a coproduct providing a value of the second type.
+    ///
+    /// - Parameter b: Value of the second type of the coproduct.
+    /// - Returns: A coproduct with a value of the second type.
     public static func second(_ b: B) -> Coproduct7<A, B, C, D, E, F, G> {
         return Coproduct7(.second(b))
     }
 
+    /// Creates an instance of a coproduct providing a value of the third type.
+    ///
+    /// - Parameter c: Value of the third type of the coproduct.
+    /// - Returns: A coproduct with a value of the third type.
     public static func third(_ c: C) -> Coproduct7<A, B, C, D, E, F, G> {
         return Coproduct7(.third(c))
     }
 
+    /// Creates an instance of a coproduct providing a value of the fourth type.
+    ///
+    /// - Parameter d: Value of the fourth type of the coproduct.
+    /// - Returns: A coproduct with a value of the fourth type.
     public static func fourth(_ d: D) -> Coproduct7<A, B, C, D, E, F, G> {
         return Coproduct7(.fourth(d))
     }
 
+    /// Creates an instance of a coproduct providing a value of the fifth type.
+    ///
+    /// - Parameter e: Value of the fifth type of the coproduct.
+    /// - Returns: A coproduct with a value of the fifth type.
     public static func fifth(_ e: E) -> Coproduct7<A, B, C, D, E, F, G> {
         return Coproduct7(.fifth(e))
     }
 
+    /// Creates an instance of a coproduct providing a value of the sixth type.
+    ///
+    /// - Parameter f: Value of the sixth type of the coproduct.
+    /// - Returns: A coproduct with a value of the sixth type.
     public static func sixth(_ f: F) -> Coproduct7<A, B, C, D, E, F, G> {
         return Coproduct7(.sixth(f))
     }
 
+    /// Creates an instance of a coproduct providing a value of the seventh type.
+    ///
+    /// - Parameter g: Value of the seventh type of the coproduct.
+    /// - Returns: A coproduct with a value of the seventh type.
     public static func seventh(_ g: G) -> Coproduct7<A, B, C, D, E, F, G> {
         return Coproduct7(.seventh(g))
     }
 
+    /// Applies a function depending on the content of the coproduct.
+    ///
+    /// - Parameters:
+    ///   - fa: Function to apply with a value of the first type.
+    ///   - fb: Function to apply with a value of the second type.
+    ///   - fc: Function to apply with a value of the third type.
+    ///   - fd: Function to apply with a value of the fourth type.
+    ///   - fe: Function to apply with a value of the fifth type.
+    ///   - ff: Function to apply with a value of the sixth type.
+    ///   - fg: Function to apply with a value of the seventh type.
+    /// - Returns: A value resulting of the application of the corresponding function based on the content of the coproduct.
     public func fold<Z>(_ fa: (A) -> Z,
                         _ fb: (B) -> Z,
                         _ fc: (C) -> Z,
@@ -56,30 +99,37 @@ public final class Coproduct7<A, B, C, D, E, F, G>: Coproduct7Of<A, B, C, D, E, 
         }
     }
 
+    /// Retrieves the value of the first type, if present.
     public var first: Option<A> {
         return fold(Option.some, constant(Option.none()), constant(Option.none()), constant(Option.none()), constant(Option.none()), constant(Option.none()), constant(Option.none()))
     }
 
+    /// Retrieves the value of the second type, if present.
     public var second: Option<B> {
         return fold(constant(Option.none()), Option.some, constant(Option.none()), constant(Option.none()), constant(Option.none()), constant(Option.none()), constant(Option.none()))
     }
 
+    /// Retrieves the value of the third type, if present.
     public var third: Option<C> {
         return fold(constant(Option.none()), constant(Option.none()), Option.some, constant(Option.none()), constant(Option.none()), constant(Option.none()), constant(Option.none()))
     }
 
+    /// Retrieves the value of the fourth type, if present.
     public var fourth: Option<D> {
         return fold(constant(Option.none()), constant(Option.none()), constant(Option.none()), Option.some, constant(Option.none()), constant(Option.none()), constant(Option.none()))
     }
 
+    /// Retrieves the value of the fifth type, if present.
     public var fifth: Option<E> {
         return fold(constant(Option.none()), constant(Option.none()), constant(Option.none()), constant(Option.none()), Option.some, constant(Option.none()), constant(Option.none()))
     }
 
+    /// Retrieves the value of the sixth type, if present.
     public var sixth: Option<F> {
         return fold(constant(Option.none()), constant(Option.none()), constant(Option.none()), constant(Option.none()), constant(Option.none()), Option.some, constant(Option.none()))
     }
 
+    /// Retrieves the value of the seventh type, if present.
     public var seventh: Option<G> {
         return fold(constant(Option.none()), constant(Option.none()), constant(Option.none()), constant(Option.none()), constant(Option.none()), constant(Option.none()), Option.some)
     }

--- a/Sources/BowGeneric/Coproduct8.swift
+++ b/Sources/BowGeneric/Coproduct8.swift
@@ -1,8 +1,12 @@
 import Bow
 
+/// Witness for the `Coproduct8` data type. To be used in simulated Higher Kinded Types.
 public final class ForCoproduct8 {}
+
+/// Higher Kinded Type alias to improve readability over `Kind8`.
 public typealias Coproduct8Of<A, B, C, D, E, F, G, H> = Kind8<ForCoproduct8, A, B, C, D, E, F, G, H>
 
+/// Represents a sum type of 8 different types.
 public final class Coproduct8<A, B, C, D, E, F, G, H>: Coproduct8Of<A, B, C, D, E, F, G, H> {
     private let cop: Cop8<A, B, C, D, E, F, G, H>
 
@@ -10,38 +14,82 @@ public final class Coproduct8<A, B, C, D, E, F, G, H>: Coproduct8Of<A, B, C, D, 
         self.cop = cop
     }
 
+    /// Creates an instance of a coproduct providing a value of the first type.
+    ///
+    /// - Parameter a: Value of the first type of the coproduct.
+    /// - Returns: A coproduct with a value of the first type.
     public static func first(_ a: A) -> Coproduct8<A, B, C, D, E, F, G, H> {
         return Coproduct8(.first(a))
     }
 
+    /// Creates an instance of a coproduct providing a value of the second type.
+    ///
+    /// - Parameter b: Value of the second type of the coproduct.
+    /// - Returns: A coproduct with a value of the second type.
     public static func second(_ b: B) -> Coproduct8<A, B, C, D, E, F, G, H> {
         return Coproduct8(.second(b))
     }
 
+    /// Creates an instance of a coproduct providing a value of the third type.
+    ///
+    /// - Parameter c: Value of the third type of the coproduct.
+    /// - Returns: A coproduct with a value of the third type.
     public static func third(_ c: C) -> Coproduct8<A, B, C, D, E, F, G, H> {
         return Coproduct8(.third(c))
     }
 
+    /// Creates an instance of a coproduct providing a value of the fourth type.
+    ///
+    /// - Parameter d: Value of the fourth type of the coproduct.
+    /// - Returns: A coproduct with a value of the fourth type.
     public static func fourth(_ d: D) -> Coproduct8<A, B, C, D, E, F, G, H> {
         return Coproduct8(.fourth(d))
     }
 
+    /// Creates an instance of a coproduct providing a value of the fifth type.
+    ///
+    /// - Parameter e: Value of the fifth type of the coproduct.
+    /// - Returns: A coproduct with a value of the fifth type.
     public static func fifth(_ e: E) -> Coproduct8<A, B, C, D, E, F, G, H> {
         return Coproduct8(.fifth(e))
     }
 
+    /// Creates an instance of a coproduct providing a value of the sixth type.
+    ///
+    /// - Parameter f: Value of the sixth type of the coproduct.
+    /// - Returns: A coproduct with a value of the sixth type.
     public static func sixth(_ f: F) -> Coproduct8<A, B, C, D, E, F, G, H> {
         return Coproduct8(.sixth(f))
     }
 
+    /// Creates an instance of a coproduct providing a value of the seventh type.
+    ///
+    /// - Parameter g: Value of the seventh type of the coproduct.
+    /// - Returns: A coproduct with a value of the seventh type.
     public static func seventh(_ g: G) -> Coproduct8<A, B, C, D, E, F, G, H> {
         return Coproduct8(.seventh(g))
     }
 
+    /// Creates an instance of a coproduct providing a value of the eighth type.
+    ///
+    /// - Parameter h: Value of the eighth type of the coproduct.
+    /// - Returns: A coproduct with a value of the eighth type.
     public static func eighth(_ h: H) -> Coproduct8<A, B, C, D, E, F, G, H> {
         return Coproduct8(.eighth(h))
     }
 
+    /// Applies a function depending on the content of the coproduct.
+    ///
+    /// - Parameters:
+    ///   - fa: Function to apply with a value of the first type.
+    ///   - fb: Function to apply with a value of the second type.
+    ///   - fc: Function to apply with a value of the third type.
+    ///   - fd: Function to apply with a value of the fourth type.
+    ///   - fe: Function to apply with a value of the fifth type.
+    ///   - ff: Function to apply with a value of the sixth type.
+    ///   - fg: Function to apply with a value of the seventh type.
+    ///   - fh: Function to apply with a value of the eighth type.
+    /// - Returns: A value resulting of the application of the corresponding function based on the content of the coproduct.
     public func fold<Z>(_ fa: (A) -> Z,
                         _ fb: (B) -> Z,
                         _ fc: (C) -> Z,
@@ -62,34 +110,42 @@ public final class Coproduct8<A, B, C, D, E, F, G, H>: Coproduct8Of<A, B, C, D, 
         }
     }
 
+    /// Retrieves the value of the first type, if present.
     public var first: Option<A> {
         return fold(Option.some, constant(Option.none()), constant(Option.none()), constant(Option.none()), constant(Option.none()), constant(Option.none()), constant(Option.none()), constant(Option.none()))
     }
 
+    /// Retrieves the value of the second type, if present.
     public var second: Option<B> {
         return fold(constant(Option.none()), Option.some, constant(Option.none()), constant(Option.none()), constant(Option.none()), constant(Option.none()), constant(Option.none()), constant(Option.none()))
     }
 
+    /// Retrieves the value of the third type, if present.
     public var third: Option<C> {
         return fold(constant(Option.none()), constant(Option.none()), Option.some, constant(Option.none()), constant(Option.none()), constant(Option.none()), constant(Option.none()), constant(Option.none()))
     }
 
+    /// Retrieves the value of the fourth type, if present.
     public var fourth: Option<D> {
         return fold(constant(Option.none()), constant(Option.none()), constant(Option.none()), Option.some, constant(Option.none()), constant(Option.none()), constant(Option.none()), constant(Option.none()))
     }
 
+    /// Retrieves the value of the fifth type, if present.
     public var fifth: Option<E> {
         return fold(constant(Option.none()), constant(Option.none()), constant(Option.none()), constant(Option.none()), Option.some, constant(Option.none()), constant(Option.none()), constant(Option.none()))
     }
 
+    /// Retrieves the value of the sixth type, if present.
     public var sixth: Option<F> {
         return fold(constant(Option.none()), constant(Option.none()), constant(Option.none()), constant(Option.none()), constant(Option.none()), Option.some, constant(Option.none()), constant(Option.none()))
     }
 
+    /// Retrieves the value of the seventh type, if present.
     public var seventh: Option<G> {
         return fold(constant(Option.none()), constant(Option.none()), constant(Option.none()), constant(Option.none()), constant(Option.none()), constant(Option.none()), Option.some, constant(Option.none()))
     }
 
+    /// Retrieves the value of the eighth type, if present.
     public var eighth: Option<H> {
         return fold(constant(Option.none()), constant(Option.none()), constant(Option.none()), constant(Option.none()), constant(Option.none()), constant(Option.none()), constant(Option.none()), Option.some)
     }

--- a/Sources/BowGeneric/Coproduct9.swift
+++ b/Sources/BowGeneric/Coproduct9.swift
@@ -1,8 +1,12 @@
 import Bow
 
+/// Witness for the `Coproduct9` data type. To be used in simulated Higher Kinded Types.
 public final class ForCoproduct9 {}
+
+/// Higher Kinded Type alias to improve readability over `Kind9`.
 public typealias Coproduct9Of<A, B, C, D, E, F, G, H, I> = Kind9<ForCoproduct9, A, B, C, D, E, F, G, H, I>
 
+/// Represents a sum type of 9 different types.
 public final class Coproduct9<A, B, C, D, E, F, G, H, I>: Coproduct9Of<A, B, C, D, E, F, G, H, I> {
     private let cop: Cop9<A, B, C, D, E, F, G, H, I>
 
@@ -10,42 +14,91 @@ public final class Coproduct9<A, B, C, D, E, F, G, H, I>: Coproduct9Of<A, B, C, 
         self.cop = cop
     }
 
+    /// Creates an instance of a coproduct providing a value of the first type.
+    ///
+    /// - Parameter a: Value of the first type of the coproduct.
+    /// - Returns: A coproduct with a value of the first type.
     public static func first(_ a: A) -> Coproduct9<A, B, C, D, E, F, G, H, I> {
         return Coproduct9(.first(a))
     }
 
+    /// Creates an instance of a coproduct providing a value of the second type.
+    ///
+    /// - Parameter b: Value of the second type of the coproduct.
+    /// - Returns: A coproduct with a value of the second type.
     public static func second(_ b: B) -> Coproduct9<A, B, C, D, E, F, G, H, I> {
         return Coproduct9(.second(b))
     }
 
+    /// Creates an instance of a coproduct providing a value of the third type.
+    ///
+    /// - Parameter c: Value of the third type of the coproduct.
+    /// - Returns: A coproduct with a value of the third type.
     public static func third(_ c: C) -> Coproduct9<A, B, C, D, E, F, G, H, I> {
         return Coproduct9(.third(c))
     }
 
+    /// Creates an instance of a coproduct providing a value of the fourth type.
+    ///
+    /// - Parameter d: Value of the fourth type of the coproduct.
+    /// - Returns: A coproduct with a value of the fourth type.
     public static func fourth(_ d: D) -> Coproduct9<A, B, C, D, E, F, G, H, I> {
         return Coproduct9(.fourth(d))
     }
 
+    /// Creates an instance of a coproduct providing a value of the fifth type.
+    ///
+    /// - Parameter e: Value of the fifth type of the coproduct.
+    /// - Returns: A coproduct with a value of the fifth type.
     public static func fifth(_ e: E) -> Coproduct9<A, B, C, D, E, F, G, H, I> {
         return Coproduct9(.fifth(e))
     }
 
+    /// Creates an instance of a coproduct providing a value of the sixth type.
+    ///
+    /// - Parameter f: Value of the sixth type of the coproduct.
+    /// - Returns: A coproduct with a value of the sixth type.
     public static func sixth(_ f: F) -> Coproduct9<A, B, C, D, E, F, G, H, I> {
         return Coproduct9(.sixth(f))
     }
 
+    /// Creates an instance of a coproduct providing a value of the seventh type.
+    ///
+    /// - Parameter g: Value of the seventh type of the coproduct.
+    /// - Returns: A coproduct with a value of the seventh type.
     public static func seventh(_ g: G) -> Coproduct9<A, B, C, D, E, F, G, H, I> {
         return Coproduct9(.seventh(g))
     }
 
+    /// Creates an instance of a coproduct providing a value of the eighth type.
+    ///
+    /// - Parameter h: Value of the eighth type of the coproduct.
+    /// - Returns: A coproduct with a value of the eighth type.
     public static func eighth(_ h: H) -> Coproduct9<A, B, C, D, E, F, G, H, I> {
         return Coproduct9(.eighth(h))
     }
 
+    /// Creates an instance of a coproduct providing a value of the ninth type.
+    ///
+    /// - Parameter i: Value of the ninth type of the coproduct.
+    /// - Returns: A coproduct with a value of the ninth type.
     public static func ninth(_ i: I) -> Coproduct9<A, B, C, D, E, F, G, H, I> {
         return Coproduct9(.ninth(i))
     }
 
+    /// Applies a function depending on the content of the coproduct.
+    ///
+    /// - Parameters:
+    ///   - fa: Function to apply with a value of the first type.
+    ///   - fb: Function to apply with a value of the second type.
+    ///   - fc: Function to apply with a value of the third type.
+    ///   - fd: Function to apply with a value of the fourth type.
+    ///   - fe: Function to apply with a value of the fifth type.
+    ///   - ff: Function to apply with a value of the sixth type.
+    ///   - fg: Function to apply with a value of the seventh type.
+    ///   - fh: Function to apply with a value of the eighth type.
+    ///   - fi: Function to apply with a value of the ninth type.
+    /// - Returns: A value resulting of the application of the corresponding function based on the content of the coproduct.
     public func fold<Z>(_ fa: (A) -> Z,
                         _ fb: (B) -> Z,
                         _ fc: (C) -> Z,
@@ -68,38 +121,47 @@ public final class Coproduct9<A, B, C, D, E, F, G, H, I>: Coproduct9Of<A, B, C, 
         }
     }
 
+    /// Retrieves the value of the first type, if present.
     public var first: Option<A> {
         return fold(Option.some, constant(Option.none()), constant(Option.none()), constant(Option.none()), constant(Option.none()), constant(Option.none()), constant(Option.none()), constant(Option.none()), constant(Option.none()))
     }
 
+    /// Retrieves the value of the second type, if present.
     public var second: Option<B> {
         return fold(constant(Option.none()), Option.some, constant(Option.none()), constant(Option.none()), constant(Option.none()), constant(Option.none()), constant(Option.none()), constant(Option.none()), constant(Option.none()))
     }
 
+    /// Retrieves the value of the third type, if present.
     public var third: Option<C> {
         return fold(constant(Option.none()), constant(Option.none()), Option.some, constant(Option.none()), constant(Option.none()), constant(Option.none()), constant(Option.none()), constant(Option.none()), constant(Option.none()))
     }
 
+    /// Retrieves the value of the fourth type, if present.
     public var fourth: Option<D> {
         return fold(constant(Option.none()), constant(Option.none()), constant(Option.none()), Option.some, constant(Option.none()), constant(Option.none()), constant(Option.none()), constant(Option.none()), constant(Option.none()))
     }
 
+    /// Retrieves the value of the fifth type, if present.
     public var fifth: Option<E> {
         return fold(constant(Option.none()), constant(Option.none()), constant(Option.none()), constant(Option.none()), Option.some, constant(Option.none()), constant(Option.none()), constant(Option.none()), constant(Option.none()))
     }
 
+    /// Retrieves the value of the sixth type, if present.
     public var sixth: Option<F> {
         return fold(constant(Option.none()), constant(Option.none()), constant(Option.none()), constant(Option.none()), constant(Option.none()), Option.some, constant(Option.none()), constant(Option.none()), constant(Option.none()))
     }
 
+    /// Retrieves the value of the seventh type, if present.
     public var seventh: Option<G> {
         return fold(constant(Option.none()), constant(Option.none()), constant(Option.none()), constant(Option.none()), constant(Option.none()), constant(Option.none()), Option.some, constant(Option.none()), constant(Option.none()))
     }
 
+    /// Retrieves the value of the eighth type, if present.
     public var eighth: Option<H> {
         return fold(constant(Option.none()), constant(Option.none()), constant(Option.none()), constant(Option.none()), constant(Option.none()), constant(Option.none()), constant(Option.none()), Option.some, constant(Option.none()))
     }
 
+    /// Retrieves the value of the ninth type, if present.
     public var ninth: Option<I> {
         return fold(constant(Option.none()), constant(Option.none()), constant(Option.none()), constant(Option.none()), constant(Option.none()), constant(Option.none()), constant(Option.none()), constant(Option.none()), Option.some)
     }


### PR DESCRIPTION
## Related issues

- Closes #387.

## Goal

Add API documentation for all Coproduct data types, from 2 to 10.