### PR TITLE
Expose generators and laws as public artifacts

### DIFF
--- a/Bow-OpticsLaws-Info.plist
+++ b/Bow-OpticsLaws-Info.plist
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plist version="1.0">
+<dict>
+  <key>CFBundleDevelopmentRegion</key>
+  <string>en</string>
+  <key>CFBundleExecutable</key>
+  <string>$(EXECUTABLE_NAME)</string>
+  <key>CFBundleIdentifier</key>
+  <string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+  <key>CFBundleInfoDictionaryVersion</key>
+  <string>6.0</string>
+  <key>CFBundleName</key>
+  <string>$(PRODUCT_NAME)</string>
+  <key>CFBundlePackageType</key>
+  <string>BNDL</string>
+  <key>CFBundleShortVersionString</key>
+  <string>1.0</string>
+  <key>CFBundleSignature</key>
+  <string>????</string>
+  <key>CFBundleVersion</key>
+  <string>$(CURRENT_PROJECT_VERSION)</string>
+  <key>NSPrincipalClass</key>
+  <string></string>
+</dict>
+</plist>

--- a/Bow.xcodeproj/project.pbxproj
+++ b/Bow.xcodeproj/project.pbxproj
@@ -18,7 +18,6 @@
 		1116D4FC224E332900507B54 /* Coproduct9.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1116D4FB224E332900507B54 /* Coproduct9.swift */; };
 		1116D500224E342200507B54 /* Coproduct10.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1116D4FF224E342200507B54 /* Coproduct10.swift */; };
 		1116D502224E3A2300507B54 /* Coproduct2.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1116D501224E3A2300507B54 /* Coproduct2.swift */; };
-		112097A322A7EBC7007F3D9C /* Nimble.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8BA0F384217E2D3400969984 /* Nimble.framework */; };
 		112097A422A7EBC7007F3D9C /* SwiftCheck.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8BA0F385217E2D3400969984 /* SwiftCheck.framework */; };
 		112097AF22A7EE46007F3D9C /* Either+Gen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 112097AE22A7EE46007F3D9C /* Either+Gen.swift */; };
 		112097B122A7F0E6007F3D9C /* ArrayK+Gen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 112097B022A7F0E6007F3D9C /* ArrayK+Gen.swift */; };
@@ -171,18 +170,14 @@
 		1160D0ED22D38DC40010323A /* SetterLaws.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BA0F3DF217E2DEF00969984 /* SetterLaws.swift */; };
 		1160D0EE22D38DC40010323A /* TraversalLaws.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BA0F3DE217E2DEF00969984 /* TraversalLaws.swift */; };
 		1166A07A22119F720032CD4E /* EqualityFunctions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1166A07822119E640032CD4E /* EqualityFunctions.swift */; };
-		117DC0CD22AE492700EF65F0 /* Nimble.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8BA0F384217E2D3400969984 /* Nimble.framework */; };
 		117DC0CE22AE492700EF65F0 /* SwiftCheck.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8BA0F385217E2D3400969984 /* SwiftCheck.framework */; };
 		117DC0D722AE49C200EF65F0 /* IO+Gen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 117DC0D622AE49C200EF65F0 /* IO+Gen.swift */; };
-		117DC0E622AE4D6C00EF65F0 /* Nimble.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8BA0F384217E2D3400969984 /* Nimble.framework */; };
 		117DC0E722AE4D6C00EF65F0 /* SwiftCheck.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8BA0F385217E2D3400969984 /* SwiftCheck.framework */; };
 		117DC0F222AE4E1C00EF65F0 /* SingleK+Gen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 117DC0F122AE4E1C00EF65F0 /* SingleK+Gen.swift */; };
 		117DC0F422AE4F3500EF65F0 /* MaybeK+Gen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 117DC0F322AE4F3500EF65F0 /* MaybeK+Gen.swift */; };
 		117DC0F622AE504500EF65F0 /* ObservableK+Gen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 117DC0F522AE504500EF65F0 /* ObservableK+Gen.swift */; };
-		117DC10122AE522000EF65F0 /* Nimble.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8BA0F384217E2D3400969984 /* Nimble.framework */; };
 		117DC10222AE522000EF65F0 /* SwiftCheck.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8BA0F385217E2D3400969984 /* SwiftCheck.framework */; };
 		117DC10D22AE533700EF65F0 /* FutureK+Gen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 117DC10C22AE533700EF65F0 /* FutureK+Gen.swift */; };
-		117DC12922AE563900EF65F0 /* Nimble.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8BA0F384217E2D3400969984 /* Nimble.framework */; };
 		117DC12A22AE563900EF65F0 /* SwiftCheck.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8BA0F385217E2D3400969984 /* SwiftCheck.framework */; };
 		117DC13722AE578A00EF65F0 /* Free+Gen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 117DC13622AE578A00EF65F0 /* Free+Gen.swift */; };
 		1186E15122BA395D001F8A5D /* Index+Optics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1186E14E22BA38CD001F8A5D /* Index+Optics.swift */; };
@@ -554,13 +549,6 @@
 			remoteGlobalIDString = 117DC0F722AE522000EF65F0;
 			remoteInfo = "Bow-BrightFuturesGenerators";
 		};
-		1126CA8222B0DE3F00F840CB /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = OBJ_1 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 117DC0B222AE492700EF65F0;
-			remoteInfo = "Bow-EffectsGenerators";
-		};
 		1126CA8422B0DE9E00F840CB /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = OBJ_1 /* Project object */;
@@ -574,13 +562,6 @@
 			proxyType = 1;
 			remoteGlobalIDString = 117DC0DC22AE4D6C00EF65F0;
 			remoteInfo = "Bow-RxGenerators";
-		};
-		1160D0BF22D38CEC0010323A /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = OBJ_1 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 1120978222A7EBC7007F3D9C;
-			remoteInfo = "Bow-Generators";
 		};
 		1160D0C122D38CEC0010323A /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -701,12 +682,12 @@
 			remoteGlobalIDString = 11E71817219D81B300B94845;
 			remoteInfo = "Bow-Free";
 		};
-		1186E15422BA4A9D001F8A5D /* PBXContainerItemProxy */ = {
+		1191BD0022D4928D0052FEA8 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = OBJ_1 /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = 1120978222A7EBC7007F3D9C;
-			remoteInfo = "Bow-Generators";
+			remoteGlobalIDString = 117DC0B222AE492700EF65F0;
+			remoteInfo = "Bow-EffectsGenerators";
 		};
 		11D97EC5219EBAA1008FC004 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -1125,7 +1106,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 0;
 			files = (
-				112097A322A7EBC7007F3D9C /* Nimble.framework in Frameworks */,
 				112097A422A7EBC7007F3D9C /* SwiftCheck.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1245,7 +1225,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 0;
 			files = (
-				117DC0CD22AE492700EF65F0 /* Nimble.framework in Frameworks */,
 				117DC0CE22AE492700EF65F0 /* SwiftCheck.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1254,7 +1233,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 0;
 			files = (
-				117DC0E622AE4D6C00EF65F0 /* Nimble.framework in Frameworks */,
 				117DC0E722AE4D6C00EF65F0 /* SwiftCheck.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1263,7 +1241,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 0;
 			files = (
-				117DC10122AE522000EF65F0 /* Nimble.framework in Frameworks */,
 				117DC10222AE522000EF65F0 /* SwiftCheck.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1272,7 +1249,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 0;
 			files = (
-				117DC12922AE563900EF65F0 /* Nimble.framework in Frameworks */,
 				117DC12A22AE563900EF65F0 /* SwiftCheck.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -2256,7 +2232,7 @@
 			buildRules = (
 			);
 			dependencies = (
-				1126CA8322B0DE3F00F840CB /* PBXTargetDependency */,
+				1191BD0122D4928D0052FEA8 /* PBXTargetDependency */,
 				11D97EF1219EBBB4008FC004 /* PBXTargetDependency */,
 				11229785219DC95B006D66C5 /* PBXTargetDependency */,
 				11229749219DC88F006D66C5 /* PBXTargetDependency */,
@@ -2363,7 +2339,6 @@
 			);
 			dependencies = (
 				1160D0F222D38E080010323A /* PBXTargetDependency */,
-				1160D0BE22D38CEC0010323A /* PBXTargetDependency */,
 				1160D0C022D38CEC0010323A /* PBXTargetDependency */,
 			);
 			name = "Bow-OpticsLaws";
@@ -2501,7 +2476,6 @@
 			);
 			dependencies = (
 				1160D0F422D38E2A0010323A /* PBXTargetDependency */,
-				1186E15522BA4A9D001F8A5D /* PBXTargetDependency */,
 				11E71806219D7DFB00B94845 /* PBXTargetDependency */,
 				11E7179F219D7D5900B94845 /* PBXTargetDependency */,
 			);
@@ -3615,11 +3589,6 @@
 			target = 117DC0F722AE522000EF65F0 /* Bow-BrightFuturesGenerators */;
 			targetProxy = 1126CA8022B0DDD100F840CB /* PBXContainerItemProxy */;
 		};
-		1126CA8322B0DE3F00F840CB /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			target = 117DC0B222AE492700EF65F0 /* Bow-EffectsGenerators */;
-			targetProxy = 1126CA8222B0DE3F00F840CB /* PBXContainerItemProxy */;
-		};
 		1126CA8522B0DE9E00F840CB /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = 117DC10E22AE563900EF65F0 /* Bow-FreeGenerators */;
@@ -3629,11 +3598,6 @@
 			isa = PBXTargetDependency;
 			target = 117DC0DC22AE4D6C00EF65F0 /* Bow-RxGenerators */;
 			targetProxy = 1126CA8622B0DF2B00F840CB /* PBXContainerItemProxy */;
-		};
-		1160D0BE22D38CEC0010323A /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			target = 1120978222A7EBC7007F3D9C /* Bow-Generators */;
-			targetProxy = 1160D0BF22D38CEC0010323A /* PBXContainerItemProxy */;
 		};
 		1160D0C022D38CEC0010323A /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
@@ -3720,10 +3684,10 @@
 			target = 11E71817219D81B300B94845 /* Bow-Free */;
 			targetProxy = 117DC13322AE56D800EF65F0 /* PBXContainerItemProxy */;
 		};
-		1186E15522BA4A9D001F8A5D /* PBXTargetDependency */ = {
+		1191BD0122D4928D0052FEA8 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			target = 1120978222A7EBC7007F3D9C /* Bow-Generators */;
-			targetProxy = 1186E15422BA4A9D001F8A5D /* PBXContainerItemProxy */;
+			target = 117DC0B222AE492700EF65F0 /* Bow-EffectsGenerators */;
+			targetProxy = 1191BD0022D4928D0052FEA8 /* PBXContainerItemProxy */;
 		};
 		11D97EC4219EBAA1008FC004 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;

--- a/Bow.xcodeproj/project.pbxproj
+++ b/Bow.xcodeproj/project.pbxproj
@@ -134,6 +134,42 @@
 		112D0CF422BBC0390032F675 /* AutoFold.swift in Sources */ = {isa = PBXBuildFile; fileRef = 112D0CF322BBC0390032F675 /* AutoFold.swift */; };
 		112D0CF622BBC17C0032F675 /* AutoTraversal.swift in Sources */ = {isa = PBXBuildFile; fileRef = 112D0CF522BBC17C0032F675 /* AutoTraversal.swift */; };
 		113CD8F4219DD82F00730E58 /* RxSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8BA0F367217E2CB100969984 /* RxSwift.framework */; };
