### PR TITLE
Add Semiring typeclass

### DIFF
--- a/Bow.xcodeproj/project.pbxproj
+++ b/Bow.xcodeproj/project.pbxproj
@@ -310,6 +310,7 @@
 		8BA0F65B217E2E9200969984 /* FunctorFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BA0F4AE217E2E9200969984 /* FunctorFilter.swift */; };
 		B8B910C0234D7F2600E44271 /* Semiring.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8B910BF234D7F2600E44271 /* Semiring.swift */; };
 		B8B910C4234D846900E44271 /* SemiringLaws.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8B910C3234D846900E44271 /* SemiringLaws.swift */; };
+		B8B910C6234DDA4000E44271 /* BoolInstancesTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8B910C5234DDA4000E44271 /* BoolInstancesTest.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -1024,6 +1025,7 @@
 		8BA0F4D2217E2E9200969984 /* Lens.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Lens.swift; sourceTree = "<group>"; };
 		B8B910BF234D7F2600E44271 /* Semiring.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Semiring.swift; sourceTree = "<group>"; };
 		B8B910C3234D846900E44271 /* SemiringLaws.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SemiringLaws.swift; sourceTree = "<group>"; };
+		B8B910C5234DDA4000E44271 /* BoolInstancesTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoolInstancesTest.swift; sourceTree = "<group>"; };
 		"Bow::Bow::Product" /* Bow.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = Bow.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		"Bow::BowTests::Product" /* BowTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; path = BowTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		OBJ_6 /* Package.swift */ = {isa = PBXFileReference; explicitFileType = sourcecode.swift; path = Package.swift; sourceTree = "<group>"; };
@@ -1658,6 +1660,7 @@
 			children = (
 				8BA0F39C217E2DEF00969984 /* NumberInstancesTest.swift */,
 				8BA0F39B217E2DEF00969984 /* StringInstancesTest.swift */,
+				B8B910C5234DDA4000E44271 /* BoolInstancesTest.swift */,
 			);
 			path = Instances;
 			sourceTree = "<group>";
@@ -2846,6 +2849,7 @@
 				113746A423435BA600D9C1AD /* DictionaryKTest.swift in Sources */,
 				8BA0F3F1217E2DEF00969984 /* StateTTest.swift in Sources */,
 				11DDCD28217F1FC200844D9D /* ReverseTest.swift in Sources */,
+				B8B910C6234DDA4000E44271 /* BoolInstancesTest.swift in Sources */,
 				8BA0F400217E2DEF00969984 /* EitherTest.swift in Sources */,
 				8BA0F408217E2DEF00969984 /* ValidatedTest.swift in Sources */,
 				111F84FE234DC00F003FE646 /* SetTest.swift in Sources */,

--- a/Bow.xcodeproj/project.pbxproj
+++ b/Bow.xcodeproj/project.pbxproj
@@ -308,6 +308,8 @@
 		8BA0F653217E2E9200969984 /* Semigroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BA0F4AC217E2E9200969984 /* Semigroup.swift */; };
 		8BA0F657217E2E9200969984 /* MonadCombine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BA0F4AD217E2E9200969984 /* MonadCombine.swift */; };
 		8BA0F65B217E2E9200969984 /* FunctorFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BA0F4AE217E2E9200969984 /* FunctorFilter.swift */; };
+		B8B910C0234D7F2600E44271 /* Semiring.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8B910BF234D7F2600E44271 /* Semiring.swift */; };
+		B8B910C4234D846900E44271 /* SemiringLaws.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8B910C3234D846900E44271 /* SemiringLaws.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -1020,6 +1022,8 @@
 		8BA0F4D0217E2E9200969984 /* At+Optics.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "At+Optics.swift"; sourceTree = "<group>"; };
 		8BA0F4D1217E2E9200969984 /* Each+Optics.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Each+Optics.swift"; sourceTree = "<group>"; };
 		8BA0F4D2217E2E9200969984 /* Lens.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Lens.swift; sourceTree = "<group>"; };
+		B8B910BF234D7F2600E44271 /* Semiring.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Semiring.swift; sourceTree = "<group>"; };
+		B8B910C3234D846900E44271 /* SemiringLaws.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SemiringLaws.swift; sourceTree = "<group>"; };
 		"Bow::Bow::Product" /* Bow.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = Bow.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		"Bow::BowTests::Product" /* BowTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; path = BowTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		OBJ_6 /* Package.swift */ = {isa = PBXFileReference; explicitFileType = sourcecode.swift; path = Package.swift; sourceTree = "<group>"; };
