### PR TITLE
Extract EnvIO and provide some instances

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ addons:
     - bow-swift/nef
     packages:
     - sourcekitten
-    - nef
+    - nef@0.3.2
 
 env:
   secure: LatJH8j809/6dhEO6WhpQyU3lAjtkOYHAqWD14+bU6lfAc5oRrRFO4B7h56gnIDu6tvYJS0Qa/IhIuB3zZQ/GlG12oivgE/FKp1xXxxHwqjmhPHdetX9YkeAbicJ8YrSQ+C0UC6NMmP1WtU7cmLBV4Q1VwdPnVvRIrOVuWdh3ITUzUz/qQMTZwi+6Z1w92QvxbyytXDqti62NrUq81ba2c7pvBbFBujMp5hyd6+EcuZojYWGNN3cIR2DcPVXD9j4kwLyDPVAcN/OROAwaJlOZ63FbsoUcZULOAX/6s5bmcU1CuYc+eBrXX7KifSqj3yUW00Ea0ynyvsn2GWldAw5b8cYgiLuqQBp3jxtPVH/tEWRdO5TdFtMl8CDEJQiblINjFCXRbnAh8fnk/9jxKTkK+e1DXNQEk/w61+vUB21j74Zw8PhPRvCsoV8XgPkd34UiSlG5XkPaj+vImRpB2/kemYxynpY2Sjq+qoK4iUJy/DXhX/agThWCpjY1hWL2LNL/24mk6DbUHZGVH+4RgoBJxBFCI7ucSp14Og0cCFmhFfsq0nttN+xNegosmHnEcv1Z4tRW750rPf2dgGlXkf6s4msbZ/kyRnccs2zlh3JYYac509Fk98FRNfLb9q0C/jLb0xpg6qf9WbI1QbMcxPHKakyGEUuo+7FO+CLzrJ0qns=

--- a/Bow.xcodeproj/project.pbxproj
+++ b/Bow.xcodeproj/project.pbxproj
@@ -143,6 +143,7 @@
 		1186E15122BA395D001F8A5D /* Index+Optics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1186E14E22BA38CD001F8A5D /* Index+Optics.swift */; };
 		1186E15722BA8A77001F8A5D /* Cons.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1186E15622BA8A77001F8A5D /* Cons.swift */; };
 		1186E15922BA8ECA001F8A5D /* Snoc.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1186E15822BA8ECA001F8A5D /* Snoc.swift */; };
+		11912B0B238C2068007D90A2 /* DispatchTimeInterval+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11912B09238C1FB4007D90A2 /* DispatchTimeInterval+Extensions.swift */; };
 		1191BD0A22D77C510052FEA8 /* BoundVar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1191BD0922D77C510052FEA8 /* BoundVar.swift */; };
 		1191BD0C22D77FED0052FEA8 /* BindingExpression.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1191BD0B22D77FED0052FEA8 /* BindingExpression.swift */; };
 		1191BD0E22D784630052FEA8 /* MonadComprenhensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1191BD0D22D784630052FEA8 /* MonadComprenhensions.swift */; };
@@ -221,6 +222,10 @@
 		11F41C9D231816F000BD1E87 /* DispatchQueue+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11F41C93231816AD00BD1E87 /* DispatchQueue+Extensions.swift */; };
 		11F41CA2231818DB00BD1E87 /* BracketLaws.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11F41C9E231818AE00BD1E87 /* BracketLaws.swift */; };
 		11F41CA3231818DB00BD1E87 /* MonadDeferLaws.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11F41C9F231818AF00BD1E87 /* MonadDeferLaws.swift */; };
+		11FB4612238EB78200EA60BF /* EnvIO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11FB4610238EB78200EA60BF /* EnvIO.swift */; };
+		11FB4614238EBF2300EA60BF /* EnvIOTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11FB4613238EBF2300EA60BF /* EnvIOTest.swift */; };
+		11FB4616238ED14F00EA60BF /* ConcurrentTraverse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11FB4615238ED14F00EA60BF /* ConcurrentTraverse.swift */; };
+		11FDD68F23867D9800EA8A4D /* Schedule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11FDD68E23867D9800EA8A4D /* Schedule.swift */; };
 		600D30432352C08F00F7B64B /* Semigroupal.swift in Sources */ = {isa = PBXBuildFile; fileRef = 600D30422352C08F00F7B64B /* Semigroupal.swift */; };
 		606B29EA23607607002334B2 /* Divide.swift in Sources */ = {isa = PBXBuildFile; fileRef = 606B29E923607607002334B2 /* Divide.swift */; };
 		606B29EB2360763C002334B2 /* SemigroupalLaws.swift in Sources */ = {isa = PBXBuildFile; fileRef = 600D30442352D03400F7B64B /* SemigroupalLaws.swift */; };
@@ -799,6 +804,7 @@
 		1186E14E22BA38CD001F8A5D /* Index+Optics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Index+Optics.swift"; sourceTree = "<group>"; };
 		1186E15622BA8A77001F8A5D /* Cons.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Cons.swift; sourceTree = "<group>"; };
 		1186E15822BA8ECA001F8A5D /* Snoc.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Snoc.swift; sourceTree = "<group>"; };
+		11912B09238C1FB4007D90A2 /* DispatchTimeInterval+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DispatchTimeInterval+Extensions.swift"; sourceTree = "<group>"; };
 		1191BD0922D77C510052FEA8 /* BoundVar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoundVar.swift; sourceTree = "<group>"; };
 		1191BD0B22D77FED0052FEA8 /* BindingExpression.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BindingExpression.swift; sourceTree = "<group>"; };
 		1191BD0D22D784630052FEA8 /* MonadComprenhensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MonadComprenhensions.swift; sourceTree = "<group>"; };
@@ -842,6 +848,10 @@
 		11F41C95231816AD00BD1E87 /* Dictionary+Extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Dictionary+Extensions.swift"; sourceTree = "<group>"; };
 		11F41C9E231818AE00BD1E87 /* BracketLaws.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BracketLaws.swift; sourceTree = "<group>"; };
 		11F41C9F231818AF00BD1E87 /* MonadDeferLaws.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MonadDeferLaws.swift; sourceTree = "<group>"; };
+		11FB4610238EB78200EA60BF /* EnvIO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EnvIO.swift; sourceTree = "<group>"; };
+		11FB4613238EBF2300EA60BF /* EnvIOTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EnvIOTest.swift; sourceTree = "<group>"; };
+		11FB4615238ED14F00EA60BF /* ConcurrentTraverse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConcurrentTraverse.swift; sourceTree = "<group>"; };
+		11FDD68E23867D9800EA8A4D /* Schedule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Schedule.swift; sourceTree = "<group>"; };
 		600D30422352C08F00F7B64B /* Semigroupal.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Semigroupal.swift; sourceTree = "<group>"; };
 		600D30442352D03400F7B64B /* SemigroupalLaws.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SemigroupalLaws.swift; sourceTree = "<group>"; };
 		606B29E923607607002334B2 /* Divide.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Divide.swift; sourceTree = "<group>"; };
@@ -1214,9 +1224,11 @@
 			isa = PBXGroup;
 			children = (
 				11F41C94231816AD00BD1E87 /* Atomic.swift */,
+				11FB4610238EB78200EA60BF /* EnvIO.swift */,
 				1104BED422C22DD2002C3F78 /* IO.swift */,
 				11F41C91231816AD00BD1E87 /* Ref.swift */,
 				1104BEE922C25AAF002C3F78 /* Resource.swift */,
+				11FDD68E23867D9800EA8A4D /* Schedule.swift */,
 				11F41C92231816AD00BD1E87 /* Internal */,
 			);
 			path = Data;