+		1160D0C322D38CEC0010323A /* AlternativeLaws.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BA0F3C6217E2DEF00969984 /* AlternativeLaws.swift */; };
+		1160D0C422D38CEC0010323A /* ApplicativeErrorLaws.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BA0F3C4217E2DEF00969984 /* ApplicativeErrorLaws.swift */; };
+		1160D0C522D38CEC0010323A /* ApplicativeLaws.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BA0F3CE217E2DEF00969984 /* ApplicativeLaws.swift */; };
+		1160D0C622D38CEC0010323A /* BimonadLaws.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BA0F3CA217E2DEF00969984 /* BimonadLaws.swift */; };
+		1160D0C722D38CEC0010323A /* ComonadLaws.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BA0F3D2217E2DEF00969984 /* ComonadLaws.swift */; };
+		1160D0C822D38CEC0010323A /* ContravariantLaws.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BA0F3C9217E2DEF00969984 /* ContravariantLaws.swift */; };
+		1160D0C922D38CEC0010323A /* EquatableKLaws.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BA0F3BF217E2DEF00969984 /* EquatableKLaws.swift */; };
+		1160D0CA22D38CEC0010323A /* FoldableLaws.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BA0F3D6217E2DEF00969984 /* FoldableLaws.swift */; };
+		1160D0CB22D38CEC0010323A /* FunctorFilterLaws.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BA0F3C1217E2DEF00969984 /* FunctorFilterLaws.swift */; };
+		1160D0CC22D38CEC0010323A /* EquatableLaws.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11A435602212C59F000C5E31 /* EquatableLaws.swift */; };
+		1160D0CD22D38CEC0010323A /* FunctorLaws.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BA0F3CC217E2DEF00969984 /* FunctorLaws.swift */; };
+		1160D0CE22D38CEC0010323A /* InvariantLaws.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BA0F3D5217E2DEF00969984 /* InvariantLaws.swift */; };
+		1160D0CF22D38CEC0010323A /* MonadCombineLaws.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BA0F3CD217E2DEF00969984 /* MonadCombineLaws.swift */; };
+		1160D0D022D38CEC0010323A /* SelectiveLaws.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11D36A1A2232787A00CBD85F /* SelectiveLaws.swift */; };
+		1160D0D122D38CEC0010323A /* MonadErrorLaws.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BA0F3BC217E2DEF00969984 /* MonadErrorLaws.swift */; };
+		1160D0D222D38CEC0010323A /* MonadFilterLaws.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BA0F3C7217E2DEF00969984 /* MonadFilterLaws.swift */; };
+		1160D0D322D38CEC0010323A /* MonadLaws.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BA0F3C0217E2DEF00969984 /* MonadLaws.swift */; };
+		1160D0D422D38CEC0010323A /* MonadStateLaws.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BA0F3CB217E2DEF00969984 /* MonadStateLaws.swift */; };
+		1160D0D522D38CEC0010323A /* MonadWriterLaws.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BA0F3C5217E2DEF00969984 /* MonadWriterLaws.swift */; };
+		1160D0D622D38CEC0010323A /* MonoidKLaws.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BA0F3D4217E2DEF00969984 /* MonoidKLaws.swift */; };
+		1160D0D722D38CEC0010323A /* MonoidLaws.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BA0F3BD217E2DEF00969984 /* MonoidLaws.swift */; };
+		1160D0D822D38CEC0010323A /* EqualityFunctions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1166A07822119E640032CD4E /* EqualityFunctions.swift */; };
+		1160D0D922D38CEC0010323A /* ComparableLaws.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BA0F3C2217E2DEF00969984 /* ComparableLaws.swift */; };
+		1160D0DA22D38CEC0010323A /* SemigroupKLaws.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BA0F3CF217E2DEF00969984 /* SemigroupKLaws.swift */; };
+		1160D0DB22D38CEC0010323A /* SemigroupLaws.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BA0F3BE217E2DEF00969984 /* SemigroupLaws.swift */; };
+		1160D0DC22D38CEC0010323A /* CustomStringConvertibleLaws.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BA0F3D1217E2DEF00969984 /* CustomStringConvertibleLaws.swift */; };
+		1160D0DD22D38CEC0010323A /* TraverseFilterLaws.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BA0F3D3217E2DEF00969984 /* TraverseFilterLaws.swift */; };
+		1160D0DE22D38CEC0010323A /* TraverseLaws.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BA0F3BB217E2DEF00969984 /* TraverseLaws.swift */; };
+		1160D0E022D38CEC0010323A /* Nimble.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8BA0F384217E2D3400969984 /* Nimble.framework */; };
+		1160D0E122D38CEC0010323A /* SwiftCheck.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8BA0F385217E2D3400969984 /* SwiftCheck.framework */; };
+		1160D0E922D38DC40010323A /* IsoLaws.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BA0F3DD217E2DEF00969984 /* IsoLaws.swift */; };
+		1160D0EA22D38DC40010323A /* LensLaws.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BA0F3DB217E2DEF00969984 /* LensLaws.swift */; };
+		1160D0EB22D38DC40010323A /* OptionalLaws.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BA0F3DC217E2DEF00969984 /* OptionalLaws.swift */; };
+		1160D0EC22D38DC40010323A /* PrismLaws.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BA0F3E0217E2DEF00969984 /* PrismLaws.swift */; };
+		1160D0ED22D38DC40010323A /* SetterLaws.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BA0F3DF217E2DEF00969984 /* SetterLaws.swift */; };
+		1160D0EE22D38DC40010323A /* TraversalLaws.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BA0F3DE217E2DEF00969984 /* TraversalLaws.swift */; };
 		1166A07A22119F720032CD4E /* EqualityFunctions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1166A07822119E640032CD4E /* EqualityFunctions.swift */; };
 		117DC0CD22AE492700EF65F0 /* Nimble.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8BA0F384217E2D3400969984 /* Nimble.framework */; };
 		117DC0CE22AE492700EF65F0 /* SwiftCheck.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8BA0F385217E2D3400969984 /* SwiftCheck.framework */; };
@@ -205,12 +241,6 @@
 		11E7180E219D7ECC00B94845 /* SetterTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BA0F3E1217E2DEF00969984 /* SetterTest.swift */; };
 		11E7180F219D7ECC00B94845 /* TestDomain.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BA0F3E7217E2DEF00969984 /* TestDomain.swift */; };
 		11E71810219D7ECC00B94845 /* TraversalTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BA0F3E2217E2DEF00969984 /* TraversalTest.swift */; };
-		11E71811219D7ECC00B94845 /* IsoLaws.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BA0F3DD217E2DEF00969984 /* IsoLaws.swift */; };
-		11E71812219D7ECC00B94845 /* LensLaws.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BA0F3DB217E2DEF00969984 /* LensLaws.swift */; };
-		11E71813219D7ECC00B94845 /* OptionalLaws.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BA0F3DC217E2DEF00969984 /* OptionalLaws.swift */; };
-		11E71814219D7ECC00B94845 /* PrismLaws.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BA0F3E0217E2DEF00969984 /* PrismLaws.swift */; };
-		11E71815219D7ECC00B94845 /* SetterLaws.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BA0F3DF217E2DEF00969984 /* SetterLaws.swift */; };
-		11E71816219D7ECC00B94845 /* TraversalLaws.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BA0F3DE217E2DEF00969984 /* TraversalLaws.swift */; };
 		11E7188E219D82BD00B94845 /* Cofree.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BA0F440217E2E9200969984 /* Cofree.swift */; };
 		11E7188F219D82BD00B94845 /* Coyoneda.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BA0F43F217E2E9200969984 /* Coyoneda.swift */; };
 		11E71890219D82BD00B94845 /* Free.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BA0F441217E2E9200969984 /* Free.swift */; };
@@ -545,6 +575,34 @@
 			remoteGlobalIDString = 117DC0DC22AE4D6C00EF65F0;
 			remoteInfo = "Bow-RxGenerators";
 		};
+		1160D0BF22D38CEC0010323A /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = OBJ_1 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 1120978222A7EBC7007F3D9C;
+			remoteInfo = "Bow-Generators";
+		};
+		1160D0C122D38CEC0010323A /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = OBJ_1 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = "Bow::Bow";
+			remoteInfo = Bow;
+		};
+		1160D0F122D38E080010323A /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = OBJ_1 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 11E71683219D704F00B94845;
+			remoteInfo = "Bow-Optics";
+		};
+		1160D0F322D38E2A0010323A /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = OBJ_1 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 1160D0BD22D38CEC0010323A;
+			remoteInfo = "Bow-OpticsLaws";
+		};
 		117DC0B422AE492700EF65F0 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = OBJ_1 /* Project object */;
@@ -805,6 +863,8 @@
 		112D0CEF22BB88F20032F675 /* Result+Optics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Result+Optics.swift"; sourceTree = "<group>"; };
 		112D0CF322BBC0390032F675 /* AutoFold.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoFold.swift; sourceTree = "<group>"; };
 		112D0CF522BBC17C0032F675 /* AutoTraversal.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoTraversal.swift; sourceTree = "<group>"; };
+		1160D0E622D38CEC0010323A /* BowOpticsLaws.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = BowOpticsLaws.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		1160D0E722D38CEC0010323A /* Bow-OpticsLaws-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; name = "Bow-OpticsLaws-Info.plist"; path = "/Users/tomasruizlopez/Development/bow/Bow-OpticsLaws-Info.plist"; sourceTree = "<absolute>"; };
 		1166A07822119E640032CD4E /* EqualityFunctions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EqualityFunctions.swift; sourceTree = "<group>"; };
 		117DC0D322AE492700EF65F0 /* BowEffectsGenerators.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = BowEffectsGenerators.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		117DC0D422AE492700EF65F0 /* Bow-Effects-Generators-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; name = "Bow-Effects-Generators-Info.plist"; path = "/Users/tomasruizlopez/Development/bow/Bow-Effects-Generators-Info.plist"; sourceTree = "<absolute>"; };
@@ -1172,6 +1232,15 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		1160D0DF22D38CEC0010323A /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 0;
+			files = (
+				1160D0E022D38CEC0010323A /* Nimble.framework in Frameworks */,
+				1160D0E122D38CEC0010323A /* SwiftCheck.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		117DC0CC22AE492700EF65F0 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 0;
@@ -1449,6 +1518,19 @@
 			path = Tuple;
 			sourceTree = "<group>";
 		};
+		1160D0E822D38DA80010323A /* BowOpticsLaws */ = {
+			isa = PBXGroup;
+			children = (
+				8BA0F3DD217E2DEF00969984 /* IsoLaws.swift */,
+				8BA0F3DB217E2DEF00969984 /* LensLaws.swift */,
+				8BA0F3DC217E2DEF00969984 /* OptionalLaws.swift */,
+				8BA0F3E0217E2DEF00969984 /* PrismLaws.swift */,
+				8BA0F3DF217E2DEF00969984 /* SetterLaws.swift */,
+				8BA0F3DE217E2DEF00969984 /* TraversalLaws.swift */,
+			);
+			path = BowOpticsLaws;
+			sourceTree = "<group>";
+		};
 		117DC0D522AE499E00EF65F0 /* BowEffectsGenerators */ = {
 			isa = PBXGroup;
 			children = (
@@ -1552,7 +1634,6 @@
 				8BA0F3E1217E2DEF00969984 /* SetterTest.swift */,
 				8BA0F3E7217E2DEF00969984 /* TestDomain.swift */,
 				8BA0F3E2217E2DEF00969984 /* TraversalTest.swift */,
-				8BA0F3DA217E2DEF00969984 /* Laws */,
 			);
 			path = BowOpticsTests;
 			sourceTree = "<group>";
@@ -1630,6 +1711,7 @@
 				11ED7A2D226E0E7600C27994 /* Bow-Info.plist */,
 				11E719FC219D883D00B94845 /* Bow-Laws-Info.plist */,
 				11E71713219D705000B94845 /* Bow-Optics-Info.plist */,
+				1160D0E722D38CEC0010323A /* Bow-OpticsLaws-Info.plist */,
 				11E71803219D7D5A00B94845 /* Bow-OpticsTests-Info.plist */,
 				112294EF219D8EF5006D66C5 /* Bow-RecursionSchemes-Info.plist */,
 				11229535219D8FF2006D66C5 /* Bow-RecursionSchemesTests-Info.plist */,
@@ -1730,19 +1812,6 @@
 				8BA0F3B3217E2DEF00969984 /* ValidatedTest.swift */,
 			);
 			path = Data;
-			sourceTree = "<group>";
-		};
-		8BA0F3DA217E2DEF00969984 /* Laws */ = {
-			isa = PBXGroup;
-			children = (
-				8BA0F3DD217E2DEF00969984 /* IsoLaws.swift */,
-				8BA0F3DB217E2DEF00969984 /* LensLaws.swift */,
-				8BA0F3DC217E2DEF00969984 /* OptionalLaws.swift */,
-				8BA0F3E0217E2DEF00969984 /* PrismLaws.swift */,
-				8BA0F3DF217E2DEF00969984 /* SetterLaws.swift */,
-				8BA0F3DE217E2DEF00969984 /* TraversalLaws.swift */,
-			);
-			path = Laws;
 			sourceTree = "<group>";
 		};
 		8BA0F43B217E2E9200969984 /* Bow */ = {
@@ -1971,6 +2040,7 @@
 				117DC0EC22AE4D6C00EF65F0 /* BowRxGenerators.framework */,
 				117DC10722AE522000EF65F0 /* BowBrightFuturesGenerators.framework */,
 				117DC12F22AE563900EF65F0 /* BowFreeGenerators.framework */,
+				1160D0E622D38CEC0010323A /* BowOpticsLaws.framework */,
 			);
 			name = Products;
 			sourceTree = BUILT_PRODUCTS_DIR;
@@ -2015,6 +2085,7 @@
 				112097AB22A7EC03007F3D9C /* BowGenerators */,
 				11229625219D95D2006D66C5 /* BowGenericTests */,
 				11E719FD219D888800B94845 /* BowLaws */,
+				1160D0E822D38DA80010323A /* BowOpticsLaws */,
 				11E71807219D7E0500B94845 /* BowOpticsTests */,
 				11229536219D9013006D66C5 /* BowRecursionSchemesTests */,
 				117DC0F022AE4DDF00EF65F0 /* BowRxGenerators */,
@@ -2280,6 +2351,26 @@
 			productReference = 11229804219DD2AB006D66C5 /* BowBrightFuturesTests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
 		};
+		1160D0BD22D38CEC0010323A /* Bow-OpticsLaws */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 1160D0E322D38CEC0010323A /* Build configuration list for PBXNativeTarget "Bow-OpticsLaws" */;
+			buildPhases = (
+				1160D0C222D38CEC0010323A /* Sources */,
+				1160D0DF22D38CEC0010323A /* Frameworks */,
+				1160D0E222D38CEC0010323A /* Run Script */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				1160D0F222D38E080010323A /* PBXTargetDependency */,
+				1160D0BE22D38CEC0010323A /* PBXTargetDependency */,
+				1160D0C022D38CEC0010323A /* PBXTargetDependency */,
+			);
+			name = "Bow-OpticsLaws";
+			productName = Bow;
+			productReference = 1160D0E622D38CEC0010323A /* BowOpticsLaws.framework */;
+			productType = "com.apple.product-type.framework";
+		};
 		117DC0B222AE492700EF65F0 /* Bow-EffectsGenerators */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = 117DC0D022AE492700EF65F0 /* Build configuration list for PBXNativeTarget "Bow-EffectsGenerators" */;