@@ -1547,6 +1551,7 @@
 				8BA0F3BE217E2DEF00969984 /* SemigroupLaws.swift */,
 				8BA0F3D3217E2DEF00969984 /* TraverseFilterLaws.swift */,
 				8BA0F3BB217E2DEF00969984 /* TraverseLaws.swift */,
+				B8B910C3234D846900E44271 /* SemiringLaws.swift */,
 			);
 			path = BowLaws;
 			sourceTree = "<group>";
@@ -1829,6 +1834,7 @@
 				8BA0F496217E2E9200969984 /* SemigroupK.swift */,
 				8BA0F49B217E2E9200969984 /* Traverse.swift */,
 				8BA0F49A217E2E9200969984 /* TraverseFilter.swift */,
+				B8B910BF234D7F2600E44271 /* Semiring.swift */,
 			);
 			path = Typeclasses;
 			sourceTree = "<group>";
@@ -2560,6 +2566,7 @@
 				11229439219D8BDE006D66C5 /* TraverseFilterLaws.swift in Sources */,
 				1191BD1322D78F6D0052FEA8 /* PropertyOperatorOverload.swift in Sources */,
 				1122943A219D8BDE006D66C5 /* TraverseLaws.swift in Sources */,
+				B8B910C4234D846900E44271 /* SemiringLaws.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2938,6 +2945,7 @@
 				8BA0F62F217E2E9200969984 /* Bimonad.swift in Sources */,
 				8BA0F627217E2E9200969984 /* Foldable.swift in Sources */,
 				8BA0F587217E2E9200969984 /* DictionaryK.swift in Sources */,
