### PR TITLE
Remove error prone binding instruction

### DIFF
--- a/Bow.xcodeproj/project.pbxproj
+++ b/Bow.xcodeproj/project.pbxproj
@@ -2350,7 +2350,6 @@
 			buildPhases = (
 				OBJ_245 /* Sources */,
 				OBJ_291 /* Frameworks */,
-				D66B91BB20680771001A5B64 /* ShellScript */,
 			);
 			buildRules = (
 			);
@@ -2470,23 +2469,6 @@
 			);
 		};
 /* End PBXProject section */
-
-/* Begin PBXShellScriptBuildPhase section */
-		D66B91BB20680771001A5B64 /* ShellScript */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 12;
-			files = (
-			);
-			inputPaths = (
-				"$(SRCROOT)/Carthage/Build/iOS/SwiftCheck.framework",
-			);
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "/usr/local/bin/carthage copy-frameworks\n";
-		};
-/* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
 		1120978522A7EBC7007F3D9C /* Sources */ = {

--- a/Sources/Bow/Typeclasses/MonadComprehensions/BindingOperator.swift
+++ b/Sources/Bow/Typeclasses/MonadComprehensions/BindingOperator.swift
@@ -18,16 +18,6 @@ public func <-<F: Monad, A>(_ bound: BoundVar<F, A>, _ fa: @autoclosure @escapin
 /// Creates a binding expression.
 ///
 /// - Parameters:
-///   - bound: Variable to be bound in the expression.
-///   - fa: Plain value.
-/// - Returns: A binding expression.
-public func <-<F: Monad, A>(_ bound: BoundVar<F, A>, _ fa: @autoclosure @escaping () -> A) -> BindingExpression<F> {
-    return BindingExpression(bound.erased, fa >>> F.pure >>> erased)
-}
-
-/// Creates a binding expression.
-///
-/// - Parameters:
 ///   - bounds: A 2-ary tuple of variables to be bound to the values produced by the effect.
 ///   - fa: Monadic effect.
 /// - Returns: A binding expresssion.
@@ -121,12 +111,4 @@ public func <-<F: Monad, A, B, C, D, E, G, H, I, J, K>(_ bounds: (BoundVar<F, A>
 /// - Returns: A binding expression.
 public prefix func |<-<F: Monad, A>(_ fa: @autoclosure @escaping () -> Kind<F, A>) -> BindingExpression<F> {
     return BindingExpression(BoundVar(), fa >>> erased)
-}
-
-/// Creates a binding expression that discards the produced value.
-///
-/// - Parameter fa: Plain value.
-/// - Returns: A binding expression.
-public prefix func |<-<F: Monad, A>(_ fa: @autoclosure @escaping () -> A) -> BindingExpression<F> {
-    return BindingExpression(BoundVar(), fa >>> F.pure)
 }

--- a/Tests/BowEffectsLaws/AsyncLaws.swift
+++ b/Tests/BowEffectsLaws/AsyncLaws.swift
@@ -61,10 +61,10 @@ public class AsyncLaws<F: Async & EquatableK> where F.E: Arbitrary {
             let l2 = F.var(String.self)
             
             return binding(
-                   |<-F.lazy().continueOn(queue1),
-                l1 <-- currentQueueLabel(),
-                   |<-F.lazy().continueOn(queue2),
-                l2 <-- currentQueueLabel(),
+                continueOn(queue1),
+                l1 <-- F.pure(currentQueueLabel()),
+                continueOn(queue2),
+                l2 <-- F.pure(currentQueueLabel()),
                 yield: l1.get + l2.get) == F.pure(id1 + id2)
         }
     }

--- a/Tests/BowLaws/BindingOperatorOverload.swift
+++ b/Tests/BowLaws/BindingOperatorOverload.swift
@@ -15,16 +15,6 @@ public func <--<F: Monad, A>(_ bound: BoundVar<F, A>, _ fa: @autoclosure @escapi
 /// Creates a binding expression.
 ///
 /// - Parameters:
-///   - bound: Variable to be bound in the expression.
-///   - fa: Plain value.
-/// - Returns: A binding expression.
-public func <--<F: Monad, A>(_ bound: BoundVar<F, A>, _ fa: @autoclosure @escaping () -> A) -> BindingExpression<F> {
-    return bound <- fa()
-}
-
-/// Creates a binding expression.
-///
-/// - Parameters:
 ///   - bounds: A 2-ary tuple of variables to be bound to the values produced by the effect.
 ///   - fa: Monadic effect.
 /// - Returns: A binding expresssion.


### PR DESCRIPTION
## Goal

Remove binding instructions of values with no context as it leads to error prone code that does not behave as expected. Removing this leverages the power of the compiler to detect non-homogeneous monad comprehensions.