### PR TITLE
Add Co, Pairing (a few Rank2 types)

### DIFF
--- a/Bow.xcodeproj/project.pbxproj
+++ b/Bow.xcodeproj/project.pbxproj
@@ -7,6 +7,10 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		09CEF84E236E28150070CF43 /* Co.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09CEF84D236E28150070CF43 /* Co.swift */; };
+		09CEF851236E28680070CF43 /* Pairing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09CEF850236E28680070CF43 /* Pairing.swift */; };
+		09CEF854236E2CFB0070CF43 /* CoTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09CEF853236E2CFB0070CF43 /* CoTest.swift */; };
+		09CEF856236E3C370070CF43 /* Co+Gen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09CEF855236E3C370070CF43 /* Co+Gen.swift */; };
 		1104BEDC22C22DEC002C3F78 /* IO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1104BED422C22DD2002C3F78 /* IO.swift */; };
 		1104BEE322C22E47002C3F78 /* UnsafeRun.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1104BEE022C22E47002C3F78 /* UnsafeRun.swift */; };
 		1104BEE422C22E47002C3F78 /* Bracket.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1104BEE122C22E47002C3F78 /* Bracket.swift */; };
@@ -131,8 +135,6 @@
 		1160D0ED22D38DC40010323A /* SetterLaws.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BA0F3DF217E2DEF00969984 /* SetterLaws.swift */; };
 		1160D0EE22D38DC40010323A /* TraversalLaws.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BA0F3DE217E2DEF00969984 /* TraversalLaws.swift */; };
 		1166A07A22119F720032CD4E /* EqualityFunctions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1166A07822119E640032CD4E /* EqualityFunctions.swift */; };
-		1167127E235EEC260067FB0D /* SemigroupalLaws.swift in Sources */ = {isa = PBXBuildFile; fileRef = 600D30442352D03400F7B64B /* SemigroupalLaws.swift */; };
-		11671283235EECDB0067FB0D /* MonoidalLaws.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11671281235EECBC0067FB0D /* MonoidalLaws.swift */; };
 		117DC0D722AE49C200EF65F0 /* IO+Gen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 117DC0D622AE49C200EF65F0 /* IO+Gen.swift */; };
 		117DC0F222AE4E1C00EF65F0 /* SingleK+Gen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 117DC0F122AE4E1C00EF65F0 /* SingleK+Gen.swift */; };
 		117DC0F422AE4F3500EF65F0 /* MaybeK+Gen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 117DC0F322AE4F3500EF65F0 /* MaybeK+Gen.swift */; };
@@ -682,6 +684,10 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		09CEF84D236E28150070CF43 /* Co.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Co.swift; sourceTree = "<group>"; };
+		09CEF850236E28680070CF43 /* Pairing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Pairing.swift; sourceTree = "<group>"; };
+		09CEF853236E2CFB0070CF43 /* CoTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoTest.swift; sourceTree = "<group>"; };
+		09CEF855236E3C370070CF43 /* Co+Gen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Co+Gen.swift"; sourceTree = "<group>"; };
 		1104BED422C22DD2002C3F78 /* IO.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IO.swift; sourceTree = "<group>"; };
 		1104BEE022C22E47002C3F78 /* UnsafeRun.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UnsafeRun.swift; sourceTree = "<group>"; };
 		1104BEE122C22E47002C3F78 /* Bracket.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Bracket.swift; sourceTree = "<group>"; };
@@ -776,7 +782,6 @@
 		1160D0E622D38CEC0010323A /* BowOpticsLaws.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = BowOpticsLaws.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		1160D0E722D38CEC0010323A /* Bow-OpticsLaws-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; name = "Bow-OpticsLaws-Info.plist"; path = "/Users/tomasruizlopez/Development/bow/Bow-OpticsLaws-Info.plist"; sourceTree = "<absolute>"; };
 		1166A07822119E640032CD4E /* EqualityFunctions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EqualityFunctions.swift; sourceTree = "<group>"; };
-		11671281235EECBC0067FB0D /* MonoidalLaws.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MonoidalLaws.swift; sourceTree = "<group>"; };
 		117DC0D322AE492700EF65F0 /* BowEffectsGenerators.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = BowEffectsGenerators.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		117DC0D422AE492700EF65F0 /* Bow-Effects-Generators-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; name = "Bow-Effects-Generators-Info.plist"; path = "/Users/tomasruizlopez/Development/bow/Bow-Effects-Generators-Info.plist"; sourceTree = "<absolute>"; };
 		117DC0D622AE49C200EF65F0 /* IO+Gen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "IO+Gen.swift"; sourceTree = "<group>"; };
@@ -1242,6 +1247,7 @@
 				112097D522A904AC007F3D9C /* Sum+Gen.swift */,
 				112097BE22A7FDEF007F3D9C /* Try+Gen.swift */,
 				112097C022A7FF37007F3D9C /* Validated+Gen.swift */,
