### PR TITLE
Fix signature about `removeItem`

### DIFF
--- a/Sources/BowEffects/Foundation/FileManager.swift
+++ b/Sources/BowEffects/Foundation/FileManager.swift
@@ -49,7 +49,7 @@ public extension FileManager {
     }
     
     /// IO suspended version of `FileManager.removeItem(atPath:)`. Refer to that method for further documentation.
-    func removeItem(atPath path: String) -> IO<Error, ()> {
+    func removeItemIO(atPath path: String) -> IO<Error, ()> {
         return IO.invoke { try self.removeItem(atPath: path) }
     }
     


### PR DESCRIPTION
## Description

Ambiguous use of `removeItem(atPath:)` - conflict with Foundation's definition