@@ -2409,6 +2500,7 @@
 			buildRules = (
 			);
 			dependencies = (
+				1160D0F422D38E2A0010323A /* PBXTargetDependency */,
 				1186E15522BA4A9D001F8A5D /* PBXTargetDependency */,
 				11E71806219D7DFB00B94845 /* PBXTargetDependency */,
 				11E7179F219D7D5900B94845 /* PBXTargetDependency */,
@@ -2568,16 +2660,17 @@
 				1122957A219D94C9006D66C5 /* Bow-Generic */,
 				112295E9219D9593006D66C5 /* Bow-GenericTests */,
 				11E71683219D704F00B94845 /* Bow-Optics */,
+				1160D0BD22D38CEC0010323A /* Bow-OpticsLaws */,
 				11E7179E219D7D5900B94845 /* Bow-OpticsTests */,
 				11229480219D8EF4006D66C5 /* Bow-RecursionSchemes */,
 				1122953D219D9186006D66C5 /* Bow-RecursionSchemesTests */,
 				112296D7219DC4B3006D66C5 /* Bow-Effects */,
+				11D97EC3219EBAA1008FC004 /* Bow-EffectsLaws */,
 				11229748219DC88F006D66C5 /* Bow-EffectsTests */,
 				11229791219DCE76006D66C5 /* Bow-Rx */,
 				112297B1219DCFDE006D66C5 /* Bow-RxTests */,
 				112297D3219DD148006D66C5 /* Bow-BrightFutures */,
 				112297EB219DD2AB006D66C5 /* Bow-BrightFuturesTests */,
-				11D97EC3219EBAA1008FC004 /* Bow-EffectsLaws */,
 			);
 		};
 /* End PBXProject section */
@@ -2747,6 +2840,26 @@
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "/usr/local/bin/carthage copy-frameworks\n";
+		};
+		1160D0E222D38CEC0010323A /* Run Script */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 8;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"$(SRCROOT)/Carthage/Build/iOS/SwiftCheck.framework",
+				"$(SRCROOT)/Carthage/Build/iOS/Nimble.framework",
+			);
+			name = "Run Script";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 1;
 			shellPath = /bin/sh;
 			shellScript = "/usr/local/bin/carthage copy-frameworks\n";
 		};
@@ -3060,6 +3173,47 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		1160D0C222D38CEC0010323A /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 0;
+			files = (
+				1160D0C322D38CEC0010323A /* AlternativeLaws.swift in Sources */,
+				1160D0C422D38CEC0010323A /* ApplicativeErrorLaws.swift in Sources */,
+				1160D0C522D38CEC0010323A /* ApplicativeLaws.swift in Sources */,
+				1160D0C622D38CEC0010323A /* BimonadLaws.swift in Sources */,
+				1160D0C722D38CEC0010323A /* ComonadLaws.swift in Sources */,
+				1160D0C822D38CEC0010323A /* ContravariantLaws.swift in Sources */,
+				1160D0C922D38CEC0010323A /* EquatableKLaws.swift in Sources */,
+				1160D0CA22D38CEC0010323A /* FoldableLaws.swift in Sources */,
+				1160D0EA22D38DC40010323A /* LensLaws.swift in Sources */,
+				1160D0E922D38DC40010323A /* IsoLaws.swift in Sources */,
+				1160D0EB22D38DC40010323A /* OptionalLaws.swift in Sources */,
+				1160D0CB22D38CEC0010323A /* FunctorFilterLaws.swift in Sources */,
+				1160D0EC22D38DC40010323A /* PrismLaws.swift in Sources */,
+				1160D0CC22D38CEC0010323A /* EquatableLaws.swift in Sources */,
+				1160D0CD22D38CEC0010323A /* FunctorLaws.swift in Sources */,
+				1160D0CE22D38CEC0010323A /* InvariantLaws.swift in Sources */,
+				1160D0CF22D38CEC0010323A /* MonadCombineLaws.swift in Sources */,
+				1160D0D022D38CEC0010323A /* SelectiveLaws.swift in Sources */,
+				1160D0D122D38CEC0010323A /* MonadErrorLaws.swift in Sources */,
+				1160D0ED22D38DC40010323A /* SetterLaws.swift in Sources */,
+				1160D0D222D38CEC0010323A /* MonadFilterLaws.swift in Sources */,
+				1160D0D322D38CEC0010323A /* MonadLaws.swift in Sources */,
+				1160D0D422D38CEC0010323A /* MonadStateLaws.swift in Sources */,
+				1160D0D522D38CEC0010323A /* MonadWriterLaws.swift in Sources */,
+				1160D0D622D38CEC0010323A /* MonoidKLaws.swift in Sources */,
+				1160D0D722D38CEC0010323A /* MonoidLaws.swift in Sources */,
+				1160D0D822D38CEC0010323A /* EqualityFunctions.swift in Sources */,
+				1160D0EE22D38DC40010323A /* TraversalLaws.swift in Sources */,
+				1160D0D922D38CEC0010323A /* ComparableLaws.swift in Sources */,
+				1160D0DA22D38CEC0010323A /* SemigroupKLaws.swift in Sources */,
+				1160D0DB22D38CEC0010323A /* SemigroupLaws.swift in Sources */,
+				1160D0DC22D38CEC0010323A /* CustomStringConvertibleLaws.swift in Sources */,
+				1160D0DD22D38CEC0010323A /* TraverseFilterLaws.swift in Sources */,
+				1160D0DE22D38CEC0010323A /* TraverseLaws.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		117DC0B522AE492700EF65F0 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 0;
@@ -3180,12 +3334,6 @@
 				11E7180E219D7ECC00B94845 /* SetterTest.swift in Sources */,
 				11E7180F219D7ECC00B94845 /* TestDomain.swift in Sources */,
 				11E71810219D7ECC00B94845 /* TraversalTest.swift in Sources */,
-				11E71811219D7ECC00B94845 /* IsoLaws.swift in Sources */,
-				11E71812219D7ECC00B94845 /* LensLaws.swift in Sources */,
-				11E71813219D7ECC00B94845 /* OptionalLaws.swift in Sources */,
-				11E71814219D7ECC00B94845 /* PrismLaws.swift in Sources */,
-				11E71815219D7ECC00B94845 /* SetterLaws.swift in Sources */,
-				11E71816219D7ECC00B94845 /* TraversalLaws.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -3481,6 +3629,26 @@
 			isa = PBXTargetDependency;
 			target = 117DC0DC22AE4D6C00EF65F0 /* Bow-RxGenerators */;
 			targetProxy = 1126CA8622B0DF2B00F840CB /* PBXContainerItemProxy */;
+		};
+		1160D0BE22D38CEC0010323A /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 1120978222A7EBC7007F3D9C /* Bow-Generators */;
+			targetProxy = 1160D0BF22D38CEC0010323A /* PBXContainerItemProxy */;
+		};
+		1160D0C022D38CEC0010323A /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = "Bow::Bow" /* Bow */;
+			targetProxy = 1160D0C122D38CEC0010323A /* PBXContainerItemProxy */;
+		};
+		1160D0F222D38E080010323A /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 11E71683219D704F00B94845 /* Bow-Optics */;
+			targetProxy = 1160D0F122D38E080010323A /* PBXContainerItemProxy */;
+		};
+		1160D0F422D38E2A0010323A /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 1160D0BD22D38CEC0010323A /* Bow-OpticsLaws */;
+			targetProxy = 1160D0F322D38E2A0010323A /* PBXContainerItemProxy */;
 		};
 		117DC0B322AE492700EF65F0 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
@@ -4201,6 +4369,54 @@
 			};
 			name = Release;
 		};
+		1160D0E422D38CEC0010323A /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ENABLE_TESTABILITY = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/iOS",
+				);
+				HEADER_SEARCH_PATHS = "$(inherited)";
+				INFOPLIST_FILE = "Bow-OpticsLaws-Info.plist";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @loader_path/Frameworks @executable_path/Frameworks";
+				OTHER_LDFLAGS = "$(inherited)";
+				OTHER_SWIFT_FLAGS = "$(inherited)";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.bow-swift.bow-optics-laws";
+				PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos";
+				SWIFT_VERSION = 5.0;
+				TARGET_NAME = BowOpticsLaws;
+			};
+			name = Debug;
+		};
+		1160D0E522D38CEC0010323A /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ENABLE_TESTABILITY = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/iOS",
+				);
+				HEADER_SEARCH_PATHS = "$(inherited)";
+				INFOPLIST_FILE = "Bow-OpticsLaws-Info.plist";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @loader_path/Frameworks @executable_path/Frameworks";
+				OTHER_LDFLAGS = "$(inherited)";
+				OTHER_SWIFT_FLAGS = "$(inherited)";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.bow-swift.bow-optics-laws";
+				PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos";
+				SWIFT_VERSION = 5.0;
+				TARGET_NAME = BowOpticsLaws;
+			};
+			name = Release;
+		};
 		117DC0D122AE492700EF65F0 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -4896,6 +5112,15 @@
 			buildConfigurations = (
 				11229802219DD2AB006D66C5 /* Debug */,
 				11229803219DD2AB006D66C5 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+		1160D0E322D38CEC0010323A /* Build configuration list for PBXNativeTarget "Bow-OpticsLaws" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				1160D0E422D38CEC0010323A /* Debug */,
+				1160D0E522D38CEC0010323A /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Debug;

--- a/Bow.xcodeproj/project.pbxproj
+++ b/Bow.xcodeproj/project.pbxproj
@@ -133,34 +133,6 @@
 		112D0CF422BBC0390032F675 /* AutoFold.swift in Sources */ = {isa = PBXBuildFile; fileRef = 112D0CF322BBC0390032F675 /* AutoFold.swift */; };
 		112D0CF622BBC17C0032F675 /* AutoTraversal.swift in Sources */ = {isa = PBXBuildFile; fileRef = 112D0CF522BBC17C0032F675 /* AutoTraversal.swift */; };
 		113CD8F4219DD82F00730E58 /* RxSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8BA0F367217E2CB100969984 /* RxSwift.framework */; };
-		1160D0C322D38CEC0010323A /* AlternativeLaws.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BA0F3C6217E2DEF00969984 /* AlternativeLaws.swift */; };
-		1160D0C422D38CEC0010323A /* ApplicativeErrorLaws.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BA0F3C4217E2DEF00969984 /* ApplicativeErrorLaws.swift */; };
-		1160D0C522D38CEC0010323A /* ApplicativeLaws.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BA0F3CE217E2DEF00969984 /* ApplicativeLaws.swift */; };
-		1160D0C622D38CEC0010323A /* BimonadLaws.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BA0F3CA217E2DEF00969984 /* BimonadLaws.swift */; };
-		1160D0C722D38CEC0010323A /* ComonadLaws.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BA0F3D2217E2DEF00969984 /* ComonadLaws.swift */; };
-		1160D0C822D38CEC0010323A /* ContravariantLaws.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BA0F3C9217E2DEF00969984 /* ContravariantLaws.swift */; };
-		1160D0C922D38CEC0010323A /* EquatableKLaws.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BA0F3BF217E2DEF00969984 /* EquatableKLaws.swift */; };
-		1160D0CA22D38CEC0010323A /* FoldableLaws.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BA0F3D6217E2DEF00969984 /* FoldableLaws.swift */; };
-		1160D0CB22D38CEC0010323A /* FunctorFilterLaws.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BA0F3C1217E2DEF00969984 /* FunctorFilterLaws.swift */; };
-		1160D0CC22D38CEC0010323A /* EquatableLaws.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11A435602212C59F000C5E31 /* EquatableLaws.swift */; };
-		1160D0CD22D38CEC0010323A /* FunctorLaws.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BA0F3CC217E2DEF00969984 /* FunctorLaws.swift */; };
-		1160D0CE22D38CEC0010323A /* InvariantLaws.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BA0F3D5217E2DEF00969984 /* InvariantLaws.swift */; };
-		1160D0CF22D38CEC0010323A /* MonadCombineLaws.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BA0F3CD217E2DEF00969984 /* MonadCombineLaws.swift */; };
-		1160D0D022D38CEC0010323A /* SelectiveLaws.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11D36A1A2232787A00CBD85F /* SelectiveLaws.swift */; };
-		1160D0D122D38CEC0010323A /* MonadErrorLaws.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BA0F3BC217E2DEF00969984 /* MonadErrorLaws.swift */; };
-		1160D0D222D38CEC0010323A /* MonadFilterLaws.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BA0F3C7217E2DEF00969984 /* MonadFilterLaws.swift */; };
-		1160D0D322D38CEC0010323A /* MonadLaws.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BA0F3C0217E2DEF00969984 /* MonadLaws.swift */; };
-		1160D0D422D38CEC0010323A /* MonadStateLaws.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BA0F3CB217E2DEF00969984 /* MonadStateLaws.swift */; };
-		1160D0D522D38CEC0010323A /* MonadWriterLaws.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BA0F3C5217E2DEF00969984 /* MonadWriterLaws.swift */; };
-		1160D0D622D38CEC0010323A /* MonoidKLaws.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BA0F3D4217E2DEF00969984 /* MonoidKLaws.swift */; };
-		1160D0D722D38CEC0010323A /* MonoidLaws.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BA0F3BD217E2DEF00969984 /* MonoidLaws.swift */; };
-		1160D0D822D38CEC0010323A /* EqualityFunctions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1166A07822119E640032CD4E /* EqualityFunctions.swift */; };
-		1160D0D922D38CEC0010323A /* ComparableLaws.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BA0F3C2217E2DEF00969984 /* ComparableLaws.swift */; };
-		1160D0DA22D38CEC0010323A /* SemigroupKLaws.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BA0F3CF217E2DEF00969984 /* SemigroupKLaws.swift */; };
-		1160D0DB22D38CEC0010323A /* SemigroupLaws.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BA0F3BE217E2DEF00969984 /* SemigroupLaws.swift */; };
-		1160D0DC22D38CEC0010323A /* CustomStringConvertibleLaws.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BA0F3D1217E2DEF00969984 /* CustomStringConvertibleLaws.swift */; };
-		1160D0DD22D38CEC0010323A /* TraverseFilterLaws.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BA0F3D3217E2DEF00969984 /* TraverseFilterLaws.swift */; };
-		1160D0DE22D38CEC0010323A /* TraverseLaws.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BA0F3BB217E2DEF00969984 /* TraverseLaws.swift */; };
 		1160D0E022D38CEC0010323A /* Nimble.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8BA0F384217E2D3400969984 /* Nimble.framework */; };
 		1160D0E122D38CEC0010323A /* SwiftCheck.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8BA0F385217E2D3400969984 /* SwiftCheck.framework */; };
 		1160D0E922D38DC40010323A /* IsoLaws.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BA0F3DD217E2DEF00969984 /* IsoLaws.swift */; };
