### PR TITLE
Usability enhancements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,12 +37,12 @@ jobs:
         - carthage update --platform iOS --cache-builds
       script:
         - set -o pipefail
-        - xcodebuild "$ACTION" -project "$PROJECT" -scheme "Bow"         -sdk "$SDK" ONLY_ACTIVE_ARCH=NO -destination "$DEST" | xcpretty -c
         - xcodebuild "$ACTION" -project "$PROJECT" -scheme "Bow-Free"    -sdk "$SDK" ONLY_ACTIVE_ARCH=NO -destination "$DEST" | xcpretty -c
         - xcodebuild "$ACTION" -project "$PROJECT" -scheme "Bow-Generic" -sdk "$SDK" ONLY_ACTIVE_ARCH=NO -destination "$DEST" | xcpretty -c
         - xcodebuild "$ACTION" -project "$PROJECT" -scheme "Bow-Optics"  -sdk "$SDK" ONLY_ACTIVE_ARCH=NO -destination "$DEST" | xcpretty -c
         - xcodebuild "$ACTION" -project "$PROJECT" -scheme "Bow-Effects" -sdk "$SDK" ONLY_ACTIVE_ARCH=NO -destination "$DEST" | xcpretty -c
         - xcodebuild "$ACTION" -project "$PROJECT" -scheme "Bow-Rx"      -sdk "$SDK" ONLY_ACTIVE_ARCH=NO -destination "$DEST" | xcpretty -c