+				09CEF855236E3C370070CF43 /* Co+Gen.swift */,
 			);
 			path = Data;
 			sourceTree = "<group>";
@@ -1708,6 +1714,7 @@
 				8BA0F3AD217E2DEF00969984 /* SumTest.swift */,
 				8BA0F3B4217E2DEF00969984 /* TryTest.swift */,
 				8BA0F3B3217E2DEF00969984 /* ValidatedTest.swift */,
+				09CEF853236E2CFB0070CF43 /* CoTest.swift */,
 			);
 			path = Data;
 			sourceTree = "<group>";
@@ -1821,6 +1828,8 @@
 				8BA0F480217E2E9200969984 /* Try.swift */,
 				8BA0F484217E2E9200969984 /* Validated.swift */,
 				601914CB2352F2B5007ACE81 /* TupleN.swift */,
+				09CEF84D236E28150070CF43 /* Co.swift */,
+				09CEF850236E28680070CF43 /* Pairing.swift */,
 			);
 			path = Data;
 			sourceTree = "<group>";
@@ -2531,6 +2540,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 0;
 			files = (
+				09CEF856236E3C370070CF43 /* Co+Gen.swift in Sources */,
 				112097D822A90644007F3D9C /* Kleisli+Gen.swift in Sources */,
 				112097BB22A7FC86007F3D9C /* NonEmptyArray+Gen.swift in Sources */,
 				112097D622A904AC007F3D9C /* Sum+Gen.swift in Sources */,
@@ -2884,6 +2894,7 @@
 				8BA0F3F0217E2DEF00969984 /* WriterTTest.swift in Sources */,
 				8BA0F3FE217E2DEF00969984 /* EitherKTest.swift in Sources */,
 				8BA0F3F2217E2DEF00969984 /* EitherTTest.swift in Sources */,
+				09CEF854236E2CFB0070CF43 /* CoTest.swift in Sources */,
 				1137469C234345F400D9C1AD /* ArrayTest.swift in Sources */,
 				8BA0F3ED217E2DEF00969984 /* KleisliTest.swift in Sources */,
 				8BA0F40D217E2DEF00969984 /* NonEmptyArrayTest.swift in Sources */,
@@ -2922,6 +2933,8 @@
 				8BA0F4D3217E2E9200969984 /* Curry.swift in Sources */,
 				8BA0F653217E2E9200969984 /* Semigroup.swift in Sources */,
 				1191BD0C22D77FED0052FEA8 /* BindingExpression.swift in Sources */,
+				09CEF84E236E28150070CF43 /* Co.swift in Sources */,
+				09CEF851236E28680070CF43 /* Pairing.swift in Sources */,
 				8BA0F593217E2E9200969984 /* NonEmptyArray.swift in Sources */,
 				8BA0F58F217E2E9200969984 /* Option.swift in Sources */,
 				8BA0F5F3217E2E9200969984 /* Comparable.swift in Sources */,

--- a/Sources/Bow/Data/Co.swift
+++ b/Sources/Bow/Data/Co.swift
@@ -1,0 +1,103 @@
+// newtype Co w a = Co (forall r. w (a -> r) -> r)
+
+public final class ForCo {}
+public final class CoPartial<W: Comonad>: Kind<ForCo, W> {}
+public typealias CoOf<W: Comonad, A> = Kind<CoPartial<W>, A>
+
+/// (Co w) gives you "the best" pairing monad for any comonad w
+/// In other words, an explorer for the state space given by w
+public class Co<W: Comonad, A> : CoOf<W, A> {
+    internal let cow : (Kind<W, (A) -> Any>) -> Any
+    
+    public static func fix(_ value : CoOf<W, A>) -> Co<W, A> {
+        value as! Co<W, A>
+    }
+    
+    /// - Returns: The pairing between the underlying comonad, `w`, and the monad `Co<w>`.
+    public static func pair() -> Pairing<W, CoPartial<W>> {
+        Pairing{ wab in
+            { cowa in
+                Co<W, /*A*/Any>.fix(cowa).runCo(wab)
+            }
+        }
+    }
+    
+    public init(_ cow: @escaping /*forall R.*/(Kind<W, (A) -> /*R*/Any>) -> /*R*/Any) {
+        self.cow = cow
+    }
+    
+    public func runCo<R>(_ w: Kind<W, (A) -> R>) -> R {
+        unsafeBitCast(self.cow, to:((Kind<W, (A) -> R>) -> R).self) (w)
+    }
+}
+
+/// Safe downcast.
+///
+/// - Parameter value: Value in higher-kind form.
+/// - Returns: Value cast to Co.
+public postfix func ^<W, A>(_ value: CoOf<W, A>) -> Co<W, A> {
+    return Co.fix(value)
+}
+
+extension CoPartial: Functor {
+    public static func map<A, B>(_ fa: CoOf<W, A>, _ f: @escaping (A) -> B) -> CoOf<W, B> {
+        Co<W, B> { b in
+            Co<W, A>.fix(fa).runCo(b.map({$0 <<< f}))
+        }
+    }
+}
+
+extension CoPartial: Applicative {
+    public static func ap<A, B>(_ ff: CoOf<W, (A) -> B>, _ fa: CoOf<W, A>) -> CoOf<W, B> {
+        let f = Co<W, (A) -> B>.fix(ff).cow
+        let a = Co<W, A>.fix(fa).cow
+        return Co<W, B> { w in
+            f(
+                w.coflatMap{ wf in
+                    { g in
+                        a(wf.map{$0 <<< g})
+                    }
+                }
+            )
+        }
+    }
+    
+    public static func pure<A>(_ a: A) -> CoOf<W, A> {
+        return Co<W, A> { w in
+            w.extract()(a)
+        }
+    }
+}
+
+extension CoPartial: Monad {
+    public static func flatMap<A, B>(_ fa: CoOf<W, A>, _ f: @escaping (A) -> CoOf<W, B>) -> CoOf<W, B> {
+        let k: (Kind<W, (A) -> Any>) -> Any = Co<W, A>.fix(fa).cow
+        return Co<W, B> { w in
+            k (
+                w.coflatMap{ wa in
+                    { a in
+                        Co<W, B>.fix(f(a)).runCo(wa)
+                    }
+                }
+            )
+        }
+    }
+    
+    public static func tailRecM<A, B>(_ a: A, _ f: @escaping (A) -> Kind<CoPartial<W>, Either<A, B>>) -> Kind<CoPartial<W>, B> {
+        // TODO: Please help
+        fatalError("TODO")
+    }
+}
+
+extension Co {
+    // I don't remember what this function does, but including it for reference.
+    public static func select<A, B>(
+        co : Co<W, (A) -> B>,
+        wa : Kind<W, A>
+        ) -> Kind<W, B> {
+        return co.runCo(wa.coflatMap{ wa in { f in
+            wa.map(f)
+            }
+        })
+    }
+}

--- a/Sources/Bow/Data/Pairing.swift
+++ b/Sources/Bow/Data/Pairing.swift
@@ -1,0 +1,38 @@
+// type Pairing f g = forall a b. f (a -> b) -> g a -> b
+
+public final class ForPairing {}
+public final class PairingPartial<F: Functor>: Kind<ForPairing, F> {}
+public typealias PairingOf<F: Functor, G: Functor> =  Kind<PairingPartial<F>, G>
+
+public class Pairing<F: Functor, G: Functor> : PairingOf<F, G> {
+    internal let pair : (Kind<F, (/*A*/Any) -> /*B*/Any>) -> (Kind<G, /*A*/Any>) -> /*B*/Any
+    
+    public static func fix(_ value : PairingOf<F, G>) -> Pairing<F, G> {
+        value as! Pairing<F, G>
+    }
+    
+    public init(_ pair: @escaping (Kind<F, (/*A*/Any) -> /*B*/Any>) -> (Kind<G, /*A*/Any>) -> /*B*/Any) {
+        self.pair = pair
+    }
+    
+    /// Annihalate the `F` and `G` effects effectively calling the wrapped function in `F` with the wrapped value
+    ///
+    /// - Parameter fab: An `F`-effectful `A -> B`
+    /// - Parameter ga: A `G`-effectful `A`
+    /// - Returns: A pure `B`
+    public func zap<A, B>(_ fab: Kind<F, (A) -> B>, ga: Kind<G, A>) -> B {
+        let gany = ga.map{ $0 as Any }
+        let fany =
+            fab.map{ aArrb in { (any: Any) in
+                aArrb(any as! A) as Any}}
+        return self.pair(fany)(gany) as! B
+    }
+}
+
+/// Safe downcast.
+///
+/// - Parameter value: Value in higher-kind form.
+/// - Returns: Value cast to Pairing.
+public postfix func ^<F, G>(_ value: PairingOf<F, G>) -> Pairing<F, G> {
+    return Pairing.fix(value)
+}

--- a/Tests/BowGenerators/Data/Co+Gen.swift
+++ b/Tests/BowGenerators/Data/Co+Gen.swift
@@ -1,0 +1,11 @@
+import Bow
+import SwiftCheck
+
+// MARK: Instance of `ArbitraryK` for `Co`
+
+extension CoPartial: ArbitraryK where W: ArbitraryK {
+    public static func generate<A: Arbitrary>() -> Kind<CoPartial<W>, A> {
+        let wa: Kind<W, A> = W.generate()
+        return Co.pure(wa.extract())
+    }
+}

--- a/Tests/BowTests/Data/CoTest.swift
+++ b/Tests/BowTests/Data/CoTest.swift
@@ -1,0 +1,26 @@
+import XCTest
+import BowLaws
+import Bow
+import BowGenerators
+
+/// Test Co and pairing (with zap) is used for the EquatableK instance
+
+extension CoPartial: EquatableK where W == ForId {
+    public static func eq<A>(_ lhs: Kind<CoPartial<W>, A>, _ rhs: Kind<CoPartial<W>, A>) -> Bool where A : Equatable {
+        return Co<W, A>.pair().zap(Id({ $0 }), ga: Co.fix(lhs)) == Co<W, A>.pair().zap(Id({ $0 }), ga: Co.fix(rhs))
+    }
+}
+
+class CoTest: XCTestCase {
+    func testFunctorLaws() {
+            FunctorLaws<CoPartial<ForId>>.check()
+    }
+    
+    func testApplicativeLaws() {
+        ApplicativeLaws<CoPartial<ForId>>.check()
+    }
+    
+    func testMonadLaws() {
+        MonadLaws<CoPartial<ForId>>.check()
+    }
+}


### PR DESCRIPTION
## Related issues

This work should help with #236 , though I'm not aware of a specific issue for Co and Pairing. I'm creating this PR as suggested here: https://twitter.com/tomasruizlopez/status/1190692278421086209

## Goal

Add Co and Pairing types to Bow as well as introduce the first implementation of Rank2 types that fully works. As implemented right now, Day's functions that should have a higher-rank forall don't work properly.

## Implementation details

I tried _a lot_ of ways to get rank2 typing to work in Swift, and the method here is the one that worked the best.

Here are some of the ways I've attempted that I remember for future reference:

1. Look at Day both in the Arrow and Bow projects and try to do rank2 types in a similar way -- this failed because of an issue with subclassing and generics in Swift and the lack of abstract classes (I believe Arrow's Day is correct, but Kotlin can handle this in a way Swift can't)
2. Since Rank2 foralls are the same as Rank1 existential types, I tried to use protocols with associated types (essentially existential type parameters) to emulate the rank2 foralls. Unfortunately, these are really not ergonomic, and would require redefining the higher-kinded types in Bow using protocols (and it's way less usable than the subclass approach).

So, I went with an approach of referring to the Rank2 variables with `Any`, there is some up-casting needed when constructing these types, but the down-casting is hidden in the implementation.

This was sufficient enough to get everything working.

As an example, I built a simple counter component using these primitives: https://gist.github.com/bkase/f9e338729eb0ef036b4e5b5b81684fc5 in the Phil Freeman Comonadic UI style: https://blog.functorial.com/posts/2016-08-07-Comonads-As-Spaces.html

For further references see 
https://github.com/paf31/purescript-pairing
and https://hackage.haskell.org/package/hdo-0.1/candidate/docs/Pairing.html
and http://hackage.haskell.org/package/kan-extensions-5.2/docs/Control-Monad-Co.html

## Testing details

Pairing's only significant logic is in `zap` and `zap` is used by Co's EquatableK instance, so I didn't feel the need to make a PairingTests.swift file explicitly. Co just runs through the Functor, Applicative, and Monad laws.