@@ -688,6 +660,13 @@
 			proxyType = 1;
 			remoteGlobalIDString = 117DC0B222AE492700EF65F0;
 			remoteInfo = "Bow-EffectsGenerators";
+		};
+		1191BD0222D4AF4C0052FEA8 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = OBJ_1 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 1120978222A7EBC7007F3D9C;
+			remoteInfo = "Bow-Generators";
 		};
 		11D97EC5219EBAA1008FC004 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -2338,6 +2317,7 @@
 			buildRules = (
 			);
 			dependencies = (
+				1191BD0322D4AF4C0052FEA8 /* PBXTargetDependency */,
 				1160D0F222D38E080010323A /* PBXTargetDependency */,
 				1160D0C022D38CEC0010323A /* PBXTargetDependency */,
 			);
@@ -3151,40 +3131,12 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 0;
 			files = (
-				1160D0C322D38CEC0010323A /* AlternativeLaws.swift in Sources */,
-				1160D0C422D38CEC0010323A /* ApplicativeErrorLaws.swift in Sources */,
-				1160D0C522D38CEC0010323A /* ApplicativeLaws.swift in Sources */,
-				1160D0C622D38CEC0010323A /* BimonadLaws.swift in Sources */,
-				1160D0C722D38CEC0010323A /* ComonadLaws.swift in Sources */,
-				1160D0C822D38CEC0010323A /* ContravariantLaws.swift in Sources */,
-				1160D0C922D38CEC0010323A /* EquatableKLaws.swift in Sources */,
-				1160D0CA22D38CEC0010323A /* FoldableLaws.swift in Sources */,
 				1160D0EA22D38DC40010323A /* LensLaws.swift in Sources */,
 				1160D0E922D38DC40010323A /* IsoLaws.swift in Sources */,
 				1160D0EB22D38DC40010323A /* OptionalLaws.swift in Sources */,
-				1160D0CB22D38CEC0010323A /* FunctorFilterLaws.swift in Sources */,
 				1160D0EC22D38DC40010323A /* PrismLaws.swift in Sources */,
-				1160D0CC22D38CEC0010323A /* EquatableLaws.swift in Sources */,
-				1160D0CD22D38CEC0010323A /* FunctorLaws.swift in Sources */,
-				1160D0CE22D38CEC0010323A /* InvariantLaws.swift in Sources */,
-				1160D0CF22D38CEC0010323A /* MonadCombineLaws.swift in Sources */,
-				1160D0D022D38CEC0010323A /* SelectiveLaws.swift in Sources */,
-				1160D0D122D38CEC0010323A /* MonadErrorLaws.swift in Sources */,
 				1160D0ED22D38DC40010323A /* SetterLaws.swift in Sources */,
-				1160D0D222D38CEC0010323A /* MonadFilterLaws.swift in Sources */,
-				1160D0D322D38CEC0010323A /* MonadLaws.swift in Sources */,
-				1160D0D422D38CEC0010323A /* MonadStateLaws.swift in Sources */,
-				1160D0D522D38CEC0010323A /* MonadWriterLaws.swift in Sources */,
-				1160D0D622D38CEC0010323A /* MonoidKLaws.swift in Sources */,
-				1160D0D722D38CEC0010323A /* MonoidLaws.swift in Sources */,
-				1160D0D822D38CEC0010323A /* EqualityFunctions.swift in Sources */,
 				1160D0EE22D38DC40010323A /* TraversalLaws.swift in Sources */,
-				1160D0D922D38CEC0010323A /* ComparableLaws.swift in Sources */,
-				1160D0DA22D38CEC0010323A /* SemigroupKLaws.swift in Sources */,
-				1160D0DB22D38CEC0010323A /* SemigroupLaws.swift in Sources */,
-				1160D0DC22D38CEC0010323A /* CustomStringConvertibleLaws.swift in Sources */,
-				1160D0DD22D38CEC0010323A /* TraverseFilterLaws.swift in Sources */,
-				1160D0DE22D38CEC0010323A /* TraverseLaws.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -3688,6 +3640,11 @@
 			isa = PBXTargetDependency;
 			target = 117DC0B222AE492700EF65F0 /* Bow-EffectsGenerators */;
 			targetProxy = 1191BD0022D4928D0052FEA8 /* PBXContainerItemProxy */;
+		};
+		1191BD0322D4AF4C0052FEA8 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 1120978222A7EBC7007F3D9C /* Bow-Generators */;
+			targetProxy = 1191BD0222D4AF4C0052FEA8 /* PBXContainerItemProxy */;
 		};
 		11D97EC4219EBAA1008FC004 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;

--- a/Bow.xcodeproj/xcshareddata/xcschemes/Bow-OpticsLaws.xcscheme
+++ b/Bow.xcodeproj/xcshareddata/xcschemes/Bow-OpticsLaws.xcscheme
@@ -15,7 +15,7 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "1160D0BD22D38CEC0010323A"
-               BuildableName = "BowLaws.framework"
+               BuildableName = "BowOpticsLaws.framework"
                BlueprintName = "Bow-OpticsLaws"
                ReferencedContainer = "container:Bow.xcodeproj">
             </BuildableReference>
@@ -46,7 +46,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "1160D0BD22D38CEC0010323A"
-            BuildableName = "BowLaws.framework"
+            BuildableName = "BowOpticsLaws.framework"
             BlueprintName = "Bow-OpticsLaws"
             ReferencedContainer = "container:Bow.xcodeproj">
          </BuildableReference>
@@ -64,7 +64,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "1160D0BD22D38CEC0010323A"
-            BuildableName = "BowLaws.framework"
+            BuildableName = "BowOpticsLaws.framework"
             BlueprintName = "Bow-OpticsLaws"
             ReferencedContainer = "container:Bow.xcodeproj">
          </BuildableReference>

--- a/Bow.xcodeproj/xcshareddata/xcschemes/Bow-OpticsLaws.xcscheme
+++ b/Bow.xcodeproj/xcshareddata/xcschemes/Bow-OpticsLaws.xcscheme
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1020"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "1160D0BD22D38CEC0010323A"
+               BuildableName = "BowLaws.framework"
+               BlueprintName = "Bow-OpticsLaws"
+               ReferencedContainer = "container:Bow.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "1160D0BD22D38CEC0010323A"
+            BuildableName = "BowLaws.framework"
+            BlueprintName = "Bow-OpticsLaws"
+            ReferencedContainer = "container:Bow.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "1160D0BD22D38CEC0010323A"
+            BuildableName = "BowLaws.framework"
+            BlueprintName = "Bow-OpticsLaws"
+            ReferencedContainer = "container:Bow.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/BowBrightFuturesGenerators.podspec
+++ b/BowBrightFuturesGenerators.podspec
@@ -1,0 +1,31 @@
+Pod::Spec.new do |s|
+  s.name        = "BowBrightFuturesGenerators"
+  s.version     = "0.4.0"
+  s.summary     = "PBT Generators for data types in BowBrightFutures."
+  s.homepage    = "https://github.com/bow-swift/bow"
+  s.license      = { :type => 'Apache License, Version 2.0', :text => <<-LICENSE
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+    LICENSE
+  }
+  s.authors     = "The Bow authors"
+
+  s.requires_arc = true
+  s.osx.deployment_target = "10.10"
+  s.ios.deployment_target = "8.0"
+  s.tvos.deployment_target = "9.1"
+  s.watchos.deployment_target = "2.0"
+  s.source   = { :git => "https://github.com/bow-swift/bow.git", :tag => "#{s.version}" }
+  s.source_files = "Tests/BowBrightFuturesGenerators/**/*.swift"
+  s.dependency "Bow", "~> #{s.version}"
+  s.dependency "BowGenerators", "~> #{s.version}"
+  s.dependency "BowBrightFutures", "~> #{s.version}"
+  s.dependency "SwiftCheck", "~> 0.12.0"
+end

--- a/BowEffectsGenerators.podspec
+++ b/BowEffectsGenerators.podspec
@@ -1,0 +1,31 @@
+Pod::Spec.new do |s|
+  s.name        = "BowEffectsGenerators"
+  s.version     = "0.4.0"
+  s.summary     = "PBT Generators for data types in BowEffects."
+  s.homepage    = "https://github.com/bow-swift/bow"
+  s.license      = { :type => 'Apache License, Version 2.0', :text => <<-LICENSE
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+    LICENSE
+  }
+  s.authors     = "The Bow authors"
+
+  s.requires_arc = true
+  s.osx.deployment_target = "10.10"
+  s.ios.deployment_target = "8.0"
+  s.tvos.deployment_target = "9.1"
+  s.watchos.deployment_target = "2.0"
+  s.source   = { :git => "https://github.com/bow-swift/bow.git", :tag => "#{s.version}" }
+  s.source_files = "Tests/BowEffectsGenerators/**/*.swift"
+  s.dependency "Bow", "~> #{s.version}"
+  s.dependency "BowGenerators", "~> #{s.version}"
+  s.dependency "BowEffects", "~> #{s.version}"
+  s.dependency "SwiftCheck", "~> 0.12.0"
+end

--- a/BowEffectsLaws.podspec
+++ b/BowEffectsLaws.podspec
@@ -1,0 +1,31 @@
+Pod::Spec.new do |s|
+  s.name        = "BowEffectsLaws"
+  s.version     = "0.4.0"
+  s.summary     = "Laws for type classes included in BowEffects."
+  s.homepage    = "https://github.com/bow-swift/bow"
+  s.license      = { :type => 'Apache License, Version 2.0', :text => <<-LICENSE
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+    LICENSE
+  }
+  s.authors     = "The Bow authors"
+
+  s.requires_arc = true
+  s.osx.deployment_target = "10.10"
+  s.ios.deployment_target = "8.0"
+  s.tvos.deployment_target = "9.1"
+  s.watchos.deployment_target = "2.0"
+  s.source   = { :git => "https://github.com/bow-swift/bow.git", :tag => "#{s.version}" }
+  s.source_files = "Tests/BowEffectsLaws/**/*.swift"
+  s.dependency "Bow", "~> #{s.version}"
+  s.dependency "BowEffects", "~> #{s.version}"
+  s.dependency "SwiftCheck", "~> 0.12.0"
+  s.dependency "Nimble", "~> 8.0.1"
+end

--- a/BowFreeGenerators.podspec
+++ b/BowFreeGenerators.podspec
@@ -1,0 +1,31 @@
+Pod::Spec.new do |s|
+  s.name        = "BowFreeGenerators"
+  s.version     = "0.4.0"
+  s.summary     = "PBT Generators for data types in BowFree."
+  s.homepage    = "https://github.com/bow-swift/bow"
+  s.license      = { :type => 'Apache License, Version 2.0', :text => <<-LICENSE
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+    LICENSE
+  }
+  s.authors     = "The Bow authors"
+
+  s.requires_arc = true
+  s.osx.deployment_target = "10.10"
+  s.ios.deployment_target = "8.0"
+  s.tvos.deployment_target = "9.1"
+  s.watchos.deployment_target = "2.0"
+  s.source   = { :git => "https://github.com/bow-swift/bow.git", :tag => "#{s.version}" }
+  s.source_files = "Tests/BowFreeGenerators/**/*.swift"
+  s.dependency "Bow", "~> #{s.version}"
+  s.dependency "BowGenerators", "~> #{s.version}"
+  s.dependency "BowFree", "~> #{s.version}"
+  s.dependency "SwiftCheck", "~> 0.12.0"
+end