+        - xcodebuild "$ACTION" -project "$PROJECT" -scheme "Bow"         -sdk "$SDK" ONLY_ACTIVE_ARCH=NO -destination "$DEST" | xcpretty -c
       after_success:
         - bash <(curl -s https://codecov.io/bash)
     - stage: deploy-docs

--- a/Sources/Bow/Arrow/Kleisli.swift
+++ b/Sources/Bow/Arrow/Kleisli.swift
@@ -46,6 +46,22 @@ public final class Kleisli<F, D, A>: KleisliOf<F, D, A> {
     public func invoke(_ value: D) -> Kind<F, A> {
         return run(value)
     }
+    
+    /// Pre-composes this Kleisli function with a function transforming the input type.
+    ///
+    /// - Parameter f: Transforming function.
+    /// - Returns: Composition of the two functions.
+    public func contramap<DD>(_ f: @escaping (DD) -> D) -> Kleisli<F, DD, A> {
+        return Kleisli<F, DD, A> { d in self.invoke(f(d)) }
+    }
+    
+    /// Pre-composes this Kleisli function with a function transforming the input type obtained from a key path.
+    ///
+    /// - Parameter f: Transforming function.
+    /// - Returns: Composition of the two functions.
+    public func contramap<DD>(_ keyPath: KeyPath<DD, D>) -> Kleisli<F, DD, A> {
+        return Kleisli<F, DD, A> { d in self.invoke(d[keyPath: keyPath]) }
+    }
 }
 
 /// Safe downcast.

--- a/Sources/Bow/Typeclasses/Applicative.swift
+++ b/Sources/Bow/Typeclasses/Applicative.swift
@@ -484,7 +484,7 @@ public extension Kind where F: Applicative {
     ///   - fa: 1st value for the tuple.
     ///   - fb: 2nd value for the tuple.
     /// - Returns: A tuple of the provided values in the context implementing this instance.
-    static func product<A, B>(_ fa: Kind<F, A>, _ fb: Kind<F, B>) -> Kind<F, (A, B)> {
+    static func product<AA, B>(_ fa: Kind<F, AA>, _ fb: Kind<F, B>) -> Kind<F, (AA, B)> where A == (AA, B) {
         return F.product(fa, fb)
     }
 
@@ -496,7 +496,7 @@ public extension Kind where F: Applicative {
     ///   - fa: A tuple of two elements in the context implementing this instance.
     ///   - fz: A value in the context implementing this instance.
     /// - Returns: A tuple with the value of the second argument added to the right of the tuple, in the context implementing this instance.
-    static func product<A, B, Z>(_ fa: Kind<F, (A, B)>, _ fz: Kind<F, Z>) -> Kind<F, (A, B, Z)> {
+    static func product<AA, B, Z>(_ fa: Kind<F, (AA, B)>, _ fz: Kind<F, Z>) -> Kind<F, (AA, B, Z)> where A == (AA, B, Z) {
         return F.product(fa, fz)
     }
 
@@ -508,7 +508,7 @@ public extension Kind where F: Applicative {
     ///   - fa: A tuple of three elements in the context implementing this instance.
     ///   - fz: A value in the context implementing this instance.
     /// - Returns: A tuple with the value of the second argument added to the right of the tuple, in the context implementing this instance.
-    static func product<A, B, C, Z>(_ fa: Kind<F, (A, B, C)>, _ fz: Kind<F, Z>) -> Kind<F, (A, B, C, Z)> {
+    static func product<AA, B, C, Z>(_ fa: Kind<F, (AA, B, C)>, _ fz: Kind<F, Z>) -> Kind<F, (AA, B, C, Z)> where A == (AA, B, C, Z) {
         return F.product(fa, fz)
     }
 
@@ -520,7 +520,7 @@ public extension Kind where F: Applicative {
     ///   - fa: A tuple of four elements in the context implementing this instance.
     ///   - fz: A value in the context implementing this instance.
     /// - Returns: A tuple with the value of the second argument added to the right of the tuple, in the context implementing this instance.
-    static func product<A, B, C, D, Z>(_ fa: Kind<F, (A, B, C, D)>, _ fz: Kind<F, Z>) -> Kind<F, (A, B, C, D, Z)> {
+    static func product<AA, B, C, D, Z>(_ fa: Kind<F, (AA, B, C, D)>, _ fz: Kind<F, Z>) -> Kind<F, (AA, B, C, D, Z)> where A == (AA, B, C, D, Z) {
         return F.product(fa, fz)
     }
 
@@ -532,7 +532,7 @@ public extension Kind where F: Applicative {
     ///   - fa: A tuple of five elements in the context implementing this instance.
     ///   - fz: A value in the context implementing this instance.
     /// - Returns: A tuple with the value of the second argument added to the right of the tuple, in the context implementing this instance.
-    static func product<A, B, C, D, E, Z>(_ fa: Kind<F, (A, B, C, D, E)>, _ fz: Kind<F, Z>) -> Kind<F, (A, B, C, D, E, Z)> {
+    static func product<AA, B, C, D, E, Z>(_ fa: Kind<F, (AA, B, C, D, E)>, _ fz: Kind<F, Z>) -> Kind<F, (AA, B, C, D, E, Z)> where A == (AA, B, C, D, E, Z) {
         return F.product(fa, fz)
     }
 
@@ -544,7 +544,7 @@ public extension Kind where F: Applicative {
     ///   - fa: A tuple of six elements in the context implementing this instance.
     ///   - fz: A value in the context implementing this instance.
     /// - Returns: A tuple with the value of the second argument added to the right of the tuple, in the context implementing this instance.
-    static func product<A, B, C, D, E, G, Z>(_ fa: Kind<F, (A, B, C, D, E, G)>, _ fz: Kind<F, Z>) -> Kind<F, (A, B, C, D, E, G, Z)> {
+    static func product<AA, B, C, D, E, G, Z>(_ fa: Kind<F, (AA, B, C, D, E, G)>, _ fz: Kind<F, Z>) -> Kind<F, (AA, B, C, D, E, G, Z)> where A == (AA, B, C, D, E, G, Z) {
         return F.product(fa, fz)
     }
 
@@ -556,7 +556,7 @@ public extension Kind where F: Applicative {
     ///   - fa: A tuple of seven elements in the context implementing this instance.
     ///   - fz: A value in the context implementing this instance.
     /// - Returns: A tuple with the value of the second argument added to the right of the tuple, in the context implementing this instance.
-    static func product<A, B, C, D, E, G, H, Z>(_ fa: Kind<F, (A, B, C, D, E, G, H)>, _ fz: Kind<F, Z>) -> Kind<F, (A, B, C, D, E, G, H, Z)> {
+    static func product<AA, B, C, D, E, G, H, Z>(_ fa: Kind<F, (AA, B, C, D, E, G, H)>, _ fz: Kind<F, Z>) -> Kind<F, (AA, B, C, D, E, G, H, Z)> where A == (AA, B, C, D, E, G, H, Z) {
         return F.product(fa, fz)
     }
 
@@ -568,7 +568,7 @@ public extension Kind where F: Applicative {
     ///   - fa: A tuple of eight elements in the context implementing this instance.
     ///   - fz: A value in the context implementing this instance.
     /// - Returns: A tuple with the value of the second argument added to the right of the tuple, in the context implementing this instance.
-    static func product<A, B, C, D, E, G, H, I, Z>(_ fa: Kind<F, (A, B, C, D, E, G, H, I)>, _ fz : Kind<F, Z>) -> Kind<F, (A, B, C, D, E, G, H, I, Z)> {
+    static func product<AA, B, C, D, E, G, H, I, Z>(_ fa: Kind<F, (AA, B, C, D, E, G, H, I)>, _ fz : Kind<F, Z>) -> Kind<F, (AA, B, C, D, E, G, H, I, Z)> where A == (AA, B, C, D, E, G, H, I, Z) {
         return F.product(fa, fz)
     }
 
@@ -580,8 +580,8 @@ public extension Kind where F: Applicative {
     ///   - a: 1st value of the tuple.
     ///   - b: 2nd value of the tuple.
     /// - Returns: A tuple in the context implementing this instance.
-    static func zip<A, B>(_ a: Kind<F, A>,
-                          _ b : Kind<F, B>) -> Kind<F, (A, B)> {
+    static func zip<AA, B>(_ a: Kind<F, AA>,
+                           _ b : Kind<F, B>) -> Kind<F, (AA, B)> where A == (AA, B){
         return F.zip(a, b)
     }
 
@@ -594,9 +594,9 @@ public extension Kind where F: Applicative {
     ///   - b: 2nd value of the tuple.
     ///   - c: 3rd value of the tuple.
     /// - Returns: A tuple in the context implementing this instance.
-    static func zip<A, B, C>(_ a: Kind<F, A>,
-                             _ b: Kind<F, B>,
-                             _ c: Kind<F, C>) -> Kind<F, (A, B, C)> {
+    static func zip<AA, B, C>(_ a: Kind<F, AA>,
+                              _ b: Kind<F, B>,
+                              _ c: Kind<F, C>) -> Kind<F, (AA, B, C)> where A == (AA, B, C) {
         return F.zip(a, b, c)
     }
 
@@ -610,10 +610,10 @@ public extension Kind where F: Applicative {
     ///   - c: 3rd value of the tuple.
     ///   - d: 4th value of the tuple.
     /// - Returns: A tuple in the context implementing this instance.
-    static func zip<A, B, C, D>(_ a: Kind<F, A>,
-                                _ b: Kind<F, B>,
-                                _ c: Kind<F, C>,
-                                _ d: Kind<F, D>) -> Kind<F, (A, B, C, D)> {
+    static func zip<AA, B, C, D>(_ a: Kind<F, AA>,
+                                 _ b: Kind<F, B>,
+                                 _ c: Kind<F, C>,
+                                 _ d: Kind<F, D>) -> Kind<F, (AA, B, C, D)> where A == (AA, B, C, D) {
         return F.zip(a, b, c, d)
     }
 
@@ -628,11 +628,11 @@ public extension Kind where F: Applicative {
     ///   - d: 4th value of the tuple.
     ///   - e: 5th value of the tuple.
     /// - Returns: A tuple in the context implementing this instance.
-    static func zip<A, B, C, D, E>(_ a: Kind<F, A>,
-                                   _ b: Kind<F, B>,
-                                   _ c: Kind<F, C>,
-                                   _ d: Kind<F, D>,
-                                   _ e: Kind<F, E>) -> Kind<F, (A, B, C, D, E)> {
+    static func zip<AA, B, C, D, E>(_ a: Kind<F, AA>,
+                                    _ b: Kind<F, B>,
+                                    _ c: Kind<F, C>,
+                                    _ d: Kind<F, D>,
+                                    _ e: Kind<F, E>) -> Kind<F, (AA, B, C, D, E)> where A == (AA, B, C, D, E) {
         return F.zip(a, b, c, d, e)
     }
 
@@ -648,12 +648,12 @@ public extension Kind where F: Applicative {
     ///   - e: 5th value of the tuple.
     ///   - g: 6th value of the tuple.
     /// - Returns: A tuple in the context implementing this instance.
-    static func zip<A, B, C, D, E, G>(_ a: Kind<F, A>,
-                                      _ b: Kind<F, B>,
-                                      _ c: Kind<F, C>,
-                                      _ d: Kind<F, D>,
-                                      _ e: Kind<F, E>,
-                                      _ g: Kind<F, G>) -> Kind<F, (A, B, C, D, E, G)> {
+    static func zip<AA, B, C, D, E, G>(_ a: Kind<F, AA>,
+                                       _ b: Kind<F, B>,
+                                       _ c: Kind<F, C>,
+                                       _ d: Kind<F, D>,
+                                       _ e: Kind<F, E>,
+                                       _ g: Kind<F, G>) -> Kind<F, (AA, B, C, D, E, G)> where A == (AA, B, C, D, E, G) {
         return F.zip(a, b, c, d, e, g)
     }
 
@@ -670,13 +670,13 @@ public extension Kind where F: Applicative {
     ///   - g: 6th value of the tuple.
     ///   - h: 7th value of the tuple.
     /// - Returns: A tuple in the context implementing this instance.
-    static func zip<A, B, C, D, E, G, H>(_ a: Kind<F, A>,
-                                         _ b: Kind<F, B>,
-                                         _ c: Kind<F, C>,
-                                         _ d: Kind<F, D>,
-                                         _ e: Kind<F, E>,
-                                         _ g: Kind<F, G>,
-                                         _ h: Kind<F, H>) -> Kind<F, (A, B, C, D, E, G, H)> {
+    static func zip<AA, B, C, D, E, G, H>(_ a: Kind<F, AA>,
+                                          _ b: Kind<F, B>,
+                                          _ c: Kind<F, C>,
+                                          _ d: Kind<F, D>,
+                                          _ e: Kind<F, E>,
+                                          _ g: Kind<F, G>,
+                                          _ h: Kind<F, H>) -> Kind<F, (AA, B, C, D, E, G, H)> where A == (AA, B, C, D, E, G, H) {
         return F.zip(a, b, c, d, e, g, h)
     }
 
@@ -694,14 +694,14 @@ public extension Kind where F: Applicative {
     ///   - h: 7th value of the tuple.
     ///   - i: 8th value of the tuple.
     /// - Returns: A tuple in the context implementing this instance.
-    static func zip<A, B, C, D, E, G, H, I>(_ a: Kind<F, A>,
-                                            _ b: Kind<F, B>,
-                                            _ c: Kind<F, C>,
-                                            _ d: Kind<F, D>,
-                                            _ e: Kind<F, E>,
-                                            _ g: Kind<F, G>,
-                                            _ h: Kind<F, H>,
-                                            _ i: Kind<F, I>) -> Kind<F, (A, B, C, D, E, G, H, I)> {
+    static func zip<AA, B, C, D, E, G, H, I>(_ a: Kind<F, AA>,
+                                             _ b: Kind<F, B>,
+                                             _ c: Kind<F, C>,
+                                             _ d: Kind<F, D>,
+                                             _ e: Kind<F, E>,
+                                             _ g: Kind<F, G>,
+                                             _ h: Kind<F, H>,
+                                             _ i: Kind<F, I>) -> Kind<F, (AA, B, C, D, E, G, H, I)> where A == (AA, B, C, D, E, G, H, I) {
         return F.zip(a, b, c, d, e, g, h, i)
     }
 
@@ -720,15 +720,15 @@ public extension Kind where F: Applicative {
     ///   - i: 8th value of the tuple.
     ///   - j: 9th value of the tuple.
     /// - Returns: A tuple in the context implementing this instance.
-    static func zip<A, B, C, D, E, G, H, I, J>(_ a: Kind<F, A>,
-                                               _ b: Kind<F, B>,
-                                               _ c: Kind<F, C>,
-                                               _ d: Kind<F, D>,
-                                               _ e: Kind<F, E>,
-                                               _ g: Kind<F, G>,
-                                               _ h: Kind<F, H>,
-                                               _ i: Kind<F, I>,
-                                               _ j: Kind<F, J>) -> Kind<F, (A, B, C, D, E, G, H, I, J)> {
+    static func zip<AA, B, C, D, E, G, H, I, J>(_ a: Kind<F, AA>,
+                                                _ b: Kind<F, B>,
+                                                _ c: Kind<F, C>,
+                                                _ d: Kind<F, D>,
+                                                _ e: Kind<F, E>,
+                                                _ g: Kind<F, G>,
+                                                _ h: Kind<F, H>,
+                                                _ i: Kind<F, I>,
+                                                _ j: Kind<F, J>) -> Kind<F, (AA, B, C, D, E, G, H, I, J)> where A == (AA, B, C, D, E, G, H, I, J) {
         return F.zip(a, b, c, d, e, g, h, i, j)
     }
 
@@ -741,9 +741,9 @@ public extension Kind where F: Applicative {
     ///   - b: 2nd computation.
     ///   - f: Combination function.
     /// - Returns: Result of combining the provided computations, in the context implementing this instance.
-    static func map<A, B, Z>(_ a: Kind<F, A>,
+    static func map<A, B, Z>(_ a: Kind<F, Z>,
                              _ b: Kind<F, B>,
-                             _ f: @escaping (A, B) -> Z) -> Kind<F, Z> {
+                             _ f: @escaping (Z, B) -> A) -> Kind<F, A> {
         return F.map(a, b, f)
     }
 
@@ -757,10 +757,10 @@ public extension Kind where F: Applicative {
     ///   - c: 3rd computation.
     ///   - f: Combination function.
     /// - Returns: Result of combining the provided computations, in the context implementing this instance.
-    static func map<A, B, C, Z>(_ a: Kind<F, A>,
+    static func map<A, B, C, Z>(_ a: Kind<F, Z>,
                                 _ b: Kind<F, B>,
                                 _ c: Kind<F, C>,
-                                _ f: @escaping (A, B, C) -> Z) -> Kind<F, Z> {
+                                _ f: @escaping (Z, B, C) -> A) -> Kind<F, A> {
         return F.map(a, b, c, f)
     }
 
@@ -775,11 +775,11 @@ public extension Kind where F: Applicative {
     ///   - d: 4th computation.
     ///   - f: Combination function.
     /// - Returns: Result of combining the provided computations, in the context implementing this instance.
-    static func map<A, B, C, D, Z>(_ a: Kind<F, A>,
+    static func map<A, B, C, D, Z>(_ a: Kind<F, Z>,
                                    _ b: Kind<F, B>,
                                    _ c: Kind<F, C>,
                                    _ d: Kind<F, D>,
-                                   _ f: @escaping (A, B, C, D) -> Z) -> Kind<F, Z> {
+                                   _ f: @escaping (Z, B, C, D) -> A) -> Kind<F, A> {
         return F.map(a, b, c, d, f)
     }
 
@@ -795,12 +795,12 @@ public extension Kind where F: Applicative {
     ///   - e: 5th computation.
     ///   - f: Combination function.
     /// - Returns: Result of combining the provided computations, in the context implementing this instance.
-    static func map<A, B, C, D, E, Z>(_ a: Kind<F, A>,
+    static func map<A, B, C, D, E, Z>(_ a: Kind<F, Z>,
                                       _ b: Kind<F, B>,
                                       _ c: Kind<F, C>,
                                       _ d: Kind<F, D>,
                                       _ e: Kind<F, E>,
-                                      _ f: @escaping (A, B, C, D, E) -> Z) -> Kind<F, Z> {
+                                      _ f: @escaping (Z, B, C, D, E) -> A) -> Kind<F, A> {
         return F.map(a, b, c, d, e, f)
     }
 
@@ -817,13 +817,13 @@ public extension Kind where F: Applicative {
     ///   - g: 6th computation.
     ///   - f: Combination function.
     /// - Returns: Result of combining the provided computations, in the context implementing this instance.
-    static func map<A, B, C, D, E, G, Z>(_ a: Kind<F, A>,
+    static func map<A, B, C, D, E, G, Z>(_ a: Kind<F, Z>,
                                          _ b: Kind<F, B>,
                                          _ c: Kind<F, C>,
                                          _ d: Kind<F, D>,
                                          _ e: Kind<F, E>,
                                          _ g: Kind<F, G>,
-                                         _ f: @escaping (A, B, C, D, E, G) -> Z) -> Kind<F, Z> {
+                                         _ f: @escaping (Z, B, C, D, E, G) -> A) -> Kind<F, A> {
         return F.map(a, b, c, d, e, g, f)
     }
 
@@ -841,14 +841,14 @@ public extension Kind where F: Applicative {
     ///   - h: 7th computation.
     ///   - f: Combination function.
     /// - Returns: Result of combining the provided computations, in the context implementing this instance.
-    static func map<A, B, C, D, E, G, H, Z>(_ a: Kind<F, A>,
+    static func map<A, B, C, D, E, G, H, Z>(_ a: Kind<F, Z>,
                                             _ b: Kind<F, B>,
                                             _ c: Kind<F, C>,
                                             _ d: Kind<F, D>,
                                             _ e: Kind<F, E>,
                                             _ g: Kind<F, G>,
                                             _ h: Kind<F, H>,
-                                            _ f: @escaping (A, B, C, D, E, G, H) -> Z) -> Kind<F, Z> {
+                                            _ f: @escaping (Z, B, C, D, E, G, H) -> A) -> Kind<F, A> {
         return F.map(a, b, c, d, e, g, h, f)
     }
 
@@ -867,7 +867,7 @@ public extension Kind where F: Applicative {
     ///   - i: 8th computation.
     ///   - f: Combination function.
     /// - Returns: Result of combining the provided computations, in the context implementing this instance.
-    static func map<A, B, C, D, E, G, H, I, Z>(_ a: Kind<F, A>,
+    static func map<A, B, C, D, E, G, H, I, Z>(_ a: Kind<F, Z>,
                                                _ b: Kind<F, B>,
                                                _ c: Kind<F, C>,
                                                _ d: Kind<F, D>,
@@ -875,7 +875,7 @@ public extension Kind where F: Applicative {
                                                _ g: Kind<F, G>,
                                                _ h: Kind<F, H>,
                                                _ i: Kind<F, I>,
-                                               _ f: @escaping (A, B, C, D, E, G, H, I) -> Z) -> Kind<F, Z> {
+                                               _ f: @escaping (Z, B, C, D, E, G, H, I) -> A) -> Kind<F, A> {
         return F.map(a, b, c, d, e, g, h, i, f)
     }
 
@@ -895,7 +895,7 @@ public extension Kind where F: Applicative {
     ///   - j: 9th computation.
     ///   - f: Combination function.
     /// - Returns: Result of combining the provided computations, in the context implementing this instance.
-    static func map<A, B, C, D, E, G, H, I, J, Z>(_ a: Kind<F, A>,
+    static func map<A, B, C, D, E, G, H, I, J, Z>(_ a: Kind<F, Z>,
                                                   _ b: Kind<F, B>,
                                                   _ c: Kind<F, C>,
                                                   _ d: Kind<F, D>,
@@ -904,7 +904,7 @@ public extension Kind where F: Applicative {
                                                   _ h: Kind<F, H>,
                                                   _ i: Kind<F, I>,
                                                   _ j: Kind<F, J>,
-                                                  _ f: @escaping (A, B, C, D, E, G, H, I, J) -> Z) -> Kind<F, Z> {
+                                                  _ f: @escaping (Z, B, C, D, E, G, H, I, J) -> A) -> Kind<F, A> {
         return F.map(a, b, c, d, e, g, h, i, j, f)
     }
 }

--- a/Sources/Bow/Typeclasses/Applicative.swift
+++ b/Sources/Bow/Typeclasses/Applicative.swift
@@ -154,7 +154,7 @@ public extension Applicative {
     ///   - a: 1st value of the tuple.
     ///   - b: 2nd value of the tuple.
     /// - Returns: A tuple in the context implementing this instance.
-    static func tupled<A, B>(_ a: Kind<Self, A>,
+    static func zip<A, B>(_ a: Kind<Self, A>,
                              _ b : Kind<Self, B>) -> Kind<Self, (A, B)> {
         return product(a, b)
     }
@@ -166,7 +166,7 @@ public extension Applicative {
     ///   - b: 2nd value of the tuple.
     ///   - c: 3rd value of the tuple.
     /// - Returns: A tuple in the context implementing this instance.
-    static func tupled<A, B, C>(_ a: Kind<Self, A>,
+    static func zip<A, B, C>(_ a: Kind<Self, A>,
                                 _ b: Kind<Self, B>,
                                 _ c: Kind<Self, C>) -> Kind<Self, (A, B, C)> {
         return product(product(a, b), c)
@@ -180,7 +180,7 @@ public extension Applicative {
     ///   - c: 3rd value of the tuple.
     ///   - d: 4th value of the tuple.
     /// - Returns: A tuple in the context implementing this instance.
-    static func tupled<A, B, C, D>(_ a: Kind<Self, A>,
+    static func zip<A, B, C, D>(_ a: Kind<Self, A>,
                                    _ b: Kind<Self, B>,
                                    _ c: Kind<Self, C>,
                                    _ d: Kind<Self, D>) -> Kind<Self, (A, B, C, D)> {
@@ -196,7 +196,7 @@ public extension Applicative {
     ///   - d: 4th value of the tuple.
     ///   - e: 5th value of the tuple.
     /// - Returns: A tuple in the context implementing this instance.
-    static func tupled<A, B, C, D, E>(_ a: Kind<Self, A>,
+    static func zip<A, B, C, D, E>(_ a: Kind<Self, A>,
                                       _ b: Kind<Self, B>,
                                       _ c: Kind<Self, C>,
                                       _ d: Kind<Self, D>,
@@ -214,7 +214,7 @@ public extension Applicative {
     ///   - e: 5th value of the tuple.
     ///   - g: 6th value of the tuple.
     /// - Returns: A tuple in the context implementing this instance.
-    static func tupled<A, B, C, D, E, G>(_ a: Kind<Self, A>,
+    static func zip<A, B, C, D, E, G>(_ a: Kind<Self, A>,
                                          _ b: Kind<Self, B>,
                                          _ c: Kind<Self, C>,
                                          _ d: Kind<Self, D>,
@@ -234,7 +234,7 @@ public extension Applicative {
     ///   - g: 6th value of the tuple.
     ///   - h: 7th value of the tuple.
     /// - Returns: A tuple in the context implementing this instance.
-    static func tupled<A, B, C, D, E, G, H>(_ a: Kind<Self, A>,
+    static func zip<A, B, C, D, E, G, H>(_ a: Kind<Self, A>,
                                             _ b: Kind<Self, B>,
                                             _ c: Kind<Self, C>,
                                             _ d: Kind<Self, D>,
@@ -256,7 +256,7 @@ public extension Applicative {
     ///   - h: 7th value of the tuple.
     ///   - i: 8th value of the tuple.
     /// - Returns: A tuple in the context implementing this instance.
-    static func tupled<A, B, C, D, E, G, H, I>(_ a: Kind<Self, A>,
+    static func zip<A, B, C, D, E, G, H, I>(_ a: Kind<Self, A>,
                                                _ b: Kind<Self, B>,
                                                _ c: Kind<Self, C>,
                                                _ d: Kind<Self, D>,
@@ -280,7 +280,7 @@ public extension Applicative {
     ///   - i: 8th value of the tuple.
     ///   - j: 9th value of the tuple.
     /// - Returns: A tuple in the context implementing this instance.
-    static func tupled<A, B, C, D, E, G, H, I, J>(_ a: Kind<Self, A>,
+    static func zip<A, B, C, D, E, G, H, I, J>(_ a: Kind<Self, A>,
                                                   _ b: Kind<Self, B>,
                                                   _ c: Kind<Self, C>,
                                                   _ d: Kind<Self, D>,
@@ -302,7 +302,7 @@ public extension Applicative {
     static func map<A, B, Z>(_ a: Kind<Self, A>,
                              _ b: Kind<Self, B>,
                              _ f: @escaping (A, B) -> Z) -> Kind<Self, Z> {
-        return map(tupled(a, b), f)
+        return map(zip(a, b), f)
     }
 
     /// Combines the result of three computations in the context implementing this instance, using the provided function.
@@ -317,7 +317,7 @@ public extension Applicative {
                                 _ b: Kind<Self, B>,
                                 _ c: Kind<Self, C>,
                                 _ f: @escaping (A, B, C) -> Z) -> Kind<Self, Z> {
-        return map(tupled(a, b, c), f)
+        return map(zip(a, b, c), f)
     }
 
     /// Combines the result of four computations in the context implementing this instance, using the provided function.
@@ -334,7 +334,7 @@ public extension Applicative {
                                    _ c: Kind<Self, C>,
                                    _ d: Kind<Self, D>,
                                    _ f: @escaping (A, B, C, D) -> Z) -> Kind<Self, Z> {
-        return map(tupled(a, b, c, d), f)
+        return map(zip(a, b, c, d), f)
     }
 
     /// Combines the result of five computations in the context implementing this instance, using the provided function.
@@ -353,7 +353,7 @@ public extension Applicative {
                                       _ d: Kind<Self, D>,
                                       _ e: Kind<Self, E>,
                                       _ f: @escaping (A, B, C, D, E) -> Z) -> Kind<Self, Z> {
-        return map(tupled(a, b, c, d, e), f)
+        return map(zip(a, b, c, d, e), f)
     }
 
     /// Combines the result of six computations in the context implementing this instance, using the provided function.
@@ -374,7 +374,7 @@ public extension Applicative {
                                          _ e: Kind<Self, E>,
                                          _ g: Kind<Self, G>,
                                          _ f: @escaping (A, B, C, D, E, G) -> Z) -> Kind<Self, Z> {
-        return map(tupled(a, b, c, d, e, g), f)
+        return map(zip(a, b, c, d, e, g), f)
     }
 
     /// Combines the result of seven computations in the context implementing this instance, using the provided function.
@@ -397,7 +397,7 @@ public extension Applicative {
                                             _ g: Kind<Self, G>,
                                             _ h: Kind<Self, H>,
                                             _ f: @escaping (A, B, C, D, E, G, H) -> Z) -> Kind<Self, Z> {
-        return map(tupled(a, b, c, d, e, g, h), f)
+        return map(zip(a, b, c, d, e, g, h), f)
     }
 
     /// Combines the result of eight computations in the context implementing this instance, using the provided function.
@@ -422,7 +422,7 @@ public extension Applicative {
                                                _ h: Kind<Self, H>,
                                                _ i: Kind<Self, I>,
                                                _ f: @escaping (A, B, C, D, E, G, H, I) -> Z) -> Kind<Self, Z> {
-        return map(tupled(a, b, c, d, e, g, h, i), f)
+        return map(zip(a, b, c, d, e, g, h, i), f)
     }
 
     /// Combines the result of nine computations in the context implementing this instance, using the provided function.
@@ -449,7 +449,7 @@ public extension Applicative {
                                                   _ i: Kind<Self, I>,
                                                   _ j: Kind<Self, J>,
                                                   _ f: @escaping (A, B, C, D, E, G, H, I, J) -> Z) -> Kind<Self, Z> {
-        return map(tupled(a, b, c, d, e, g, h, i, j), f)
+        return map(zip(a, b, c, d, e, g, h, i, j), f)
     }
 }
 
@@ -574,35 +574,35 @@ public extension Kind where F: Applicative {
 
     /// Creates a tuple out of two values in the context implementing this instance.
     ///
-    /// This is a convenience method to call `Applicative.tupled` as a static method of this type.
+    /// This is a convenience method to call `Applicative.zip` as a static method of this type.
     ///
     /// - Parameters:
     ///   - a: 1st value of the tuple.
     ///   - b: 2nd value of the tuple.
     /// - Returns: A tuple in the context implementing this instance.
-    static func tupled<A, B>(_ a: Kind<F, A>,
-                             _ b : Kind<F, B>) -> Kind<F, (A, B)> {
-        return F.tupled(a, b)
+    static func zip<A, B>(_ a: Kind<F, A>,
+                          _ b : Kind<F, B>) -> Kind<F, (A, B)> {
+        return F.zip(a, b)
     }
 
     /// Creates a tuple out of three values in the context implementing this instance.
     ///
-    /// This is a convenience method to call `Applicative.tupled` as a static method of this type.
+    /// This is a convenience method to call `Applicative.zip` as a static method of this type.
     ///
     /// - Parameters:
     ///   - a: 1st value of the tuple.
     ///   - b: 2nd value of the tuple.
     ///   - c: 3rd value of the tuple.
     /// - Returns: A tuple in the context implementing this instance.
-    static func tupled<A, B, C>(_ a: Kind<F, A>,
-                                _ b: Kind<F, B>,
-                                _ c: Kind<F, C>) -> Kind<F, (A, B, C)> {
-        return F.tupled(a, b, c)
+    static func zip<A, B, C>(_ a: Kind<F, A>,
+                             _ b: Kind<F, B>,
+                             _ c: Kind<F, C>) -> Kind<F, (A, B, C)> {
+        return F.zip(a, b, c)
     }
 
     /// Creates a tuple out of four values in the context implementing this instance.
     ///
-    /// This is a convenience method to call `Applicative.tupled` as a static method of this type.
+    /// This is a convenience method to call `Applicative.zip` as a static method of this type.
     ///
     /// - Parameters:
     ///   - a: 1st value of the tuple.
@@ -610,16 +610,16 @@ public extension Kind where F: Applicative {
     ///   - c: 3rd value of the tuple.
     ///   - d: 4th value of the tuple.
     /// - Returns: A tuple in the context implementing this instance.
-    static func tupled<A, B, C, D>(_ a: Kind<F, A>,
-                                   _ b: Kind<F, B>,
-                                   _ c: Kind<F, C>,
-                                   _ d: Kind<F, D>) -> Kind<F, (A, B, C, D)> {
-        return F.tupled(a, b, c, d)
+    static func zip<A, B, C, D>(_ a: Kind<F, A>,
+                                _ b: Kind<F, B>,
+                                _ c: Kind<F, C>,
+                                _ d: Kind<F, D>) -> Kind<F, (A, B, C, D)> {
+        return F.zip(a, b, c, d)
     }
 
     /// Creates a tuple out of five values in the context implementing this instance.
     ///
-    /// This is a convenience method to call `Applicative.tupled` as a static method of this type.
+    /// This is a convenience method to call `Applicative.zip` as a static method of this type.
     ///
     /// - Parameters:
     ///   - a: 1st value of the tuple.
@@ -628,17 +628,17 @@ public extension Kind where F: Applicative {
     ///   - d: 4th value of the tuple.
     ///   - e: 5th value of the tuple.
     /// - Returns: A tuple in the context implementing this instance.
-    static func tupled<A, B, C, D, E>(_ a: Kind<F, A>,
-                                      _ b: Kind<F, B>,
-                                      _ c: Kind<F, C>,
-                                      _ d: Kind<F, D>,
-                                      _ e: Kind<F, E>) -> Kind<F, (A, B, C, D, E)> {
-        return F.tupled(a, b, c, d, e)
+    static func zip<A, B, C, D, E>(_ a: Kind<F, A>,
+                                   _ b: Kind<F, B>,
+                                   _ c: Kind<F, C>,
+                                   _ d: Kind<F, D>,
+                                   _ e: Kind<F, E>) -> Kind<F, (A, B, C, D, E)> {
+        return F.zip(a, b, c, d, e)
     }
 
     /// Creates a tuple out of six values in the context implementing this instance.
     ///
-    /// This is a convenience method to call `Applicative.tupled` as a static method of this type.
+    /// This is a convenience method to call `Applicative.zip` as a static method of this type.
     ///
     /// - Parameters:
     ///   - a: 1st value of the tuple.
@@ -648,18 +648,18 @@ public extension Kind where F: Applicative {
     ///   - e: 5th value of the tuple.
     ///   - g: 6th value of the tuple.
     /// - Returns: A tuple in the context implementing this instance.
-    static func tupled<A, B, C, D, E, G>(_ a: Kind<F, A>,
-                                         _ b: Kind<F, B>,
-                                         _ c: Kind<F, C>,
-                                         _ d: Kind<F, D>,
-                                         _ e: Kind<F, E>,
-                                         _ g: Kind<F, G>) -> Kind<F, (A, B, C, D, E, G)> {
-        return F.tupled(a, b, c, d, e, g)
+    static func zip<A, B, C, D, E, G>(_ a: Kind<F, A>,
+                                      _ b: Kind<F, B>,
+                                      _ c: Kind<F, C>,
+                                      _ d: Kind<F, D>,
+                                      _ e: Kind<F, E>,
+                                      _ g: Kind<F, G>) -> Kind<F, (A, B, C, D, E, G)> {
+        return F.zip(a, b, c, d, e, g)
     }
 
     /// Creates a tuple out of seven values in the context implementing this instance.
     ///
-    /// This is a convenience method to call `Applicative.tupled` as a static method of this type.
+    /// This is a convenience method to call `Applicative.zip` as a static method of this type.
     ///
     /// - Parameters:
     ///   - a: 1st value of the tuple.
@@ -670,19 +670,19 @@ public extension Kind where F: Applicative {
     ///   - g: 6th value of the tuple.
     ///   - h: 7th value of the tuple.
     /// - Returns: A tuple in the context implementing this instance.
-    static func tupled<A, B, C, D, E, G, H>(_ a: Kind<F, A>,
-                                            _ b: Kind<F, B>,
-                                            _ c: Kind<F, C>,
-                                            _ d: Kind<F, D>,
-                                            _ e: Kind<F, E>,
-                                            _ g: Kind<F, G>,
-                                            _ h: Kind<F, H>) -> Kind<F, (A, B, C, D, E, G, H)> {
-        return F.tupled(a, b, c, d, e, g, h)
+    static func zip<A, B, C, D, E, G, H>(_ a: Kind<F, A>,
+                                         _ b: Kind<F, B>,
+                                         _ c: Kind<F, C>,
+                                         _ d: Kind<F, D>,
+                                         _ e: Kind<F, E>,
+                                         _ g: Kind<F, G>,
+                                         _ h: Kind<F, H>) -> Kind<F, (A, B, C, D, E, G, H)> {
+        return F.zip(a, b, c, d, e, g, h)
     }
 
     /// Creates a tuple out of eight values in the context implementing this instance.
     ///
-    /// This is a convenience method to call `Applicative.tupled` as a static method of this type.
+    /// This is a convenience method to call `Applicative.zip` as a static method of this type.
     ///
     /// - Parameters:
     ///   - a: 1st value of the tuple.
@@ -694,20 +694,20 @@ public extension Kind where F: Applicative {
     ///   - h: 7th value of the tuple.
     ///   - i: 8th value of the tuple.
     /// - Returns: A tuple in the context implementing this instance.
-    static func tupled<A, B, C, D, E, G, H, I>(_ a: Kind<F, A>,
-                                               _ b: Kind<F, B>,
-                                               _ c: Kind<F, C>,
-                                               _ d: Kind<F, D>,
-                                               _ e: Kind<F, E>,
-                                               _ g: Kind<F, G>,
-                                               _ h: Kind<F, H>,
-                                               _ i: Kind<F, I>) -> Kind<F, (A, B, C, D, E, G, H, I)> {
-        return F.tupled(a, b, c, d, e, g, h, i)
+    static func zip<A, B, C, D, E, G, H, I>(_ a: Kind<F, A>,
+                                            _ b: Kind<F, B>,
+                                            _ c: Kind<F, C>,
+                                            _ d: Kind<F, D>,
+                                            _ e: Kind<F, E>,
+                                            _ g: Kind<F, G>,
+                                            _ h: Kind<F, H>,
+                                            _ i: Kind<F, I>) -> Kind<F, (A, B, C, D, E, G, H, I)> {
+        return F.zip(a, b, c, d, e, g, h, i)
     }
 
     /// Creates a tuple out of nine values in the context implementing this instance.
     ///
-    /// This is a convenience method to call `Applicative.tupled` as a static method of this type.
+    /// This is a convenience method to call `Applicative.zip` as a static method of this type.
     ///
     /// - Parameters:
     ///   - a: 1st value of the tuple.
@@ -720,16 +720,16 @@ public extension Kind where F: Applicative {
     ///   - i: 8th value of the tuple.
     ///   - j: 9th value of the tuple.
     /// - Returns: A tuple in the context implementing this instance.
-    static func tupled<A, B, C, D, E, G, H, I, J>(_ a: Kind<F, A>,
-                                                  _ b: Kind<F, B>,
-                                                  _ c: Kind<F, C>,
-                                                  _ d: Kind<F, D>,
-                                                  _ e: Kind<F, E>,
-                                                  _ g: Kind<F, G>,
-                                                  _ h: Kind<F, H>,
-                                                  _ i: Kind<F, I>,
-                                                  _ j: Kind<F, J>) -> Kind<F, (A, B, C, D, E, G, H, I, J)> {
-        return F.tupled(a, b, c, d, e, g, h, i, j)
+    static func zip<A, B, C, D, E, G, H, I, J>(_ a: Kind<F, A>,
+                                               _ b: Kind<F, B>,
+                                               _ c: Kind<F, C>,
+                                               _ d: Kind<F, D>,
+                                               _ e: Kind<F, E>,
+                                               _ g: Kind<F, G>,
+                                               _ h: Kind<F, H>,
+                                               _ i: Kind<F, I>,
+                                               _ j: Kind<F, J>) -> Kind<F, (A, B, C, D, E, G, H, I, J)> {
+        return F.zip(a, b, c, d, e, g, h, i, j)
     }
 
     /// Combines the result of two computations in the context implementing this instance, using the provided function.

--- a/Sources/Bow/Typeclasses/Functor.swift
+++ b/Sources/Bow/Typeclasses/Functor.swift
@@ -29,6 +29,16 @@ public extension Functor {
     static func imap<A, B>(_ fa: Kind<Self, A>, _ f: @escaping (A) -> B, _ g: @escaping (B) -> A) -> Kind<Self, B> {
         return map(fa, f)
     }
+    
+    /// Creates a new value transforming the type using the provided key path, preserving the structure of the original type.
+    ///
+    /// - Parameters:
+    ///   - fa: A value in the context of the type implementing this instance of `Functor`.
+    ///   - keyPath: A key path.
+    /// - Returns: The result of transforming the value type using the provided function, maintaining the structure of the original value.
+    static func map<A, B>(_ fa: Kind<Self, A>, _ keyPath: KeyPath<A, B>) -> Kind<Self, B> {
+        return map(fa, { a in a[keyPath: keyPath] })
+    }
 
     /// Given a function, provides a new function lifted to the context type implementing this instance of `Functor`.
     ///
@@ -99,6 +109,17 @@ public extension Kind where F: Functor {
     /// - Returns: The result of transforming the value type using the provided function, maintaining the structure of the original value.
     func map<B>(_ f: @escaping (A) -> B) -> Kind<F, B> {
         return F.map(self, f)
+    }
+    
+    /// Creates a new value transforming the type using the provided key path, preserving the structure of the original type.
+    ///
+    /// This is a convenience method to call `Functor.map` as an instance method in this type.
+    ///
+    /// - Parameters:
+    ///   - keyPath: A key path.
+    /// - Returns: The result of transforming the value type using the provided function, maintaining the structure of the original value.
+    func map<B>(_ keyPath: KeyPath<A, B>) -> Kind<F, B> {
+        return F.map(self, keyPath)
     }
 
     /// Given a function, provides a new function lifted to the context type implementing this instance of `Functor`.

--- a/Sources/Bow/Typeclasses/Selective.swift
+++ b/Sources/Bow/Typeclasses/Selective.swift
@@ -33,8 +33,8 @@ public extension Selective {
     ///
     /// - Parameters:
     ///   - fab: Computation producing an `Either` value, to decide which computation is executed afterwards.
-    ///   - fa: Computation that will be executed if `fab` evaluates to an `Either.left` value.
-    ///   - fb: Computation that will be executed if `fab` evaluates to an `Either.right` value.
+    ///   - ifLeft: Computation that will be executed if `fab` evaluates to an `Either.left` value.
+    ///   - ifRight: Computation that will be executed if `fab` evaluates to an `Either.right` value.
     /// - Returns: Composition of the computations.
     static func branch<A, B, C>(_ fab: Kind<Self, Either<A, B>>, ifLeft fa: Kind<Self, (A) -> C>, ifRight fb: Kind<Self, (B) -> C>) -> Kind<Self, C> {
         let x = map(fab) { eab in Either.fix(eab.map(Either<B, C>.left)) }
@@ -46,8 +46,8 @@ public extension Selective {
     ///
     /// - Parameters:
     ///   - x: Computation producing a boolean value to decide which computation is exectured afterwards.
-    ///   - t: Computation that will be executed if the first evaluates to `true`.
-    ///   - e: Computation that will be executed if the first evaluates to `false`.
+    ///   - then: Computation that will be executed if the first evaluates to `true`.
+    ///   - else: Computation that will be executed if the first evaluates to `false`.
     /// - Returns: Composition of the computations.
     static func ifS<A>(_ x: Kind<Self, Bool>, then t: Kind<Self, A>, else e: Kind<Self, A>) -> Kind<Self, A> {
         return branch(selector(x), ifLeft: map(t, { tt in constant(tt) }), ifRight: map(e, { ee in constant(ee) }))

--- a/Sources/Bow/Typeclasses/Selective.swift
+++ b/Sources/Bow/Typeclasses/Selective.swift
@@ -22,9 +22,9 @@ public extension Selective {
     ///
     /// - Parameters:
     ///   - cond: A computation evaluating to a boolean value.
-    ///   - f: A computation that will be evaluated if the first computation evaluates to `true`.
+    ///   - then: A computation that will be evaluated if the first computation evaluates to `true`.
     /// - Returns: Composition of the two computations.
-    static func whenS(_ cond: Kind<Self, Bool>, _ f: Kind<Self, ()>) -> Kind<Self, ()> {
+    static func whenS(_ cond: Kind<Self, Bool>, then f: Kind<Self, ()>) -> Kind<Self, ()> {
         let effect = map(f) { ff in { (_: ()) in } }
         return select(selector(cond), effect)
     }
@@ -36,7 +36,7 @@ public extension Selective {
     ///   - fa: Computation that will be executed if `fab` evaluates to an `Either.left` value.
     ///   - fb: Computation that will be executed if `fab` evaluates to an `Either.right` value.
     /// - Returns: Composition of the computations.
-    static func branch<A, B, C>(_ fab: Kind<Self, Either<A, B>>, _ fa: Kind<Self, (A) -> C>, _ fb: Kind<Self, (B) -> C>) -> Kind<Self, C> {
+    static func branch<A, B, C>(_ fab: Kind<Self, Either<A, B>>, ifLeft fa: Kind<Self, (A) -> C>, ifRight fb: Kind<Self, (B) -> C>) -> Kind<Self, C> {
         let x = map(fab) { eab in Either.fix(eab.map(Either<B, C>.left)) }
         let y = map(fa) { f in { a in Either<B, C>.right(f(a)) } }
         return select(select(x, y), fb)
@@ -49,8 +49,8 @@ public extension Selective {
     ///   - t: Computation that will be executed if the first evaluates to `true`.
     ///   - e: Computation that will be executed if the first evaluates to `false`.
     /// - Returns: Composition of the computations.
-    static func ifS<A>(_ x: Kind<Self, Bool>, _ t: Kind<Self, A>, _ e: Kind<Self, A>) -> Kind<Self, A> {
-        return branch(selector(x), map(t, { tt in constant(tt) }), map(e, { ee in constant(ee) }))
+    static func ifS<A>(_ x: Kind<Self, Bool>, then t: Kind<Self, A>, else e: Kind<Self, A>) -> Kind<Self, A> {
+        return branch(selector(x), ifLeft: map(t, { tt in constant(tt) }), ifRight: map(e, { ee in constant(ee) }))
     }
 
     /// A lifted version of lazy boolean or.
@@ -60,7 +60,7 @@ public extension Selective {
     ///   - y: Computation to be or'ed.
     /// - Returns: Result of the or operation on the two computations.
     static func orS(_ x: Kind<Self, Bool>, _ y: Kind<Self, Bool>) -> Kind<Self, Bool> {
-        return ifS(x, pure(true), y)
+        return ifS(x, then: pure(true), else: y)
     }
 
     /// A lifted version of lazy boolean and.
@@ -70,7 +70,7 @@ public extension Selective {
     ///   - y: Computation to be and'ed.
     /// - Returns: Result of the and operation on the two computations.
     static func andS(_ x: Kind<Self, Bool>, _ y: Kind<Self, Bool>) -> Kind<Self, Bool> {
-        return ifS(x, y, pure(false))
+        return ifS(x, then: y, else: pure(false))
     }
 
     /// Evaluates an optional computation, providing a default value for the empty case.
@@ -109,7 +109,7 @@ public extension Selective {
     /// - Parameter x: A computation.
     /// - Returns: A potentially lazy computation.
     static func whileS(_ x: Kind<Self, Bool>) -> Eval<Kind<Self, ()>> {
-        return Eval.later { whenS(x, whileS(x).value()) }
+        return Eval.later { whenS(x, then: whileS(x).value()) }
     }
 }
 
@@ -128,72 +128,66 @@ public extension Kind where F: Selective {
     /// Evaluates one out of two computations based on the result of this computation.
     ///
     /// - Parameters:
-    ///   - fa: Computation that will be executed if this computation evaluates to an `Either.left` value.
-    ///   - fb: Computation that will be executed if this computation evaluates to an `Either.right` value.
+    ///   - ifLeft: Computation that will be executed if this computation evaluates to an `Either.left` value.
+    ///   - ifRight: Computation that will be executed if this computation evaluates to an `Either.right` value.
     /// - Returns: Composition of the computations.
-    func branch<AA, B, C>(_ fa: Kind<F, (AA) -> C>, _ fb: Kind<F, (B) -> C>) -> Kind<F, C> where A == Either<AA, B> {
-        return F.branch(self, fa, fb)
+    func branch<AA, B, C>(ifLeft fa: Kind<F, (AA) -> C>, ifRight fb: Kind<F, (B) -> C>) -> Kind<F, C> where A == Either<AA, B> {
+        return F.branch(self, ifLeft: fa, ifRight: fb)
     }
 
     // Evaluates an optional computation, providing a default value for the empty case.
     ///
     /// - Parameters:
-    ///   - x: Default value for the empty case.
-    ///   - mx: A computation resulting in an optional value.
+    ///   - defaultValue: Default value for the empty case.
     /// - Returns: Composition of the two computations.
-    static func fromOptionS(_ x: Kind<F, A>, _ mx: Kind<F, Option<A>>) -> Kind<F, A> {
-        return F.fromOptionS(x, mx)
+    func fromOptionS<AA>(defaultValue x: Kind<F, AA>) -> Kind<F, AA> where A == Option<AA> {
+        return F.fromOptionS(x, self)
     }
 }
 
 public extension Kind where F: Selective, A == Bool {
-    /// Evaluates the second computation when the first evaluates to `true`.
+    /// Evaluates the second computation when this evaluates to `true`.
     ///
     /// - Parameters:
-    ///   - cond: A computation evaluating to a boolean value.
-    ///   - f: A computation that will be evaluated if the first computation evaluates to `true`.
+    ///   - then: A computation that will be evaluated if the first computation evaluates to `true`.
     /// - Returns: Composition of the two computations.
-    static func whenS(_ cond: Kind<F, Bool>, _ f: Kind<F, ()>) -> Kind<F, ()> {
-        return F.whenS(cond, f)
+    func whenS(then f: Kind<F, ()>) -> Kind<F, ()> {
+        return F.whenS(self, then: f)
     }
 
     /// Evaluates one out of two computations based on the result of another computation.
     ///
     /// - Parameters:
-    ///   - x: Computation producing a boolean value to decide which computation is exectured afterwards.
-    ///   - t: Computation that will be executed if the first evaluates to `true`.
-    ///   - e: Computation that will be executed if the first evaluates to `false`.
+    ///   - then: Computation that will be executed if this evaluates to `true`.
+    ///   - else: Computation that will be executed if this evaluates to `false`.
     /// - Returns: Composition of the computations.
-    static func ifS<A>(_ x: Kind<F, Bool>, _ t: Kind<F, A>, _ e: Kind<F, A>) -> Kind<F, A> {
-        return F.ifS(x, t, e)
+    func ifS<A>(then t: Kind<F, A>, else e: Kind<F, A>) -> Kind<F, A> {
+        return F.ifS(self, then: t, else: e)
     }
 
     /// A lifted version of lazy boolean or.
     ///
     /// - Parameters:
-    ///   - x: Computation to be or'ed.
     ///   - y: Computation to be or'ed.
     /// - Returns: Result of the or operation on the two computations.
-    static func orS(_ x: Kind<F, Bool>, _ y: Kind<F, Bool>) -> Kind<F, Bool> {
-        return F.orS(x, y)
+    func orS(_ y: Kind<F, Bool>) -> Kind<F, Bool> {
+        return F.orS(self, y)
     }
 
     /// A lifted version of lazy boolean and.
     ///
     /// - Parameters:
-    ///   - x: Computation to be and'ed.
     ///   - y: Computation to be and'ed.
     /// - Returns: Result of the and operation on the two computations.
-    static func andS(_ x: Kind<F, Bool>, _ y: Kind<F, Bool>) -> Kind<F, Bool> {
-        return F.andS(x, y)
+    func andS(_ y: Kind<F, Bool>) -> Kind<F, Bool> {
+        return F.andS(self, y)
     }
 
-    /// Evaluates a computation as long as it evaluates to `true`.
+    /// Evaluates this computation as long as it evaluates to `true`.
     ///
-    /// - Parameter x: A computation.
     /// - Returns: A potentially lazy computation.
-    static func whileS(_ x: Kind<F, Bool>) -> Eval<Kind<F, ()>> {
-        return F.whileS(x)
+    func whileS() -> Eval<Kind<F, ()>> {
+        return F.whileS(self)
     }
 }
 
@@ -213,6 +207,6 @@ public extension ArrayK {
     ///   - p: A lifted predicate to check all elements of this array match it.
     /// - Returns: A boolean computation describing if all elements of the array match the predicate.
     func allS<F: Selective>(_ p: @escaping (A) -> Kind<F, Bool>) -> Kind<F, Bool> {
-        return F.anyS(p, self)
+        return F.allS(p, self)
     }
 }

--- a/Sources/BowEffects/Data/IO.swift
+++ b/Sources/BowEffects/Data/IO.swift
@@ -11,6 +11,15 @@ public typealias Task<A> = IO<Error, A>
 public typealias ForUIO = IOPartial<Never>
 public typealias UIO<A> = IO<Never, A>
 
+public typealias EnvIOPartial<D, E: Error> = KleisliPartial<IOPartial<E>, D>
+public typealias EnvIO<D, E: Error, A> = Kleisli<IOPartial<E>, D, A>
+
+public typealias RIOPartial<D, A> = EnvIOPartial<D, Error>
+public typealias RIO<D, A> = EnvIO<D, Error, A>
+
+public typealias URIOPartial<D, A> = EnvIOPartial<D, Never>
+public typealias URIO<D, A> = EnvIO<D, Never, A>
+
 public enum IOError: Error {
     case timeout
 }

--- a/Sources/BowEffects/Data/IO.swift
+++ b/Sources/BowEffects/Data/IO.swift
@@ -555,7 +555,7 @@ extension IOPartial: MonadError {}
 
 // MARK: Instance of `Bracket` for `IO`
 extension IOPartial: Bracket {
-    public static func bracketCase<A, B>(_ fa: IOOf<E, A>, _ release: @escaping (A, ExitCase<E>) -> IOOf<E, ()>, _ use: @escaping (A) throws -> IOOf<E, B>) -> IOOf<E, B> {
+    public static func bracketCase<A, B>(acquire fa: IOOf<E, A>, release: @escaping (A, ExitCase<E>) -> IOOf<E, ()>, use: @escaping (A) throws -> IOOf<E, B>) -> IOOf<E, B> {
         return BracketIO<E, A, B>(fa^, release, use)
     }
 }

--- a/Sources/BowEffects/Data/IO.swift
+++ b/Sources/BowEffects/Data/IO.swift
@@ -61,54 +61,54 @@ public class IO<E: Error, A>: IOOf<E, A> {
         return invoke { try f().toEither() }
     }
     
-    public static func merge<B>(_ fa: @escaping () throws -> A,
-                                _ fb: @escaping () throws -> B) -> IO<E, (A, B)> {
-        return IO.tupled(
-            IO<E, A>.invoke(fa),
+    public static func merge<Z, B>(_ fa: @escaping () throws -> Z,
+                                   _ fb: @escaping () throws -> B) -> IO<E, (Z, B)> where A == (Z, B) {
+        return IO.zip(
+            IO<E, Z>.invoke(fa),
             IO<E, B>.invoke(fb))^
     }
     
-    public static func merge<B, C>(_ fa: @escaping () throws -> A,
-                                   _ fb: @escaping () throws -> B,
-                                   _ fc: @escaping () throws -> C) -> IO<E, (A, B, C)> {
-        return IO.tupled(
-            IO<E, A>.invoke(fa),
+    public static func merge<Z, B, C>(_ fa: @escaping () throws -> Z,
+                                      _ fb: @escaping () throws -> B,
+                                      _ fc: @escaping () throws -> C) -> IO<E, (Z, B, C)> where A == (Z, B, C) {
+        return IO.zip(
+            IO<E, Z>.invoke(fa),
             IO<E, B>.invoke(fb),
             IO<E, C>.invoke(fc))^
     }
     
-    public static func merge<B, C, D>(_ fa: @escaping () throws -> A,
-                                      _ fb: @escaping () throws -> B,
-                                      _ fc: @escaping () throws -> C,
-                                      _ fd: @escaping () throws -> D) -> IO<E, (A, B, C, D)> {
-        return IO.tupled(
-            IO<E, A>.invoke(fa),
+    public static func merge<Z, B, C, D>(_ fa: @escaping () throws -> Z,
+                                         _ fb: @escaping () throws -> B,
+                                         _ fc: @escaping () throws -> C,
+                                         _ fd: @escaping () throws -> D) -> IO<E, (Z, B, C, D)> where A == (Z, B, C, D) {
+        return IO.zip(
+            IO<E, Z>.invoke(fa),
             IO<E, B>.invoke(fb),
             IO<E, C>.invoke(fc),
             IO<E, D>.invoke(fd))^
     }
     
-    public static func merge<B, C, D, F>(_ fa: @escaping () throws -> A,
-                                         _ fb: @escaping () throws -> B,
-                                         _ fc: @escaping () throws -> C,
-                                         _ fd: @escaping () throws -> D,
-                                         _ ff: @escaping () throws -> F) -> IO<E, (A, B, C, D, F)> {
-        return IO.tupled(
-            IO<E, A>.invoke(fa),
+    public static func merge<Z, B, C, D, F>(_ fa: @escaping () throws -> Z,
+                                            _ fb: @escaping () throws -> B,
+                                            _ fc: @escaping () throws -> C,
+                                            _ fd: @escaping () throws -> D,
+                                            _ ff: @escaping () throws -> F) -> IO<E, (Z, B, C, D, F)> where A == (Z, B, C, D, F) {
+        return IO.zip(
+            IO<E, Z>.invoke(fa),
             IO<E, B>.invoke(fb),
             IO<E, C>.invoke(fc),
             IO<E, D>.invoke(fd),
             IO<E, F>.invoke(ff))^
     }
     
-    public static func merge<B, C, D, F, G>(_ fa: @escaping () throws -> A,
-                                            _ fb: @escaping () throws -> B,
-                                            _ fc: @escaping () throws -> C,
-                                            _ fd: @escaping () throws -> D,
-                                            _ ff: @escaping () throws -> F,
-                                            _ fg: @escaping () throws -> G) -> IO<E, (A, B, C, D, F, G)> {
-        return IO.tupled(
-            IO<E, A>.invoke(fa),
+    public static func merge<Z, B, C, D, F, G>(_ fa: @escaping () throws -> Z,
+                                               _ fb: @escaping () throws -> B,
+                                               _ fc: @escaping () throws -> C,
+                                               _ fd: @escaping () throws -> D,
+                                               _ ff: @escaping () throws -> F,
+                                               _ fg: @escaping () throws -> G) -> IO<E, (Z, B, C, D, F, G)> where A == (Z, B, C, D, F, G){
+        return IO.zip(
+            IO<E, Z>.invoke(fa),
             IO<E, B>.invoke(fb),
             IO<E, C>.invoke(fc),
             IO<E, D>.invoke(fd),
@@ -116,15 +116,15 @@ public class IO<E: Error, A>: IOOf<E, A> {
             IO<E, G>.invoke(fg))^
     }
     
-    public static func merge<B, C, D, F, G, H>(_ fa: @escaping () throws -> A,
-                                               _ fb: @escaping () throws -> B,
-                                               _ fc: @escaping () throws -> C,
-                                               _ fd: @escaping () throws -> D,
-                                               _ ff: @escaping () throws -> F,
-                                               _ fg: @escaping () throws -> G,
-                                               _ fh: @escaping () throws -> H ) -> IO<E, (A, B, C, D, F, G, H)> {
-        return IO.tupled(
-            IO<E, A>.invoke(fa),
+    public static func merge<Z, B, C, D, F, G, H>(_ fa: @escaping () throws -> Z,
+                                                  _ fb: @escaping () throws -> B,
+                                                  _ fc: @escaping () throws -> C,
+                                                  _ fd: @escaping () throws -> D,
+                                                  _ ff: @escaping () throws -> F,
+                                                  _ fg: @escaping () throws -> G,
+                                                  _ fh: @escaping () throws -> H ) -> IO<E, (Z, B, C, D, F, G, H)> where A == (Z, B, C, D, F, G, H) {
+        return IO.zip(
+            IO<E, Z>.invoke(fa),
             IO<E, B>.invoke(fb),
             IO<E, C>.invoke(fc),
             IO<E, D>.invoke(fd),
@@ -133,16 +133,16 @@ public class IO<E: Error, A>: IOOf<E, A> {
             IO<E, H>.invoke(fh))^
     }
     
-    public static func merge<B, C, D, F, G, H, I>(_ fa: @escaping () throws -> A,
-                                                  _ fb: @escaping () throws -> B,
-                                                  _ fc: @escaping () throws -> C,
-                                                  _ fd: @escaping () throws -> D,
-                                                  _ ff: @escaping () throws -> F,
-                                                  _ fg: @escaping () throws -> G,
-                                                  _ fh: @escaping () throws -> H,
-                                                  _ fi: @escaping () throws -> I) -> IO<E, (A, B, C, D, F, G, H, I)> {
-        return IO.tupled(
-            IO<E, A>.invoke(fa),
+    public static func merge<Z, B, C, D, F, G, H, I>(_ fa: @escaping () throws -> Z,
+                                                     _ fb: @escaping () throws -> B,
+                                                     _ fc: @escaping () throws -> C,
+                                                     _ fd: @escaping () throws -> D,
+                                                     _ ff: @escaping () throws -> F,
+                                                     _ fg: @escaping () throws -> G,
+                                                     _ fh: @escaping () throws -> H,
+                                                     _ fi: @escaping () throws -> I) -> IO<E, (Z, B, C, D, F, G, H, I)> where A == (Z, B, C, D, F, G, H, I) {
+        return IO.zip(
+            IO<E, Z>.invoke(fa),
             IO<E, B>.invoke(fb),
             IO<E, C>.invoke(fc),
             IO<E, D>.invoke(fd),
@@ -152,17 +152,17 @@ public class IO<E: Error, A>: IOOf<E, A> {
             IO<E, I>.invoke(fi))^
     }
     
-    public static func merge<B, C, D, F, G, H, I, J>(_ fa: @escaping () throws -> A,
-                                                     _ fb: @escaping () throws -> B,
-                                                     _ fc: @escaping () throws -> C,
-                                                     _ fd: @escaping () throws -> D,
-                                                     _ ff: @escaping () throws -> F,
-                                                     _ fg: @escaping () throws -> G,
-                                                     _ fh: @escaping () throws -> H,
-                                                     _ fi: @escaping () throws -> I,
-                                                     _ fj: @escaping () throws -> J ) -> IO<E, (A, B, C, D, F, G, H, I, J)> {
-        return IO.tupled(
-            IO<E, A>.invoke(fa),
+    public static func merge<Z, B, C, D, F, G, H, I, J>(_ fa: @escaping () throws -> Z,
+                                                        _ fb: @escaping () throws -> B,
+                                                        _ fc: @escaping () throws -> C,
+                                                        _ fd: @escaping () throws -> D,
+                                                        _ ff: @escaping () throws -> F,
+                                                        _ fg: @escaping () throws -> G,
+                                                        _ fh: @escaping () throws -> H,
+                                                        _ fi: @escaping () throws -> I,
+                                                        _ fj: @escaping () throws -> J ) -> IO<E, (Z, B, C, D, F, G, H, I, J)> where A == (Z, B, C, D, F, G, H, I, J) {
+        return IO.zip(
+            IO<E, Z>.invoke(fa),
             IO<E, B>.invoke(fb),
             IO<E, C>.invoke(fc),
             IO<E, D>.invoke(fd),

--- a/Sources/BowEffects/Data/Resource.swift
+++ b/Sources/BowEffects/Data/Resource.swift
@@ -81,7 +81,7 @@ private class RegularResource<F: Bracket, A>: Resource<F, A> {
     }
     
     override func use<C>(_ f: @escaping (A) -> Kind<F, C>) -> Kind<F, C> {
-        return acquire().bracketCase(release, f)
+        return acquire().bracketCase(release: release, use: f)
     }
 }
 

--- a/Sources/BowEffects/Typeclasses/Bracket.swift
+++ b/Sources/BowEffects/Typeclasses/Bracket.swift
@@ -34,46 +34,46 @@ public func ==<E: Equatable>(lhs: ExitCase<E>, rhs: ExitCase<E>) -> Bool {
 }
 
 public protocol Bracket: MonadError {
-    static func bracketCase<A, B>(_ fa: Kind<Self, A>,
-                                  _ release: @escaping (A, ExitCase<Self.E>) -> Kind<Self, ()>,
-                                  _ use: @escaping (A) throws -> Kind<Self, B>) -> Kind<Self, B>
+    static func bracketCase<A, B>(acquire fa: Kind<Self, A>,
+                                  release: @escaping (A, ExitCase<Self.E>) -> Kind<Self, ()>,
+                                  use: @escaping (A) throws -> Kind<Self, B>) -> Kind<Self, B>
 }
 
 // MARK: Related functions
 
 public extension Bracket {
-    static func bracket<A, B>(_ fa: Kind<Self, A>,
-                              _ release: @escaping (A) -> Kind<Self, ()>,
-                              _ use: @escaping (A) throws -> Kind<Self, B>) -> Kind<Self, B> {
-        return bracketCase(fa, { a, _ in release(a) }, use)
+    static func bracket<A, B>(acquire fa: Kind<Self, A>,
+                              release: @escaping (A) -> Kind<Self, ()>,
+                              use: @escaping (A) throws -> Kind<Self, B>) -> Kind<Self, B> {
+        return bracketCase(acquire: fa, release: { a, _ in release(a) }, use: use)
     }
     
     static func uncancelable<A>(_ fa: Kind<Self, A>) -> Kind<Self, A> {
-        return bracket(fa, constant(pure(())), { x in pure(x) })
+        return bracket(acquire: fa, release: constant(pure(())), use: { x in pure(x) })
     }
     
     static func guarantee<A>(_ fa: Kind<Self, A>,
-                             _ finalizer: Kind<Self, ()>) -> Kind<Self, A> {
-        return bracket(fa, constant(finalizer), constant(fa))
+                             finalizer: Kind<Self, ()>) -> Kind<Self, A> {
+        return bracket(acquire: fa, release: constant(finalizer), use: constant(fa))
     }
     
     static func guaranteeCase<A>(_ fa: Kind<Self, A>,
-                                 _ finalizer: @escaping (ExitCase<Self.E>) -> Kind<Self, ()>) -> Kind<Self, A> {
-        return bracketCase(fa, { _, e in finalizer(e) }, constant(fa))
+                                 finalizer: @escaping (ExitCase<Self.E>) -> Kind<Self, ()>) -> Kind<Self, A> {
+        return bracketCase(acquire: fa, release: { _, e in finalizer(e) }, use: constant(fa))
     }
 }
 
 // MARK: Syntax for Bracket
 
 public extension Kind where F: Bracket {
-    func bracketCase<B>(_ release: @escaping (A, ExitCase<F.E>) -> Kind<F, ()>,
-                        _ use: @escaping (A) throws -> Kind<F, B>) -> Kind<F, B> {
-        return F.bracketCase(self, release, use)
+    func bracketCase<B>(release: @escaping (A, ExitCase<F.E>) -> Kind<F, ()>,
+                        use: @escaping (A) throws -> Kind<F, B>) -> Kind<F, B> {
+        return F.bracketCase(acquire: self, release: release, use: use)
     }
     
-    func bracket<B>(_ release: @escaping (A) -> Kind<F, ()>,
-                    _ use: @escaping (A) throws -> Kind<F, B>) -> Kind<F, B> {
-        return F.bracket(self, release, use)
+    func bracket<B>(release: @escaping (A) -> Kind<F, ()>,
+                    use: @escaping (A) throws -> Kind<F, B>) -> Kind<F, B> {
+        return F.bracket(acquire: self, release: release, use: use)
     }
     
     func uncancelable() -> Kind<F, A> {
@@ -81,10 +81,10 @@ public extension Kind where F: Bracket {
     }
     
     func guarantee(_ finalizer: Kind<F, ()>) -> Kind<F, A> {
-        return F.guarantee(self, finalizer)
+        return F.guarantee(self, finalizer: finalizer)
     }
     
     func guaranteeCase(_ finalizer: @escaping (ExitCase<F.E>) -> Kind<F, ()>) -> Kind<F, A> {
-        return F.guaranteeCase(self, finalizer)
+        return F.guaranteeCase(self, finalizer: finalizer)
     }
 }

--- a/Sources/BowRx/MaybeK.swift
+++ b/Sources/BowRx/MaybeK.swift
@@ -179,9 +179,9 @@ extension ForMaybeK: Concurrent {
 // MARK: Instance of `Bracket` for `MaybeK`
 extension ForMaybeK: Bracket {
     public static func bracketCase<A, B>(
-        _ fa: Kind<ForMaybeK, A>,
-        _ release: @escaping (A, ExitCase<Error>) -> Kind<ForMaybeK, ()>,
-        _ use: @escaping (A) throws -> Kind<ForMaybeK, B>) -> Kind<ForMaybeK, B> {
+        acquire fa: Kind<ForMaybeK, A>,
+        release: @escaping (A, ExitCase<Error>) -> Kind<ForMaybeK, ()>,
+        use: @escaping (A) throws -> Kind<ForMaybeK, B>) -> Kind<ForMaybeK, B> {
         return Maybe.create { emitter in
             return fa.handleErrorWith { t in MaybeK.from { emitter(.error(t)) }.value.flatMap { Maybe.error(t) }.k() }
                 .flatMap { a in

--- a/Sources/BowRx/ObservableK.swift
+++ b/Sources/BowRx/ObservableK.swift
@@ -220,9 +220,9 @@ extension ForObservableK: ConcurrentEffect {
 // MARK: Instance of `Bracket` for `ObservableK`
 extension ForObservableK: Bracket {
     public static func bracketCase<A, B>(
-        _ fa: Kind<ForObservableK, A>,
-        _ release: @escaping (A, ExitCase<Error>) -> Kind<ForObservableK, ()>,
-        _ use: @escaping (A) throws -> Kind<ForObservableK, B>) -> Kind<ForObservableK, B> {
+        acquire fa: Kind<ForObservableK, A>,
+        release: @escaping (A, ExitCase<Error>) -> Kind<ForObservableK, ()>,
+        use: @escaping (A) throws -> Kind<ForObservableK, B>) -> Kind<ForObservableK, B> {
         return Observable.create { emitter in
             fa.handleErrorWith { e in ObservableK.from { emitter.on(.error(e)) }.value.flatMap { _ in Observable.error(e) }.k() }^
                 .concatMap { a in

--- a/Sources/BowRx/SingleK.swift
+++ b/Sources/BowRx/SingleK.swift
@@ -187,9 +187,9 @@ extension ForSingleK: Concurrent {
 // MARK: Instance of `Bracket` for `SingleK`
 extension ForSingleK: Bracket {
     public static func bracketCase<A, B>(
-        _ fa: Kind<ForSingleK, A>,
-        _ release: @escaping (A, ExitCase<Error>) -> Kind<ForSingleK, ()>,
-        _ use: @escaping (A) throws -> Kind<ForSingleK, B>) -> Kind<ForSingleK, B> {
+        acquire fa: Kind<ForSingleK, A>,
+        release: @escaping (A, ExitCase<Error>) -> Kind<ForSingleK, ()>,
+        use: @escaping (A) throws -> Kind<ForSingleK, B>) -> Kind<ForSingleK, B> {
         return Single.create { emitter in
             fa.handleErrorWith { t in SingleK.from { emitter(.error(t)) }.value.flatMap { _ in Single.error(t) }.k() }
                 .flatMap { a in

--- a/Tests/BowEffectsLaws/BracketLaws.swift
+++ b/Tests/BowEffectsLaws/BracketLaws.swift
@@ -22,28 +22,28 @@ public class BracketLaws<F: Bracket & EquatableK> where F.E: Equatable & Arbitra
     private static func bracketCaseWithJustUnitEqvMap() {
         property("bracketCaseWithJustUnitEqvMap") <~ forAll { (a: Int, f: ArrowOf<Int, Int>) in
             let fa = F.pure(a)
-            return fa.bracketCase(constant(F.pure(())), { x in F.pure(f.getArrow(x)) }) == fa.map(f.getArrow)
+            return fa.bracketCase(release: constant(F.pure(())), use: { x in F.pure(f.getArrow(x)) }) == fa.map(f.getArrow)
         }
     }
 
     private static func bracketCaseWithJustUnitIsUncancelable() {
         property("bracketCaseWithJustUnitIsUncancelable") <~ forAll { (a: Int) in
             let fa = F.pure(a)
-            return fa.bracketCase(constant(F.pure(())), F.pure) == fa.uncancelable().flatMap(F.pure)
+            return fa.bracketCase(release: constant(F.pure(())), use: F.pure) == fa.uncancelable().flatMap(F.pure)
         }
     }
 
     private static func bracketCaseFailureInAcquisitionRemainsFailure() {
         property("bracketCaseFailureInAcquisitionRemainsFailure") <~ forAll { (e: F.E) in
             let fe = Kind<F, Int>.raiseError(e)
-            return fe.bracketCase(constant(F.pure(())), F.pure) == F.raiseError(e)
+            return fe.bracketCase(release: constant(F.pure(())), use: F.pure) == F.raiseError(e)
         }
     }
 
     private static func bracketIsDerivedFromBracketCase() {
         property("bracketIsDerivedFromBracketCase") <~ forAll { (a: Int) in
             let fa = F.pure(a)
-            return fa.bracket(constant(F.pure(())), F.pure) == fa.bracketCase(constant(F.pure(())), F.pure)
+            return fa.bracket(release: constant(F.pure(())), use: F.pure) == fa.bracketCase(release: constant(F.pure(())), use: F.pure)
         }
     }
 
@@ -52,7 +52,7 @@ public class BracketLaws<F: Bracket & EquatableK> where F.E: Equatable & Arbitra
             let fa = F.pure(a)
             let onCancel = F.pure(())
             let onFinish = F.pure(())
-            return F.pure(()).bracketCase({ _, b in (b == ExitCase<F.E>.canceled) ? onCancel : onFinish}, { fa }).uncancelable() ==
+            return F.pure(()).bracketCase(release: { _, b in (b == ExitCase<F.E>.canceled) ? onCancel : onFinish}, use: { fa }).uncancelable() ==
                 fa.guarantee(onFinish)
         }
     }
@@ -61,7 +61,7 @@ public class BracketLaws<F: Bracket & EquatableK> where F.E: Equatable & Arbitra
         property("acquireAndReleaseAreUncancelable") <~ forAll { (a: Int) in
             let fa = F.pure(a)
             let release: (Int) -> Kind<F, ()> = constant(F.pure(()))
-            return fa.uncancelable().bracket({ x in release(x).uncancelable() }, F.pure) == fa.bracket(release, F.pure)
+            return fa.uncancelable().bracket(release: { x in release(x).uncancelable() }, use: F.pure) == fa.bracket(release: release, use: F.pure)
         }
     }
 
@@ -69,7 +69,7 @@ public class BracketLaws<F: Bracket & EquatableK> where F.E: Equatable & Arbitra
         property("guaranteeIsDerivedFromBracket") <~ forAll { (a: Int) in
             let fa = F.pure(a)
             let finalizer = F.pure(())
-            return fa.guarantee(finalizer) == F.pure(()).bracket({ finalizer }, { fa })
+            return fa.guarantee(finalizer) == F.pure(()).bracket(release: { finalizer }, use: { fa })
         }
     }
 
@@ -77,7 +77,7 @@ public class BracketLaws<F: Bracket & EquatableK> where F.E: Equatable & Arbitra
         property("guaranteeCaseIsDerivedFromBracketCase") <~ forAll { (a: Int) in
             let fa = F.pure(a)
             let finalizer: (ExitCase<F.E>) -> Kind<F, ()> = constant(F.pure(()))
-            return fa.guaranteeCase(finalizer) == F.pure(()).bracketCase({ _, e in finalizer(e) }, { fa })
+            return fa.guaranteeCase(finalizer) == F.pure(()).bracketCase(release: { _, e in finalizer(e) }, use: { fa })
         }
     }
 
@@ -86,14 +86,14 @@ public class BracketLaws<F: Bracket & EquatableK> where F.E: Equatable & Arbitra
             let acquire = F.pure(a)
             let use = f.getArrow >>> F.pure
             let release = g.getArrow >>> { _ in F.pure(()) }
-            return acquire.bracket(release, use) == acquire.flatMap { x in use(x).flatMap { y in release(x).map { y } } }
+            return acquire.bracket(release: release, use: use) == acquire.flatMap { x in use(x).flatMap { y in release(x).map { y } } }
         }
     }
 
     private static func bracketMustRunReleaseTask() {
         property("bracketMustRunReleaseTask") <~ forAll { (a: Int, e: F.E) in
             var msg = 0
-            return F.pure(a).bracket({ i in msg = i; return F.pure(()) }, { _ -> Kind<F, Int> in throw e })
+            return F.pure(a).bracket(release: { i in msg = i; return F.pure(()) }, use: { _ -> Kind<F, Int> in throw e })
                 .attempt()
                 .map { _ in msg } == F.pure(a)
         }

--- a/Tests/BowEffectsTests/IOTest.swift
+++ b/Tests/BowEffectsTests/IOTest.swift
@@ -54,7 +54,7 @@ extension IOPartial: EquatableK where E: Equatable {
         var aError, bError : E?
         
         do {
-            aValue = try IO.fix(lhs).unsafePerformIO()
+            aValue = try IO.fix(lhs).unsafeRunSync()
         } catch let error as E {
             aError = error
         } catch {
@@ -62,7 +62,7 @@ extension IOPartial: EquatableK where E: Equatable {
         }
         
         do {
-            bValue = try IO.fix(rhs).unsafePerformIO()
+            bValue = try IO.fix(rhs).unsafeRunSync()
         } catch let error as E {
             bError = error
         } catch {

--- a/Tests/BowLaws/ApplicativeLaws.swift
+++ b/Tests/BowLaws/ApplicativeLaws.swift
@@ -49,7 +49,7 @@ public class ApplicativeLaws<F: Applicative & EquatableK & ArbitraryK> {
     
     private static func cartesianBuilderTupled() {
         property("cartesian builder map") <~ forAll() { (a: Int, b: Int, c: Int, d: Int, e: Int, f: Int, g: Int) in
-            let left: Kind<F, Int> = F.map(F.tupled(F.pure(a), F.pure(b), F.pure(c), F.pure(d), F.pure(e), F.pure(f)), { x, y, z, u, v, w in x + y + z - u - v - w })
+            let left: Kind<F, Int> = F.map(F.zip(F.pure(a), F.pure(b), F.pure(c), F.pure(d), F.pure(e), F.pure(f)), { x, y, z, u, v, w in x + y + z - u - v - w })
             let right: Kind<F, Int> = F.pure(a + b + c - d - e - f)
             return left == right
         }


### PR DESCRIPTION
## Goal

Add several usability improvements to the library.

- Bracket methods now include labels for `acquire`, `release` and `use` to make them easier to remember.
- Type aliases for `EnvIO`, `RIO` and `URIO` have been added.
- Utilities to built an IO from Either, Validated, Result and Try.
- Added contramap on Kleisli.
- Added the ability to map using key paths on Functor.
- Renamed `Applicative.tupled` to `Applicative.zip`.
- Reordered type arguments on `Applicative` for easier usage.
- Selective methods now include labels for the cases and methods that operate on `F<Bool>` are now instance methods instead of static.