+				B8B910C0234D7F2600E44271 /* Semiring.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Sources/Bow/Instances/BoolInstances.swift
+++ b/Sources/Bow/Instances/BoolInstances.swift
@@ -1,15 +1,26 @@
 import Foundation
 
-/// Instance of `Semigroup` for `Bool`. Uses conjunction as combination of elements.
+/// Instance of `Semigroup` for `Bool`. Uses disjunction as combination of elements.
 extension Bool: Semigroup {
     public func combine(_ other: Bool) -> Bool {
-        return self && other
+        return self || other
     }
 }
 
-/// Instance of `Monoid` for `Bool`. Uses conjunction as combination of elements and `true` as empty element.
+/// Instance of `Monoid` for `Bool`. Uses disjunction as combination of elements and `false` as empty element.
 extension Bool: Monoid {
     public static func empty() -> Bool {
+        return false
+    }
+}
+
+/// Instance of `Semiring` for `Bool`. Uses conjunction as multiplication of elements and `true` as empty element.
+extension Bool: Semiring {
+    public func times(_ other: Bool) -> Bool {
+        return self && other
+    }
+    
+    public static func one() -> Bool {
         return true
     }
 }

--- a/Sources/Bow/Instances/BoolInstances.swift
+++ b/Sources/Bow/Instances/BoolInstances.swift
@@ -16,7 +16,7 @@ extension Bool: Monoid {
 
 /// Instance of `Semiring` for `Bool`. Uses conjunction as multiplication of elements and `true` as empty element.
 extension Bool: Semiring {
-    public func times(_ other: Bool) -> Bool {
+    public func multiply(_ other: Bool) -> Bool {
         return self && other
     }
     

--- a/Sources/Bow/Instances/NumberInstances.swift
+++ b/Sources/Bow/Instances/NumberInstances.swift
@@ -264,7 +264,18 @@ extension Float: Monoid {
     }
 }
 
-/// Instance of `Semigroup` for `Double`. Uses sum as combination of elements.
+/// Instance of `Semiring` for `Float`. Uses multiplication as multiplication of elements and one as one element.
+extension Float: Semiring {
+    public func multiply(_ other: Float) -> Float {
+        return self * other
+    }
+    
+    public static func one() -> Float {
+        return 1
+    }
+}
+
+/// Instance of `Semigroup` for `Double`. Uses addition as combination of elements.
 extension Double: Semigroup {
     public func combine(_ other: Double) -> Double {
         return self + other
@@ -275,5 +286,16 @@ extension Double: Semigroup {
 extension Double: Monoid {
     public static func empty() -> Double {
         return 0
+    }
+}
+
+/// Instance of `Semiring` for `Double`. Uses addition as multiplication of elements and one as one element.
+extension Double: Semiring {
+    public func multiply(_ other: Double) -> Double {
+        return self * other
+    }
+    
+    public static func one() -> Double {
+        return 1
     }
 }

--- a/Sources/Bow/Instances/NumberInstances.swift
+++ b/Sources/Bow/Instances/NumberInstances.swift
@@ -139,6 +139,17 @@ extension UInt: Monoid {
     }
 }
 
+/// Instance of `Semiring` for `UInt`. Uses multiplication as multiplication of elements and one as one element.
+extension UInt: Semiring {
+    public func multiply(_ other: UInt) -> UInt {
+        return self * other
+    }
+    
+    public static func one() -> UInt {
+        return 1
+    }
+}
+
 /// Instance of `Semigroup` for `UInt8`. Uses sum as combination of elements.
 extension UInt8: Semigroup {
     public func combine(_ other: UInt8) -> UInt8 {
@@ -150,6 +161,17 @@ extension UInt8: Semigroup {
 extension UInt8: Monoid {
     public static func empty() -> UInt8 {
         return 0
+    }
+}
+
+/// Instance of `Semiring` for `UInt8`. Uses multiplication as multiplication of elements and one as one element.
+extension UInt8: Semiring {
+    public func multiply(_ other: UInt8) -> UInt8 {
+        return self.multipliedReportingOverflow(by: other).partialValue
+    }
+    
+    public static func one() -> UInt8 {
+        return 1
     }
 }
 
@@ -167,6 +189,17 @@ extension UInt16: Monoid {
     }
 }
 
+/// Instance of `Semiring` for `UInt16`. Uses multiplication as multiplication of elements and one as one element.
+extension UInt16: Semiring {
+    public func multiply(_ other: UInt16) -> UInt16 {
+        return self.multipliedReportingOverflow(by: other).partialValue
+    }
+    
+    public static func one() -> UInt16 {
+        return 1
+    }
+}
+
 /// Instance of `Semigroup` for `UInt32`. Uses sum as combination of elements.
 extension UInt32: Semigroup {
     public func combine(_ other: UInt32) -> UInt32 {
@@ -181,6 +214,17 @@ extension UInt32: Monoid {
     }
 }
 
+/// Instance of `Semiring` for `UInt32`. Uses multiplication as multiplication of elements and one as one element.
+extension UInt32: Semiring {
+    public func multiply(_ other: UInt32) -> UInt32 {
+        return self.multipliedReportingOverflow(by: other).partialValue
+    }
+    
+    public static func one() -> UInt32 {
+        return 1
+    }
+}
+
 /// Instance of `Semigroup` for `UInt64`. Uses sum as combination of elements.
 extension UInt64: Semigroup {
     public func combine(_ other: UInt64) -> UInt64 {
@@ -192,6 +236,17 @@ extension UInt64: Semigroup {
 extension UInt64: Monoid {
     public static func empty() -> UInt64 {
         return 0
+    }
+}
+
+/// Instance of `Semiring` for `UInt64`. Uses multiplication as multiplication of elements and one as one element.
+extension UInt64: Semiring {
+    public func multiply(_ other: UInt64) -> UInt64 {
+        return self.multipliedReportingOverflow(by: other).partialValue
+    }
+    
+    public static func one() -> UInt64 {
+        return 1
     }
 }
 

--- a/Sources/Bow/Instances/NumberInstances.swift
+++ b/Sources/Bow/Instances/NumberInstances.swift
@@ -14,6 +14,17 @@ extension Int: Monoid {
     }
 }
 
+/// Instance of `Semiring` for `Int`. Uses multiplication as multiplication of elements and one as one element.
+extension Int: Semiring {
+    public func multiply(_ other: Int) -> Int {
+        return self * other
+    }
+    
+    public static func one() -> Int {
+        return 1
+    }
+}
+
 /// Instance of `Semigroup` for `Int8`. Uses sum as combination of elements.
 extension Int8: Semigroup {
     public func combine(_ other: Int8) -> Int8 {
@@ -25,6 +36,17 @@ extension Int8: Semigroup {
 extension Int8: Monoid {
     public static func empty() -> Int8 {
         return 0
+    }
+}
+
+/// Instance of `Semiring` for `Int8`. Uses multiplication as multiplication of elements and one as one element.
+extension Int8: Semiring {
+    public func multiply(_ other: Int8) -> Int8 {
+        return self.multipliedReportingOverflow(by: other).partialValue
+    }
+    
+    public static func one() -> Int8 {
+        return 1
     }
 }
 
@@ -42,6 +64,17 @@ extension Int16: Monoid {
     }
 }
 
+/// Instance of `Semiring` for `Int16`. Uses multiplication as multiplication of elements and one as one element.
+extension Int16: Semiring {
+    public func multiply(_ other: Int16) -> Int16 {
+        return self.multipliedReportingOverflow(by: other).partialValue
+    }
+    
+    public static func one() -> Int16 {
+        return 1
+    }
+}
+
 /// Instance of `Semigroup` for `Int32`. Uses sum as combination of elements.
 extension Int32: Semigroup {
     public func combine(_ other: Int32) -> Int32 {
@@ -56,6 +89,17 @@ extension Int32: Monoid {
     }
 }
 
+/// Instance of `Semiring` for `Int32`. Uses multiplication as multiplication of elements and one as one element.
+extension Int32: Semiring {
+    public func multiply(_ other: Int32) -> Int32 {
+        return self.multipliedReportingOverflow(by: other).partialValue
+    }
+    
+    public static func one() -> Int32 {
+        return 1
+    }
+}
+
 /// Instance of `Semigroup` for `Int64`. Uses sum as combination of elements.
 extension Int64: Semigroup {
     public func combine(_ other: Int64) -> Int64 {
@@ -67,6 +111,17 @@ extension Int64: Semigroup {
 extension Int64: Monoid {
     public static func empty() -> Int64 {
         return 0
+    }
+}
+
+/// Instance of `Semiring` for `Int64`. Uses multiplication as multiplication of elements and one as one element.
+extension Int64: Semiring {
+    public func multiply(_ other: Int64) -> Int64 {
+        return self.multipliedReportingOverflow(by: other).partialValue
+    }
+    
+    public static func one() -> Int64 {
+        return 1
     }
 }
 

--- a/Sources/Bow/Instances/NumberInstances.swift
+++ b/Sources/Bow/Instances/NumberInstances.swift
@@ -14,7 +14,7 @@ extension Int: Monoid {
     }
 }
 
-/// Instance of `Semiring` for `Int`. Uses multiplication as multiplication of elements and one as one element.
+/// Instance of `Semiring` for `Int`. Uses product (`*`) as multiplication of elements and `1` as one element.
 extension Int: Semiring {
     public func multiply(_ other: Int) -> Int {
         return self * other
@@ -39,7 +39,7 @@ extension Int8: Monoid {
     }
 }
 
-/// Instance of `Semiring` for `Int8`. Uses multiplication as multiplication of elements and one as one element.
+/// Instance of `Semiring` for `Int8`. Uses product (`*`) as multiplication of elements and `1` as one element.
 extension Int8: Semiring {
     public func multiply(_ other: Int8) -> Int8 {
         return self.multipliedReportingOverflow(by: other).partialValue
@@ -64,7 +64,7 @@ extension Int16: Monoid {
     }
 }
 
-/// Instance of `Semiring` for `Int16`. Uses multiplication as multiplication of elements and one as one element.
+/// Instance of `Semiring` for `Int16`. Uses product (`*`) as multiplication of elements and `1` as one element.
 extension Int16: Semiring {
     public func multiply(_ other: Int16) -> Int16 {
         return self.multipliedReportingOverflow(by: other).partialValue
@@ -89,7 +89,7 @@ extension Int32: Monoid {
     }
 }
 
-/// Instance of `Semiring` for `Int32`. Uses multiplication as multiplication of elements and one as one element.
+/// Instance of `Semiring` for `Int32`. Uses product (`*`) as multiplication of elements and `1` as one element.
 extension Int32: Semiring {
     public func multiply(_ other: Int32) -> Int32 {
         return self.multipliedReportingOverflow(by: other).partialValue
@@ -114,7 +114,7 @@ extension Int64: Monoid {
     }
 }
 
-/// Instance of `Semiring` for `Int64`. Uses multiplication as multiplication of elements and one as one element.
+/// Instance of `Semiring` for `Int64`. Uses product (`*`) as multiplication of elements and `1` as one element.
 extension Int64: Semiring {
     public func multiply(_ other: Int64) -> Int64 {
         return self.multipliedReportingOverflow(by: other).partialValue
@@ -139,7 +139,7 @@ extension UInt: Monoid {
     }
 }
 
-/// Instance of `Semiring` for `UInt`. Uses multiplication as multiplication of elements and one as one element.
+/// Instance of `Semiring` for `UInt`. Uses product (`*`) as multiplication of elements and `1` as one element.
 extension UInt: Semiring {
     public func multiply(_ other: UInt) -> UInt {
         return self * other
@@ -164,7 +164,7 @@ extension UInt8: Monoid {
     }
 }
 
-/// Instance of `Semiring` for `UInt8`. Uses multiplication as multiplication of elements and one as one element.
+/// Instance of `Semiring` for `UInt8`. Uses product (`*`) as multiplication of elements and `1` as one element.
 extension UInt8: Semiring {
     public func multiply(_ other: UInt8) -> UInt8 {
         return self.multipliedReportingOverflow(by: other).partialValue
@@ -189,7 +189,7 @@ extension UInt16: Monoid {
     }
 }
 
-/// Instance of `Semiring` for `UInt16`. Uses multiplication as multiplication of elements and one as one element.
+/// Instance of `Semiring` for `UInt16`. Uses product (`*`) as multiplication of elements and `1` as one element.
 extension UInt16: Semiring {
     public func multiply(_ other: UInt16) -> UInt16 {
         return self.multipliedReportingOverflow(by: other).partialValue
@@ -214,7 +214,7 @@ extension UInt32: Monoid {
     }
 }
 
-/// Instance of `Semiring` for `UInt32`. Uses multiplication as multiplication of elements and one as one element.
+/// Instance of `Semiring` for `UInt32`. Uses product (`*`) as multiplication of elements and `1` as one element.
 extension UInt32: Semiring {
     public func multiply(_ other: UInt32) -> UInt32 {
         return self.multipliedReportingOverflow(by: other).partialValue
@@ -239,7 +239,7 @@ extension UInt64: Monoid {
     }
 }
 
-/// Instance of `Semiring` for `UInt64`. Uses multiplication as multiplication of elements and one as one element.
+/// Instance of `Semiring` for `UInt64`. Uses product (`*`) as multiplication of elements and `1` as one element.
 extension UInt64: Semiring {
     public func multiply(_ other: UInt64) -> UInt64 {
         return self.multipliedReportingOverflow(by: other).partialValue
@@ -264,7 +264,7 @@ extension Float: Monoid {
     }
 }
 
-/// Instance of `Semiring` for `Float`. Uses multiplication as multiplication of elements and one as one element.
+/// Instance of `Semiring` for `Float`. Uses product (`*`) as multiplication of elements and `1` as one element.
 extension Float: Semiring {
     public func multiply(_ other: Float) -> Float {
         return self * other
@@ -289,7 +289,7 @@ extension Double: Monoid {
     }
 }
 
-/// Instance of `Semiring` for `Double`. Uses addition as multiplication of elements and one as one element.
+/// Instance of `Semiring` for `Double`. Uses addition as multiplication of elements and `1` as one element.
 extension Double: Semiring {
     public func multiply(_ other: Double) -> Double {
         return self * other

--- a/Sources/Bow/Typeclasses/Semiring.swift
+++ b/Sources/Bow/Typeclasses/Semiring.swift
@@ -6,17 +6,17 @@ public protocol Semiring: Monoid {
     ///
     /// This operation must satisfy the semigroup laws:
     ///
-    ///     a.times(b).times(c) == a.times(b.times(c))
+    ///     a.multiply(b).multiply(c) == a.multiply(b.multiply(c))
     ///
     /// - Parameter other: Value to multipy with the receiver.
     /// - Returns: Multiplication of the receiver value with the parameter value.
-    func times(_ other: Self) -> Self
+    func multiply(_ other: Self) -> Self
     
     /// Zero element.
     ///
     /// The zero element must obey the semirings laws:
     ///
-    ///     a.times(zero()) == zero().times(a) == zero()
+    ///     a.multiply(zero()) == zero().multiply(a) == zero()
     ///
     /// That is, multiplying any element with `zero` must return the `zero`.
     /// It is also an alias for `empty` of `Monoid`.
@@ -28,7 +28,7 @@ public protocol Semiring: Monoid {
     ///
     /// The one element must obey the semirings laws:
     ///
-    ///     a.times(one()) == one().times(a) == a
+    ///     a.multiply(one()) == one().multiply(a) == a
     ///
     /// That is, multiplying any element with `one` must return the original element.
     ///

--- a/Sources/Bow/Typeclasses/Semiring.swift
+++ b/Sources/Bow/Typeclasses/Semiring.swift
@@ -1,0 +1,41 @@
+import Foundation
+
+/// A semiring is an algebraic structure that has the same properties as a commutative monoid for addition, with multiplication.
+public protocol Semiring: Monoid {
+    /// An associative operation to combine values of the implementing type.
+    ///
+    /// This operation must satisfy the semigroup laws:
+    ///
+    ///     a.times(b).times(c) == a.times(b.times(c))
+    ///
+    /// - Parameter other: Value to multipy with the receiver.
+    /// - Returns: Multiplication of the receiver value with the parameter value.
+    func times(_ other: Self) -> Self
+    
+    /// Zero element.
+    ///
+    /// The zero element must obey the semirings laws:
+    ///
+    ///     a.times(zero()) == zero().times(a) == zero()
+    ///
+    /// That is, multiplying any element with `zero` must return the `zero`.
+    /// It is also an alias for `empty` of `Monoid`.
+    ///
+    /// - Returns: A value of the implementing type satisfying the semiring laws.
+    static func zero() -> Self
+    
+    /// One element.
+    ///
+    /// The one element must obey the semirings laws:
+    ///
+    ///     a.times(one()) == one().times(a) == a
+    ///
+    /// That is, multiplying any element with `one` must return the original element.
+    ///
+    /// - Returns: A value of the implementing type satisfying the semiring laws.
+    static func one() -> Self
+}
+
+public extension Semiring {
+    static func zero() -> Self { Self.empty() }
+}

--- a/Sources/BowOptics/Fold.swift
+++ b/Sources/BowOptics/Fold.swift
@@ -133,7 +133,7 @@ open class Fold<S, A>: FoldOf<S, A> {
     /// - Parameter s: Source.
     /// - Returns: True if the source has no foci; false otherwise.
     public func isEmpty(_ s: S) -> Bool {
-        return foldMap(s, constant(false))
+        return !nonEmpty(s)
     }
 
     /// Checks if a source is non-empty.
@@ -141,7 +141,7 @@ open class Fold<S, A>: FoldOf<S, A> {
     /// - Parameter s: Source.
     /// - Returns: False is the source has no foci; true otherwise.
     public func nonEmpty(_ s: S) -> Bool {
-        return !isEmpty(s)
+        return foldMap(s, constant(true))
     }
 
     /// Retrieves the first focus, if any.

--- a/Tests/BowLaws/SemiringLaws.swift
+++ b/Tests/BowLaws/SemiringLaws.swift
@@ -1,0 +1,64 @@
+import Bow
+import SwiftCheck
+
+public class SemiringLaws<A: Semiring & Equatable & Arbitrary> {
+    public static func check() {
+        MonoidLaws<A>.check()
+        commutativityForCombining()
+        associativityForMultiplying()
+        leftIdentityForMultiplying()
+        rightIdentityForMultiplying()
+        leftDistribution()
+        rightDistribution()
+        leftAnnihilation()
+        rightAnnihilation()
+    }
+    
+    private static func commutativityForCombining() {
+        property("Commutativity for combining") <~ forAll { (a: A) in
+            return A.zero().combine(a) == a.combine(.zero())
+        }
+    }
+    
+    private static func associativityForMultiplying() {
+        property("Ascociativity for multiplying") <~ forAll { (a: A, b: A, c: A) in
+            return (a.times(b)).times(c) == a.times(b.times(c))
+        }
+    }
+    
+    private static func leftIdentityForMultiplying() {
+        property("Left identity for multiplying") <~ forAll { (a: A) in
+            return A.one().times(a) == a
+        }
+    }
+    
+    private static func rightIdentityForMultiplying() {
+        property("Right identity for multiplying") <~ forAll { (a: A) in
+            return a.times(.one()) == a
+        }
+    }
+    
+    private static func leftDistribution() {
+        property("Left distribution") <~ forAll { (a: A, b: A, c: A) in
+            return a.times(b.combine(c)) == (a.times(b)).combine(a.times(c))
+       }
+    }
+    
+    private static func rightDistribution() {
+        property("Right distribution") <~ forAll { (a: A, b: A, c: A) in
+            return (a.combine(b)).times(c) == (a.times(c)).combine(b.times(c))
+       }
+    }
+
+    private static func leftAnnihilation() {
+        property("Left Annihilation") <~ forAll { (a: A) in
+            return A.zero().times(a) == .zero()
+       }
+    }
+    
+    private static func rightAnnihilation() {
+        property("Right Annihilation") <~ forAll { (a: A) in
+            return a.times(.zero()) == .zero()
+       }
+    }
+}

--- a/Tests/BowLaws/SemiringLaws.swift
+++ b/Tests/BowLaws/SemiringLaws.swift
@@ -22,43 +22,43 @@ public class SemiringLaws<A: Semiring & Equatable & Arbitrary> {
     
     private static func associativityForMultiplying() {
         property("Ascociativity for multiplying") <~ forAll { (a: A, b: A, c: A) in
-            return (a.times(b)).times(c) == a.times(b.times(c))
+            return (a.multiply(b)).multiply(c) == a.multiply(b.multiply(c))
         }
     }
     
     private static func leftIdentityForMultiplying() {
         property("Left identity for multiplying") <~ forAll { (a: A) in
-            return A.one().times(a) == a
+            return A.one().multiply(a) == a
         }
     }
     
     private static func rightIdentityForMultiplying() {
         property("Right identity for multiplying") <~ forAll { (a: A) in
-            return a.times(.one()) == a
+            return a.multiply(.one()) == a
         }
     }
     
     private static func leftDistribution() {
         property("Left distribution") <~ forAll { (a: A, b: A, c: A) in
-            return a.times(b.combine(c)) == (a.times(b)).combine(a.times(c))
+            return a.multiply(b.combine(c)) == (a.multiply(b)).combine(a.multiply(c))
        }
     }
     
     private static func rightDistribution() {
         property("Right distribution") <~ forAll { (a: A, b: A, c: A) in
-            return (a.combine(b)).times(c) == (a.times(c)).combine(b.times(c))
+            return (a.combine(b)).multiply(c) == (a.multiply(c)).combine(b.multiply(c))
        }
     }
 
     private static func leftAnnihilation() {
         property("Left Annihilation") <~ forAll { (a: A) in
-            return A.zero().times(a) == .zero()
+            return A.zero().multiply(a) == .zero()
        }
     }
     
     private static func rightAnnihilation() {
         property("Right Annihilation") <~ forAll { (a: A) in
-            return a.times(.zero()) == .zero()
+            return a.multiply(.zero()) == .zero()
        }
     }
 }

--- a/Tests/BowOpticsTests/FoldTest.swift
+++ b/Tests/BowOpticsTests/FoldTest.swift
@@ -42,7 +42,7 @@ class FoldTest: XCTestCase {
         
         property("Check if all targets match the predicate") <~ forAll { (array: ArrayK<Int>) in
             return ArrayK<Int>.foldK.forAll(array, { x in x % 2 == 0 }) ==
-                array.asArray.map { x in x % 2 == 0 }.reduce(true, and)
+                array.asArray.map { x in x % 2 == 0 }.reduce(false, or)
         }
         
         property("Check if there is no target") <~ forAll { (array: ArrayK<Int>) in

--- a/Tests/BowTests/Instances/BoolInstancesTest.swift
+++ b/Tests/BowTests/Instances/BoolInstancesTest.swift
@@ -1,0 +1,15 @@
+import XCTest
+import BowLaws
+import Bow
+
+class BoolInstancesTest: XCTestCase {
+
+    func testBoolEqLaws() {
+        EquatableLaws<Bool>.check()
+    }
+    
+    func testBoolSemiringLaws() {
+        SemiringLaws<Bool>.check()
+    }
+
+}

--- a/Tests/BowTests/Instances/BoolInstancesTest.swift
+++ b/Tests/BowTests/Instances/BoolInstancesTest.swift
@@ -11,5 +11,4 @@ class BoolInstancesTest: XCTestCase {
     func testBoolSemiringLaws() {
         SemiringLaws<Bool>.check()
     }
-
 }

--- a/Tests/BowTests/Instances/NumberInstancesTest.swift
+++ b/Tests/BowTests/Instances/NumberInstancesTest.swift
@@ -11,7 +11,7 @@ class NumberInstancesTest: XCTestCase {
     func testIntOrderLaws() {
         ComparableLaws<Int>.check()
     }
-    
+
     func testInt8EqLaws() {
         EquatableLaws<Int8>.check()
     }
@@ -19,7 +19,7 @@ class NumberInstancesTest: XCTestCase {
     func testInt8OrderLaws() {
         ComparableLaws<Int8>.check()
     }
-    
+
     func testInt16EqLaws() {
         EquatableLaws<Int16>.check()
     }
@@ -35,7 +35,7 @@ class NumberInstancesTest: XCTestCase {
     func testInt32OrderLaws() {
         ComparableLaws<Int32>.check()
     }
-    
+
     func testInt64EqLaws() {
         EquatableLaws<Int64>.check()
     }
@@ -43,7 +43,7 @@ class NumberInstancesTest: XCTestCase {
     func testInt64OrderLaws() {
         ComparableLaws<Int64>.check()
     }
-    
+
     func testUIntEqLaws() {
         EquatableLaws<UInt>.check()
     }
@@ -186,5 +186,25 @@ class NumberInstancesTest: XCTestCase {
     
     func testDoubleMonoidLaws() {
         MonoidLaws<Double>.check()
+    }
+
+    func testIntSemiringLaws() {
+        SemiringLaws<Int>.check()
+    }
+
+    func testInt8SemiringLaws() {
+        SemiringLaws<Int8>.check()
+    }
+
+    func testInt16SemiringLaws() {
+        SemiringLaws<Int16>.check()
+    }
+
+    func testInt32SemiringLaws() {
+        SemiringLaws<Int32>.check()
+    }
+
+    func testInt64SemiringLaws() {
+        SemiringLaws<Int64>.check()
     }
 }

--- a/Tests/BowTests/Instances/NumberInstancesTest.swift
+++ b/Tests/BowTests/Instances/NumberInstancesTest.swift
@@ -227,4 +227,12 @@ class NumberInstancesTest: XCTestCase {
     func testUInt64SemiringLaws() {
         SemiringLaws<UInt64>.check()
     }
+    
+    func testFloatSemiringLaws() {
+        SemiringLaws<UInt64>.check()
+    }
+    
+    func testDoubleSemiringLaws() {
+        SemiringLaws<UInt64>.check()
+    }
 }

--- a/Tests/BowTests/Instances/NumberInstancesTest.swift
+++ b/Tests/BowTests/Instances/NumberInstancesTest.swift
@@ -207,4 +207,24 @@ class NumberInstancesTest: XCTestCase {
     func testInt64SemiringLaws() {
         SemiringLaws<Int64>.check()
     }
+    
+    func testUIntSemiringLaws() {
+        SemiringLaws<UInt>.check()
+    }
+
+    func testUInt8SemiringLaws() {
+        SemiringLaws<UInt8>.check()
+    }
+
+    func testUInt16SemiringLaws() {
+        SemiringLaws<UInt16>.check()
+    }
+
+    func testUInt32SemiringLaws() {
+        SemiringLaws<UInt32>.check()
+    }
+
+    func testUInt64SemiringLaws() {
+        SemiringLaws<UInt64>.check()
+    }
 }


### PR DESCRIPTION
Resolve #448

Also add `Semiring` instances for `Bool` and Numbers

For `Bool`, I also update `Monoid` instance that define `&&` and `true`
as `Monoid` which is more multiplicative. So I change to `||` and
`false` for `Monoid` and add `&&` and `true` to `Semiring`
multiplication