--- a/BowGenerators.podspec
+++ b/BowGenerators.podspec
@@ -1,0 +1,29 @@
+Pod::Spec.new do |s|
+  s.name        = "BowGenerators"
+  s.version     = "0.4.0"
+  s.summary     = "PBT Generators for data types in Bow."
+  s.homepage    = "https://github.com/bow-swift/bow"
+  s.license      = { :type => 'Apache License, Version 2.0', :text => <<-LICENSE
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+    LICENSE
+  }
+  s.authors     = "The Bow authors"
+
+  s.requires_arc = true
+  s.osx.deployment_target = "10.10"
+  s.ios.deployment_target = "8.0"
+  s.tvos.deployment_target = "9.1"
+  s.watchos.deployment_target = "2.0"
+  s.source   = { :git => "https://github.com/bow-swift/bow.git", :tag => "#{s.version}" }
+  s.source_files = "Tests/BowGenerators/**/*.swift"
+  s.dependency "Bow", "~> #{s.version}"
+  s.dependency "SwiftCheck", "~> 0.12.0"
+end

--- a/BowLaws.podspec
+++ b/BowLaws.podspec
@@ -1,0 +1,31 @@
+Pod::Spec.new do |s|
+  s.name        = "BowLaws"
+  s.version     = "0.4.0"
+  s.summary     = "Laws for type classes included in Bow."
+  s.homepage    = "https://github.com/bow-swift/bow"
+  s.license      = { :type => 'Apache License, Version 2.0', :text => <<-LICENSE
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+    LICENSE
+  }
+  s.authors     = "The Bow authors"
+
+  s.requires_arc = true
+  s.osx.deployment_target = "10.10"
+  s.ios.deployment_target = "8.0"
+  s.tvos.deployment_target = "9.1"
+  s.watchos.deployment_target = "2.0"
+  s.source   = { :git => "https://github.com/bow-swift/bow.git", :tag => "#{s.version}" }
+  s.source_files = "Tests/BowLaws/**/*.swift"
+  s.dependency "Bow", "~> #{s.version}"
+  s.dependency "BowGenerators", "~> #{s.version}"
+  s.dependency "SwiftCheck", "~> 0.12.0"
+  s.dependency "Nimble", "~> 8.0.1"
+end

--- a/BowOpticsLaws.podspec
+++ b/BowOpticsLaws.podspec
@@ -1,0 +1,31 @@
+Pod::Spec.new do |s|
+  s.name        = "BowOpticsLaws"
+  s.version     = "0.4.0"
+  s.summary     = "Laws for type classes included in BowOptics."
+  s.homepage    = "https://github.com/bow-swift/bow"
+  s.license      = { :type => 'Apache License, Version 2.0', :text => <<-LICENSE
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+    LICENSE
+  }
+  s.authors     = "The Bow authors"
+
+  s.requires_arc = true
+  s.osx.deployment_target = "10.10"
+  s.ios.deployment_target = "8.0"
+  s.tvos.deployment_target = "9.1"
+  s.watchos.deployment_target = "2.0"
+  s.source   = { :git => "https://github.com/bow-swift/bow.git", :tag => "#{s.version}" }
+  s.source_files = "Tests/BowOpticsLaws/**/*.swift"
+  s.dependency "Bow", "~> #{s.version}"
+  s.dependency "BowOptics", "~> #{s.version}"
+  s.dependency "SwiftCheck", "~> 0.12.0"
+  s.dependency "Nimble", "~> 8.0.1"
+end

--- a/BowRxGenerators.podspec
+++ b/BowRxGenerators.podspec
@@ -1,0 +1,31 @@
+Pod::Spec.new do |s|
+  s.name        = "BowRxGenerators"
+  s.version     = "0.4.0"
+  s.summary     = "PBT Generators for data types in BowRx."
+  s.homepage    = "https://github.com/bow-swift/bow"
+  s.license      = { :type => 'Apache License, Version 2.0', :text => <<-LICENSE
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+    LICENSE
+  }
+  s.authors     = "The Bow authors"
+
+  s.requires_arc = true
+  s.osx.deployment_target = "10.10"
+  s.ios.deployment_target = "8.0"
+  s.tvos.deployment_target = "9.1"
+  s.watchos.deployment_target = "2.0"
+  s.source   = { :git => "https://github.com/bow-swift/bow.git", :tag => "#{s.version}" }
+  s.source_files = "Tests/BowRxGenerators/**/*.swift"
+  s.dependency "Bow", "~> #{s.version}"
+  s.dependency "BowGenerators", "~> #{s.version}"
+  s.dependency "BowRx", "~> #{s.version}"
+  s.dependency "SwiftCheck", "~> 0.12.0"
+end

--- a/Package.swift
+++ b/Package.swift
@@ -12,25 +12,25 @@ let package = Package(
         .library(name: "BowEffects",                 targets: ["BowEffects"]),
         .library(name: "BowRx",                      targets: ["BowRx"]),
         .library(name: "BowBrightFutures",           targets: ["BowBrightFutures"]),
-        
+
         .library(name: "BowLaws",                    targets: ["BowLaws"]),
         .library(name: "BowOpticsLaws",              targets: ["BowOpticsLaws"]),
         .library(name: "BowEffectsLaws",             targets: ["BowEffectsLaws"]),
-        
+
         .library(name: "BowGenerators",              targets: ["BowGenerators"]),
         .library(name: "BowFreeGenerators",          targets: ["BowFreeGenerators"]),
         .library(name: "BowEffectsGenerators",       targets: ["BowEffectsGenerators"]),
         .library(name: "BowRxGenerators",            targets: ["BowRxGenerators"]),
         .library(name: "BowBrightFuturesGenerators", targets: ["BowBrightFuturesGenerators"])
     ],
-    
+
     dependencies: [
         .package(url: "https://github.com/typelift/SwiftCheck.git",   from: "0.12.0"),
         .package(url: "https://github.com/Quick/Nimble.git",          from: "8.0.1"),
         .package(url: "https://github.com/ReactiveX/RxSwift.git",     from: "5.0.1"),
         .package(url: "https://github.com/Thomvis/BrightFutures.git", from: "8.0.0"),
     ],
