### PR TITLE
Remove pipe operator when using offset

### DIFF
--- a/docs/_includes/_nav.html
+++ b/docs/_includes/_nav.html
@@ -10,7 +10,7 @@
             <li>
             {% include _navigation-api-versions.html %}
             </li>
-            {% for item in site.data.menu.nav | offset: 2 %}
+            {% for item in site.data.menu.nav offset: 2 %}
             <li>
                 <a href="{{ item.url | relative_url }}" title="{{ item.title }}" alt="{{ item.title }}">
                 {% if item.icon != "" %}

--- a/docs/_includes/_navigation-api-versions.html
+++ b/docs/_includes/_navigation-api-versions.html
@@ -19,7 +19,7 @@
         </a>
       </li>
 
-      {% for item in site.data.versions | offset: 1 %}
+      {% for item in site.data.versions offset: 1 %}
       <li class="dropdown-item">
         <a class="dropdown-item-link" href="/{{ item.title | append: site.data.menu.nav[1].url }}">
             <span>

--- a/docs/_includes/_navigation-doc-versions.html
+++ b/docs/_includes/_navigation-doc-versions.html
@@ -19,7 +19,7 @@
         </a>
       </li>
 
-      {% for item in site.data.versions | offset: 1 %}
+      {% for item in site.data.versions offset: 1 %}
       <li class="dropdown-item">
         <a class="dropdown-item-link" href="/{{ item.title | append: site.data.menu.nav[0].url }}">
             <span>

--- a/docs/_includes/_sidebar-doc-versions.html
+++ b/docs/_includes/_sidebar-doc-versions.html
@@ -18,7 +18,7 @@
         </a>
       </li>
 
-      {% for item in site.data.versions | offset: 1 %}
+      {% for item in site.data.versions offset: 1 %}
       <li class="dropdown-item">
         <a class="dropdown-item-link" href="/{{ item.title | append: site.data.menu.nav[0].url }}">
             <span>


### PR DESCRIPTION
## Related issues

Just noticed that the pipe operator was being used incorrectly when looping through collections in some website layouts.

https://shopify.github.io/liquid/tags/iteration/

## Goal

Remove that bad usage, that was causing warning on site generation builds.

## Implementation details

Just removed the pipes where they were not necessary.