@@ -1344,6 +1356,7 @@
 		11229786219DC968006D66C5 /* BowEffectsTests */ = {
 			isa = PBXGroup;
 			children = (
+				11FB4613238EBF2300EA60BF /* EnvIOTest.swift */,
 				8BA0F3A0217E2DEF00969984 /* IOTest.swift */,
 			);
 			path = BowEffectsTests;
@@ -1632,6 +1645,7 @@
 			children = (
 				11F41C95231816AD00BD1E87 /* Dictionary+Extensions.swift */,
 				11F41C93231816AD00BD1E87 /* DispatchQueue+Extensions.swift */,
+				11912B09238C1FB4007D90A2 /* DispatchTimeInterval+Extensions.swift */,
 			);
 			path = Internal;
 			sourceTree = "<group>";
@@ -1799,6 +1813,7 @@
 				1104BEE122C22E47002C3F78 /* Bracket.swift */,
 				1104BEE222C22E47002C3F78 /* Concurrent.swift */,
 				8BA0F46A217E2E9200969984 /* ConcurrentEffect.swift */,
+				11FB4615238ED14F00EA60BF /* ConcurrentTraverse.swift */,
 				8BA0F46B217E2E9200969984 /* Effect.swift */,
 				11F0367E2327D08900B39A80 /* EffectComprehensions.swift */,
 				8BA0F46D217E2E9200969984 /* MonadDefer.swift */,
@@ -2683,13 +2698,17 @@
 				1104BEDC22C22DEC002C3F78 /* IO.swift in Sources */,
 				11F036822327D4AC00B39A80 /* URLSession.swift in Sources */,
 				11229744219DC557006D66C5 /* Async.swift in Sources */,
+				11FB4612238EB78200EA60BF /* EnvIO.swift in Sources */,
 				11F41C9B231816F000BD1E87 /* Atomic.swift in Sources */,
 				11F036842327E1C900B39A80 /* ConsoleIO.swift in Sources */,
+				11FB4616238ED14F00EA60BF /* ConcurrentTraverse.swift in Sources */,
+				11912B0B238C2068007D90A2 /* DispatchTimeInterval+Extensions.swift in Sources */,
 				11F41C9A231816D800BD1E87 /* Ref.swift in Sources */,
 				1104BEE322C22E47002C3F78 /* UnsafeRun.swift in Sources */,
 				11229745219DC557006D66C5 /* ConcurrentEffect.swift in Sources */,
 				1104BEE422C22E47002C3F78 /* Bracket.swift in Sources */,
 				11F41C9D231816F000BD1E87 /* DispatchQueue+Extensions.swift in Sources */,
+				11FDD68F23867D9800EA8A4D /* Schedule.swift in Sources */,
 				11F0367F2327D08900B39A80 /* EffectComprehensions.swift in Sources */,
 				11229746219DC557006D66C5 /* Effect.swift in Sources */,
 				11F41C9C231816F000BD1E87 /* Dictionary+Extensions.swift in Sources */,
@@ -2703,6 +2722,7 @@
 			buildActionMask = 0;
 			files = (
 				11229787219DCA18006D66C5 /* IOTest.swift in Sources */,
+				11FB4614238EBF2300EA60BF /* EnvIOTest.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Bow.xcodeproj/xcshareddata/xcschemes/Bow-Effects.xcscheme
+++ b/Bow.xcodeproj/xcshareddata/xcschemes/Bow-Effects.xcscheme
@@ -26,9 +26,18 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
       codeCoverageEnabled = "YES"
-      onlyGenerateCoverageForSpecifiedTargets = "YES"
-      shouldUseLaunchSchemeArgsEnv = "YES">
+      onlyGenerateCoverageForSpecifiedTargets = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "112296D7219DC4B3006D66C5"
+            BuildableName = "BowEffects.framework"
+            BlueprintName = "Bow-Effects"
+            ReferencedContainer = "container:Bow.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
       <CodeCoverageTargets>
          <BuildableReference
             BuildableIdentifier = "primary"
@@ -50,17 +59,6 @@
             </BuildableReference>
          </TestableReference>
       </Testables>
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "112296D7219DC4B3006D66C5"
-            BuildableName = "BowEffects.framework"
-            BlueprintName = "Bow-Effects"
-            ReferencedContainer = "container:Bow.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -81,8 +79,6 @@
             ReferencedContainer = "container:Bow.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/Sources/Bow/Data/Either.swift
+++ b/Sources/Bow/Data/Either.swift
@@ -183,6 +183,13 @@ public extension Either where B: Equatable {
     }
 }
 
+public extension Either where A == B {
+    /// Returns a value from either side.
+    func merge() -> A {
+        fold(id, id)
+    }
+}
+
 // MARK: Either from Optional
 public extension Optional {
     /// Converts this optional to an `Either.right` value, providing a default value if it is nil.

--- a/Sources/BowEffects/Data/EnvIO.swift
+++ b/Sources/BowEffects/Data/EnvIO.swift
@@ -1,0 +1,118 @@
+import Bow
+import Foundation
+
+/// Partial application of the `EnvIO` type constructor, omitting the last type parameter.
+public typealias EnvIOPartial<D, E: Error> = KleisliPartial<IOPartial<E>, D>
+
+/// EnvIO is a data type to perform IO operations that produce errors of type `E` and values of type `A`, having access to an immutable environment of type `D`. It can be seen as a Kleisli function `(D) -> IO<E, A>`.
+public typealias EnvIO<D, E: Error, A> = Kleisli<IOPartial<E>, D, A>
+
+/// Partial application of the EnvIO data type, omitting the last parameter.
+public typealias RIOPartial<D> = EnvIOPartial<D, Error>
+
+/// A RIO is a data type like EnvIO with no explicit error type, resorting to the `Error` protocol to handle them.
+public typealias RIO<D, A> = EnvIO<D, Error, A>
+
+/// Partial application of the URIO data type, omitting the last parameter.
+public typealias URIOPartial<D> = EnvIOPartial<D, Never>
+
+/// An URIO is a data type like EnvIO that never fails; i.e. it never produces errors.
+public typealias URIO<D, A> = EnvIO<D, Never, A>
+
+// MARK: Functions for EnvIO
+
+public extension Kleisli {
+    /// Transforms the error type of this EnvIO
+    ///
+    /// - Parameter f: Function transforming the error.
+    /// - Returns: An EnvIO value with the new error type.
+    func mapError<E: Error, EE: Error>(_ f: @escaping (E) -> EE) -> EnvIO<D, EE, A> where F == IOPartial<E> {
+        return EnvIO { env in self.invoke(env)^.mapLeft(f) }
+    }
+    
+    /// Provides the required environment.
+    ///
+    /// - Parameter d: Environment.
+    /// - Returns: An IO resulting from running this computation with the provided environment.
+    func provide<E: Error>(_ d: D) -> IO<E, A> where F == IOPartial<E> {
+        return self.invoke(d)^
+    }
+    
+    /// Performs the side effects that are suspended in this IO in a synchronous manner.
+    ///
+    /// - Parameter queue: Dispatch queue used to execute the side effects. Defaults to the main queue.
+    /// - Returns: Value produced after running the suspended side effects.
+    /// - Throws: Error of type `E` that may happen during the evaluation of the side-effects. Errors of other types thrown from the evaluation of this IO will cause a fatal error.
+    func unsafeRunSync<E: Error>(on queue: DispatchQueue = .main) throws -> A where D == Any, F == IOPartial<E> {
+        try self.provide(()).unsafeRunSync(on: queue)
+    }
+    
+    /// Performs the side effects that are suspended in this EnvIO in a synchronous manner.
+    ///
+    /// - Parameter queue: Dispatch queue used to execute the side effects. Defaults to the main queue.
+    /// - Returns: An Either wrapping errors in the left side and values on the right side. Errors of other types thrown from the evaluation of this IO will cause a fatal error.
+    func unsafeRunSyncEither<E: Error>(on queue: DispatchQueue = .main) -> Either<E, A> where D == Any, F == IOPartial<E> {
+        self.provide(()).unsafeRunSyncEither(on: queue)
+    }
+    
+    /// Performs the side effects that are suspended in this EnvIO in an asynchronous manner.
+    ///
+    /// - Parameters:
+    ///   - queue: Dispatch queue used to execute the side effects. Defaults to the main queue.
+    ///   - callback: A callback function to receive the results of the evaluation. Errors of other types thrown from the evaluation of this IO will cause a fatal error.
+    func unsafeRunAsync<E: Error>(on queue: DispatchQueue = .main, _ callback: @escaping Callback<E, A>) where D == Any, F == IOPartial<E> {
+        self.provide(()).unsafeRunAsync(on: queue, callback)
+    }
+}
+
+public extension Kleisli where A == Void {
+    static func sleep<E: Error>(_ interval: DispatchTimeInterval) -> EnvIO<D, E, Void> where F == IOPartial<E> {
+        EnvIO { _ in IO.sleep(interval) }
+    }
+    
+    static func sleep<E: Error>(_ interval: TimeInterval) -> EnvIO<D, E, Void> where F == IOPartial<E> {
+        EnvIO { _ in IO.sleep(interval) }
+    }
+}
+
+// MARK: Instance of `MonadDefer` for `Kleisli`
+
+extension KleisliPartial: MonadDefer where F: MonadDefer {
+    public static func `defer`<A>(_ fa: @escaping () -> Kind<KleisliPartial<F, D>, A>) -> Kind<KleisliPartial<F, D>, A> {
+        Kleisli { d in F.defer { fa()^.invoke(d) } }
+    }
+}
+
+// MARK: Instance of `Async` for `Kleisli`
+
+extension KleisliPartial: Async where F: Async {
+    public static func asyncF<A>(_ procf: @escaping (@escaping (Either<F.E, A>) -> ()) -> Kind<KleisliPartial<F, D>, ()>) -> Kind<KleisliPartial<F, D>, A> {
+        Kleisli { d in
+            F.asyncF { callback in
+                procf(callback)^.invoke(d)
+            }
+        }
+    }
+    
+    public static func continueOn<A>(_ fa: Kind<KleisliPartial<F, D>, A>, _ queue: DispatchQueue) -> Kind<KleisliPartial<F, D>, A> {
+        Kleisli { d in
+            fa^.invoke(d).continueOn(queue)
+        }
+    }
+}
+
+// MARK: Instance of `Concurrent` for `Kleisli`
+
+extension KleisliPartial: Concurrent where F: Concurrent {
+    public static func parMap<A, B, Z>(_ fa: Kind<KleisliPartial<F, D>, A>, _ fb: Kind<KleisliPartial<F, D>, B>, _ f: @escaping (A, B) -> Z) -> Kind<KleisliPartial<F, D>, Z> {
+        Kleisli { d in
+            F.parMap(fa^.invoke(d), fb^.invoke(d), f)
+        }
+    }
+    
+    public static func parMap<A, B, C, Z>(_ fa: Kind<KleisliPartial<F, D>, A>, _ fb: Kind<KleisliPartial<F, D>, B>, _ fc: Kind<KleisliPartial<F, D>, C>, _ f: @escaping (A, B, C) -> Z) -> Kind<KleisliPartial<F, D>, Z> {
+        Kleisli { d in
+            F.parMap(fa^.invoke(d), fb^.invoke(d), fc^.invoke(d), f)
+        }
+    }
+}

--- a/Sources/BowEffects/Data/EnvIO.swift
+++ b/Sources/BowEffects/Data/EnvIO.swift
@@ -38,12 +38,102 @@ public extension Kleisli {
         return self.invoke(d)^
     }
     
+    /// Folds over the result of this computation by accepting an effect to execute in case of error, and another one in the case of success.
+    ///
+    /// - Parameters:
+    ///   - f: Function to run in case of error.
+    ///   - g: Function to run in case of success.
+    /// - Returns: A computation from the result of applying the provided functions to the result of this computation.
+    func foldM<B, E: Error>(_ f: @escaping (E) -> EnvIO<D, E, B>, _ g: @escaping (A) -> EnvIO<D, E, B>) -> EnvIO<D, E, B> where F == IOPartial<E> {
+        self.flatMap(g).handleErrorWith(f)^
+    }
+    
+    /// Retries this computation if it fails based on the provided retrial policy.
+    ///
+    /// This computation will be at least executed once, and if it fails, it will be retried according to the policy.
+    ///
+    /// - Parameter policy: Retrial policy.
+    /// - Returns: A computation that is retried based on the provided policy when it fails.
+    func retry<S, O, E: Error>(_ policy: Schedule<D, E, S, O>) -> EnvIO<D, E, A> where F == IOPartial<E> {
+        retry(policy, orElse: { e, _ in EnvIO.raiseError(e)^ })
+            .map { x in x.merge() }^
+    }
+    
+    /// Retries this computation if it fails based on the provided retrial policy, providing a default computation to handle failures after retrial.
+    ///
+    /// This computation will be at least executed once, and if it fails, it will be retried according to the policy.
+    ///
+    /// - Parameters:
+    ///   - policy: Retrial policy.
+    ///   - orElse: Function to handle errors after retrying.
+    /// - Returns: A computation that is retried based on the provided policy when it fails.
+    func retry<S, O, B, E: Error>(_ policy: Schedule<D, E, S, O>, orElse: @escaping (E, O) -> EnvIO<D, E, B>) -> EnvIO<D, E, Either<B, A>> where F == IOPartial<E> {
+        func loop(_ state: S) -> EnvIO<D, E, Either<B, A>> {
+            self.foldM(
+                { err in
+                    policy.update(err, state)
+                        .mapError { _ in err }
+                        .foldM({ _ in orElse(err, policy.extract(err, state)).map(Either<B, A>.left)^ },
+                               loop)
+                    
+                },
+                { a in EnvIO<D, E, Either<B, A>>.pure(.right(a))^ })
+        }
+        
+        return policy.initial
+            .mapError { x in x as! E }
+            .flatMap(loop)^
+    }
+    
+    /// Repeats this computation until the provided repeating policy completes, or until it fails.
+    ///
+    /// This computation will be at least executed once, and if it succeeds, it will be repeated additional times according to the policy.
+    ///
+    /// - Parameters:
+    ///   - policy: Repeating policy.
+    ///   - onUpdateError: A function providing an error in case the policy fails to update properly.
+    /// - Returns: A computation that is repeated based on the provided policy when it succeeds.
+    func `repeat`<S, O, E: Error>(_ policy: Schedule<D, A, S, O>, onUpdateError: @escaping () -> E) -> EnvIO<D, E, O> where F == IOPartial<E> {
+        self.repeat(policy, onUpdateError: onUpdateError) { e, _ in
+            EnvIO<D, E, O>.raiseError(e)^
+        }.map { x in x.merge() }^
+    }
+    
+    /// Repeats this computation until the provided repeating policy completes, or until it fails, with a function to handle potential failures.
+    ///
+    /// - Parameters:
+    ///   - policy: Repeating policy.
+    ///   - onUpdateError: A function providing an error in case the policy fails to update properly.
+    ///   - orElse: A function to return a computation in case of error.
+    /// - Returns: A computation that is repeated based on the provided policy when it succeeds.
+    func `repeat`<S, O, B, E: Error>(_ policy: Schedule<D, A, S, O>, onUpdateError: @escaping () -> E, orElse: @escaping (E, O?) -> EnvIO<D, E, B>) -> EnvIO<D, E, Either<B, O>> where F == IOPartial<E> {
+        func loop(_ last: A, _ state: S) -> EnvIO<D, E, Either<B, O>> {
+            policy.update(last, state)
+                .mapError { _ in onUpdateError() }
+                .foldM(
+                    { _ in EnvIO<D, E, Either<B, O>>.pure(.right(policy.extract(last, state)))^ },
+                    { s in
+                        self.foldM(
+                            { e in orElse(e, policy.extract(last, state)).map(Either.left)^ },
+                            { a in loop(a, s) })
+                })
+        }
+        
+        return self.foldM(
+            { e in orElse(e, nil).map(Either.left)^ },
+            { a in policy.initial
+                .mapError { x in x as! E }
+                .flatMap { s in loop(a, s) }^ })
+    }
+}
+
+public extension Kleisli where D == Any {
     /// Performs the side effects that are suspended in this IO in a synchronous manner.
     ///
     /// - Parameter queue: Dispatch queue used to execute the side effects. Defaults to the main queue.
     /// - Returns: Value produced after running the suspended side effects.
     /// - Throws: Error of type `E` that may happen during the evaluation of the side-effects. Errors of other types thrown from the evaluation of this IO will cause a fatal error.
-    func unsafeRunSync<E: Error>(on queue: DispatchQueue = .main) throws -> A where D == Any, F == IOPartial<E> {
+    func unsafeRunSync<E: Error>(on queue: DispatchQueue = .main) throws -> A where F == IOPartial<E> {
         try self.provide(()).unsafeRunSync(on: queue)
     }
     
@@ -51,7 +141,7 @@ public extension Kleisli {
     ///
     /// - Parameter queue: Dispatch queue used to execute the side effects. Defaults to the main queue.
     /// - Returns: An Either wrapping errors in the left side and values on the right side. Errors of other types thrown from the evaluation of this IO will cause a fatal error.
-    func unsafeRunSyncEither<E: Error>(on queue: DispatchQueue = .main) -> Either<E, A> where D == Any, F == IOPartial<E> {
+    func unsafeRunSyncEither<E: Error>(on queue: DispatchQueue = .main) -> Either<E, A> where F == IOPartial<E> {
         self.provide(()).unsafeRunSyncEither(on: queue)
     }
     
@@ -60,16 +150,24 @@ public extension Kleisli {
     /// - Parameters:
     ///   - queue: Dispatch queue used to execute the side effects. Defaults to the main queue.
     ///   - callback: A callback function to receive the results of the evaluation. Errors of other types thrown from the evaluation of this IO will cause a fatal error.
-    func unsafeRunAsync<E: Error>(on queue: DispatchQueue = .main, _ callback: @escaping Callback<E, A>) where D == Any, F == IOPartial<E> {
+    func unsafeRunAsync<E: Error>(on queue: DispatchQueue = .main, _ callback: @escaping Callback<E, A>) where F == IOPartial<E> {
         self.provide(()).unsafeRunAsync(on: queue, callback)
     }
 }
 
 public extension Kleisli where A == Void {
+    /// Sleep for the specified amount of time.
+    ///
+    /// - Parameter interval: Time to sleep.
+    /// - Returns: A computation that sleeps for the specified amount of time.
     static func sleep<E: Error>(_ interval: DispatchTimeInterval) -> EnvIO<D, E, Void> where F == IOPartial<E> {
         EnvIO { _ in IO.sleep(interval) }
     }
     
+    /// Sleep for the specified amount of time.
+    ///
+    /// - Parameter interval: Time to sleep.
+    /// - Returns: A computation that sleeps for the specified amount of time.
     static func sleep<E: Error>(_ interval: TimeInterval) -> EnvIO<D, E, Void> where F == IOPartial<E> {
         EnvIO { _ in IO.sleep(interval) }
     }
@@ -104,6 +202,12 @@ extension KleisliPartial: Async where F: Async {
 // MARK: Instance of `Concurrent` for `Kleisli`
 
 extension KleisliPartial: Concurrent where F: Concurrent {
+    public static func race<A, B>(_ fa: Kind<KleisliPartial<F, D>, A>, _ fb: Kind<KleisliPartial<F, D>, B>) -> Kind<KleisliPartial<F, D>, Either<A, B>> {
+        Kleisli { d in
+            F.race(fa^.invoke(d), fb^.invoke(d))
+        }
+    }
+    
     public static func parMap<A, B, Z>(_ fa: Kind<KleisliPartial<F, D>, A>, _ fb: Kind<KleisliPartial<F, D>, B>, _ f: @escaping (A, B) -> Z) -> Kind<KleisliPartial<F, D>, Z> {
         Kleisli { d in
             F.parMap(fa^.invoke(d), fb^.invoke(d), f)

--- a/Sources/BowEffects/Data/Internal/DispatchTimeInterval+Extensions.swift
+++ b/Sources/BowEffects/Data/Internal/DispatchTimeInterval+Extensions.swift
@@ -1,0 +1,25 @@
+import Foundation
+
+extension DispatchTimeInterval {
+    func toDouble() -> Double? {
+        switch self {
+        case .seconds(let value): return Double(value)
+        case .milliseconds(let value): return Double(value) * 0.001
+        case .microseconds(let value): return Double(value) * 0.000_001
+        case .nanoseconds(let value): return Double(value) * 0.000_000_001
+        case .never: return nil
+        @unknown default: return nil
+        }
+    }
+}
+
+func >=(lhs: DispatchTimeInterval, rhs: DispatchTimeInterval) -> Bool {
+    let now = DispatchTime.now()
+    return now + lhs >= now + rhs
+}
+
+func -(lhs: DispatchTime, rhs: DispatchTime) -> DispatchTimeInterval {
+    let l = Int(lhs.rawValue)
+    let r = Int(rhs.rawValue)
+    return .nanoseconds(Int(l - r))
+}

--- a/Sources/BowEffects/Data/Schedule.swift
+++ b/Sources/BowEffects/Data/Schedule.swift
@@ -1,0 +1,768 @@
+import Foundation
+import Bow
+
+/// A single error. This is a workaround over not being able to make `Void` conform to `Error`.
+public enum Unit: Error {
+    case unit
+}
+
+/// A stateful, effectful and recurring schedule of actions.
+///
+/// A schedule consumes values of type `A` and based on its internal state of type `State`, decides to continue or stop. Every decision has a delay and an output of type `B`.
+public class Schedule<R, A, State, B> {
+    /// Initial state for this schedule.
+    let initial: EnvIO<R, Never, State>
+    
+    /// Extract the output if this schedule based on an input and its internal state.
+    let extract: (A, State) -> B
+    
+    /// Update the state of this schedule based on an input and its internal state.
+    let update: (A, State) -> EnvIO<R, Unit, State>
+    
+    init(initial: EnvIO<R, Never, State>,
+         extract: @escaping (A, State) -> B,
+         update: @escaping (A, State) -> EnvIO<R, Unit, State>) {
+        self.initial = initial
+        self.extract = extract
+        self.update = update
+    }
+    
+    /// Composes this schedule with another one, providing a new schedule that continues as long as both continue, using the maximum delay of the two schedules.
+    ///
+    /// - Parameter that: Schedule to be composed with this one.
+    public func and<State2, C>(_ that: Schedule<R, A, State2, C>) -> Schedule<R, A, (State, State2), (B, C)> {
+        Schedule<R, A, (State, State2), (B, C)>(
+            initial: EnvIO<R, Never, (State, State2)>.parZip(self.initial, that.initial)^,
+            extract: { a, s in (self.extract(a, s.0), that.extract(a, s.1)) },
+            update: { a, s in EnvIO<R, Unit, (State, State2)>.parZip(self.update(a, s.0), that.update(a, s.1))^ }
+        )
+    }
+    
+    /// Composes this schedule with another one, providing a new schedule that needs the input of both schedules and provides the output of both. It continues as long as both continue, using the maximum delay of the two schedules.
+    ///
+    /// - Parameter that: Schedule to be composed with this one.
+    public func split<State2, C, D>(_ that: Schedule<R, C, State2, D>) -> Schedule<R, (A, C), (State, State2), (B, D)> {
+        Schedule<R, (A, C), (State, State2), (B, D)>(
+            initial: self.initial.zip(that.initial),
+            extract: { a, s in (self.extract(a.0, s.0), that.extract(a.1, s.1)) },
+            update: { a, s in EnvIO<R, Unit, (State, State2)>.parZip(self.update(a.0, s.0), that.update(a.1, s.1))^ }
+        )
+    }
+    
+    /// Chooses between two schedules with different inputs and outputs.
+    ///
+    /// - Parameter that: Schedule to be composed with this one.
+    public func choose<State2, C, D>(_ that: Schedule<R, C, State2, D>) -> Schedule<R, Either<A, C>, (State, State2), Either<B, D>> {
+        Schedule<R, Either<A, C>, (State, State2), Either<B, D>>(
+            initial: self.initial.zip(that.initial),
+            extract: { a, s in
+                a.fold({ aa in .left(self.extract(aa, s.0)) },
+                       { c in .right(that.extract(c, s.1)) })
+            },
+            update: { a, s in
+                a.fold({ aa in self.update(aa, s.0).map { x in (x, s.1) }^ },
+                       { c in that.update(c, s.1).map { x in (s.0, x) }^ })
+            }
+        )
+    }
+    
+    /// Chooses between two schedules with different inputs and the same output.
+    ///
+    /// - Parameter that: Schedule to be composed with this one.
+    public func choose<State2, C>(_ that: Schedule<R, C, State2, B>) -> Schedule<R, Either<A, C>, (State, State2), B> {
+        self.choose(that).map { b in b.merge() }
+    }
+    
+    /// Composes this schedule with another one, providing a new schedule that continues as long as both continue, using the maximum delay of the two schedules.
+    ///
+    /// - Parameter that: Schedule to be composed with this one.
+    public func zip<State2, C>(_ that: Schedule<R, A, State2, C>) -> Schedule<R, A, (State, State2), (B, C)> {
+        self.and(that)
+    }
+    
+    /// Composes this schedule with another one, providing a new schedule that continues as long as both continue, using the maximum delay of the two schedules, and ignoring the output of this schedule.
+    ///
+    /// - Parameter that: Schedule to be composed with this one.
+    public func zipRight<State2, C>(_ that: Schedule<R, A, State2, C>) -> Schedule<R, A, (State, State2), C> {
+        self.and(that).map { x in x.1 }
+    }
+    
+    /// Composes this schedule with another one, providing a new schedule that continues as long as both continue, using the maximum delay of the two schedules, and ignoring the output of the provided schedule.
+    ///
+    /// - Parameter that: Schedule to be composed with this one.
+    public func zipLeft<State2, C>(_ that: Schedule<R, A, State2, C>) -> Schedule<R, A, (State, State2), B> {
+        self.and(that).map { x in x.0 }
+    }
+    
+    /// Pipes the output of this schedule as the input of the provided one. Effects described by this schedule will always be performed before the effects described by the second schedule.
+    ///
+    /// - Parameter that: Schedule to be piped after this one.
+    public func pipe<State2, C>(_ that: Schedule<R, B, State2, C>) -> Schedule<R, A, (State, State2), C> {
+        Schedule<R, A, (State, State2), C>(
+            initial: self.initial.zip(that.initial),
+            extract: { a, s in that.extract(self.extract(a, s.0), s.1) },
+            update: { a, s in
+                let s1 = EnvIO<R, Unit, State>.var()
+                let s2 = EnvIO<R, Unit, State2>.var()
+                
+                return binding(
+                    s1 <- self.update(a, s.0),
+                    s2 <- that.update(self.extract(a, s.0), s.1),
+                    yield: (s1.get, s2.get))^
+            }
+        )
+    }
+    
+    /// Pipes the output of the provided schedule as the input of this schedule. Effects described by the provided schedule will always be performed before the effects described by this schedule.
+    ///
+    /// - Parameter that: Schedule to be piped before this one.
+    public func reversePipe<State2, C>(_ that: Schedule<R, C, State2, A>) -> Schedule<R, C, (State2, State), B> {
+        that.pipe(self)
+    }
+    
+    /// Composes with a schedule resulting in another one that continues as long as either schedule continues, using the minimum of the delays of the two schedules.
+    ///
+    /// - Parameter that: Schedule to be composed with this one.
+    public func or<State2, C>(_ that: Schedule<R, A, State2, C>) -> Schedule<R, A, (State, State2), (B, C)> {
+        Schedule<R, A, (State, State2), (B, C)>(
+            initial: self.initial.zip(that.initial),
+            extract: { a, s in (self.extract(a, s.0), that.extract(a, s.1)) },
+            update: { a, s in
+                EnvIO.race(self.update(a, s.0),
+                           that.update(a, s.1)).map { either in
+                    either.fold(
+                        { s0 in (s0, s.1) },
+                        { s1 in (s.0, s1)})
+                }^
+            })
+    }
+    
+    /// Adds a delay of the specified duration based on the output of this schedule.
+    ///
+    /// - Parameter f: Function computing the delay time based on the output of the schedule.
+    public func addDelay(_ f: @escaping (B) -> DispatchTimeInterval) -> Schedule<R, A, State, B> {
+        addDelayM { b in EnvIO<R, Never, DispatchTimeInterval>.pure(f(b))^ }
+    }
+    
+    /// Adds a delay of the specified duration based on the output of this schedule.
+    ///
+    /// - Parameter f: An effectful function that provides the delay time based on the output of the schedule.
+    public func addDelayM(_ f: @escaping (B) -> EnvIO<R, Never, DispatchTimeInterval>) -> Schedule<R, A, State, B> {
+        addDelayM { b in f(b).map { x in x.toDouble() ?? 0 }^ }
+    }
+    
+    /// Adds a delay of the specified duration based on the output of this schedule.
+    ///
+    /// - Parameter f: Function computing the delay time based on the output of the schedule.
+    public func addDelay(_ f: @escaping (B) -> TimeInterval) -> Schedule<R, A, State, B> {
+        addDelayM { b in EnvIO<R, Never, TimeInterval>.pure(f(b))^ }
+    }
+    
+    /// Adds a delay of the specified duration based on the output of this schedule.
+    ///
+    /// - Parameter f: An effectful function that provides the delay time based on the output of the schedule.
+    public func addDelayM(_ f: @escaping (B) -> EnvIO<R, Never, TimeInterval>) -> Schedule<R, A, State, B> {
+        updated { upd in
+            { a, s in
+                let delay = EnvIO<R, Unit, TimeInterval>.var()
+                let s1 = EnvIO<R, Unit, State>.var()
+                return binding(
+                    delay <- f(self.extract(a, s)).unitError(),
+                    s1 <- upd(a, s),
+                    |<-EnvIO.sleep(delay.get),
+                    yield: s1.get)^
+            }
+        }
+    }
+    
+    /// Composes two schedules with the same input and output by applying them sequentially. It executes the first to completion, and then executes the second.
+    ///
+    /// - Parameter that: Schedule to be composed with this one.
+    public func andThen<State2>(_ that: Schedule<R, A, State2, B>) -> Schedule<R, A, Either<State, State2>, B> {
+        andThenEither(that).map { x in x.merge() }
+    }
+    
+    /// Composes two schedules with the same input but different outputs by applying them sequentially. It executes the first to completion, and then executes the second.
+    ///
+    /// - Parameter that: Schedule to be composed with this one.
+    public func andThenEither<State2, C>(_ that: Schedule<R, A, State2, C>) -> Schedule<R, A, Either<State, State2>, Either<B, C>> {
+        Schedule<R, A, Either<State, State2>, Either<B, C>>(
+            initial: self.initial.map(Either.left)^,
+            extract: { a, s in
+                s.fold({ s1 in .left(self.extract(a, s1)) },
+                       { s2 in .right(that.extract(a, s2)) })
+            },
+            update: { a, s in
+                s.fold({ s1 in
+                    self.update(a, s1).map(Either.left)
+                        .handleErrorWith { _ in
+                            that.initial.unitError().flatMap { x in that.update(a, x) }.map(Either.right)^
+                        }^
+                },
+                       { s2 in that.update(a, s2).map(Either.right)^ })
+            })
+    }
+    
+    /// Transforms the output of this schedule to a fixed value.
+    ///
+    /// - Parameter c: Fixed value to return as output of this schedule.
+    public func `as`<C>(_ c: C) -> Schedule<R, A, State, C> {
+        map { _ in c }
+    }
+    
+    /// Composes this schedule with another one, providing a new schedule that continues as long as both continue, using the maximum delay of the two schedules.
+    ///
+    /// - Parameter that: Schedule to be composed with this one.
+    public func both<State2, C>(_ that: Schedule<R, A, State2, C>) -> Schedule<R, A, (State, State2), (B, C)> {
+        self.and(that)
+    }
+    
+    /// Composes this schedule with another one, providing a new schedule that continues as long as both continue, using the maximum delay of the two schedules, and combining the outputs of both using the provided function.
+    ///
+    /// - Parameters:
+    ///     - that: Schedule to be composed with this one.
+    ///     - f: Transforming function.
+    public func bothWith<State2, C, D>(_ that: Schedule<R, A, State2, C>, _ f: @escaping (B, C) -> D) -> Schedule<R, A, (State, State2), D> {
+        self.and(that).map(f)
+    }
+    
+    /// Peeks at the output produced by this schedule and executes a test to determine if the schedule should continue or not.
+    ///
+    /// - Parameter test: Effectful predicate to determine if the schedule should continue or not based on the current input and output.
+    public func check(_ test: @escaping (A, B) -> EnvIO<R, Never, Bool>) -> Schedule<R, A, State, B> {
+        updated { upd in
+            { a, s in
+                test(a, self.extract(a, s)).unitError().flatMap { flag in
+                    flag ?
+                        upd(a, s) :
+                        EnvIO.raiseError(.unit)
+                }^
+            }
+        }
+    }
+    
+    /// Collects all the output of this schedule in an array.
+    public func collectAll() -> Schedule<R, A, (State, [B]), [B]> {
+        fold([]) { xs, x in xs + [x] }
+    }
+    
+    /// Pipes the output of the provided schedule as the input of this schedule. Effects described by the provided schedule will always be performed before the effects described by this schedule.
+    ///
+    /// - Parameter that: Schedule to be piped before this one.
+    public func compose<State2, C>(_ that: Schedule<R, C, State2, A>) -> Schedule<R, C, (State2, State), B> {
+        self.reversePipe(that)
+    }
+    
+    /// Provides an schedule that deals with a narrower class of inputs than this schedule.
+    ///
+    /// - Parameter f: Function transforming the input of this schedule.
+    public func contramap<AA>(_ f: @escaping (AA) -> A) -> Schedule<R, AA, State, B> {
+        Schedule<R, AA, State, B>(
+            initial: self.initial,
+            extract: { a, s in self.extract(f(a), s) },
+            update: { a, s in self.update(f(a), s) })
+    }
+    
+    /// Provides an schedule that contramaps the input and maps the output with the provided functions.
+    ///
+    /// - Parameters:
+    ///   - f: Function to contramap.
+    ///   - g: Function to map.
+    public func dimap<AA, C>(_ f: @escaping (AA) -> A, _ g: @escaping (B) -> C) -> Schedule<R, AA, State, C> {
+        contramap(f).map(g)
+    }
+    
+    /// Composes with a schedule resulting in another one that continues as long as either schedule continues, using the minimum of the delays of the two schedules.
+    ///
+    /// - Parameter that: Schedule to be composed with this one.
+    public func either<State2, C>(_ that: Schedule<R, A, State2, C>) -> Schedule<R, A, (State, State2), (B, C)> {
+        self.or(that)
+    }
+    
+    /// Composes with a schedule resulting in another one that continues as long as either schedule continues, using the minimum of the delays of the two schedules, and transforming the outputs with the provided function.
+    ///
+    /// - Parameters:
+    ///     - that: Schedule to be composed with this one.
+    ///     - f: Transforming function.
+    public func eitherWith<State2, C, D>(_ that: Schedule<R, A, State2, C>, _ f: @escaping (B, C) -> D) -> Schedule<R, A, (State, State2), D> {
+        self.or(that).map(f)
+    }
+    
+    /// Puts this schedule into the first element of a tuple and passes an unmodified element as the second element of the tuple.
+    public func first<C>() -> Schedule<R, (A, C), (State, Unit), (B, C)> {
+        self.split(Schedule<R, C, Unit, C>.identity())
+    }
+    
+    /// Provides a schedule that folds the outputs of this one.
+    ///
+    /// - Parameters:
+    ///   - z: Initial value for the folding process.
+    ///   - f: Folding function.
+    public func fold<Z>(_ z: Z, _ f: @escaping (Z, B) -> Z) -> Schedule<R, A, (State, Z), Z> {
+        Schedule<R, A, (State, Z), Z>(
+            initial: self.initial.map { x in (x, z) }^,
+            extract: { a, s in f(s.1, self.extract(a, s.0)) },
+            update: { a, s in
+                self.update(a, s.0).map { s1 in (s1, f(s.1, self.extract(a, s.0))) }^
+            })
+    }
+    
+    /// Returns a new schedule that loops this one forever, resetting the state when this schedule is completed.
+    public func forever() -> Schedule<R, A, State, B> {
+        Schedule(
+            initial: self.initial,
+            extract: self.extract,
+            update: { a, s in self.update(a, s).handleErrorWith { _ in
+                self.initial.unitError().flatMap { x in self.update(a, x) }
+            }^ })
+    }
+    
+    /// Returns a new schedule with the specified initial state transformed by a function.
+    ///
+    /// - Parameter f: Function transforming the initial state.
+    public func initialized(_ f: @escaping (EnvIO<R, Never, State>) -> EnvIO<R, Never, State>) -> Schedule<R, A, State, B> {
+        Schedule(
+            initial: f(self.initial),
+            extract: self.extract,
+            update: self.update)
+    }
+    
+    /// Puts the schedule into the left side of an `Either` and passes an unmodified value as the right side of the `Either`.
+    public func left<C>() -> Schedule<R, Either<A, C>, (State, Unit), Either<B, C>> {
+        self.choose(Schedule<R, C, Unit, C>.identity())
+    }
+    
+    /// Transforms the output of this schedule with the provided function.
+    ///
+    /// - Parameter f: Transforming function.
+    public func map<C>(_ f: @escaping (B) -> C) -> Schedule<R, A, State, C> {
+        Schedule<R, A, State, C>(
+            initial: self.initial,
+            extract: { a, s in f(self.extract(a, s)) },
+            update: self.update)
+    }
+    
+    /// Provides a new schedule that emits the number of repetitions of this schedule.
+    public func repetitions() -> Schedule<R, A, (State, Int), Int> {
+        fold(0) { n, _ in n + 1 }
+    }
+    
+    /// Puts the schedule into the right side of an `Either` and passes an unmodified value as the left side of the `Either`.
+    public func right<C>() -> Schedule<R, Either<C, A>, (Unit, State), Either<C, B>> {
+        Schedule<R, C, Unit, C>.identity().choose(self)
+    }
+    
+    /// Puts this schedule into the second element of a tuple and passes an unmodified element as the first element of the tuple.
+    public func second<C>() -> Schedule<R, (C, A), (Unit, State), (C, B)> {
+        Schedule<R, C, Unit, C>.identity().split(self)
+    }
+    
+    /// Performs an additional effect for every input.
+    ///
+    /// - Parameter f: Effectful function to run after every input.
+    public func tapInput(_ f: @escaping (A) -> EnvIO<R, Never, Void>) -> Schedule<R, A, State, B> {
+        updated { upd in
+            { a, s in
+                f(a).unitError().flatMap { _ in upd(a, s) }^
+            }
+        }
+    }
+    
+    /// Performs an additional effect for every output.
+    ///
+    /// - Parameter f: Effectful function to run after every output.
+    public func tapOutput(_ f: @escaping (B) -> EnvIO<R, Never, Void>) -> Schedule<R, A, State, B> {
+        updated { upd in
+            { a, s in
+                upd(a, s).flatMap { ss in f(self.extract(a, ss)).unitError().as(ss) }^
+            }
+        }
+    }
+    
+    func updated(_ f: @escaping (@escaping (A, State) -> EnvIO<R, Unit, State>) -> (A, State) -> EnvIO<R, Unit, State>) -> Schedule<R, A, State, B> {
+        Schedule(
+            initial: self.initial,
+            extract: self.extract,
+            update: f(self.update)
+        )
+    }
+    
+    /// Wipes out the output produced by this schedule.
+    public func void() -> Schedule<R, A, State, Void> {
+        `as`(())
+    }
+    
+    /// Provides a schedule that iterates this schedule until the input matches a given predicate.
+    ///
+    /// - Parameter f: Predicate to test the input of this schedule.
+    public func untilInput(_ f: @escaping (A) -> Bool) -> Schedule<R, A, State, B> {
+        untilInputM { a in EnvIO.pure(f(a))^ }
+    }
+    
+    /// Provides a schedule that iterates this schedule until the input matches a given effectful predicate.
+    ///
+    /// - Parameter f: Effectful predicate to test the input of this schedule.
+    public func untilInputM(_ f: @escaping (A) -> EnvIO<R, Never, Bool>) -> Schedule<R, A, State, B> {
+        updated { upd in
+            { a, s in
+                f(a).unitError().flatMap { flag in
+                    flag ?
+                        EnvIO.raiseError(.unit)^ :
+                        upd(a, s)
+                }^
+            }
+        }
+    }
+    
+    /// Provides a schedule that iterates this schedule until the output matches a given predicate.
+    ///
+    /// - Parameter f: Predicate to test the output of this schedule.
+    public func untilOutput(_ f: @escaping (B) -> Bool) -> Schedule<R, A, State, B> {
+        untilOutputM { b in EnvIO.pure(f(b))^ }
+    }
+    
+    /// Provides a schedule that iterates this schedule until the output matches a given effectful predicate.
+    ///
+    /// - Parameter f: Effectful predicate to test the output of this schedule.
+    public func untilOutputM(_ f: @escaping (B) -> EnvIO<R, Never, Bool>) -> Schedule<R, A, State, B> {
+        updated { upd in
+            { a, s in
+                f(self.extract(a, s)).unitError().flatMap { flag in
+                    flag ?
+                        EnvIO.raiseError(.unit)^ :
+                        upd(a, s)
+                }^
+            }
+        }
+    }
+    
+    /// Provides a schedule that iterates this schedule while the input matches a given predicate.
+    ///
+    /// - Parameter f: Predicate to test the input of this schedule.
+    public func whileInput(_ f: @escaping (A) -> Bool) -> Schedule<R, A, State, B> {
+        whileInputM { a in EnvIO.pure(f(a))^ }
+    }
+    
+    /// Provides a schedule that iterates this schedule while the input matches a given effectful predicate.
+    ///
+    /// - Parameter f: Effectful predicate to test the input of this schedule.
+    public func whileInputM(_ f: @escaping (A) -> EnvIO<R, Never, Bool>) -> Schedule<R, A, State, B> {
+        check { a, _ in f(a) }
+    }
+    
+    /// Provides a schedule that iterates this schedule while the output matches a given predicate.
+    ///
+    /// - Parameter f: Predicate to test the output of this schedule.
+    public func whileOutput(_ f: @escaping (B) -> Bool) -> Schedule<R, A, State, B> {
+        whileOutputM { b in EnvIO.pure(f(b))^ }
+    }
+    
+    /// Provides a schedule that iterates this schedule while the output matches a given effectful predicate.
+    ///
+    /// - Parameter f: Effectful predicate to test the output of this schedule.
+    public func whileOutputM(_ f: @escaping (B) -> EnvIO<R, Never, Bool>) -> Schedule<R, A, State, B> {
+        check { _, b in f(b) }
+    }
+    
+    /// Provides a schedule that always recurs without delay and computes the output through subsequent applications of a function to an initial value.
+    ///
+    /// - Parameters:
+    ///   - a: Initial value.
+    ///   - f: Unfolding function.
+    public static func unfold(_ a: B, _ f: @escaping (B) -> B) -> Schedule<R, A, B, B> {
+        unfoldM(EnvIO.pure(a)^, { a in EnvIO.pure(f(a))^ })
+    }
+    
+    /// Provides a schedule that always recurs without delay and computes the output through subsequent applications of an effectful function to an initial value.
+    ///
+    /// - Parameters:
+    ///   - a: Initial effect.
+    ///   - f: Unfolding effectful function.
+    public static func unfoldM(_ a: EnvIO<R, Never, B>, _ f: @escaping (B) -> EnvIO<R, Never, B>) -> Schedule<R, A, B, B> {
+        Schedule<R, A, B, B>(
+            initial: a,
+            extract: { _, a in a },
+            update: { _, a in f(a).unitError() }
+        )
+    }
+}
+
+extension Schedule where B == DispatchTimeInterval {
+    /// Provides a schedule from the given schedule which transforms the delays into effectufl sleeps.
+    ///
+    /// - Parameter s: A schedule producing time intervals.
+    public static func delayed(_ s: Schedule<R, A, State, DispatchTimeInterval>) -> Schedule<R, A, State, DispatchTimeInterval> {
+        s.addDelay(id)
+    }
+}
+
+extension Schedule where B == TimeInterval {
+    /// Provides a schedule from the given schedule which transforms the delays into effectufl sleeps.
+    ///
+    /// - Parameter s: A schedule producing time intervals.
+    public static func delayed(_ s: Schedule<R, A, State, TimeInterval>) -> Schedule<R, A, State, TimeInterval> {
+        s.addDelay(id)
+    }
+}
+
+extension Schedule where State == (DispatchTime, DispatchTimeInterval), B == DispatchTimeInterval {
+    private static func now() -> EnvIO<R, Never, DispatchTime> {
+        EnvIO.pure(DispatchTime.now())^
+    }
+    
+    /// Provides a schedule that recurs forever without a delay, returning the elapsed time since it began.
+    public static func elapsed() -> Schedule<R, A, (DispatchTime, DispatchTimeInterval), DispatchTimeInterval> {
+        Schedule<R, A, (DispatchTime, DispatchTimeInterval), DispatchTimeInterval>(
+            initial: now().map { s in (s, DispatchTimeInterval.seconds(0)) }^,
+            extract: { _, s in s.1 },
+            update: { _, s in now().unitError().map { currentTime in (s.0, currentTime - s.0) }^ }
+        )
+    }
+    
+    /// Provides a schedule that recurs until the specified duration elapsed, returning the total elapsed time.
+    ///
+    /// - Parameter interval: Time interval for this schedule to recur.
+    public static func duration(_ interval: DispatchTimeInterval) -> Schedule<R, A, (DispatchTime, DispatchTimeInterval), DispatchTimeInterval> {
+        elapsed().untilOutput { x in x >= interval }
+    }
+}
+
+extension Schedule where State == Int, B == Int {
+    /// Provides a schedule that waits for the specified amount of time between each input. Returns the number of received inputs.
+    ///
+    /// - Parameter interval: Time interval to wait between each action.
+    public static func spaced(_ interval: DispatchTimeInterval) -> Schedule<R, A, State, Int> {
+        forever().addDelay { _ in interval }
+    }
+    
+    /// Provides a schedule that waits for the specified amount of time between each input. Returns the number of received inputs.
+    ///
+    /// - Parameter interval: Time interval to wait between each action.
+    public static func spaced(_ interval: TimeInterval) -> Schedule<R, A, State, Int> {
+        forever().addDelay { _ in interval }
+    }
+}
+
+extension Schedule where State == Int, B == TimeInterval {
+    /// Provides a schedule that always recurs, waiting an amount of time between repetitions, given by an exponential backoff algorithm, and returning the current duration between recurrences.
+    ///
+    /// The time to wait is given by the formula `base * pow(n + 1)`, where `n` is the number of repetitions so far.
+    ///
+    /// - Parameters:
+    ///   - base: Base time interval to wait between repetitions.
+    ///   - factor: Factor for the exponential backoff. Defaults to 2.0.
+    public static func exponential(_ base: DispatchTimeInterval, factor: Double = 2.0) -> Schedule<R, A, Int, TimeInterval> {
+        exponential(base.toDouble() ?? 1, factor: factor)
+    }
+    
+    /// Provides a schedule that always recurs, waiting an amount of time between repetitions, given by an exponential backoff algorithm, and returning the current duration between recurrences.
+    ///
+    /// The time to wait is given by the formula `base * pow(n + 1)`, where `n` is the number of repetitions so far.
+    ///
+    /// - Parameters:
+    ///   - base: Base time interval to wait between repetitions.
+    ///   - factor: Factor for the exponential backoff. Defaults to 2.0.
+    public static func exponential(_ base: TimeInterval, factor: Double = 2.0) -> Schedule<R, A, Int, TimeInterval> {
+        delayed(Schedule<R, A, Int, Int>.forever().map { i in
+            base * pow(factor, Double(i + 1))
+        })
+    }
+    
+    /// Provides a schedule that always recurs, waiting an amount of time between repetitions, given by a linear backoff algorithm, and returning the current duration between recurrences.
+    ///
+    /// The time to wait is given by the formula `base * (n + 1)`, where `n` is the number of repetitions so far.
+    ///
+    /// - Parameter base: Base time interval to wait between repetitions.
+    public static func linear(_ base: DispatchTimeInterval) -> Schedule<R, A, Int, TimeInterval> {
+        linear(base.toDouble() ?? 1)
+    }
+    
+    /// Provides a schedule that always recurs, waiting an amount of time between repetitions, given by a linear backoff algorithm, and returning the current duration between recurrences.
+    ///
+    /// The time to wait is given by the formula `base * (n + 1)`, where `n` is the number of repetitions so far.
+    ///
+    /// - Parameter base: Base time interval to wait between repetitions.
+    public static func linear(_ base: TimeInterval) -> Schedule<R, A, Int, TimeInterval> {
+        delayed(Schedule<R, A, Int, Int>.forever().map { i in
+            base * Double(i + 1)
+        })
+    }
+}
+
+extension Schedule where State == (TimeInterval, TimeInterval), B == TimeInterval {
+    
+    /// Provides a schedule that always recurs, increasing delays by summing the preceding two delays, as in the Fibonacci sequence. Returns the current duration between recurrences.
+    ///
+    /// - Parameter one: Time interval for the initial delay.
+    public static func fibonacci(_ one: DispatchTimeInterval) -> Schedule<R, A, (TimeInterval, TimeInterval), TimeInterval> {
+        fibonacci(one.toDouble() ?? 1)
+    }
+    
+    /// Provides a schedule that always recurs, increasing delays by summing the preceding two delays, as in the Fibonacci sequence. Returns the current duration between recurrences.
+    ///
+    /// - Parameter one: Time interval for the initial delay.
+    public static func fibonacci(_ one: TimeInterval) -> Schedule<R, A, (TimeInterval, TimeInterval), TimeInterval> {
+        delayed(
+            Schedule<R, A, (TimeInterval, TimeInterval), (TimeInterval, TimeInterval)>.unfold((one, one)) { x in
+                (x.1, x.0 + x.1)
+            }.map { x in x.0 })
+    }
+}
+
+extension Schedule where B == Void, State == Unit {
+    /// Provides a schedule that wipes out the output.
+    public static func void() -> Schedule<R, A, Unit, Void> {
+        Schedule<R, A, Unit, A>.identity().void()
+    }
+}
+
+extension Schedule where A == B, State == Unit {
+    /// Provides a schedule that returns the input, unmodified.
+    public static func identity() -> Schedule<R, A, Unit, A> {
+        Schedule<R, A, Unit, A>(
+            initial: EnvIO.pure(.unit)^,
+            extract: { a, _ in a },
+            update: { _, _ in EnvIO.pure(.unit)^ })
+    }
+    
+    /// Provides a schedule that recurs as long as the predicate evaluates to true.
+    ///
+    /// - Parameter f: Predicate to test the input.
+    public static func doWhile(_ f: @escaping (A) -> Bool) -> Schedule<R, A, Unit, A> {
+        doWhileM { a in EnvIO.pure(f(a))^ }
+    }
+    
+    /// Provides a schedule that recurs as long as the effectful predicate evaluates to true.
+    ///
+    /// - Parameter f: Effectful predicate to test the input.
+    public static func doWhileM(_ f: @escaping (A) -> EnvIO<R, Never, Bool>) -> Schedule<R, A, Unit, A> {
+        identity().whileInputM(f)
+    }
+    
+    /// Provides a schedule that recurs until the predicate evaluates to true.
+    ///
+    /// - Parameter f: Predicate to test the input.
+    public static func doUntil(_ f: @escaping (A) -> Bool) -> Schedule<R, A, Unit, A> {
+        doUntilM { a in EnvIO.pure(f(a))^ }
+    }
+    
+    /// Provides a schedule that recurs until the effectful predicate evaluates to true.
+    ///
+    /// - Parameter f: Effectful predicate to test the input.
+    public static func doUntilM(_ f: @escaping (A) -> EnvIO<R, Never, Bool>) -> Schedule<R, A, Unit, A> {
+        identity().untilInputM(f)
+    }
+    
+    /// Provides a schedule that executes an effect for every consumed input.
+    ///
+    /// - Parameter f: Effectful function to run after every input.
+    public static func tapInput(_ f: @escaping (A) -> EnvIO<R, Never, Void>) -> Schedule<R, A, Unit, A> {
+        identity().tapInput(f)
+    }
+    
+    /// Provides a schedule that executes an effect for every produced output.
+    ///
+    /// - Parameter f: Effectful function to run after every output.
+    public static func tapOutput(_ f: @escaping (A) -> EnvIO<R, Never, Void>) -> Schedule<R, A, Unit, A> {
+        identity().tapOutput(f)
+    }
+}
+
+extension Schedule where State == Unit {
+    /// Provides a schedule that recurs forever, mapping input values through the provided function.
+    ///
+    /// - Parameter function: Transforming function.
+    public static func from(function: @escaping (A) -> B) -> Schedule<R, A, State, B> {
+        Schedule<R, A, Unit, A>.identity().map(function)
+    }
+}
+
+extension Schedule where A == B, State == Unit, A: Equatable {
+    /// Provides a schedule that recurs as long as the input is equal to a specific value.
+    ///
+    /// - Parameter a: Value to compare the input of the schedule.
+    public static func doWhileEquals(_ a: A) -> Schedule<R, A, Unit, A> {
+        identity().whileInput { x in x == a }
+    }
+    
+    /// Provides a schedule that recurs as long as the input is not equal to a specific value.
+    ///
+    /// - Parameter a: Value to compare the input of the schedule.
+    public static func doUntilEquals(_ a: A) -> Schedule<R, A, Unit, A> {
+        identity().untilInput { x in x == a }
+    }
+}
+
+extension Schedule where B == Int, State == Int {
+    /// Provides a schedule that runs forever and emits the number of iterations it has performed.
+    public static func forever() -> Schedule<R, A, Int, Int> {
+        Schedule<R, A, Int, Int>.unfold(0) { $0 + 1 }
+    }
+    
+    /// Provides a schedule that recurs a specific number of times, emitting the current iteration it is in.
+    ///
+    /// - Parameter n: Number of iterations to perform.
+    public static func recurs(_ n: Int) -> Schedule<R, A, Int, Int> {
+        forever().whileOutput { $0 < n }
+    }
+    
+    /// Provides a schedule that recurs only once.
+    public static func once() -> Schedule<R, A, Int, Void> {
+        recurs(1).void()
+    }
+    
+    /// Provides a schedule that recurs zero times.
+    public static func stop() -> Schedule<R, A, Int, Void> {
+        recurs(0).void()
+    }
+}
+
+extension Schedule where B == Never, A == Any, State == Never {
+    /// Provides a schedule that never recurs.
+    public static func never() -> Schedule<R, Any, Never, Never> {
+        Schedule(
+            initial: EnvIO.never()^,
+            extract: { _, never in never },
+            update: { _, _ in EnvIO.never()^ })
+    }
+}
+
+extension Schedule where B == [A], State == (Unit, [A]) {
+    /// Provides a schedule that recurs forever and collects all its outputs in an array.
+    public static func collectAll() -> Schedule<R, A, State, [A]> {
+        Schedule<R, A, Unit, A>.identity().collectAll()
+    }
+    
+    /// Provides a schedule that collects its outputs in an array as long as the outputs match a given predicate.
+    ///
+    /// - Parameter f: Predicate to test the outputs.
+    public static func collectWhile(_ f: @escaping (A) -> Bool) -> Schedule<R, A, State, [A]> {
+        Schedule<R, A, Unit, A>.doWhile(f).collectAll()
+    }
+    
+    /// Provides a schedule that collects its outputs in an array as long as the outputs match a given effectful predicate.
+    ///
+    /// - Parameter f: Effectful predicate to test the outputs.
+    public static func collectWhileM(_ f: @escaping (A) -> EnvIO<R, Never, Bool>) -> Schedule<R, A, State, [A]> {
+        Schedule<R, A, Unit, A>.doWhileM(f).collectAll()
+    }
+    
+    /// Provides a schedule that collects its outputs in an array until an output matches a given predicate.
+    ///
+    /// - Parameter f: Predicate to test the outputs.
+    public static func collectUntil(_ f: @escaping (A) -> Bool) -> Schedule<R, A, State, [A]> {
+        Schedule<R, A, Unit, A>.doUntil(f).collectAll()
+    }
+    
+    /// Provides a schedule that collects its outputs in an array until an output matches a given effectful predicate.
+    /// - Parameter f: Effectful predicate to test the outputs.
+    public static func collectUntilM(_ f: @escaping (A) -> EnvIO<R, Never, Bool>) -> Schedule<R, A, State, [A]> {
+        Schedule<R, A, Unit, A>.doUntilM(f).collectAll()
+    }
+}
+
+extension Kleisli {
+    func unitError<E: Error>() -> EnvIO<D, Unit, A> where F == IOPartial<E> {
+        self.mapError { _ in .unit }
+    }
+}

--- a/Sources/BowEffects/Typeclasses/Concurrent.swift
+++ b/Sources/BowEffects/Typeclasses/Concurrent.swift
@@ -26,6 +26,15 @@ public protocol Concurrent: Async {
                                    _ fb: Kind<Self, B>,
                                    _ fc: Kind<Self, C>,
                                    _ f: @escaping (A, B, C) -> Z) -> Kind<Self, Z>
+    
+    /// Runs 2 computations in parallel and returns the result of the first one finishing.
+    ///
+    /// - Parameters:
+    ///   - fa: 1st computation
+    ///   - fb: 2nd computation
+    /// - Returns: A computation with the result of the first computation that finished.
+    static func race<A, B>(_ fa: Kind<Self, A>,
+                           _ fb: Kind<Self, B>) -> Kind<Self, Either<A, B>>
 }
 
 // MARK: Related functions
@@ -468,7 +477,18 @@ public extension Kind where F: Concurrent {
                                                   _ fh: Kind<F, H>,
                                                   _ fi: Kind<F, I>,
                                                   _ fj: Kind<F, J>) -> Kind<F, (Z, B, C, D, E, G, H, I, J)> where A == (Z, B, C, D, E, G, H, I, J) {
-        return F.parMap(fa, fb, fc, fd, fe, fg, fh, fi, fj, { a, b, c, d, e, g, h, i, j in (a, b, c, d, e, g, h, i, j) })
+        F.parMap(fa, fb, fc, fd, fe, fg, fh, fi, fj, { a, b, c, d, e, g, h, i, j in (a, b, c, d, e, g, h, i, j) })
+    }
+    
+    /// Runs 2 computations in parallel and returns the result of the first one finishing.
+    ///
+    /// - Parameters:
+    ///   - fb: 1st computation
+    ///   - fc: 2nd computation
+    /// - Returns: A computation with the result of the first computation that finished.
+    static func race<B, C>(_ fb: Kind<F, B>,
+                           _ fc: Kind<F, C>) -> Kind<F, A> where A == Either<B, C> {
+        F.race(fb, fc)
     }
     
     /// Runs 2 computations in parallel and combines their results using the provided function.
@@ -481,7 +501,7 @@ public extension Kind where F: Concurrent {
     static func parMap<B, Z>(_ fa: Kind<F, Z>,
                             _ fb: Kind<F, B>,
                             _ f: @escaping (Z, B) -> A) -> Kind<F, A> {
-        return F.parMap(fa, fb, f)
+        F.parMap(fa, fb, f)
     }
     
     /// Runs 3 computations in parallel and combines their results using the provided function.
@@ -496,7 +516,7 @@ public extension Kind where F: Concurrent {
                                 _ fb: Kind<F, B>,
                                 _ fc: Kind<F, C>,
                                 _ f: @escaping (Z, B, C) -> A) -> Kind<F, A> {
-        return F.parMap(fa, fb, fc, f)
+        F.parMap(fa, fb, fc, f)
     }
     
     /// Runs 4 computations in parallel and combines their results using the provided function.
@@ -513,7 +533,7 @@ public extension Kind where F: Concurrent {
                                    _ fc: Kind<F, C>,
                                    _ fd: Kind<F, D>,
                                    _ f: @escaping (Z, B, C, D) -> A) -> Kind<F, A> {
-        return F.parMap(fa, fb, fc, fd, f)
+        F.parMap(fa, fb, fc, fd, f)
     }
     
     /// Runs 5 computations in parallel and combines their results using the provided function.
@@ -532,7 +552,7 @@ public extension Kind where F: Concurrent {
                                       _ fd: Kind<F, D>,
                                       _ fe: Kind<F, E>,
                                       _ f: @escaping (Z, B, C, D, E) -> A) -> Kind<F, A> {
-        return F.parMap(fa, fb, fc, fd, fe, f)
+        F.parMap(fa, fb, fc, fd, fe, f)
     }
     
     /// Runs 6 computations in parallel and combines their results using the provided function.
@@ -553,7 +573,7 @@ public extension Kind where F: Concurrent {
                                          _ fe: Kind<F, E>,
                                          _ fg: Kind<F, G>,
                                          _ f: @escaping (Z, B, C, D, E, G) -> A) -> Kind<F, A> {
-        return F.parMap(fa, fb, fc, fd, fe, fg, f)
+        F.parMap(fa, fb, fc, fd, fe, fg, f)
     }
     
     /// Runs 7 computations in parallel and combines their results using the provided function.
@@ -576,7 +596,7 @@ public extension Kind where F: Concurrent {
                                             _ fg: Kind<F, G>,
                                             _ fh: Kind<F, H>,
                                             _ f: @escaping (Z, B, C, D, E, G, H) -> A) -> Kind<F, A> {
-        return F.parMap(fa, fb, fc, fd, fe, fg, fh, f)
+        F.parMap(fa, fb, fc, fd, fe, fg, fh, f)
     }
     
     /// Runs 8 computations in parallel and combines their results using the provided function.
@@ -601,7 +621,7 @@ public extension Kind where F: Concurrent {
                                                _ fh: Kind<F, H>,
                                                _ fi: Kind<F, I>,
                                                _ f: @escaping (Z, B, C, D, E, G, H, I) -> A) -> Kind<F, A> {
-        return F.parMap(fa, fb, fc, fd, fe, fg, fh, fi, f)
+        F.parMap(fa, fb, fc, fd, fe, fg, fh, fi, f)
     }
     
     /// Runs 9 computations in parallel and combines their results using the provided function.
@@ -628,108 +648,6 @@ public extension Kind where F: Concurrent {
                                                   _ fi: Kind<F, I>,
                                                   _ fj: Kind<F, J>,
                                                   _ f: @escaping (Z, B, C, D, E, G, H, I, J) -> A) -> Kind<F, A> {
-        return F.parMap(fa, fb, fc, fd, fe, fg, fh, fi, fj, f)
-    }
-}
-
-// MARK: Extensions for Traverse where inner effect is Concurrent
-
-public extension Traverse {
-    /// Maps each element of a structure to an effect, evaluates in parallel and collects the results.
-    ///
-    /// - Parameters:
-    ///   - fa: A structure of values.
-    ///   - f: A function producing an effect.
-    /// - Returns: Results collected under the context of the effect provided by the function.
-    static func parTraverse<G: Concurrent, A, B>(_ fa: Kind<Self, A>, _ f: @escaping (A) -> Kind<G, B>) -> Kind<G, Kind<Self, B>> {
-        let ff = f >>> ParApplicative.init
-        return fa.traverse(ff)^.fa
-    }
-    
-    /// Evaluate each effect in a structure of values in parallel and collects the results.
-    ///
-    /// - Parameter fga: A structure of values.
-    /// - Returns: Results collected under the context of the effects.
-    static func parSequence<G: Concurrent, A>(_ fa: Kind<Self, Kind<G, A>>) -> Kind<G, Kind<Self, A>> {
-        parTraverse(fa, id)
-    }
-}
-
-// MARK: Extensions for Traverse and Monad where inner effect is Concurrent
-
-public extension Traverse where Self: Monad {
-    /// A parallel traverse followed by flattening the inner result.
-    ///
-    /// - Parameters:
-    ///   - fa: A structure of values.
-    ///   - f: A transforming function yielding nested effects.
-    /// - Returns: Results collected and flattened under the context of the effects.
-    static func parFlatTraverse<G: Concurrent, A, B>(_ fa: Kind<Self, A>, _ f: @escaping (A) -> Kind<G, Kind<Self, B>>) -> Kind<G, Kind<Self, B>> {
-        G.map(parTraverse(fa, f), Self.flatten)
-    }
-}
-
-// MARK: Syntax for Kind where F is Traverse and inner effect is Concurrent
-
-public extension Kind where F: Traverse {
-    /// Maps each element of this structure to an effect, evaluates them in parallel and collects the results.
-    ///
-    /// - Parameters:
-    ///   - f: A function producing an effect.
-    /// - Returns: Results collected under the context of the effect provided by the function.
-    func parTraverse<G: Concurrent, B>(_ f: @escaping (A) -> Kind<G, B>) -> Kind<G, Kind<F, B>> {
-        F.parTraverse(self, f)
-    }
-    
-    /// Evaluate each effect in this structure of values in parallel and collects the results.
-    ///
-    /// - Returns: Results collected under the context of the effects.
-    func parSequence<G: Concurrent, AA>() -> Kind<G, Kind<F, AA>> where A == Kind<G, AA> {
-        F.parSequence(self)
-    }
-}
-
-// MARK: Syntax for Kind where F is Traverse and Monad and inner effect is Concurrent
-
-public extension Kind where F: Traverse & Monad {
-    /// A parallel traverse followed by flattening the inner result.
-    ///
-    /// - Parameters:
-    ///   - f: A transforming function yielding nested effects.
-    /// - Returns: Results collected and flattened under the context of the effects.
-    func parFlatTraverse<G: Concurrent, B>(_ f: @escaping (A) -> Kind<G, Kind<F, B>>) -> Kind<G, Kind<F, B>> {
-        return F.parFlatTraverse(self, f)
-    }
-}
-
-fileprivate final class ForParApplicative {}
-fileprivate final class ParApplicativePartial<F: Concurrent>: Kind<ForParApplicative, F> {}
-fileprivate typealias ParApplicativeOf<F: Concurrent, A> = Kind<ParApplicativePartial<F>, A>
-
-fileprivate final class ParApplicative<F: Concurrent, A>: ParApplicativeOf<F, A> {
-    let fa: Kind<F, A>
-    
-    init(_ fa: Kind<F, A>) {
-        self.fa = fa
-    }
-}
-
-fileprivate postfix func ^<F, A>(_ value: ParApplicativeOf<F, A>) -> ParApplicative<F, A> {
-    value as! ParApplicative<F, A>
-}
-
-extension ParApplicativePartial: Functor {
-    static func map<A, B>(_ fa: Kind<ParApplicativePartial<F>, A>, _ f: @escaping (A) -> B) -> Kind<ParApplicativePartial<F>, B> {
-        ParApplicative(fa^.fa.map(f))
-    }
-}
-
-extension ParApplicativePartial: Applicative {
-    static func pure<A>(_ a: A) -> Kind<ParApplicativePartial<F>, A> {
-        ParApplicative(F.pure(a))
-    }
-    
-    static func ap<A, B>(_ ff: Kind<ParApplicativePartial<F>, (A) -> B>, _ fa: Kind<ParApplicativePartial<F>, A>) -> Kind<ParApplicativePartial<F>, B> {
-        ParApplicative(F.parMap(ff^.fa, fa^.fa) { f, a in f(a) })
+        F.parMap(fa, fb, fc, fd, fe, fg, fh, fi, fj, f)
     }
 }

--- a/Sources/BowEffects/Typeclasses/ConcurrentTraverse.swift
+++ b/Sources/BowEffects/Typeclasses/ConcurrentTraverse.swift
@@ -1,0 +1,103 @@
+import Bow
+
+// MARK: Extensions for Traverse where inner effect is Concurrent
+
+public extension Traverse {
+    /// Maps each element of a structure to an effect, evaluates in parallel and collects the results.
+    ///
+    /// - Parameters:
+    ///   - fa: A structure of values.
+    ///   - f: A function producing an effect.
+    /// - Returns: Results collected under the context of the effect provided by the function.
+    static func parTraverse<G: Concurrent, A, B>(_ fa: Kind<Self, A>, _ f: @escaping (A) -> Kind<G, B>) -> Kind<G, Kind<Self, B>> {
+        let ff = f >>> ParApplicative.init
+        return fa.traverse(ff)^.fa
+    }
+    
+    /// Evaluate each effect in a structure of values in parallel and collects the results.
+    ///
+    /// - Parameter fga: A structure of values.
+    /// - Returns: Results collected under the context of the effects.
+    static func parSequence<G: Concurrent, A>(_ fa: Kind<Self, Kind<G, A>>) -> Kind<G, Kind<Self, A>> {
+        parTraverse(fa, id)
+    }
+}
+
+// MARK: Extensions for Traverse and Monad where inner effect is Concurrent
+
+public extension Traverse where Self: Monad {
+    /// A parallel traverse followed by flattening the inner result.
+    ///
+    /// - Parameters:
+    ///   - fa: A structure of values.
+    ///   - f: A transforming function yielding nested effects.
+    /// - Returns: Results collected and flattened under the context of the effects.
+    static func parFlatTraverse<G: Concurrent, A, B>(_ fa: Kind<Self, A>, _ f: @escaping (A) -> Kind<G, Kind<Self, B>>) -> Kind<G, Kind<Self, B>> {
+        G.map(parTraverse(fa, f), Self.flatten)
+    }
+}
+
+// MARK: Syntax for Kind where F is Traverse and inner effect is Concurrent
+
+public extension Kind where F: Traverse {
+    /// Maps each element of this structure to an effect, evaluates them in parallel and collects the results.
+    ///
+    /// - Parameters:
+    ///   - f: A function producing an effect.
+    /// - Returns: Results collected under the context of the effect provided by the function.
+    func parTraverse<G: Concurrent, B>(_ f: @escaping (A) -> Kind<G, B>) -> Kind<G, Kind<F, B>> {
+        F.parTraverse(self, f)
+    }
+    
+    /// Evaluate each effect in this structure of values in parallel and collects the results.
+    ///
+    /// - Returns: Results collected under the context of the effects.
+    func parSequence<G: Concurrent, AA>() -> Kind<G, Kind<F, AA>> where A == Kind<G, AA> {
+        F.parSequence(self)
+    }
+}
+
+// MARK: Syntax for Kind where F is Traverse and Monad and inner effect is Concurrent
+
+public extension Kind where F: Traverse & Monad {
+    /// A parallel traverse followed by flattening the inner result.
+    ///
+    /// - Parameters:
+    ///   - f: A transforming function yielding nested effects.
+    /// - Returns: Results collected and flattened under the context of the effects.
+    func parFlatTraverse<G: Concurrent, B>(_ f: @escaping (A) -> Kind<G, Kind<F, B>>) -> Kind<G, Kind<F, B>> {
+        return F.parFlatTraverse(self, f)
+    }
+}
+
+fileprivate final class ForParApplicative {}
+fileprivate final class ParApplicativePartial<F: Concurrent>: Kind<ForParApplicative, F> {}
+fileprivate typealias ParApplicativeOf<F: Concurrent, A> = Kind<ParApplicativePartial<F>, A>
+
+fileprivate final class ParApplicative<F: Concurrent, A>: ParApplicativeOf<F, A> {
+    let fa: Kind<F, A>
+    
+    init(_ fa: Kind<F, A>) {
+        self.fa = fa
+    }
+}
+
+fileprivate postfix func ^<F, A>(_ value: ParApplicativeOf<F, A>) -> ParApplicative<F, A> {
+    value as! ParApplicative<F, A>
+}
+
+extension ParApplicativePartial: Functor {
+    static func map<A, B>(_ fa: Kind<ParApplicativePartial<F>, A>, _ f: @escaping (A) -> B) -> Kind<ParApplicativePartial<F>, B> {
+        ParApplicative(fa^.fa.map(f))
+    }
+}
+
+extension ParApplicativePartial: Applicative {
+    static func pure<A>(_ a: A) -> Kind<ParApplicativePartial<F>, A> {
+        ParApplicative(F.pure(a))
+    }
+    
+    static func ap<A, B>(_ ff: Kind<ParApplicativePartial<F>, (A) -> B>, _ fa: Kind<ParApplicativePartial<F>, A>) -> Kind<ParApplicativePartial<F>, B> {
+        ParApplicative(F.parMap(ff^.fa, fa^.fa) { f, a in f(a) })
+    }
+}

--- a/Sources/BowRx/MaybeK.swift
+++ b/Sources/BowRx/MaybeK.swift
@@ -199,6 +199,12 @@ extension ForMaybeK: Effect {
 
 // MARK: Instance of `Concurrent` for `MaybeK`
 extension ForMaybeK: Concurrent {
+    public static func race<A, B>(_ fa: Kind<ForMaybeK, A>, _ fb: Kind<ForMaybeK, B>) -> Kind<ForMaybeK, Either<A, B>> {
+        let left = fa.map(Either<A, B>.left)^.value.asObservable()
+        let right = fb.map(Either<A, B>.right)^.value.asObservable()
+        return left.amb(right).asMaybe().k()
+    }
+    
     public static func parMap<A, B, Z>(_ fa: Kind<ForMaybeK, A>, _ fb: Kind<ForMaybeK, B>, _ f: @escaping (A, B) -> Z) -> Kind<ForMaybeK, Z> {
         return Maybe.zip(fa^.value, fb^.value, resultSelector: f).k()
     }

--- a/Sources/BowRx/ObservableK.swift
+++ b/Sources/BowRx/ObservableK.swift
@@ -232,6 +232,12 @@ extension ForObservableK: Effect {
 
 // MARK: Instance of `Concurrent` for `ObservableK`
 extension ForObservableK: Concurrent {
+    public static func race<A, B>(_ fa: Kind<ForObservableK, A>, _ fb: Kind<ForObservableK, B>) -> Kind<ForObservableK, Either<A, B>> {
+        let left = fa.map(Either<A, B>.left)^.value
+        let right = fb.map(Either<A, B>.right)^.value
+        return left.amb(right).k()
+    }
+    
     public static func parMap<A, B, Z>(_ fa: Kind<ForObservableK, A>, _ fb: Kind<ForObservableK, B>, _ f: @escaping (A, B) -> Z) -> Kind<ForObservableK, Z> {
         return Observable.zip(fa^.value, fb^.value, resultSelector: f).k()
     }

--- a/Tests/BowEffectsTests/EnvIOTest.swift
+++ b/Tests/BowEffectsTests/EnvIOTest.swift
@@ -1,0 +1,17 @@
+import XCTest
+import SwiftCheck
+@testable import BowLaws
+import Bow
+import BowEffects
+import BowEffectsGenerators
+import BowEffectsLaws
+
+class EnvIOTest: XCTestCase {
+    func testMonadDeferLaws() {
+        MonadDeferLaws<EnvIOPartial<Int, CategoryError>>.check()
+    }
+    
+    func testAsyncLaws() {
+        AsyncLaws<EnvIOPartial<Int, CategoryError>>.check()
+    }
+}


### PR DESCRIPTION
## Related issues

`EnvIO` was scattered through the `IO` file and starting to grow too big. Also, some instances can be provided for `Kleisli` when `F` has instances for some effect type classes.

## Goal

- Extract `EnvIO` to its own file.
- Provide type class instances for `Kleisli` when `F` has instances for `MonadDefer`, `Async` and `Concurrent`.
- Test laws for the given instances.