### PR TITLE
Docs deployment fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: objective-c
 osx_image: xcode11
 sudo: required
+git:
+  depth: 200
 addons:
   homebrew:
     taps:
@@ -37,5 +39,4 @@ jobs:
         provider: pages
         skip-cleanup: true
         github-token: $GITHUB_TOKEN
-        keep-history: true
         local-dir: pub-dir

--- a/scripts/gen-docs.rb
+++ b/scripts/gen-docs.rb
@@ -15,7 +15,7 @@ $current_branch_path = "next"
 # This is a list to filter -out- tags we know are not valuable to generate docs
 # for. If you set one tag in the default_version, you can add it here, so it's
 # not generated twice. Unless you want to have the same content at two paths.
-$invalid_tags = ["0.1.0", "0.2.0", "0.3.0"]
+$invalid_tags = ["0.1.0", "0.2.0", "0.3.0", "0.5.0"]
 
 # This is a list to filter -in- tags. Unless it's empty, where it will be ignored.
 # If you want an empty tags list in the end (for some reason ¯\_(ツ)_/¯)


### PR DESCRIPTION
## Related issues

#427 


## Goal

We found that by default Travis shallow clones a repository with a depth of 50 commits, which could cause problems if one of the tags that we want to deploy is older than that. In an effort to find the right balance we are setting a depth of 200 here. The Git history is being also deactivated just to have a clean branch for deployments. Additionally, the `0.5.0` tag is being removed from the generated tags, as it being the default one is not necessary to generate it twice.


## Implementation details

* Increase git cloning depth to allow that clone to access older tags
* Deactivate the history keeping for the `gh-pages` branch
* Remove 0.5.0 from the list of generated tags, as it's the default one