-    
+
     targets: [
         // Library targets
         .target(name:"Bow",                 dependencies: []),
@@ -41,7 +41,7 @@ let package = Package(
         .target(name:"BowEffects",          dependencies: ["Bow"]),
         .target(name:"BowRx",               dependencies: ["RxSwift", "RxCocoa", "Bow", "BowEffects"]),
         .target(name:"BowBrightFutures",    dependencies: ["BrightFutures", "Bow", "BowEffects"]),
-        
+
         // Test targets
         .testTarget(name: "BowTests",                 dependencies: ["Bow", "BowLaws", "SwiftCheck", "Nimble"]),
         .testTarget(name: "BowOpticsTests",           dependencies: ["Bow", "BowOptics", "BowOpticsLaws", "SwiftCheck"]),
@@ -51,12 +51,12 @@ let package = Package(
         .testTarget(name: "BowEffectsTests",          dependencies: ["Bow", "BowEffects", "BowEffectsLaws", "BowEffectsGenerators", "BowLaws", "SwiftCheck", "Nimble"]),
         .testTarget(name: "BowRxTests",               dependencies: ["Bow", "BowRx", "RxSwift", "RxCocoa", "BowLaws", "BowEffects", "BowEffectsLaws", "BowEffectsGenerators", "SwiftCheck", "Nimble"]),
         .testTarget(name: "BowBrightFuturesTests",    dependencies: ["Bow", "BowBrightFutures", "BrightFutures", "BowLaws", "BowEffects", "BowEffectsLaws", "BowBrightFuturesGenerators", "SwiftCheck", "Nimble"]),
-        
+
         // Type class Laws
         .testTarget(name:"BowLaws",        dependencies: ["Bow", "BowGenerators", "SwiftCheck", "Nimble"]),
         .testTarget(name:"BowEffectsLaws", dependencies: ["Bow", "BowEffects", "SwiftCheck", "Nimble"]),
         .testTarget(name:"BowOpticsLaws",  dependencies: ["Bow", "BowOptics", "SwiftCheck", "Nimble"]),
-        
+
         // Generators for Property-based Testing
         .testTarget(name: "BowGenerators",              dependencies: ["Bow", "SwiftCheck"]),
         .testTarget(name: "BowFreeGenerators",          dependencies: ["Bow", "BowFree", "BowGenerators", "SwiftCheck"]),

--- a/Package.swift
+++ b/Package.swift
@@ -4,39 +4,64 @@ import PackageDescription
 let package = Package(
     name: "Bow",
     products: [
-        .library(name: "Bow", targets: ["Bow"]),
-        .library(name: "BowOptics", targets: ["BowOptics"]),
-        .library(name: "BowRecursionSchemes", targets: ["BowRecursionSchemes"]),
-        .library(name: "BowFree", targets: ["BowFree"]),
-        .library(name: "BowGeneric", targets: ["BowGeneric"]),
-        .library(name: "BowEffects", targets: ["BowEffects"]),
-        .library(name: "BowRx", targets: ["BowRx"]),
-        .library(name: "BowBrightFutures", targets: ["BowBrightFutures"]),
+        .library(name: "Bow",                        targets: ["Bow"]),
+        .library(name: "BowOptics",                  targets: ["BowOptics"]),
+        .library(name: "BowRecursionSchemes",        targets: ["BowRecursionSchemes"]),
+        .library(name: "BowFree",                    targets: ["BowFree"]),
+        .library(name: "BowGeneric",                 targets: ["BowGeneric"]),
+        .library(name: "BowEffects",                 targets: ["BowEffects"]),
+        .library(name: "BowRx",                      targets: ["BowRx"]),
+        .library(name: "BowBrightFutures",           targets: ["BowBrightFutures"]),
+        
+        .library(name: "BowLaws",                    targets: ["BowLaws"]),
+        .library(name: "BowOpticsLaws",              targets: ["BowOpticsLaws"]),
+        .library(name: "BowEffectsLaws",             targets: ["BowEffectsLaws"]),
+        
+        .library(name: "BowGenerators",              targets: ["BowGenerators"]),
+        .library(name: "BowFreeGenerators",          targets: ["BowFreeGenerators"]),
+        .library(name: "BowEffectsGenerators",       targets: ["BowEffectsGenerators"]),
+        .library(name: "BowRxGenerators",            targets: ["BowRxGenerators"]),
+        .library(name: "BowBrightFuturesGenerators", targets: ["BowBrightFuturesGenerators"])
     ],
+    
     dependencies: [
-        .package(url: "https://github.com/typelift/SwiftCheck.git", from: "0.12.0"),
-        .package(url: "https://github.com/Quick/Nimble.git", from: "8.0.1"),
-        .package(url: "https://github.com/ReactiveX/RxSwift.git", from: "5.0.1"),
+        .package(url: "https://github.com/typelift/SwiftCheck.git",   from: "0.12.0"),
+        .package(url: "https://github.com/Quick/Nimble.git",          from: "8.0.1"),
+        .package(url: "https://github.com/ReactiveX/RxSwift.git",     from: "5.0.1"),
         .package(url: "https://github.com/Thomvis/BrightFutures.git", from: "8.0.0"),
     ],
+    
     targets: [
-        .target(name: "Bow", dependencies: []),
-        .testTarget(name: "BowTests", dependencies: ["Bow", "BowLaws", "SwiftCheck", "Nimble"]),
-        .target(name:"BowOptics", dependencies: ["Bow"]),
-        .testTarget(name: "BowOpticsTests", dependencies: ["BowOptics", "Bow", "SwiftCheck"]),
+        // Library targets
+        .target(name:"Bow",                 dependencies: []),
+        .target(name:"BowOptics",           dependencies: ["Bow"]),
         .target(name:"BowRecursionSchemes", dependencies: ["Bow"]),
-        .testTarget(name: "BowRecursionSchemesTests", dependencies: ["BowRecursionSchemes", "Bow", "BowLaws", "SwiftCheck", "Nimble"]),
-        .target(name:"BowFree", dependencies: ["Bow"]),
-        .testTarget(name: "BowFreeTests", dependencies: ["BowFree", "Bow", "BowLaws", "SwiftCheck", "Nimble"]),
-        .target(name:"BowGeneric", dependencies: ["Bow"]),
-        .testTarget(name: "BowGenericTests", dependencies: ["BowGeneric", "Bow"]),
-        .target(name:"BowEffects", dependencies: ["Bow"]),
-        .testTarget(name: "BowEffectsTests", dependencies: ["BowEffects", "BowEffectsLaws", "Bow", "BowLaws", "SwiftCheck", "Nimble"]),
-        .target(name:"BowRx", dependencies: ["RxSwift", "RxCocoa", "Bow", "BowEffects"]),
-        .testTarget(name: "BowRxTests", dependencies: ["BowRx", "RxSwift", "RxCocoa", "Bow", "BowLaws", "BowEffects", "BowEffectsLaws", "SwiftCheck", "Nimble"]),
-        .target(name:"BowBrightFutures", dependencies: ["BrightFutures", "Bow", "BowEffects"]),
-        .testTarget(name: "BowBrightFuturesTests", dependencies: ["BowBrightFutures", "BrightFutures", "Bow",  "BowLaws", "BowEffects", "BowEffectsLaws", "SwiftCheck", "Nimble"]),
-        .testTarget(name:"BowLaws", dependencies: ["Bow", "SwiftCheck", "Nimble"]),
+        .target(name:"BowFree",             dependencies: ["Bow"]),
+        .target(name:"BowGeneric",          dependencies: ["Bow"]),
+        .target(name:"BowEffects",          dependencies: ["Bow"]),
+        .target(name:"BowRx",               dependencies: ["RxSwift", "RxCocoa", "Bow", "BowEffects"]),
+        .target(name:"BowBrightFutures",    dependencies: ["BrightFutures", "Bow", "BowEffects"]),
+        
+        // Test targets
+        .testTarget(name: "BowTests",                 dependencies: ["Bow", "BowLaws", "SwiftCheck", "Nimble"]),
+        .testTarget(name: "BowOpticsTests",           dependencies: ["Bow", "BowOptics", "BowOpticsLaws", "SwiftCheck"]),
+        .testTarget(name: "BowRecursionSchemesTests", dependencies: ["Bow", "BowRecursionSchemes", "BowLaws", "SwiftCheck", "Nimble"]),
+        .testTarget(name: "BowFreeTests",             dependencies: ["Bow", "BowFree", "BowFreeGenerators", "BowLaws", "SwiftCheck", "Nimble"]),
+        .testTarget(name: "BowGenericTests",          dependencies: ["Bow", "BowGeneric"]),
+        .testTarget(name: "BowEffectsTests",          dependencies: ["Bow", "BowEffects", "BowEffectsLaws", "BowEffectsGenerators", "BowLaws", "SwiftCheck", "Nimble"]),
+        .testTarget(name: "BowRxTests",               dependencies: ["Bow", "BowRx", "RxSwift", "RxCocoa", "BowLaws", "BowEffects", "BowEffectsLaws", "BowEffectsGenerators", "SwiftCheck", "Nimble"]),
+        .testTarget(name: "BowBrightFuturesTests",    dependencies: ["Bow", "BowBrightFutures", "BrightFutures", "BowLaws", "BowEffects", "BowEffectsLaws", "BowBrightFuturesGenerators", "SwiftCheck", "Nimble"]),
+        
+        // Type class Laws
+        .testTarget(name:"BowLaws",        dependencies: ["Bow", "BowGenerators", "SwiftCheck", "Nimble"]),
         .testTarget(name:"BowEffectsLaws", dependencies: ["Bow", "BowEffects", "SwiftCheck", "Nimble"]),
+        .testTarget(name:"BowOpticsLaws",  dependencies: ["Bow", "BowOptics", "SwiftCheck", "Nimble"]),
+        
+        // Generators for Property-based Testing
+        .testTarget(name: "BowGenerators",              dependencies: ["Bow", "SwiftCheck"]),
+        .testTarget(name: "BowFreeGenerators",          dependencies: ["Bow", "BowFree", "BowGenerators", "SwiftCheck"]),
+        .testTarget(name: "BowEffectsGenerators",       dependencies: ["Bow", "BowEffects", "BowGenerators", "SwiftCheck"]),
+        .testTarget(name: "BowRxGenerators",            dependencies: ["Bow", "BowRx", "BowGenerators", "SwiftCheck"]),
+        .testTarget(name: "BowBrightFuturesGenerators", dependencies: ["Bow", "BowBrightFutures", "BowGenerators", "SwiftCheck"]),
     ]
 )

--- a/README.md
+++ b/README.md
@@ -27,6 +27,17 @@ Bow is split in multiple modules that can be consumed independently. These modul
 - `BowBrightFutures`: module to provide an integration with BrightFutures.
 - `BowRx`: module to provide an integration with RxSwift.
 
+There are also some modules for testing:
+
+- `BowLaws`: laws for type classes in the core module.
+- `BowOpticsLaws`: laws for optics.
+- `BowEffectsLaws`: laws for effects.
+- `BowGenerators`: generators for Property-based Testing for data types in the core module.
+- `BowFreeGenerators`: generators for Property-based Testing for data types in BowFree.
+- `BowEffectsGenerators`: generators for Property-based Testing for data types in BowEffects.
+- `BowRxGenerators`: generators for Property-based Testing for data types in BowRx.
+- `BowBrightFuturesGenerators`: generators for Property-based Testing for data types in BowBrightFutures.
+
 Bow is available using CocoaPods, Carthage and Swift Package Manager.
 
 ### CocoaPods
@@ -44,6 +55,24 @@ pod "BowRx",               "~> 0.4.0"
 pod "BowBrightFutures",    "~> 0.4.0"
 ```
 
+Testing laws:
+
+```ruby
+pod "BowLaws",        "~> {version}"
+pod "BowOpticsLaws",  "~> {version}"
+pod "BowEffectsLaws", "~> {version}"
+```
+
+Generators for property-based testing with SwiftCheck:
+
+```ruby
+pod "BowGenerators",              "~> {version}"
+pod "BowFreeGenerators",          "~> {version}"
+pod "BowEffectsGenerators",       "~> {version}"
+pod "BowRxGenerators",            "~> {version}"
+pod "BowBrightFuturesGenerators", "~> {version}"
+```
+
 ### Carthage
 
 Carthage will download the whole Bow project, but it will compile individual frameworks for each module that you can use separately. Add this line to your Cartfile:
@@ -56,7 +85,7 @@ github "bow-swift/Bow" ~> 0.4.0
 
 Create a `Package.swift` file similar to the next one and use the dependencies at your convenience.
 
-```
+```swift
 // swift-tools-version:5.0
 
 import PackageDescription
@@ -64,7 +93,7 @@ import PackageDescription
 let package = Package(
     name: "BowTestProject",
     dependencies: [
-        .package(url: "https://github.com/bow-swift/bow.git", from: "0.4.0")
+        .package(url: "https://github.com/bow-swift/bow.git", from: "{version}")
     ],
     targets: [
         .target(name: "BowTestProject",
@@ -76,8 +105,20 @@ let package = Package(
                     "BowGeneric",
                     "BowEffects",
                     "BowRx",
-                    "BowBrightFutures"]
-        )
+                    "BowBrightFutures"]),
+        .testTarget(name: "BowTestProjectTests",
+                    dependencies: [
+                        // Type class laws
+                        "BowLaws",
+                        "BowOpticsLaws",
+                        "BowEffectsLaws",
+
+                        // Generators for PBT with SwiftCheck
+                        "BowGenerators",
+                        "BowFreeGenerators",
+                        "BowEffectsGenerators",
+                        "BowRxGenerators",
+                        "BowBrightFuturesGenerators"])
     ]
 )
 ```

--- a/Tests/BowBrightFuturesTests/FutureKTest.swift
+++ b/Tests/BowBrightFuturesTests/FutureKTest.swift
@@ -4,7 +4,7 @@ import BrightFutures
 import Bow
 import BowBrightFutures
 import BowBrightFuturesGenerators
-@testable import BowEffectsLaws
+import BowEffectsLaws
 
 private let forcedFutureQueue = DispatchQueue(label: "forcedFutureQueue", attributes: .concurrent)
 

--- a/Tests/BowEffectsLaws/AsyncLaws.swift
+++ b/Tests/BowEffectsLaws/AsyncLaws.swift
@@ -3,9 +3,8 @@ import SwiftCheck
 import Bow
 import BowEffects
 
-class AsyncLaws<F: Async & EquatableK> where F.E: Arbitrary {
-    
-    static func check() {
+public class AsyncLaws<F: Async & EquatableK> where F.E: Arbitrary {
+    public static func check() {
         success()
         error()
     }
@@ -17,7 +16,6 @@ class AsyncLaws<F: Async & EquatableK> where F.E: Arbitrary {
     }
     
     private static func error() {
-        
         property("Error equivalence") <- forAll { (error: F.E) in
             return F.runAsync({ ff in ff(Either<F.E, Int>.left(error)) }) ==
                 F.raiseError(error)

--- a/Tests/BowEffectsTests/IOTest.swift
+++ b/Tests/BowEffectsTests/IOTest.swift
@@ -4,7 +4,7 @@ import SwiftCheck
 import Bow
 import BowEffects
 import BowEffectsGenerators
-@testable import BowEffectsLaws
+import BowEffectsLaws
 
 class IOTest: XCTestCase {
     func testEquatableLaws() {

--- a/Tests/BowFreeTests/FreeTest.swift
+++ b/Tests/BowFreeTests/FreeTest.swift
@@ -2,7 +2,7 @@ import XCTest
 import Bow
 import BowFree
 import BowFreeGenerators
-@testable import BowLaws
+import BowLaws
 
 fileprivate final class ForOps {}
 

--- a/Tests/BowGenericTests/GenericTest.swift
+++ b/Tests/BowGenericTests/GenericTest.swift
@@ -1,6 +1,6 @@
 import XCTest
-@testable import Bow
-@testable import BowGeneric
+import Bow
+import BowGeneric
 
 class GenericTest : XCTestCase {
     

--- a/Tests/BowLaws/AlternativeLaws.swift
+++ b/Tests/BowLaws/AlternativeLaws.swift
@@ -2,7 +2,7 @@ import SwiftCheck
 import Bow
 import BowGenerators
 
-class AlternativeLaws<F: Alternative & EquatableK & ArbitraryK> {
+public class AlternativeLaws<F: Alternative & EquatableK & ArbitraryK> {
     public static func check()  {
         rightAbsorption()
         leftDistributivity()

--- a/Tests/BowLaws/ApplicativeErrorLaws.swift
+++ b/Tests/BowLaws/ApplicativeErrorLaws.swift
@@ -2,8 +2,8 @@ import SwiftCheck
 import Bow
 import BowGenerators
 
-class ApplicativeErrorLaws<F: ApplicativeError & EquatableK> where F.E: Equatable, F.E: Arbitrary {
-    static func check()  {
+public class ApplicativeErrorLaws<F: ApplicativeError & EquatableK> where F.E: Equatable, F.E: Arbitrary {
+    public static func check()  {
         handle()
         handleWith()
         handleWithPure()

--- a/Tests/BowLaws/ApplicativeLaws.swift
+++ b/Tests/BowLaws/ApplicativeLaws.swift
@@ -3,8 +3,8 @@ import SwiftCheck
 import Bow
 import BowGenerators
 
-class ApplicativeLaws<F: Applicative & EquatableK & ArbitraryK> {
-    static func check() {
+public class ApplicativeLaws<F: Applicative & EquatableK & ArbitraryK> {
+    public static func check() {
         apIdentity()
         homomorphism()
         interchange()

--- a/Tests/BowLaws/BimonadLaws.swift
+++ b/Tests/BowLaws/BimonadLaws.swift
@@ -1,8 +1,8 @@
 import Bow
 import BowGenerators
 
-class BimonadLaws<F: Bimonad & EquatableK & ArbitraryK> {
-    static func check() {
+public class BimonadLaws<F: Bimonad & EquatableK & ArbitraryK> {
+    public static func check() {
         MonadLaws<F>.check()
         ComonadLaws<F>.check()
     }

--- a/Tests/BowLaws/ComonadLaws.swift
+++ b/Tests/BowLaws/ComonadLaws.swift
@@ -2,8 +2,8 @@ import SwiftCheck
 import Bow
 import BowGenerators
 
-class ComonadLaws<F: Comonad & EquatableK & ArbitraryK> {
-    static func check() {
+public class ComonadLaws<F: Comonad & EquatableK & ArbitraryK> {
+    public static func check() {
         duplicateThenExtractIsId()
         duplicateThenMapExtractIsId()
         mapAndCoflatMapCoherence()

--- a/Tests/BowLaws/ComparableLaws.swift
+++ b/Tests/BowLaws/ComparableLaws.swift
@@ -1,9 +1,9 @@
 import SwiftCheck
 import Bow
 
-class ComparableLaws<A: Comparable & Arbitrary> {
+public class ComparableLaws<A: Comparable & Arbitrary> {
     
-    static func check() {
+    public static func check() {
         reflexivityOfLessThanOrEqual()
         antisymmetryOfLessThanOrEqual()
         transitivityOfLessThanOrEqual()

--- a/Tests/BowLaws/ContravariantLaws.swift
+++ b/Tests/BowLaws/ContravariantLaws.swift
@@ -2,9 +2,9 @@ import SwiftCheck
 import Bow
 import BowGenerators
 
-class ContravariantLaws<F: Contravariant & EquatableK & ArbitraryK> {
+public class ContravariantLaws<F: Contravariant & EquatableK & ArbitraryK> {
     
-    static func check() {
+    public static func check() {
         InvariantLaws<F>.check()
         identity()
         composition()

--- a/Tests/BowLaws/CustomStringConvertibleLaws.swift
+++ b/Tests/BowLaws/CustomStringConvertibleLaws.swift
@@ -1,8 +1,8 @@
 import SwiftCheck
 import Bow
 
-class CustomStringConvertibleLaws<A: CustomStringConvertible & Arbitrary> {
-    static func check(){
+public class CustomStringConvertibleLaws<A: CustomStringConvertible & Arbitrary> {
+    public static func check(){
         equality()
     }
     

--- a/Tests/BowLaws/EqualityFunctions.swift
+++ b/Tests/BowLaws/EqualityFunctions.swift
@@ -1,10 +1,10 @@
 import Bow
 
-func isEqual<F: EquatableK & Functor>(_ fa: Kind<F, ()>, _ fb: Kind<F, ()>) -> Bool {
+public func isEqual<F: EquatableK & Functor>(_ fa: Kind<F, ()>, _ fb: Kind<F, ()>) -> Bool {
     return fa.map { 0 } == fb.map { 0 }
 }
 
-func isEqual<F: EquatableK & Functor, A: Equatable, B: Equatable>(_ fa: Kind<F, (A, B)>, _ fb: Kind<F, (A, B)>) -> Bool {
+public func isEqual<F: EquatableK & Functor, A: Equatable, B: Equatable>(_ fa: Kind<F, (A, B)>, _ fb: Kind<F, (A, B)>) -> Bool {
     return fa.map { x in x.0 } == fb.map { y in y.0 } &&
         fa.map { x in x.1 } == fb.map { y in y.1 }
 }

--- a/Tests/BowLaws/EquatableKLaws.swift
+++ b/Tests/BowLaws/EquatableKLaws.swift
@@ -2,9 +2,9 @@ import SwiftCheck
 import Bow
 import BowGenerators
 
-class EquatableKLaws<F: EquatableK & ArbitraryK, A: Arbitrary & Equatable> {
+public class EquatableKLaws<F: EquatableK & ArbitraryK, A: Arbitrary & Equatable> {
     
-    static func check() {
+    public static func check() {
         identity()
         commutativity()
         transitivity()

--- a/Tests/BowLaws/EquatableLaws.swift
+++ b/Tests/BowLaws/EquatableLaws.swift
@@ -1,8 +1,8 @@
 import SwiftCheck
 import Bow
 
-class EquatableLaws<A: Equatable & Arbitrary> {
-    static func check() {
+public class EquatableLaws<A: Equatable & Arbitrary> {
+    public static func check() {
         identity()
         commutativity()
         transitivity()

--- a/Tests/BowLaws/FoldableLaws.swift
+++ b/Tests/BowLaws/FoldableLaws.swift
@@ -2,7 +2,7 @@ import SwiftCheck
 import Bow
 import BowGenerators
 
-class FoldableLaws<F: Foldable & EquatableK & ArbitraryK> {
+public class FoldableLaws<F: Foldable & EquatableK & ArbitraryK> {
     public static func check() {
         leftFoldConsistentWithFoldMap()
         rightFoldConsistentWithFoldMap()

--- a/Tests/BowLaws/FunctorFilterLaws.swift
+++ b/Tests/BowLaws/FunctorFilterLaws.swift
@@ -2,9 +2,8 @@ import SwiftCheck
 import Bow
 import BowGenerators
 
-class FunctorFilterLaws<F: FunctorFilter & EquatableK & ArbitraryK> {
-    
-    static func check() {
+public class FunctorFilterLaws<F: FunctorFilter & EquatableK & ArbitraryK> {
+    public static func check() {
         mapFilterComposition()
         mapFilterMapConsistency()
     }

--- a/Tests/BowLaws/FunctorLaws.swift
+++ b/Tests/BowLaws/FunctorLaws.swift
@@ -2,8 +2,8 @@ import SwiftCheck
 import Bow
 import BowGenerators
 
-class FunctorLaws<F: Functor & EquatableK & ArbitraryK> {
-    static func check() {
+public class FunctorLaws<F: Functor & EquatableK & ArbitraryK> {
+    public static func check() {
         InvariantLaws<F>.check()
         covariantIdentity()
         covariantComposition()

--- a/Tests/BowLaws/InvariantLaws.swift
+++ b/Tests/BowLaws/InvariantLaws.swift
@@ -2,8 +2,8 @@ import SwiftCheck
 import Bow
 import BowGenerators
 
-class InvariantLaws<F: Invariant & EquatableK & ArbitraryK> {
-    static func check() {
+public class InvariantLaws<F: Invariant & EquatableK & ArbitraryK> {
+    public static func check() {
         self.identity()
         self.composition()
     }

--- a/Tests/BowLaws/MonadCombineLaws.swift
+++ b/Tests/BowLaws/MonadCombineLaws.swift
@@ -1,8 +1,8 @@
 import Bow
 import BowGenerators
 
-class MonadCombineLaws<F: MonadCombine & EquatableK & ArbitraryK> {
-    static func check() {
+public class MonadCombineLaws<F: MonadCombine & EquatableK & ArbitraryK> {
+    public static func check() {
         AlternativeLaws<F>.check()
         MonadFilterLaws<F>.check()
     }

--- a/Tests/BowLaws/MonadErrorLaws.swift
+++ b/Tests/BowLaws/MonadErrorLaws.swift
@@ -2,8 +2,8 @@ import SwiftCheck
 import Bow
 import BowGenerators
 
-class MonadErrorLaws<F: MonadError & EquatableK & ArbitraryK> where F.E: Arbitrary {
-    static func check()  {
+public class MonadErrorLaws<F: MonadError & EquatableK & ArbitraryK> where F.E: Arbitrary {
+    public static func check()  {
         leftZero()
         ensureConsistency()
     }

--- a/Tests/BowLaws/MonadFilterLaws.swift
+++ b/Tests/BowLaws/MonadFilterLaws.swift
@@ -2,8 +2,8 @@ import SwiftCheck
 import Bow
 import BowGenerators
 
-class MonadFilterLaws<F: MonadFilter & EquatableK & ArbitraryK> {
-    static func check() {
+public class MonadFilterLaws<F: MonadFilter & EquatableK & ArbitraryK> {
+    public static func check() {
         leftEmpty()
         rightEmpty()
         consistency()

--- a/Tests/BowLaws/MonadLaws.swift
+++ b/Tests/BowLaws/MonadLaws.swift
@@ -3,8 +3,8 @@ import Nimble
 import Bow
 import BowGenerators
 
-class MonadLaws<F: Monad & EquatableK & ArbitraryK> {
-    static func check() {
+public class MonadLaws<F: Monad & EquatableK & ArbitraryK> {
+    public static func check() {
         leftIdentity()
         rightIdentity()
         kleisliLeftIdentity()

--- a/Tests/BowLaws/MonadStateLaws.swift
+++ b/Tests/BowLaws/MonadStateLaws.swift
@@ -1,9 +1,8 @@
 import SwiftCheck
 import Bow
 
-class MonadStateLaws<F: MonadState & EquatableK> where F.S == Int {
-    
-    static func check() {
+public class MonadStateLaws<F: MonadState & EquatableK> where F.S == Int {
+    public static func check() {
         getIdempotent()
         setTwice()
         setGet()

--- a/Tests/BowLaws/MonadWriterLaws.swift
+++ b/Tests/BowLaws/MonadWriterLaws.swift
@@ -1,8 +1,8 @@
 import SwiftCheck
 import Bow
 
-class MonadWriterLaws<F: MonadWriter & EquatableK> where F.W == Int {
-    static func check() {
+public class MonadWriterLaws<F: MonadWriter & EquatableK> where F.W == Int {
+    public static func check() {
         writerPure()
         tellFusion()
         listenPure()

--- a/Tests/BowLaws/MonoidKLaws.swift
+++ b/Tests/BowLaws/MonoidKLaws.swift
@@ -2,8 +2,8 @@ import SwiftCheck
 import Bow
 import BowGenerators
 
-class MonoidKLaws<F: MonoidK & EquatableK & ArbitraryK> {
-    static func check() {
+public class MonoidKLaws<F: MonoidK & EquatableK & ArbitraryK> {
+    public static func check() {
         leftIdentity()
         rightIdentity()
         fold()

--- a/Tests/BowLaws/MonoidLaws.swift
+++ b/Tests/BowLaws/MonoidLaws.swift
@@ -1,8 +1,8 @@
 import Bow
 import SwiftCheck
 
-class MonoidLaws<A: Monoid & Equatable & Arbitrary> {
-    static func check() {
+public class MonoidLaws<A: Monoid & Equatable & Arbitrary> {
+    public static func check() {
         leftIdentity()
         rightIdentity()
     }

--- a/Tests/BowLaws/SemigroupKLaws.swift
+++ b/Tests/BowLaws/SemigroupKLaws.swift
@@ -2,9 +2,8 @@ import SwiftCheck
 import Bow
 import BowGenerators
 
-class SemigroupKLaws<F: SemigroupK & EquatableK & ArbitraryK> {
-    
-    static func check() {
+public class SemigroupKLaws<F: SemigroupK & EquatableK & ArbitraryK> {
+    public static func check() {
         associative()
     }
     

--- a/Tests/BowLaws/SemigroupLaws.swift
+++ b/Tests/BowLaws/SemigroupLaws.swift
@@ -1,8 +1,8 @@
 import SwiftCheck
 import Bow
 
-class SemigroupLaws<A: Semigroup & Arbitrary & Equatable> {
-    static func check() {
+public class SemigroupLaws<A: Semigroup & Arbitrary & Equatable> {
+    public static func check() {
         associativity()
         reduction()
     }

--- a/Tests/BowLaws/TraverseFilterLaws.swift
+++ b/Tests/BowLaws/TraverseFilterLaws.swift
@@ -2,8 +2,8 @@ import SwiftCheck
 import Bow
 import BowGenerators
 
-class TraverseFilterLaws<F: TraverseFilter & Applicative & EquatableK & ArbitraryK> {
-    static func check() {
+public class TraverseFilterLaws<F: TraverseFilter & Applicative & EquatableK & ArbitraryK> {
+    public static func check() {
         identityTraverseFilter()
         filterAConsistentWithTraverseFilter()
     }

--- a/Tests/BowLaws/TraverseLaws.swift
+++ b/Tests/BowLaws/TraverseLaws.swift
@@ -2,8 +2,8 @@ import SwiftCheck
 import Bow
 import BowGenerators
 
-class TraverseLaws<F: Traverse & EquatableK & ArbitraryK> {
-    static func check() {
+public class TraverseLaws<F: Traverse & EquatableK & ArbitraryK> {
+    public static func check() {
         identityTraverse()
         sequentialComposition()
         parallelComposition()

--- a/Tests/BowOpticsLaws/IsoLaws.swift
+++ b/Tests/BowOpticsLaws/IsoLaws.swift
@@ -2,9 +2,9 @@ import SwiftCheck
 import Bow
 import BowOptics
 
-class IsoLaws<A: Equatable & Arbitrary, B: Equatable & Arbitrary & CoArbitrary & Hashable & Monoid> {
+public class IsoLaws<A: Equatable & Arbitrary, B: Equatable & Arbitrary & CoArbitrary & Hashable & Monoid> {
     
-    static func check(iso: Iso<A, B>) {
+    public static func check(iso: Iso<A, B>) {
         roundTripOneWay(iso)
         roundTripOtherWay(iso)
         modifyIdentity(iso)

--- a/Tests/BowOpticsLaws/LensLaws.swift
+++ b/Tests/BowOpticsLaws/LensLaws.swift
@@ -2,9 +2,9 @@ import SwiftCheck
 import Bow
 import BowOptics
 
-class LensLaws<A: Equatable & Arbitrary, B: Equatable & Arbitrary & CoArbitrary & Hashable & Monoid> {
+public class LensLaws<A: Equatable & Arbitrary, B: Equatable & Arbitrary & CoArbitrary & Hashable & Monoid> {
     
-    static func check(lens: Lens<A, B>) {
+    public static func check(lens: Lens<A, B>) {
         getSet(lens)
         setGet(lens)
         setIdempotent(lens)

--- a/Tests/BowOpticsLaws/OptionalLaws.swift
+++ b/Tests/BowOpticsLaws/OptionalLaws.swift
@@ -2,9 +2,9 @@ import SwiftCheck
 import Bow
 import BowOptics
 
-class OptionalLaws<A: Equatable & Arbitrary, B: Equatable & Arbitrary & CoArbitrary & Hashable> {
+public class OptionalLaws<A: Equatable & Arbitrary, B: Equatable & Arbitrary & CoArbitrary & Hashable> {
     
-    static func check(optional: BowOptics.Optional<A, B>) {
+    public static func check(optional: BowOptics.Optional<A, B>) {
         getOptionSet(optional)
         setGetOption(optional)
         setIdempotent(optional)

--- a/Tests/BowOpticsLaws/PrismLaws.swift
+++ b/Tests/BowOpticsLaws/PrismLaws.swift
@@ -2,9 +2,9 @@ import SwiftCheck
 import Bow
 import BowOptics
 
-class PrismLaws<A: Arbitrary & Equatable, B: Arbitrary & CoArbitrary & Hashable & Equatable> {
+public class PrismLaws<A: Arbitrary & Equatable, B: Arbitrary & CoArbitrary & Hashable & Equatable> {
     
-    static func check(prism: Prism<A, B>) {
+    public static func check(prism: Prism<A, B>) {
         partialRoundTripOneWay(prism)
         roundTripOtherWay(prism)
         modifyId(prism)

--- a/Tests/BowOpticsLaws/SetterLaws.swift
+++ b/Tests/BowOpticsLaws/SetterLaws.swift
@@ -2,9 +2,9 @@ import SwiftCheck
 import Bow
 import BowOptics
 
-class SetterLaws<A: Equatable & Arbitrary, B: Equatable & Arbitrary & CoArbitrary & Hashable> {
+public class SetterLaws<A: Equatable & Arbitrary, B: Equatable & Arbitrary & CoArbitrary & Hashable> {
     
-    static func check(setter: Setter<A, B>) {
+    public static func check(setter: Setter<A, B>) {
         setIdempotent(setter)
         modifyId(setter)
         composeModify(setter)

--- a/Tests/BowOpticsLaws/TraversalLaws.swift
+++ b/Tests/BowOpticsLaws/TraversalLaws.swift
@@ -2,9 +2,9 @@ import SwiftCheck
 import Bow
 import BowOptics
 
-class TraversalLaws<A: Equatable & Arbitrary, B: Equatable & Arbitrary & CoArbitrary & Hashable> {
+public class TraversalLaws<A: Equatable & Arbitrary, B: Equatable & Arbitrary & CoArbitrary & Hashable> {
     
-    static func check(traversal: Traversal<A, B>) {
+    public static func check(traversal: Traversal<A, B>) {
         headOption(traversal)
         modifyGetAll(traversal)
         setIdempotent(traversal)

--- a/Tests/BowOpticsTests/IsoTest.swift
+++ b/Tests/BowOpticsTests/IsoTest.swift
@@ -2,6 +2,7 @@ import XCTest
 import SwiftCheck
 import Bow
 import BowOptics
+import BowOpticsLaws
 
 class IsoTest: XCTestCase {
     

--- a/Tests/BowOpticsTests/LensTest.swift
+++ b/Tests/BowOpticsTests/LensTest.swift
@@ -2,6 +2,7 @@ import XCTest
 import SwiftCheck
 import Bow
 import BowOptics
+import BowOpticsLaws
 
 class LensTest: XCTestCase {
     

--- a/Tests/BowOpticsTests/OptionalTest.swift
+++ b/Tests/BowOpticsTests/OptionalTest.swift
@@ -2,6 +2,7 @@ import XCTest
 import SwiftCheck
 import Bow
 import BowOptics
+import BowOpticsLaws
 
 class OptionalTest: XCTestCase {
 

--- a/Tests/BowOpticsTests/PrismTest.swift
+++ b/Tests/BowOpticsTests/PrismTest.swift
@@ -2,6 +2,7 @@ import XCTest
 import SwiftCheck
 import Bow
 import BowOptics
+import BowOpticsLaws
 
 class PrismTest: XCTestCase {
     

--- a/Tests/BowOpticsTests/SetterTest.swift
+++ b/Tests/BowOpticsTests/SetterTest.swift
@@ -2,6 +2,7 @@ import XCTest
 import SwiftCheck
 import Bow
 import BowOptics
+import BowOpticsLaws
 
 class SetterTest: XCTestCase {
     

--- a/Tests/BowOpticsTests/TraversalTest.swift
+++ b/Tests/BowOpticsTests/TraversalTest.swift
@@ -3,6 +3,7 @@ import SwiftCheck
 import Bow
 import BowGenerators
 import BowOptics
+import BowOpticsLaws
 
 class TraversalTest: XCTestCase {
     func testTraversalLaws() {

--- a/Tests/BowRecursionSchemesTests/RecursionTest.swift
+++ b/Tests/BowRecursionSchemesTests/RecursionTest.swift
@@ -1,6 +1,6 @@
 import XCTest
-@testable import Bow
-@testable import BowRecursionSchemes
+import Bow
+import BowRecursionSchemes
 
 class RecursionTest: XCTestCase {
     func testA() {

--- a/Tests/BowRxTests/MaybeKTest.swift
+++ b/Tests/BowRxTests/MaybeKTest.swift
@@ -1,9 +1,9 @@
 import XCTest
-@testable import BowLaws
+import BowLaws
 import Bow
 @testable import BowRx
 import BowRxGenerators
-@testable import BowEffectsLaws
+import BowEffectsLaws
 
 extension ForMaybeK: EquatableK {
     public static func eq<A: Equatable>(_ lhs: Kind<ForMaybeK, A>, _ rhs: Kind<ForMaybeK, A>) -> Bool {

--- a/Tests/BowRxTests/ObservableKTest.swift
+++ b/Tests/BowRxTests/ObservableKTest.swift
@@ -1,9 +1,9 @@
 import XCTest
-@testable import BowLaws
+import BowLaws
 import Bow
 @testable import BowRx
 import BowRxGenerators
-@testable import BowEffectsLaws
+import BowEffectsLaws
 
 extension ForObservableK: EquatableK {
     public static func eq<A: Equatable>(_ lhs: Kind<ForObservableK, A>, _ rhs: Kind<ForObservableK, A>) -> Bool {

--- a/Tests/BowRxTests/SingleKTest.swift
+++ b/Tests/BowRxTests/SingleKTest.swift
@@ -1,9 +1,9 @@
 import XCTest
-@testable import BowLaws
+import BowLaws
 import Bow
 @testable import BowRx
 import BowRxGenerators
-@testable import BowEffectsLaws
+import BowEffectsLaws
 
 extension ForSingleK: EquatableK {
     public static func eq<A: Equatable>(_ lhs: Kind<ForSingleK, A>, _ rhs: Kind<ForSingleK, A>) -> Bool {

--- a/Tests/BowTests/Arrow/Function0Test.swift
+++ b/Tests/BowTests/Arrow/Function0Test.swift
@@ -1,5 +1,5 @@
 import XCTest
-@testable import BowLaws
+import BowLaws
 import Bow
 
 class Function0Test: XCTestCase {

--- a/Tests/BowTests/Data/ArrayKTest.swift
+++ b/Tests/BowTests/Data/ArrayKTest.swift
@@ -1,5 +1,5 @@
 import XCTest
-@testable import BowLaws
+import BowLaws
 import Bow
 
 class ArrayKTest: XCTestCase {

--- a/Tests/BowTests/Data/ConstTest.swift
+++ b/Tests/BowTests/Data/ConstTest.swift
@@ -1,5 +1,5 @@
 import XCTest
-@testable import BowLaws
+import BowLaws
 import Bow
 
 class ConstTest: XCTestCase {

--- a/Tests/BowTests/Data/DayTest.swift
+++ b/Tests/BowTests/Data/DayTest.swift
@@ -1,6 +1,6 @@
 import XCTest
 import Nimble
-@testable import BowLaws
+import BowLaws
 import Bow
 
 extension DayPartial: EquatableK where F == ForId, G == ForId {

--- a/Tests/BowTests/Data/EitherKTest.swift
+++ b/Tests/BowTests/Data/EitherKTest.swift
@@ -1,5 +1,5 @@
 import XCTest
-@testable import BowLaws
+import BowLaws
 import Bow
 import BowGenerators
 import SwiftCheck

--- a/Tests/BowTests/Data/IdTest.swift
+++ b/Tests/BowTests/Data/IdTest.swift
@@ -1,5 +1,5 @@
 import XCTest
-@testable import BowLaws
+import BowLaws
 import Bow
 
 class IdTest: XCTestCase {

--- a/Tests/BowTests/Data/MooreTest.swift
+++ b/Tests/BowTests/Data/MooreTest.swift
@@ -1,6 +1,6 @@
 import XCTest
 import Nimble
-@testable import BowLaws
+import BowLaws
 import Bow
 
 extension MoorePartial: EquatableK {

--- a/Tests/BowTests/Data/NonEmptyArrayTest.swift
+++ b/Tests/BowTests/Data/NonEmptyArrayTest.swift
@@ -1,6 +1,6 @@
 import XCTest
 import SwiftCheck
-@testable import BowLaws
+import BowLaws
 import Bow
 
 class NonEmptyArrayTest: XCTestCase {

--- a/Tests/BowTests/Data/OptionTest.swift
+++ b/Tests/BowTests/Data/OptionTest.swift
@@ -1,6 +1,6 @@
 import XCTest
 import SwiftCheck
-@testable import BowLaws
+import BowLaws
 import Bow
 
 class OptionTest: XCTestCase {

--- a/Tests/BowTests/Data/SetKTest.swift
+++ b/Tests/BowTests/Data/SetKTest.swift
@@ -1,6 +1,6 @@
 import XCTest
 import SwiftCheck
-@testable import BowLaws
+import BowLaws
 import Bow
 
 class SetKTest: XCTestCase {

--- a/Tests/BowTests/Data/StoreTest.swift
+++ b/Tests/BowTests/Data/StoreTest.swift
@@ -1,6 +1,6 @@
 import XCTest
 import Nimble
-@testable import BowLaws
+import BowLaws
 import Bow
 
 extension StorePartial: EquatableK {

--- a/Tests/BowTests/Data/SumTest.swift
+++ b/Tests/BowTests/Data/SumTest.swift
@@ -1,6 +1,6 @@
 import XCTest
 import Nimble
-@testable import BowLaws
+import BowLaws
 import Bow
 
 extension SumPartial: EquatableK where F: Comonad, G: Comonad {

--- a/Tests/BowTests/Data/TryTest.swift
+++ b/Tests/BowTests/Data/TryTest.swift
@@ -1,5 +1,5 @@
 import XCTest
-@testable import BowLaws
+import BowLaws
 import Bow
 
 class TryTest: XCTestCase {

--- a/Tests/BowTests/Instances/NumberInstancesTest.swift
+++ b/Tests/BowTests/Instances/NumberInstancesTest.swift
@@ -1,5 +1,5 @@
 import XCTest
-@testable import BowLaws
+import BowLaws
 import Bow
 
 class NumberInstancesTest: XCTestCase {

--- a/Tests/BowTests/Instances/StringInstancesTest.swift
+++ b/Tests/BowTests/Instances/StringInstancesTest.swift
@@ -1,5 +1,5 @@
 import XCTest
-@testable import BowLaws
+import BowLaws
 import Bow
 
 class StringInstancesTest: XCTestCase {

--- a/contents/Documentation/Quick start.playground/Pages/Getting started.xcplaygroundpage/Contents.swift
+++ b/contents/Documentation/Quick start.playground/Pages/Getting started.xcplaygroundpage/Contents.swift
@@ -26,7 +26,25 @@
  pod "BowBrightFutures",    "~> {version}"
  ```
 
-After that, run the following command in the terminal:
+ Bow also provides some pods for testing that can be consumed with:
+
+ ```ruby
+ pod "BowLaws",        "~> {version}"
+ pod "BowOpticsLaws",  "~> {version}"
+ pod "BowEffectsLaws", "~> {version}"
+ ```
+
+ And generators for property-based testing with SwiftCheck:
+ 
+ ```ruby
+ pod "BowGenerators",              "~> {version}"
+ pod "BowFreeGenerators",          "~> {version}"
+ pod "BowEffectsGenerators",       "~> {version}"
+ pod "BowRxGenerators",            "~> {version}"
+ pod "BowBrightFuturesGenerators", "~> {version}"
+ ```
+
+ After including the pods you would like to use in your Podfile, run the following command in the terminal:
 
 ```
 $ pod install
@@ -76,13 +94,25 @@ let package = Package(
                     "BowGeneric",
                     "BowEffects",
                     "BowRx",
-                    "BowBrightFutures"]
-        )
+                    "BowBrightFutures"]),
+        .testTarget(name: "BowTestProjectTests",
+                    dependencies: [
+                        // Type class laws
+                        "BowLaws",
+                        "BowOpticsLaws",
+                        "BowEffectsLaws",
+ 
+                        // Generators for PBT with SwiftCheck
+                        "BowGenerators",
+                        "BowFreeGenerators",
+                        "BowEffectsGenerators",
+                        "BowRxGenerators",
+                        "BowBrightFuturesGenerators"])
     ]
 )
 ```
 
- To build it, just run the following command in the terminal:
+ Feel free to include or remove the targets above at your convenience. To build the project, just run the following command in the terminal:
 
  ```
  $ swift build

--- a/contents/Documentation/Quick start.playground/Pages/Modules.xcplaygroundpage/Contents.swift
+++ b/contents/Documentation/Quick start.playground/Pages/Modules.xcplaygroundpage/Contents.swift
@@ -34,4 +34,33 @@
  | Recursion Schemes | Recursive data structures, F-algebras and folding / unfolding functions. | `import BowRecursionSchemes` |
  | Free | Free monads. | `import BowFree` |
  | Generic | Data types for generic programming. | `import BowGeneric` |
+ 
+ # Modules for testing
+ 
+ Bow also provides some modules that are used in testing. These modules are:
+ 
+ ## Generators for Property-based Testing with SwiftCheck
+ 
+ {:.intermediate}
+ intermediate
+ 
+ | Module | Description | Swift import |
+ | ------ | ----------- | ------------ |
+ | Generators | Generators for data types in the core module | `import BowGenerators` |
+ | FreeGenerators | Generators for data types in BowFree | `import BowFreeGenerators` |
+ | EffectsGenerators | Generators for data types in BowEffects | `import BowEffectsGenerators` |
+ | RxGenerators | Generators for data types in BowRx | `import BowRxGenerators` |
+ | BrightFuturesGenerators | Generators for data types in BowBrightFutures | `import BowBrightFuturesGenerators` |
+ 
+ ## Laws to test instances of type classes
+ 
+ {:.intermediate}
+ intermediate
+ 
+ | Module | Description | Swift import |
+ | ------ | ----------- | ------------ |
+ | Laws | Laws for type classes in the core module | `import BowLaws` |
+ | OpticsLaws | Laws for optics | `import BowOpticsLaws` |
+ | EffectsLaws | Laws for effects | `import BowEffectsLaws` |
+ 
  */


### PR DESCRIPTION
## Goal

This PR exposes the following modules that are use internally as public artifacts that can be consumed for testing in other projects:

Laws:
- BowLaws
- BowOpticsLaws
- BowEffectsLaws

PBT Generators
- BowGenerators
- BowFreeGenerators
- BowEffectsGenerators
- BowRxGenerators
- BowBrightFuturesGenerators

Documentation and README have been updated accordingly to describe the new modules. Swift Package Manifest includes the new targets, their dependencies and the exposed artifacts. Podspecs have been created as well for each of the artifact that is exposed.