### PR TITLE
Fix censor implementation in MonadWriter

### DIFF
--- a/Sources/Bow/Typeclasses/MonadWriter.swift
+++ b/Sources/Bow/Typeclasses/MonadWriter.swift
@@ -50,7 +50,7 @@ public extension MonadWriter {
     ///   - f: Transforming function.
     /// - Returns: A computation with the same result as the provided one, with the transformed side stream of data.
     static func censor<A>(_ fa: Kind<Self, A>, _ f: @escaping (W) -> W) -> Kind<Self, A> {
-        return self.flatMap(self.listen(fa), { pair in writer((f(pair.0), pair.1)) })
+        return pass(fa.map { a in (f, a) })
     }
 }
 

--- a/Tests/BowTests/Transformers/WriterTTest.swift
+++ b/Tests/BowTests/Transformers/WriterTTest.swift
@@ -50,4 +50,15 @@ class WriterTTest: XCTestCase {
     func testMonadErrorLaws() {
         MonadErrorLaws<WriterTPartial<EitherPartial<CategoryError>, Int>>.check()
     }
+    
+    func testCensor() {
+        let x = Writer.writer(("A", 1))
+        let result = x.censor { x in x.lowercased() }
+        let expected = Writer.writer(("a", 1))
+        
+        print(result^.run)
+        print(expected^.run)
+        
+        XCTAssertEqual(result, expected)
+    }
 }


### PR DESCRIPTION
## Goal

- Implementation of `censor` for `MonadWriter` was wrong as it was accumulating the transformed stream to its transformation.
- Utilities to work with `Writer` (a.k.a. WriterT<ForId, W, A>) have been added.
