### PR TITLE
Fix bad space char at docs

### DIFF
--- a/contents/Documentation/Effects.playground/Pages/Running side effects.xcplaygroundpage/Contents.swift
+++ b/contents/Documentation/Effects.playground/Pages/Running side effects.xcplaygroundpage/Contents.swift
@@ -33,7 +33,7 @@ func fetchArticles(from category: Category, page: UInt, limit: UInt) -> IO<APIEr
 { return IO.pure([])^ }
 // nef:end
 /*:
- ## Synchronous run
+ ## Synchronous run
  
  We can run the function above synchronously using the `unsafeRunSync ` method on `IO`:
  */


### PR DESCRIPTION
## Goal

An incorrect space char is causing a title in the _Running Side Effects_ page to not be properly styled: 

https://bow-swift.io/next/docs/effects/running-side-effects/

If the character gets analyzed it's the standard Unicode space (https://unicode.org/cldr/utility/character.jsp?a=0020), but somehow it is not, as it can be checked in this commit diff...

:man_shrugging: :man_shrugging: :man_shrugging: 

https://bow-swift.io/next/docs/effects/running-side-effects/

## Implementation details

This PR set a proper space on that title.
