### PR TITLE
Install cocoapods explicitely when deploying docs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,7 @@ jobs:
       before_install:
         - gem update --system
         - gem install bundler
+        - gem install cocoapods
       script:
         - ./scripts/gen-docs.rb
       deploy:


### PR DESCRIPTION
## Goal

Bow version 6.0.0 have introduced the need to support various Swift versions, which is only available since Cocoapods 1.7.0 (http://blog.cocoapods.org/CocoaPods-1.7.0-beta/)

## Implementation details

Install cocoapods explicitely when deploying docs, which will install latest available Cocoapods version.
