### PR TITLE
Add monoidal type class

### DIFF
--- a/Sources/Bow/Data/Option.swift
+++ b/Sources/Bow/Data/Option.swift
@@ -283,6 +283,13 @@ extension ForOption: Semigroupal {
 	}
 }
 
+// MARK: Instance of `Monoidal` for `Option`,
+extension ForOption: Monoidal {
+    public static func identity<A>() -> Kind<ForOption, A> {
+        Option.none()
+    }
+}
+
 // MARK: Instance of `Monoid` for `Option`, provided that `A` has an instance of `Monoid`.
 extension Option: Monoid where A: Monoid {
     public static func empty() -> Option<A> {

--- a/Sources/Bow/Data/Option.swift
+++ b/Sources/Bow/Data/Option.swift
@@ -278,9 +278,9 @@ extension Option: Semigroup where A: Semigroup {
 
 // MARK: Instance of `Semigroupal` for `Option`,
 extension ForOption: Semigroupal {
-	public static func product<A, B>(_ a: Kind<ForOption, A>, _ b: Kind<ForOption, B>) -> Kind<ForOption, (A, B)> {
+    public static func product<A, B>(_ a: Kind<ForOption, A>, _ b: Kind<ForOption, B>) -> Kind<ForOption, (A, B)> {
         ForOption.zip(a, b)
-	}
+    }
 }
 
 // MARK: Instance of `Monoidal` for `Option`,

--- a/Sources/Bow/Typeclasses/Monoidal.swift
+++ b/Sources/Bow/Typeclasses/Monoidal.swift
@@ -1,0 +1,23 @@
+/// The Monoidal type class adds an identity element to Semigroupal type class by defining the function identity
+///
+/// identity returns a specific identity `Kind<F, A>` value for a given type F and A.
+///
+/// This type class complies with the following law:
+/// fa.product(identity) == identity.product(fa) == identity
+///
+/// In addition, the laws of Semigroupal type class also apply.
+///
+/// Currently, Monoidal instance is defined for Option
+///
+public protocol Monoidal: Semigroupal {
+    
+    /// Given a type A, create a "identity" for a F<A> value
+    static func identity<A>() -> Kind<Self, A>
+}
+
+// MARK: Syntax for Monoidal
+public extension Kind where F: Monoidal {
+    static func identity() -> Kind<F, A> {
+        F.identity()
+    }
+}

--- a/Sources/Bow/Typeclasses/Monoidal.swift
+++ b/Sources/Bow/Typeclasses/Monoidal.swift
@@ -1,12 +1,13 @@
-/// The Monoidal type class adds an identity element to Semigroupal type class by defining the function identity
+/// The Monoidal type class adds an identity element to Semigroupal type class by defining the function identity.
 ///
-/// identity returns a specific identity `Kind<F, A>` value for a given type F and A.
+/// Identity returns a specific identity `Kind<F, A>` value for a given type F and A.
 ///
 /// This type class complies with the following law:
 /// fa.product(identity) == identity.product(fa) == identity
 ///
 /// In addition, the laws of Semigroupal type class also apply.
-///
+/// 
+/// - Note:
 /// Currently, Monoidal instance is defined for Option
 ///
 public protocol Monoidal: Semigroupal {

--- a/Tests/BowLaws/MonoidalLaws.swift
+++ b/Tests/BowLaws/MonoidalLaws.swift
@@ -3,27 +3,19 @@ import BowGenerators
 import SwiftCheck
 
 public final class MonoidalLaws<F: Monoidal & ArbitraryK & EquatableK> {
-    public static func check(
-        isEqual: @escaping (Kind<F, (Int, Int)>, Kind<F, Int>) -> Bool,
-        associatveSemigroupalEqual: @escaping (Kind<F, ((Int, Int), Int)>, Kind<F, (Int, (Int, Int))>) -> Bool
-    ) {
-        SemigroupalLaws.check(isEqual: associatveSemigroupalEqual)
+    public static func check(isEqual: @escaping (Kind<F, (Int, Int)>, Kind<F, Int>) -> Bool) {
         leftIdentity(isEqual: isEqual)
         rightIdentity(isEqual: isEqual)
     }
     
-    private static func leftIdentity(
-        isEqual: @escaping (Kind<F, (Int, Int)>, Kind<F, Int>) -> Bool
-    ) {
+    private static func leftIdentity(isEqual: @escaping (Kind<F, (Int, Int)>, Kind<F, Int>) -> Bool) {
         property("Monoidal left identity") <~ forAll { (fa: KindOf<F, Int>) in
             isEqual(Kind<F, Int>.identity().product(fa.value),
                     Kind<F, Int>.identity())
         }
     }
     
-    private static func rightIdentity(
-        isEqual: @escaping (Kind<F, (Int, Int)>, Kind<F, Int>) -> Bool
-    ) {
+    private static func rightIdentity(isEqual: @escaping (Kind<F, (Int, Int)>, Kind<F, Int>) -> Bool) {
         property("Monoidal right identity") <~ forAll { (fa: KindOf<F, Int>) in
             isEqual(fa.value.product(Kind<F, Int>.identity()),
                     Kind<F, Int>.identity())

--- a/Tests/BowLaws/MonoidalLaws.swift
+++ b/Tests/BowLaws/MonoidalLaws.swift
@@ -1,0 +1,33 @@
+import Bow
+import BowGenerators
+import SwiftCheck
+
+public final class MonoidalLaws<F: Monoidal & ArbitraryK & EquatableK> {
+    public static func check(
+        isEqual: @escaping (Kind<F, (Int, Int)>, Kind<F, Int>) -> Bool,
+        associatveSemigroupalEqual: @escaping (Kind<F, ((Int, Int), Int)>, Kind<F, (Int, (Int, Int))>) -> Bool
+    ) {
+        SemigroupalLaws.check(isEqual: associatveSemigroupalEqual)
+        leftIdentity(isEqual: isEqual)
+        rightIdentity(isEqual: isEqual)
+    }
+    
+    private static func leftIdentity(
+        isEqual: @escaping (Kind<F, (Int, Int)>, Kind<F, Int>) -> Bool
+    ) {
+        property("Monoidal left identity") <~ forAll { (fa: KindOf<F, Int>) in
+            isEqual(Kind<F, Int>.identity().product(fa.value),
+                    Kind<F, Int>.identity())
+        }
+    }
+    
+    private static func rightIdentity(
+        isEqual: @escaping (Kind<F, (Int, Int)>, Kind<F, Int>) -> Bool
+    ) {
+        property("Monoidal right identity") <~ forAll { (fa: KindOf<F, Int>) in
+            isEqual(fa.value.product(Kind<F, Int>.identity()),
+                    Kind<F, Int>.identity())
+        }
+    }
+}
+

--- a/Tests/BowTests/Data/OptionTest.swift
+++ b/Tests/BowTests/Data/OptionTest.swift
@@ -72,6 +72,13 @@ class OptionTest: XCTestCase {
         SemigroupalLaws<ForOption>.check(isEqual: isEqual(_:_:))
 	}
     
+    func testMonoidalLaws() {
+        func isMonoidalEqual<A, B>(_ fa: Kind<ForOption, A>, _ fb: Kind<ForOption, B>) -> Bool {
+            fa.isEmpty && fb.isEmpty
+        }
+        MonoidalLaws<ForOption>.check(isEqual: isMonoidalEqual, associatveSemigroupalEqual: isEqual(_:_:))
+    }
+    
     func testFromToOption() {
         property("fromOption - toOption isomorphism") <~ forAll { (x: Int?, option: Option<Int>) in
             return Option.fromOptional(x).toOptional() == x &&

--- a/Tests/BowTests/Data/OptionTest.swift
+++ b/Tests/BowTests/Data/OptionTest.swift
@@ -76,7 +76,7 @@ class OptionTest: XCTestCase {
         func isMonoidalEqual<A, B>(_ fa: Kind<ForOption, A>, _ fb: Kind<ForOption, B>) -> Bool {
             fa.isEmpty && fb.isEmpty
         }
-        MonoidalLaws<ForOption>.check(isEqual: isMonoidalEqual, associatveSemigroupalEqual: isEqual(_:_:))
+        MonoidalLaws<ForOption>.check(isEqual: isMonoidalEqual)
     }
     
     func testFromToOption() {


### PR DESCRIPTION
## Related issues

Closes #450 

## Goal

This PR adds the Monoidal type class and Monoidal laws. Also includes the implementation for Option monoidal and tests.

## Implementation details
The Monoidal laws verify the left and right identity; `fa.product(identity) == identity.product(fa) == identity`

## Testing details
Nothing remarkable, it follows the same pattern as others.