### PR TITLE
Scheduling policies to retry and repeat effectful computations

### DIFF
--- a/Bow.xcodeproj/project.pbxproj
+++ b/Bow.xcodeproj/project.pbxproj
@@ -143,6 +143,7 @@
 		1186E15122BA395D001F8A5D /* Index+Optics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1186E14E22BA38CD001F8A5D /* Index+Optics.swift */; };
 		1186E15722BA8A77001F8A5D /* Cons.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1186E15622BA8A77001F8A5D /* Cons.swift */; };
 		1186E15922BA8ECA001F8A5D /* Snoc.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1186E15822BA8ECA001F8A5D /* Snoc.swift */; };
+		11912B0B238C2068007D90A2 /* DispatchTimeInterval+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11912B09238C1FB4007D90A2 /* DispatchTimeInterval+Extensions.swift */; };
 		1191BD0A22D77C510052FEA8 /* BoundVar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1191BD0922D77C510052FEA8 /* BoundVar.swift */; };
 		1191BD0C22D77FED0052FEA8 /* BindingExpression.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1191BD0B22D77FED0052FEA8 /* BindingExpression.swift */; };
 		1191BD0E22D784630052FEA8 /* MonadComprenhensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1191BD0D22D784630052FEA8 /* MonadComprenhensions.swift */; };
@@ -221,6 +222,10 @@
 		11F41C9D231816F000BD1E87 /* DispatchQueue+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11F41C93231816AD00BD1E87 /* DispatchQueue+Extensions.swift */; };
 		11F41CA2231818DB00BD1E87 /* BracketLaws.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11F41C9E231818AE00BD1E87 /* BracketLaws.swift */; };
 		11F41CA3231818DB00BD1E87 /* MonadDeferLaws.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11F41C9F231818AF00BD1E87 /* MonadDeferLaws.swift */; };
+		11FB4612238EB78200EA60BF /* EnvIO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11FB4610238EB78200EA60BF /* EnvIO.swift */; };
+		11FB4614238EBF2300EA60BF /* EnvIOTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11FB4613238EBF2300EA60BF /* EnvIOTest.swift */; };
+		11FB4616238ED14F00EA60BF /* ConcurrentTraverse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11FB4615238ED14F00EA60BF /* ConcurrentTraverse.swift */; };
+		11FDD68F23867D9800EA8A4D /* Schedule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11FDD68E23867D9800EA8A4D /* Schedule.swift */; };
 		600D30432352C08F00F7B64B /* Semigroupal.swift in Sources */ = {isa = PBXBuildFile; fileRef = 600D30422352C08F00F7B64B /* Semigroupal.swift */; };
 		606B29EA23607607002334B2 /* Divide.swift in Sources */ = {isa = PBXBuildFile; fileRef = 606B29E923607607002334B2 /* Divide.swift */; };
 		606B29EB2360763C002334B2 /* SemigroupalLaws.swift in Sources */ = {isa = PBXBuildFile; fileRef = 600D30442352D03400F7B64B /* SemigroupalLaws.swift */; };
@@ -799,6 +804,7 @@
 		1186E14E22BA38CD001F8A5D /* Index+Optics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Index+Optics.swift"; sourceTree = "<group>"; };
 		1186E15622BA8A77001F8A5D /* Cons.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Cons.swift; sourceTree = "<group>"; };
 		1186E15822BA8ECA001F8A5D /* Snoc.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Snoc.swift; sourceTree = "<group>"; };
+		11912B09238C1FB4007D90A2 /* DispatchTimeInterval+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DispatchTimeInterval+Extensions.swift"; sourceTree = "<group>"; };
 		1191BD0922D77C510052FEA8 /* BoundVar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoundVar.swift; sourceTree = "<group>"; };
 		1191BD0B22D77FED0052FEA8 /* BindingExpression.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BindingExpression.swift; sourceTree = "<group>"; };
 		1191BD0D22D784630052FEA8 /* MonadComprenhensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MonadComprenhensions.swift; sourceTree = "<group>"; };
@@ -842,6 +848,10 @@
 		11F41C95231816AD00BD1E87 /* Dictionary+Extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Dictionary+Extensions.swift"; sourceTree = "<group>"; };
 		11F41C9E231818AE00BD1E87 /* BracketLaws.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BracketLaws.swift; sourceTree = "<group>"; };
 		11F41C9F231818AF00BD1E87 /* MonadDeferLaws.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MonadDeferLaws.swift; sourceTree = "<group>"; };
+		11FB4610238EB78200EA60BF /* EnvIO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EnvIO.swift; sourceTree = "<group>"; };
+		11FB4613238EBF2300EA60BF /* EnvIOTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EnvIOTest.swift; sourceTree = "<group>"; };
+		11FB4615238ED14F00EA60BF /* ConcurrentTraverse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConcurrentTraverse.swift; sourceTree = "<group>"; };
+		11FDD68E23867D9800EA8A4D /* Schedule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Schedule.swift; sourceTree = "<group>"; };
 		600D30422352C08F00F7B64B /* Semigroupal.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Semigroupal.swift; sourceTree = "<group>"; };
 		600D30442352D03400F7B64B /* SemigroupalLaws.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SemigroupalLaws.swift; sourceTree = "<group>"; };
 		606B29E923607607002334B2 /* Divide.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Divide.swift; sourceTree = "<group>"; };
@@ -1214,9 +1224,11 @@
 			isa = PBXGroup;
 			children = (
 				11F41C94231816AD00BD1E87 /* Atomic.swift */,
+				11FB4610238EB78200EA60BF /* EnvIO.swift */,
 				1104BED422C22DD2002C3F78 /* IO.swift */,
 				11F41C91231816AD00BD1E87 /* Ref.swift */,
 				1104BEE922C25AAF002C3F78 /* Resource.swift */,
+				11FDD68E23867D9800EA8A4D /* Schedule.swift */,
 				11F41C92231816AD00BD1E87 /* Internal */,
 			);
 			path = Data;
@@ -1344,6 +1356,7 @@
 		11229786219DC968006D66C5 /* BowEffectsTests */ = {
 			isa = PBXGroup;
 			children = (
+				11FB4613238EBF2300EA60BF /* EnvIOTest.swift */,
 				8BA0F3A0217E2DEF00969984 /* IOTest.swift */,
 			);
 			path = BowEffectsTests;
@@ -1632,6 +1645,7 @@
 			children = (
 				11F41C95231816AD00BD1E87 /* Dictionary+Extensions.swift */,
 				11F41C93231816AD00BD1E87 /* DispatchQueue+Extensions.swift */,
+				11912B09238C1FB4007D90A2 /* DispatchTimeInterval+Extensions.swift */,
 			);
 			path = Internal;
 			sourceTree = "<group>";
@@ -1799,6 +1813,7 @@
 				1104BEE122C22E47002C3F78 /* Bracket.swift */,
 				1104BEE222C22E47002C3F78 /* Concurrent.swift */,
 				8BA0F46A217E2E9200969984 /* ConcurrentEffect.swift */,
+				11FB4615238ED14F00EA60BF /* ConcurrentTraverse.swift */,
 				8BA0F46B217E2E9200969984 /* Effect.swift */,
 				11F0367E2327D08900B39A80 /* EffectComprehensions.swift */,
 				8BA0F46D217E2E9200969984 /* MonadDefer.swift */,
@@ -2683,13 +2698,17 @@
 				1104BEDC22C22DEC002C3F78 /* IO.swift in Sources */,
 				11F036822327D4AC00B39A80 /* URLSession.swift in Sources */,
 				11229744219DC557006D66C5 /* Async.swift in Sources */,
+				11FB4612238EB78200EA60BF /* EnvIO.swift in Sources */,
 				11F41C9B231816F000BD1E87 /* Atomic.swift in Sources */,
 				11F036842327E1C900B39A80 /* ConsoleIO.swift in Sources */,
+				11FB4616238ED14F00EA60BF /* ConcurrentTraverse.swift in Sources */,
+				11912B0B238C2068007D90A2 /* DispatchTimeInterval+Extensions.swift in Sources */,
 				11F41C9A231816D800BD1E87 /* Ref.swift in Sources */,
 				1104BEE322C22E47002C3F78 /* UnsafeRun.swift in Sources */,
 				11229745219DC557006D66C5 /* ConcurrentEffect.swift in Sources */,
 				1104BEE422C22E47002C3F78 /* Bracket.swift in Sources */,
 				11F41C9D231816F000BD1E87 /* DispatchQueue+Extensions.swift in Sources */,
+				11FDD68F23867D9800EA8A4D /* Schedule.swift in Sources */,
 				11F0367F2327D08900B39A80 /* EffectComprehensions.swift in Sources */,
 				11229746219DC557006D66C5 /* Effect.swift in Sources */,
 				11F41C9C231816F000BD1E87 /* Dictionary+Extensions.swift in Sources */,
@@ -2703,6 +2722,7 @@
 			buildActionMask = 0;
 			files = (
 				11229787219DCA18006D66C5 /* IOTest.swift in Sources */,
+				11FB4614238EBF2300EA60BF /* EnvIOTest.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Bow.xcodeproj/xcshareddata/xcschemes/Bow-Effects.xcscheme
+++ b/Bow.xcodeproj/xcshareddata/xcschemes/Bow-Effects.xcscheme
@@ -26,9 +26,18 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
       codeCoverageEnabled = "YES"
-      onlyGenerateCoverageForSpecifiedTargets = "YES"
-      shouldUseLaunchSchemeArgsEnv = "YES">
+      onlyGenerateCoverageForSpecifiedTargets = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "112296D7219DC4B3006D66C5"
+            BuildableName = "BowEffects.framework"
+            BlueprintName = "Bow-Effects"
+            ReferencedContainer = "container:Bow.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
       <CodeCoverageTargets>
          <BuildableReference
             BuildableIdentifier = "primary"
@@ -50,17 +59,6 @@
             </BuildableReference>
          </TestableReference>
       </Testables>
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "112296D7219DC4B3006D66C5"
-            BuildableName = "BowEffects.framework"
-            BlueprintName = "Bow-Effects"
-            ReferencedContainer = "container:Bow.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -81,8 +79,6 @@
             ReferencedContainer = "container:Bow.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/Sources/Bow/Data/Either.swift
+++ b/Sources/Bow/Data/Either.swift
@@ -183,6 +183,13 @@ public extension Either where B: Equatable {
     }
 }
 
+public extension Either where A == B {
+    /// Returns a value from either side.
+    func merge() -> A {
+        fold(id, id)
+    }
+}
+
 // MARK: Either from Optional
 public extension Optional {
     /// Converts this optional to an `Either.right` value, providing a default value if it is nil.

--- a/Sources/BowEffects/Data/EnvIO.swift
+++ b/Sources/BowEffects/Data/EnvIO.swift
@@ -38,15 +38,35 @@ public extension Kleisli {
         return self.invoke(d)^
     }
     
+    /// Folds over the result of this computation by accepting an effect to execute in case of error, and another one in the case of success.
+    ///
+    /// - Parameters:
+    ///   - f: Function to run in case of error.
+    ///   - g: Function to run in case of success.
+    /// - Returns: A computation from the result of applying the provided functions to the result of this computation.
     func foldM<B, E: Error>(_ f: @escaping (E) -> EnvIO<D, E, B>, _ g: @escaping (A) -> EnvIO<D, E, B>) -> EnvIO<D, E, B> where F == IOPartial<E> {
         self.flatMap(g).handleErrorWith(f)^
     }
     
+    /// Retries this computation if it fails based on the provided retrial policy.
+    ///
+    /// This computation will be at least executed once, and if it fails, it will be retried according to the policy.
+    ///
+    /// - Parameter policy: Retrial policy.
+    /// - Returns: A computation that is retried based on the provided policy when it fails.
     func retry<S, O, E: Error>(_ policy: Schedule<D, E, S, O>) -> EnvIO<D, E, A> where F == IOPartial<E> {
         retry(policy, orElse: { e, _ in EnvIO.raiseError(e)^ })
             .map { x in x.fold(id, id) }^
     }
     
+    /// Retries this computation if it fails based on the provided retrial policy, providing a default computation to handle failures after retrial.
+    ///
+    /// This computation will be at least executed once, and if it fails, it will be retried according to the policy.
+    ///
+    /// - Parameters:
+    ///   - policy: Retrial policy.
+    ///   - orElse: Function to handle errors after retrying.
+    /// - Returns: A computation that is retried based on the provided policy when it fails.
     func retry<S, O, B, E: Error>(_ policy: Schedule<D, E, S, O>, orElse: @escaping (E, O) -> EnvIO<D, E, B>) -> EnvIO<D, E, Either<B, A>> where F == IOPartial<E> {
         func loop(_ state: S) -> EnvIO<D, E, Either<B, A>> {
             self.foldM(
@@ -65,12 +85,27 @@ public extension Kleisli {
             .flatMap(loop)^
     }
     
+    /// Repeats this computation until the provided repeating policy completes, or until it fails.
+    ///
+    /// This computation will be at least executed once, and if it succeeds, it will be repeated additional times according to the policy.
+    ///
+    /// - Parameters:
+    ///   - policy: Repeating policy.
+    ///   - onUpdateError: A function providing an error in case the policy fails to update properly.
+    /// - Returns: A computation that is repeated based on the provided policy when it succeeds.
     func `repeat`<S, O, E: Error>(_ policy: Schedule<D, A, S, O>, onUpdateError: @escaping () -> E) -> EnvIO<D, E, O> where F == IOPartial<E> {
         self.repeat(policy, onUpdateError: onUpdateError) { e, _ in
             EnvIO<D, E, O>.raiseError(e)^
         }.map { x in x.fold(id, id) }^
     }
     
+    /// Repeats this computation until the provided repeating policy completes, or until it fails, with a function to handle potential failures.
+    ///
+    /// - Parameters:
+    ///   - policy: Repeating policy.
+    ///   - onUpdateError: A function providing an error in case the policy fails to update properly.
+    ///   - orElse: A function to return a computation in case of error.
+    /// - Returns: A computation that is repeated based on the provided policy when it succeeds.
     func `repeat`<S, O, B, E: Error>(_ policy: Schedule<D, A, S, O>, onUpdateError: @escaping () -> E, orElse: @escaping (E, O?) -> EnvIO<D, E, B>) -> EnvIO<D, E, Either<B, O>> where F == IOPartial<E> {
         func loop(_ last: A, _ state: S) -> EnvIO<D, E, Either<B, O>> {
             policy.update(last, state)
@@ -121,10 +156,18 @@ public extension Kleisli where D == Any {
 }
 
 public extension Kleisli where A == Void {
+    /// Sleep for the specified amount of time.
+    ///
+    /// - Parameter interval: Time to sleep.
+    /// - Returns: A computation that sleeps for the specified amount of time.
     static func sleep<E: Error>(_ interval: DispatchTimeInterval) -> EnvIO<D, E, Void> where F == IOPartial<E> {
         EnvIO { _ in IO.sleep(interval) }
     }
     
+    /// Sleep for the specified amount of time.
+    ///
+    /// - Parameter interval: Time to sleep.
+    /// - Returns: A computation that sleeps for the specified amount of time.
     static func sleep<E: Error>(_ interval: TimeInterval) -> EnvIO<D, E, Void> where F == IOPartial<E> {
         EnvIO { _ in IO.sleep(interval) }
     }

--- a/Sources/BowEffects/Data/EnvIO.swift
+++ b/Sources/BowEffects/Data/EnvIO.swift
@@ -56,7 +56,7 @@ public extension Kleisli {
     /// - Returns: A computation that is retried based on the provided policy when it fails.
     func retry<S, O, E: Error>(_ policy: Schedule<D, E, S, O>) -> EnvIO<D, E, A> where F == IOPartial<E> {
         retry(policy, orElse: { e, _ in EnvIO.raiseError(e)^ })
-            .map { x in x.fold(id, id) }^
+            .map { x in x.merge() }^
     }
     
     /// Retries this computation if it fails based on the provided retrial policy, providing a default computation to handle failures after retrial.
@@ -96,7 +96,7 @@ public extension Kleisli {
     func `repeat`<S, O, E: Error>(_ policy: Schedule<D, A, S, O>, onUpdateError: @escaping () -> E) -> EnvIO<D, E, O> where F == IOPartial<E> {
         self.repeat(policy, onUpdateError: onUpdateError) { e, _ in
             EnvIO<D, E, O>.raiseError(e)^
-        }.map { x in x.fold(id, id) }^
+        }.map { x in x.merge() }^
     }
     
     /// Repeats this computation until the provided repeating policy completes, or until it fails, with a function to handle potential failures.

--- a/Sources/BowEffects/Data/IO.swift
+++ b/Sources/BowEffects/Data/IO.swift
@@ -371,52 +371,19 @@ public class IO<E: Error, A>: IOOf<E, A> {
     }
     
     public func retry<S, O>(_ policy: Schedule<Any, E, S, O>) -> IO<E, A> {
-        retry(policy, orElse: { e, _ in IO.raiseError(e)^ })
-            .map { x in x.fold(id, id) }^
+        self.env.retry(policy).provide(())
     }
     
     public func retry<S, O, B>(_ policy: Schedule<Any, E, S, O>, orElse: @escaping (E, O) -> IO<E, B>) -> IO<E, Either<B, A>> {
-        func loop(_ state: S) -> IO<E, Either<B, A>> {
-            self.foldM(
-                { err in
-                    policy.update(err, state).provide(())
-                        .mapLeft { _ in err }
-                        .foldM({ _ in orElse(err, policy.extract(err, state)).map(Either<B, A>.left)^ },
-                               loop)
-                    
-                },
-                { a in IO<E, Either<B, A>>.pure(.right(a))^ })
-        }
-        
-        return policy.initial.provide(())
-            .mapLeft { x in x as! E }
-            .flatMap(loop)^
+        self.env.retry(policy, orElse: { e, o in orElse(e, o).env }).provide(())
     }
     
     public func `repeat`<S, O>(_ policy: Schedule<Any, A, S, O>, onUpdateError: @escaping () -> E) -> IO<E, O> {
-        self.repeat(policy, onUpdateError: onUpdateError) { e, _ in
-            IO<E, O>.raiseError(e)^
-        }.map { x in x.fold(id, id) }^
+        self.env.repeat(policy, onUpdateError: onUpdateError).provide(())
     }
     
     public func `repeat`<S, O, B>(_ policy: Schedule<Any, A, S, O>, onUpdateError: @escaping () -> E, orElse: @escaping (E, O?) -> IO<E, B>) -> IO<E, Either<B, O>> {
-        func loop(_ last: A, _ state: S) -> IO<E, Either<B, O>> {
-            policy.update(last, state).provide(())
-                .mapLeft { _ in onUpdateError() }
-                .foldM(
-                    { _ in IO<E, Either<B, O>>.pure(.right(policy.extract(last, state)))^ },
-                    { s in
-                        self.foldM(
-                            { e in orElse(e, policy.extract(last, state)).map(Either.left)^ },
-                            { a in loop(a, s) })
-                })
-        }
-        
-        return self.foldM(
-            { e in orElse(e, nil).map(Either.left)^ },
-            { a in policy.initial.provide(())
-                .mapLeft { x in x as! E }
-                .flatMap { s in loop(a, s) }^ })
+        self.env.repeat(policy, onUpdateError: onUpdateError, orElse: { e, o in orElse(e, o).env }).provide(())
     }
 }
 

--- a/Sources/BowEffects/Data/Internal/DispatchTimeInterval+Extensions.swift
+++ b/Sources/BowEffects/Data/Internal/DispatchTimeInterval+Extensions.swift
@@ -1,0 +1,25 @@
+import Foundation
+
+extension DispatchTimeInterval {
+    func toDouble() -> Double? {
+        switch self {
+        case .seconds(let value): return Double(value)
+        case .milliseconds(let value): return Double(value) * 0.001
+        case .microseconds(let value): return Double(value) * 0.000001
+        case .nanoseconds(let value): return Double(value) * 0.000000001
+        case .never: return nil
+        @unknown default: return nil
+        }
+    }
+}
+
+func >=(lhs: DispatchTimeInterval, rhs: DispatchTimeInterval) -> Bool {
+    let now = DispatchTime.now()
+    return now + lhs >= now + rhs
+}
+
+func -(lhs: DispatchTime, rhs: DispatchTime) -> DispatchTimeInterval {
+    let l = Int(lhs.rawValue)
+    let r = Int(rhs.rawValue)
+    return .nanoseconds(Int(l - r))
+}

--- a/Sources/BowEffects/Data/Internal/DispatchTimeInterval+Extensions.swift
+++ b/Sources/BowEffects/Data/Internal/DispatchTimeInterval+Extensions.swift
@@ -5,8 +5,8 @@ extension DispatchTimeInterval {
         switch self {
         case .seconds(let value): return Double(value)
         case .milliseconds(let value): return Double(value) * 0.001
-        case .microseconds(let value): return Double(value) * 0.000001
-        case .nanoseconds(let value): return Double(value) * 0.000000001
+        case .microseconds(let value): return Double(value) * 0.000_001
+        case .nanoseconds(let value): return Double(value) * 0.000_000_001
         case .never: return nil
         @unknown default: return nil
         }

--- a/Sources/BowEffects/Data/Schedule.swift
+++ b/Sources/BowEffects/Data/Schedule.swift
@@ -70,7 +70,7 @@ public class Schedule<R, A, State, B> {
     ///
     /// - Parameter that: Schedule to be composed with this one.
     public func choose<State2, C>(_ that: Schedule<R, C, State2, B>) -> Schedule<R, Either<A, C>, (State, State2), B> {
-        self.choose(that).map { b in b.fold(id, id) }
+        self.choose(that).map { b in b.merge() }
     }
     
     /// Composes this schedule with another one, providing a new schedule that continues as long as both continue, using the maximum delay of the two schedules.
@@ -179,7 +179,7 @@ public class Schedule<R, A, State, B> {
     ///
     /// - Parameter that: Schedule to be composed with this one.
     public func andThen<State2>(_ that: Schedule<R, A, State2, B>) -> Schedule<R, A, Either<State, State2>, B> {
-        andThenEither(that).map { x in x.fold(id, id) }
+        andThenEither(that).map { x in x.merge() }
     }
     
     /// Composes two schedules with the same input but different outputs by applying them sequentially. It executes the first to completion, and then executes the second.

--- a/Sources/BowEffects/Data/Schedule.swift
+++ b/Sources/BowEffects/Data/Schedule.swift
@@ -1,13 +1,22 @@
 import Foundation
 import Bow
 
+/// A single error. This is a workaround over not being able to make `Void` conform to `Error`.
 public enum Unit: Error {
     case unit
 }
 
+/// A stateful, effectful and recurring schedule of actions.
+///
+/// A schedule consumes values of type `A` and based on its internal state of type `State`, decides to continue or stop. Every decision has a delay and an output of type `B`.
 public class Schedule<R, A, State, B> {
+    /// Initial state for this schedule.
     let initial: EnvIO<R, Never, State>
+    
+    /// Extract the output if this schedule based on an input and its internal state.
     let extract: (A, State) -> B
+    
+    /// Update the state of this schedule based on an input and its internal state.
     let update: (A, State) -> EnvIO<R, Unit, State>
     
     init(initial: EnvIO<R, Never, State>,
@@ -18,6 +27,9 @@ public class Schedule<R, A, State, B> {
         self.update = update
     }
     
+    /// Composes this schedule with another one, providing a new schedule that continues as long as both continue, using the maximum delay of the two schedules.
+    ///
+    /// - Parameter that: Schedule to be composed with this one.
     public func and<State2, C>(_ that: Schedule<R, A, State2, C>) -> Schedule<R, A, (State, State2), (B, C)> {
         Schedule<R, A, (State, State2), (B, C)>(
             initial: EnvIO<R, Never, (State, State2)>.parZip(self.initial, that.initial)^,
@@ -26,6 +38,9 @@ public class Schedule<R, A, State, B> {
         )
     }
     
+    /// Composes this schedule with another one, providing a new schedule that needs the input of both schedules and provides the output of both. It continues as long as both continue, using the maximum delay of the two schedules.
+    ///
+    /// - Parameter that: Schedule to be composed with this one.
     public func split<State2, C, D>(_ that: Schedule<R, C, State2, D>) -> Schedule<R, (A, C), (State, State2), (B, D)> {
         Schedule<R, (A, C), (State, State2), (B, D)>(
             initial: self.initial.zip(that.initial),
@@ -34,6 +49,9 @@ public class Schedule<R, A, State, B> {
         )
     }
     
+    /// Chooses between two schedules with different inputs and outputs.
+    ///
+    /// - Parameter that: Schedule to be composed with this one.
     public func choose<State2, C, D>(_ that: Schedule<R, C, State2, D>) -> Schedule<R, Either<A, C>, (State, State2), Either<B, D>> {
         Schedule<R, Either<A, C>, (State, State2), Either<B, D>>(
             initial: self.initial.zip(that.initial),
@@ -48,22 +66,37 @@ public class Schedule<R, A, State, B> {
         )
     }
     
+    /// Chooses between two schedules with different inputs and the same output.
+    ///
+    /// - Parameter that: Schedule to be composed with this one.
     public func choose<State2, C>(_ that: Schedule<R, C, State2, B>) -> Schedule<R, Either<A, C>, (State, State2), B> {
         self.choose(that).map { b in b.fold(id, id) }
     }
     
+    /// Composes this schedule with another one, providing a new schedule that continues as long as both continue, using the maximum delay of the two schedules.
+    ///
+    /// - Parameter that: Schedule to be composed with this one.
     public func zip<State2, C>(_ that: Schedule<R, A, State2, C>) -> Schedule<R, A, (State, State2), (B, C)> {
         self.and(that)
     }
     
+    /// Composes this schedule with another one, providing a new schedule that continues as long as both continue, using the maximum delay of the two schedules, and ignoring the output of this schedule.
+    ///
+    /// - Parameter that: Schedule to be composed with this one.
     public func zipRight<State2, C>(_ that: Schedule<R, A, State2, C>) -> Schedule<R, A, (State, State2), C> {
         self.and(that).map { x in x.1 }
     }
     
+    /// Composes this schedule with another one, providing a new schedule that continues as long as both continue, using the maximum delay of the two schedules, and ignoring the output of the provided schedule.
+    ///
+    /// - Parameter that: Schedule to be composed with this one.
     public func zipLeft<State2, C>(_ that: Schedule<R, A, State2, C>) -> Schedule<R, A, (State, State2), B> {
         self.and(that).map { x in x.0 }
     }
     
+    /// Pipes the output of this schedule as the input of the provided one. Effects described by this schedule will always be performed before the effects described by the second schedule.
+    ///
+    /// - Parameter that: Schedule to be piped after this one.
     public func pipe<State2, C>(_ that: Schedule<R, B, State2, C>) -> Schedule<R, A, (State, State2), C> {
         Schedule<R, A, (State, State2), C>(
             initial: self.initial.zip(that.initial),
@@ -80,10 +113,16 @@ public class Schedule<R, A, State, B> {
         )
     }
     
+    /// Pipes the output of the provided schedule as the input of this schedule. Effects described by the provided schedule will always be performed before the effects described by this schedule.
+    ///
+    /// - Parameter that: Schedule to be piped before this one.
     public func reversePipe<State2, C>(_ that: Schedule<R, C, State2, A>) -> Schedule<R, C, (State2, State), B> {
         that.pipe(self)
     }
     
+    /// Composes with a schedule resulting in another one that continues as long as either schedule continues, using the minimum of the delays of the two schedules.
+    ///
+    /// - Parameter that: Schedule to be composed with this one.
     public func or<State2, C>(_ that: Schedule<R, A, State2, C>) -> Schedule<R, A, (State, State2), (B, C)> {
         Schedule<R, A, (State, State2), (B, C)>(
             initial: self.initial.zip(that.initial),
@@ -98,18 +137,30 @@ public class Schedule<R, A, State, B> {
             })
     }
     
+    /// Adds a delay of the specified duration based on the output of this schedule.
+    ///
+    /// - Parameter f: Function computing the delay time based on the output of the schedule.
     public func addDelay(_ f: @escaping (B) -> DispatchTimeInterval) -> Schedule<R, A, State, B> {
         addDelayM { b in EnvIO<R, Never, DispatchTimeInterval>.pure(f(b))^ }
     }
     
+    /// Adds a delay of the specified duration based on the output of this schedule.
+    ///
+    /// - Parameter f: An effectful function that provides the delay time based on the output of the schedule.
     public func addDelayM(_ f: @escaping (B) -> EnvIO<R, Never, DispatchTimeInterval>) -> Schedule<R, A, State, B> {
         addDelayM { b in f(b).map { x in x.toDouble() ?? 0 }^ }
     }
     
+    /// Adds a delay of the specified duration based on the output of this schedule.
+    ///
+    /// - Parameter f: Function computing the delay time based on the output of the schedule.
     public func addDelay(_ f: @escaping (B) -> TimeInterval) -> Schedule<R, A, State, B> {
         addDelayM { b in EnvIO<R, Never, TimeInterval>.pure(f(b))^ }
     }
     
+    /// Adds a delay of the specified duration based on the output of this schedule.
+    ///
+    /// - Parameter f: An effectful function that provides the delay time based on the output of the schedule.
     public func addDelayM(_ f: @escaping (B) -> EnvIO<R, Never, TimeInterval>) -> Schedule<R, A, State, B> {
         updated { upd in
             { a, s in
@@ -124,10 +175,16 @@ public class Schedule<R, A, State, B> {
         }
     }
     
+    /// Composes two schedules with the same input and output by applying them sequentially. It executes the first to completion, and then executes the second.
+    ///
+    /// - Parameter that: Schedule to be composed with this one.
     public func andThen<State2>(_ that: Schedule<R, A, State2, B>) -> Schedule<R, A, Either<State, State2>, B> {
         andThenEither(that).map { x in x.fold(id, id) }
     }
     
+    /// Composes two schedules with the same input but different outputs by applying them sequentially. It executes the first to completion, and then executes the second.
+    ///
+    /// - Parameter that: Schedule to be composed with this one.
     public func andThenEither<State2, C>(_ that: Schedule<R, A, State2, C>) -> Schedule<R, A, Either<State, State2>, Either<B, C>> {
         Schedule<R, A, Either<State, State2>, Either<B, C>>(
             initial: self.initial.map(Either.left)^,
@@ -146,18 +203,32 @@ public class Schedule<R, A, State, B> {
             })
     }
     
+    /// Transforms the output of this schedule to a fixed value.
+    ///
+    /// - Parameter c: Fixed value to return as output of this schedule.
     public func `as`<C>(_ c: C) -> Schedule<R, A, State, C> {
         map { _ in c }
     }
     
+    /// Composes this schedule with another one, providing a new schedule that continues as long as both continue, using the maximum delay of the two schedules.
+    ///
+    /// - Parameter that: Schedule to be composed with this one.
     public func both<State2, C>(_ that: Schedule<R, A, State2, C>) -> Schedule<R, A, (State, State2), (B, C)> {
         self.and(that)
     }
     
+    /// Composes this schedule with another one, providing a new schedule that continues as long as both continue, using the maximum delay of the two schedules, and combining the outputs of both using the provided function.
+    ///
+    /// - Parameters:
+    ///     - that: Schedule to be composed with this one.
+    ///     - f: Transforming function.
     public func bothWith<State2, C, D>(_ that: Schedule<R, A, State2, C>, _ f: @escaping (B, C) -> D) -> Schedule<R, A, (State, State2), D> {
         self.and(that).map(f)
     }
     
+    /// Peeks at the output produced by this schedule and executes a test to determine if the schedule should continue or not.
+    ///
+    /// - Parameter test: Effectful predicate to determine if the schedule should continue or not based on the current input and output.
     public func check(_ test: @escaping (A, B) -> EnvIO<R, Never, Bool>) -> Schedule<R, A, State, B> {
         updated { upd in
             { a, s in
@@ -170,14 +241,21 @@ public class Schedule<R, A, State, B> {
         }
     }
     
+    /// Collects all the output of this schedule in an array.
     public func collectAll() -> Schedule<R, A, (State, [B]), [B]> {
-        fold([]) { xs, x in [x] + xs }.map { x in Array(x.reversed()) }
+        fold([]) { xs, x in xs + [x] }
     }
     
+    /// Pipes the output of the provided schedule as the input of this schedule. Effects described by the provided schedule will always be performed before the effects described by this schedule.
+    ///
+    /// - Parameter that: Schedule to be piped before this one.
     public func compose<State2, C>(_ that: Schedule<R, C, State2, A>) -> Schedule<R, C, (State2, State), B> {
         self.reversePipe(that)
     }
     
+    /// Provides an schedule that deals with a narrower class of inputs than this schedule.
+    ///
+    /// - Parameter f: Function transforming the input of this schedule.
     public func contramap<AA>(_ f: @escaping (AA) -> A) -> Schedule<R, AA, State, B> {
         Schedule<R, AA, State, B>(
             initial: self.initial,
@@ -185,22 +263,41 @@ public class Schedule<R, A, State, B> {
             update: { a, s in self.update(f(a), s) })
     }
     
+    /// Provides an schedule that contramaps the input and maps the output with the provided functions.
+    ///
+    /// - Parameters:
+    ///   - f: Function to contramap.
+    ///   - g: Function to map.
     public func dimap<AA, C>(_ f: @escaping (AA) -> A, _ g: @escaping (B) -> C) -> Schedule<R, AA, State, C> {
         contramap(f).map(g)
     }
     
+    /// Composes with a schedule resulting in another one that continues as long as either schedule continues, using the minimum of the delays of the two schedules.
+    ///
+    /// - Parameter that: Schedule to be composed with this one.
     public func either<State2, C>(_ that: Schedule<R, A, State2, C>) -> Schedule<R, A, (State, State2), (B, C)> {
         self.or(that)
     }
     
+    /// Composes with a schedule resulting in another one that continues as long as either schedule continues, using the minimum of the delays of the two schedules, and transforming the outputs with the provided function.
+    ///
+    /// - Parameters:
+    ///     - that: Schedule to be composed with this one.
+    ///     - f: Transforming function.
     public func eitherWith<State2, C, D>(_ that: Schedule<R, A, State2, C>, _ f: @escaping (B, C) -> D) -> Schedule<R, A, (State, State2), D> {
         self.or(that).map(f)
     }
     
-    func first<C>() -> Schedule<R, (A, C), (State, Unit), (B, C)> {
+    /// Puts this schedule into the first element of a tuple and passes an unmodified element as the second element of the tuple.
+    public func first<C>() -> Schedule<R, (A, C), (State, Unit), (B, C)> {
         self.split(Schedule<R, C, Unit, C>.identity())
     }
     
+    /// Provides a schedule that folds the outputs of this one.
+    ///
+    /// - Parameters:
+    ///   - z: Initial value for the folding process.
+    ///   - f: Folding function.
     public func fold<Z>(_ z: Z, _ f: @escaping (Z, B) -> Z) -> Schedule<R, A, (State, Z), Z> {
         Schedule<R, A, (State, Z), Z>(
             initial: self.initial.map { x in (x, z) }^,
@@ -210,6 +307,7 @@ public class Schedule<R, A, State, B> {
             })
     }
     
+    /// Returns a new schedule that loops this one forever, resetting the state when this schedule is completed.
     public func forever() -> Schedule<R, A, State, B> {
         Schedule(
             initial: self.initial,
@@ -219,6 +317,9 @@ public class Schedule<R, A, State, B> {
             }^ })
     }
     
+    /// Returns a new schedule with the specified initial state transformed by a function.
+    ///
+    /// - Parameter f: Function transforming the initial state.
     public func initialized(_ f: @escaping (EnvIO<R, Never, State>) -> EnvIO<R, Never, State>) -> Schedule<R, A, State, B> {
         Schedule(
             initial: f(self.initial),
@@ -226,10 +327,14 @@ public class Schedule<R, A, State, B> {
             update: self.update)
     }
     
-    func left<C>() -> Schedule<R, Either<A, C>, (State, Unit), Either<B, C>> {
+    /// Puts the schedule into the left side of an `Either` and passes an unmodified value as the right side of the `Either`.
+    public func left<C>() -> Schedule<R, Either<A, C>, (State, Unit), Either<B, C>> {
         self.choose(Schedule<R, C, Unit, C>.identity())
     }
     
+    /// Transforms the output of this schedule with the provided function.
+    ///
+    /// - Parameter f: Transforming function.
     public func map<C>(_ f: @escaping (B) -> C) -> Schedule<R, A, State, C> {
         Schedule<R, A, State, C>(
             initial: self.initial,
@@ -237,10 +342,24 @@ public class Schedule<R, A, State, B> {
             update: self.update)
     }
     
+    /// Provides a new schedule that emits the number of repetitions of this schedule.
     public func repetitions() -> Schedule<R, A, (State, Int), Int> {
         fold(0) { n, _ in n + 1 }
     }
     
+    /// Puts the schedule into the right side of an `Either` and passes an unmodified value as the left side of the `Either`.
+    public func right<C>() -> Schedule<R, Either<C, A>, (Unit, State), Either<C, B>> {
+        Schedule<R, C, Unit, C>.identity().choose(self)
+    }
+    
+    /// Puts this schedule into the second element of a tuple and passes an unmodified element as the first element of the tuple.
+    public func second<C>() -> Schedule<R, (C, A), (Unit, State), (C, B)> {
+        Schedule<R, C, Unit, C>.identity().split(self)
+    }
+    
+    /// Performs an additional effect for every input.
+    ///
+    /// - Parameter f: Effectful function to run after every input.
     public func tapInput(_ f: @escaping (A) -> EnvIO<R, Never, Void>) -> Schedule<R, A, State, B> {
         updated { upd in
             { a, s in
@@ -249,6 +368,9 @@ public class Schedule<R, A, State, B> {
         }
     }
     
+    /// Performs an additional effect for every output.
+    ///
+    /// - Parameter f: Effectful function to run after every output.
     public func tapOutput(_ f: @escaping (B) -> EnvIO<R, Never, Void>) -> Schedule<R, A, State, B> {
         updated { upd in
             { a, s in
@@ -265,14 +387,21 @@ public class Schedule<R, A, State, B> {
         )
     }
     
+    /// Wipes out the output produced by this schedule.
     public func void() -> Schedule<R, A, State, Void> {
         `as`(())
     }
     
+    /// Provides a schedule that iterates this schedule until the input matches a given predicate.
+    ///
+    /// - Parameter f: Predicate to test the input of this schedule.
     public func untilInput(_ f: @escaping (A) -> Bool) -> Schedule<R, A, State, B> {
         untilInputM { a in EnvIO.pure(f(a))^ }
     }
     
+    /// Provides a schedule that iterates this schedule until the input matches a given effectful predicate.
+    ///
+    /// - Parameter f: Effectful predicate to test the input of this schedule.
     public func untilInputM(_ f: @escaping (A) -> EnvIO<R, Never, Bool>) -> Schedule<R, A, State, B> {
         updated { upd in
             { a, s in
@@ -285,10 +414,16 @@ public class Schedule<R, A, State, B> {
         }
     }
     
+    /// Provides a schedule that iterates this schedule until the output matches a given predicate.
+    ///
+    /// - Parameter f: Predicate to test the output of this schedule.
     public func untilOutput(_ f: @escaping (B) -> Bool) -> Schedule<R, A, State, B> {
         untilOutputM { b in EnvIO.pure(f(b))^ }
     }
     
+    /// Provides a schedule that iterates this schedule until the output matches a given effectful predicate.
+    ///
+    /// - Parameter f: Effectful predicate to test the output of this schedule.
     public func untilOutputM(_ f: @escaping (B) -> EnvIO<R, Never, Bool>) -> Schedule<R, A, State, B> {
         updated { upd in
             { a, s in
@@ -301,26 +436,48 @@ public class Schedule<R, A, State, B> {
         }
     }
     
+    /// Provides a schedule that iterates this schedule while the input matches a given predicate.
+    ///
+    /// - Parameter f: Predicate to test the input of this schedule.
     public func whileInput(_ f: @escaping (A) -> Bool) -> Schedule<R, A, State, B> {
         whileInputM { a in EnvIO.pure(f(a))^ }
     }
     
+    /// Provides a schedule that iterates this schedule while the input matches a given effectful predicate.
+    ///
+    /// - Parameter f: Effectful predicate to test the input of this schedule.
     public func whileInputM(_ f: @escaping (A) -> EnvIO<R, Never, Bool>) -> Schedule<R, A, State, B> {
         check { a, _ in f(a) }
     }
     
+    /// Provides a schedule that iterates this schedule while the output matches a given predicate.
+    ///
+    /// - Parameter f: Predicate to test the output of this schedule.
     public func whileOutput(_ f: @escaping (B) -> Bool) -> Schedule<R, A, State, B> {
         whileOutputM { b in EnvIO.pure(f(b))^ }
     }
     
+    /// Provides a schedule that iterates this schedule while the output matches a given effectful predicate.
+    ///
+    /// - Parameter f: Effectful predicate to test the output of this schedule.
     public func whileOutputM(_ f: @escaping (B) -> EnvIO<R, Never, Bool>) -> Schedule<R, A, State, B> {
         check { _, b in f(b) }
     }
     
+    /// Provides a schedule that always recurs without delay and computes the output through subsequent applications of a function to an initial value.
+    ///
+    /// - Parameters:
+    ///   - a: Initial value.
+    ///   - f: Unfolding function.
     public static func unfold(_ a: B, _ f: @escaping (B) -> B) -> Schedule<R, A, B, B> {
         unfoldM(EnvIO.pure(a)^, { a in EnvIO.pure(f(a))^ })
     }
     
+    /// Provides a schedule that always recurs without delay and computes the output through subsequent applications of an effectful function to an initial value.
+    ///
+    /// - Parameters:
+    ///   - a: Initial effect.
+    ///   - f: Unfolding effectful function.
     public static func unfoldM(_ a: EnvIO<R, Never, B>, _ f: @escaping (B) -> EnvIO<R, Never, B>) -> Schedule<R, A, B, B> {
         Schedule<R, A, B, B>(
             initial: a,
@@ -331,12 +488,18 @@ public class Schedule<R, A, State, B> {
 }
 
 extension Schedule where B == DispatchTimeInterval {
+    /// Provides a schedule from the given schedule which transforms the delays into effectufl sleeps.
+    ///
+    /// - Parameter s: A schedule producing time intervals.
     public static func delayed(_ s: Schedule<R, A, State, DispatchTimeInterval>) -> Schedule<R, A, State, DispatchTimeInterval> {
         s.addDelay(id)
     }
 }
 
 extension Schedule where B == TimeInterval {
+    /// Provides a schedule from the given schedule which transforms the delays into effectufl sleeps.
+    ///
+    /// - Parameter s: A schedule producing time intervals.
     public static func delayed(_ s: Schedule<R, A, State, TimeInterval>) -> Schedule<R, A, State, TimeInterval> {
         s.addDelay(id)
     }
@@ -347,6 +510,7 @@ extension Schedule where State == (DispatchTime, DispatchTimeInterval), B == Dis
         EnvIO.pure(DispatchTime.now())^
     }
     
+    /// Provides a schedule that recurs forever without a delay, returning the elapsed time since it began.
     public static func elapsed() -> Schedule<R, A, (DispatchTime, DispatchTimeInterval), DispatchTimeInterval> {
         Schedule<R, A, (DispatchTime, DispatchTimeInterval), DispatchTimeInterval>(
             initial: now().map { s in (s, DispatchTimeInterval.seconds(0)) }^,
@@ -355,36 +519,69 @@ extension Schedule where State == (DispatchTime, DispatchTimeInterval), B == Dis
         )
     }
     
+    /// Provides a schedule that recurs until the specified duration elapsed, returning the total elapsed time.
+    ///
+    /// - Parameter interval: Time interval for this schedule to recur.
     public static func duration(_ interval: DispatchTimeInterval) -> Schedule<R, A, (DispatchTime, DispatchTimeInterval), DispatchTimeInterval> {
         elapsed().untilOutput { x in x >= interval }
     }
 }
 
 extension Schedule where State == Int, B == Int {
+    /// Provides a schedule that waits for the specified amount of time between each input. Returns the number of received inputs.
+    ///
+    /// - Parameter interval: Time interval to wait between each action.
     public static func spaced(_ interval: DispatchTimeInterval) -> Schedule<R, A, State, Int> {
         forever().addDelay { _ in interval }
     }
     
+    /// Provides a schedule that waits for the specified amount of time between each input. Returns the number of received inputs.
+    ///
+    /// - Parameter interval: Time interval to wait between each action.
     public static func spaced(_ interval: TimeInterval) -> Schedule<R, A, State, Int> {
         forever().addDelay { _ in interval }
     }
 }
 
 extension Schedule where State == Int, B == TimeInterval {
+    /// Provides a schedule that always recurs, waiting an amount of time between repetitions, given by an exponential backoff algorithm, and returning the current duration between recurrences.
+    ///
+    /// The time to wait is given by the formula `base * pow(n + 1)`, where `n` is the number of repetitions so far.
+    ///
+    /// - Parameters:
+    ///   - base: Base time interval to wait between repetitions.
+    ///   - factor: Factor for the exponential backoff. Defaults to 2.0.
     public static func exponential(_ base: DispatchTimeInterval, factor: Double = 2.0) -> Schedule<R, A, Int, TimeInterval> {
         exponential(base.toDouble() ?? 1, factor: factor)
     }
     
+    /// Provides a schedule that always recurs, waiting an amount of time between repetitions, given by an exponential backoff algorithm, and returning the current duration between recurrences.
+    ///
+    /// The time to wait is given by the formula `base * pow(n + 1)`, where `n` is the number of repetitions so far.
+    ///
+    /// - Parameters:
+    ///   - base: Base time interval to wait between repetitions.
+    ///   - factor: Factor for the exponential backoff. Defaults to 2.0.
     public static func exponential(_ base: TimeInterval, factor: Double = 2.0) -> Schedule<R, A, Int, TimeInterval> {
         delayed(Schedule<R, A, Int, Int>.forever().map { i in
             base * pow(factor, Double(i + 1))
         })
     }
     
+    /// Provides a schedule that always recurs, waiting an amount of time between repetitions, given by a linear backoff algorithm, and returning the current duration between recurrences.
+    ///
+    /// The time to wait is given by the formula `base * (n + 1)`, where `n` is the number of repetitions so far.
+    ///
+    /// - Parameter base: Base time interval to wait between repetitions.
     public static func linear(_ base: DispatchTimeInterval) -> Schedule<R, A, Int, TimeInterval> {
         linear(base.toDouble() ?? 1)
     }
     
+    /// Provides a schedule that always recurs, waiting an amount of time between repetitions, given by a linear backoff algorithm, and returning the current duration between recurrences.
+    ///
+    /// The time to wait is given by the formula `base * (n + 1)`, where `n` is the number of repetitions so far.
+    ///
+    /// - Parameter base: Base time interval to wait between repetitions.
     public static func linear(_ base: TimeInterval) -> Schedule<R, A, Int, TimeInterval> {
         delayed(Schedule<R, A, Int, Int>.forever().map { i in
             base * Double(i + 1)
@@ -393,19 +590,34 @@ extension Schedule where State == Int, B == TimeInterval {
 }
 
 extension Schedule where State == (TimeInterval, TimeInterval), B == TimeInterval {
+    
+    /// Provides a schedule that always recurs, increasing delays by summing the preceding two delays, as in the Fibonacci sequence. Returns the current duration between recurrences.
+    ///
+    /// - Parameter one: Time interval for the initial delay.
     public static func fibonacci(_ one: DispatchTimeInterval) -> Schedule<R, A, (TimeInterval, TimeInterval), TimeInterval> {
+        fibonacci(one.toDouble() ?? 1)
+    }
+    
+    /// Provides a schedule that always recurs, increasing delays by summing the preceding two delays, as in the Fibonacci sequence. Returns the current duration between recurrences.
+    ///
+    /// - Parameter one: Time interval for the initial delay.
+    public static func fibonacci(_ one: TimeInterval) -> Schedule<R, A, (TimeInterval, TimeInterval), TimeInterval> {
         delayed(
-            Schedule<R, A, (TimeInterval, TimeInterval), (TimeInterval, TimeInterval)>.unfold((one.toDouble() ?? 1, one.toDouble() ?? 1)) { x in (x.1, x.0 + x.1) }.map { x in x.0 })
+            Schedule<R, A, (TimeInterval, TimeInterval), (TimeInterval, TimeInterval)>.unfold((one, one)) { x in
+                (x.1, x.0 + x.1)
+            }.map { x in x.0 })
     }
 }
 
 extension Schedule where B == Void, State == Unit {
+    /// Provides a schedule that wipes out the output.
     public static func void() -> Schedule<R, A, Unit, Void> {
         Schedule<R, A, Unit, A>.identity().void()
     }
 }
 
 extension Schedule where A == B, State == Unit {
+    /// Provides a schedule that returns the input, unmodified.
     public static func identity() -> Schedule<R, A, Unit, A> {
         Schedule<R, A, Unit, A>(
             initial: EnvIO.pure(.unit)^,
@@ -413,91 +625,137 @@ extension Schedule where A == B, State == Unit {
             update: { _, _ in EnvIO.pure(.unit)^ })
     }
     
+    /// Provides a schedule that recurs as long as the predicate evaluates to true.
+    ///
+    /// - Parameter f: Predicate to test the input.
     public static func doWhile(_ f: @escaping (A) -> Bool) -> Schedule<R, A, Unit, A> {
         doWhileM { a in EnvIO.pure(f(a))^ }
     }
     
+    /// Provides a schedule that recurs as long as the effectful predicate evaluates to true.
+    ///
+    /// - Parameter f: Effectful predicate to test the input.
     public static func doWhileM(_ f: @escaping (A) -> EnvIO<R, Never, Bool>) -> Schedule<R, A, Unit, A> {
         identity().whileInputM(f)
     }
     
+    /// Provides a schedule that recurs until the predicate evaluates to true.
+    ///
+    /// - Parameter f: Predicate to test the input.
     public static func doUntil(_ f: @escaping (A) -> Bool) -> Schedule<R, A, Unit, A> {
         doUntilM { a in EnvIO.pure(f(a))^ }
     }
     
+    /// Provides a schedule that recurs until the effectful predicate evaluates to true.
+    ///
+    /// - Parameter f: Effectful predicate to test the input.
     public static func doUntilM(_ f: @escaping (A) -> EnvIO<R, Never, Bool>) -> Schedule<R, A, Unit, A> {
         identity().untilInputM(f)
     }
     
+    /// Provides a schedule that executes an effect for every consumed input.
+    ///
+    /// - Parameter f: Effectful function to run after every input.
     public static func tapInput(_ f: @escaping (A) -> EnvIO<R, Never, Void>) -> Schedule<R, A, Unit, A> {
         identity().tapInput(f)
     }
     
+    /// Provides a schedule that executes an effect for every produced output.
+    ///
+    /// - Parameter f: Effectful function to run after every output.
     public static func tapOutput(_ f: @escaping (A) -> EnvIO<R, Never, Void>) -> Schedule<R, A, Unit, A> {
         identity().tapOutput(f)
     }
 }
 
 extension Schedule where State == Unit {
+    /// Provides a schedule that recurs forever, mapping input values through the provided function.
+    ///
+    /// - Parameter function: Transforming function.
     public static func from(function: @escaping (A) -> B) -> Schedule<R, A, State, B> {
         Schedule<R, A, Unit, A>.identity().map(function)
     }
 }
 
 extension Schedule where A == B, State == Unit, A: Equatable {
+    /// Provides a schedule that recurs as long as the input is equal to a specific value.
+    ///
+    /// - Parameter a: Value to compare the input of the schedule.
     public static func doWhileEquals(_ a: A) -> Schedule<R, A, Unit, A> {
         identity().whileInput { x in x == a }
     }
     
+    /// Provides a schedule that recurs as long as the input is not equal to a specific value.
+    ///
+    /// - Parameter a: Value to compare the input of the schedule.
     public static func doUntilEquals(_ a: A) -> Schedule<R, A, Unit, A> {
         identity().untilInput { x in x == a }
     }
 }
 
 extension Schedule where B == Int, State == Int {
+    /// Provides a schedule that runs forever and emits the number of iterations it has performed.
     public static func forever() -> Schedule<R, A, Int, Int> {
         Schedule<R, A, Int, Int>.unfold(0) { $0 + 1 }
     }
     
+    /// Provides a schedule that recurs a specific number of times, emitting the current iteration it is in.
+    ///
+    /// - Parameter n: Number of iterations to perform.
     public static func recurs(_ n: Int) -> Schedule<R, A, Int, Int> {
         forever().whileOutput { $0 < n }
     }
     
+    /// Provides a schedule that recurs only once.
     public static func once() -> Schedule<R, A, Int, Void> {
         recurs(1).void()
     }
     
+    /// Provides a schedule that recurs zero times.
     public static func stop() -> Schedule<R, A, Int, Void> {
         recurs(0).void()
     }
 }
 
 extension Schedule where B == Never, A == Any, State == Never {
+    /// Provides a schedule that never recurs.
     public static func never() -> Schedule<R, Any, Never, Never> {
         Schedule(
-            initial: EnvIO { _ in IO.never() },
+            initial: EnvIO.never()^,
             extract: { _, never in never },
-            update: { _, _ in EnvIO { _ in IO.never() }})
+            update: { _, _ in EnvIO.never()^ })
     }
 }
 
 extension Schedule where B == [A], State == (Unit, [A]) {
+    /// Provides a schedule that recurs forever and collects all its outputs in an array.
     public static func collectAll() -> Schedule<R, A, State, [A]> {
         Schedule<R, A, Unit, A>.identity().collectAll()
     }
     
+    /// Provides a schedule that collects its outputs in an array as long as the outputs match a given predicate.
+    ///
+    /// - Parameter f: Predicate to test the outputs.
     public static func collectWhile(_ f: @escaping (A) -> Bool) -> Schedule<R, A, State, [A]> {
         Schedule<R, A, Unit, A>.doWhile(f).collectAll()
     }
     
+    /// Provides a schedule that collects its outputs in an array as long as the outputs match a given effectful predicate.
+    ///
+    /// - Parameter f: Effectful predicate to test the outputs.
     public static func collectWhileM(_ f: @escaping (A) -> EnvIO<R, Never, Bool>) -> Schedule<R, A, State, [A]> {
         Schedule<R, A, Unit, A>.doWhileM(f).collectAll()
     }
     
+    /// Provides a schedule that collects its outputs in an array until an output matches a given predicate.
+    ///
+    /// - Parameter f: Predicate to test the outputs.
     public static func collectUntil(_ f: @escaping (A) -> Bool) -> Schedule<R, A, State, [A]> {
         Schedule<R, A, Unit, A>.doUntil(f).collectAll()
     }
     
+    /// Provides a schedule that collects its outputs in an array until an output matches a given effectful predicate.
+    /// - Parameter f: Effectful predicate to test the outputs.
     public static func collectUntilM(_ f: @escaping (A) -> EnvIO<R, Never, Bool>) -> Schedule<R, A, State, [A]> {
         Schedule<R, A, Unit, A>.doUntilM(f).collectAll()
     }

--- a/Sources/BowEffects/Data/Schedule.swift
+++ b/Sources/BowEffects/Data/Schedule.swift
@@ -1,0 +1,510 @@
+import Foundation
+import Bow
+
+public enum Unit: Error {
+    case unit
+}
+
+public class Schedule<R, A, State, B> {
+    let initial: EnvIO<R, Never, State>
+    let extract: (A, State) -> B
+    let update: (A, State) -> EnvIO<R, Unit, State>
+    
+    init(initial: EnvIO<R, Never, State>,
+         extract: @escaping (A, State) -> B,
+         update: @escaping (A, State) -> EnvIO<R, Unit, State>) {
+        self.initial = initial
+        self.extract = extract
+        self.update = update
+    }
+    
+    public func and<State2, C>(_ that: Schedule<R, A, State2, C>) -> Schedule<R, A, (State, State2), (B, C)> {
+        Schedule<R, A, (State, State2), (B, C)>(
+            initial: EnvIO<R, Never, (State, State2)>.parZip(self.initial, that.initial)^,
+            extract: { a, s in (self.extract(a, s.0), that.extract(a, s.1)) },
+            update: { a, s in EnvIO<R, Unit, (State, State2)>.parZip(self.update(a, s.0), that.update(a, s.1))^ }
+        )
+    }
+    
+    public func split<State2, C, D>(_ that: Schedule<R, C, State2, D>) -> Schedule<R, (A, C), (State, State2), (B, D)> {
+        Schedule<R, (A, C), (State, State2), (B, D)>(
+            initial: self.initial.zip(that.initial),
+            extract: { a, s in (self.extract(a.0, s.0), that.extract(a.1, s.1)) },
+            update: { a, s in EnvIO<R, Unit, (State, State2)>.parZip(self.update(a.0, s.0), that.update(a.1, s.1))^ }
+        )
+    }
+    
+    public func choose<State2, C, D>(_ that: Schedule<R, C, State2, D>) -> Schedule<R, Either<A, C>, (State, State2), Either<B, D>> {
+        Schedule<R, Either<A, C>, (State, State2), Either<B, D>>(
+            initial: self.initial.zip(that.initial),
+            extract: { a, s in
+                a.fold({ aa in .left(self.extract(aa, s.0)) },
+                       { c in .right(that.extract(c, s.1)) })
+            },
+            update: { a, s in
+                a.fold({ aa in self.update(aa, s.0).map { x in (x, s.1) }^ },
+                       { c in that.update(c, s.1).map { x in (s.0, x) }^ })
+            }
+        )
+    }
+    
+    public func choose<State2, C>(_ that: Schedule<R, C, State2, B>) -> Schedule<R, Either<A, C>, (State, State2), B> {
+        self.choose(that).map { b in b.fold(id, id) }
+    }
+    
+    public func zip<State2, C>(_ that: Schedule<R, A, State2, C>) -> Schedule<R, A, (State, State2), (B, C)> {
+        self.and(that)
+    }
+    
+    public func zipRight<State2, C>(_ that: Schedule<R, A, State2, C>) -> Schedule<R, A, (State, State2), C> {
+        self.and(that).map { x in x.1 }
+    }
+    
+    public func zipLeft<State2, C>(_ that: Schedule<R, A, State2, C>) -> Schedule<R, A, (State, State2), B> {
+        self.and(that).map { x in x.0 }
+    }
+    
+    public func pipe<State2, C>(_ that: Schedule<R, B, State2, C>) -> Schedule<R, A, (State, State2), C> {
+        Schedule<R, A, (State, State2), C>(
+            initial: self.initial.zip(that.initial),
+            extract: { a, s in that.extract(self.extract(a, s.0), s.1) },
+            update: { a, s in
+                let s1 = EnvIO<R, Unit, State>.var()
+                let s2 = EnvIO<R, Unit, State2>.var()
+                
+                return binding(
+                    s1 <- self.update(a, s.0),
+                    s2 <- that.update(self.extract(a, s.0), s.1),
+                    yield: (s1.get, s2.get))^
+            }
+        )
+    }
+    
+    public func reversePipe<State2, C>(_ that: Schedule<R, C, State2, A>) -> Schedule<R, C, (State2, State), B> {
+        that.pipe(self)
+    }
+    
+    public func or<State2, C>(_ that: Schedule<R, A, State2, C>) -> Schedule<R, A, (State, State2), (B, C)> {
+        Schedule<R, A, (State, State2), (B, C)>(
+            initial: self.initial.zip(that.initial),
+            extract: { a, s in (self.extract(a, s.0), that.extract(a, s.1)) },
+            update: { a, s in
+                EnvIO.race(self.update(a, s.0),
+                           that.update(a, s.1)).map { either in
+                    either.fold(
+                        { s0 in (s0, s.1) },
+                        { s1 in (s.0, s1)})
+                }^
+            })
+    }
+    
+    public func addDelay(_ f: @escaping (B) -> DispatchTimeInterval) -> Schedule<R, A, State, B> {
+        addDelayM { b in EnvIO<R, Never, DispatchTimeInterval>.pure(f(b))^ }
+    }
+    
+    public func addDelayM(_ f: @escaping (B) -> EnvIO<R, Never, DispatchTimeInterval>) -> Schedule<R, A, State, B> {
+        addDelayM { b in f(b).map { x in x.toDouble() ?? 0 }^ }
+    }
+    
+    public func addDelay(_ f: @escaping (B) -> TimeInterval) -> Schedule<R, A, State, B> {
+        addDelayM { b in EnvIO<R, Never, TimeInterval>.pure(f(b))^ }
+    }
+    
+    public func addDelayM(_ f: @escaping (B) -> EnvIO<R, Never, TimeInterval>) -> Schedule<R, A, State, B> {
+        updated { upd in
+            { a, s in
+                let delay = EnvIO<R, Unit, TimeInterval>.var()
+                let s1 = EnvIO<R, Unit, State>.var()
+                return binding(
+                    delay <- f(self.extract(a, s)).unitError(),
+                    s1 <- upd(a, s),
+                    |<-EnvIO.sleep(delay.get),
+                    yield: s1.get)^
+            }
+        }
+    }
+    
+    public func andThen<State2>(_ that: Schedule<R, A, State2, B>) -> Schedule<R, A, Either<State, State2>, B> {
+        andThenEither(that).map { x in x.fold(id, id) }
+    }
+    
+    public func andThenEither<State2, C>(_ that: Schedule<R, A, State2, C>) -> Schedule<R, A, Either<State, State2>, Either<B, C>> {
+        Schedule<R, A, Either<State, State2>, Either<B, C>>(
+            initial: self.initial.map(Either.left)^,
+            extract: { a, s in
+                s.fold({ s1 in .left(self.extract(a, s1)) },
+                       { s2 in .right(that.extract(a, s2)) })
+            },
+            update: { a, s in
+                s.fold({ s1 in
+                    self.update(a, s1).map(Either.left)
+                        .handleErrorWith { _ in
+                            that.initial.unitError().flatMap { x in that.update(a, x) }.map(Either.right)^
+                        }^
+                },
+                       { s2 in that.update(a, s2).map(Either.right)^ })
+            })
+    }
+    
+    public func `as`<C>(_ c: C) -> Schedule<R, A, State, C> {
+        map { _ in c }
+    }
+    
+    public func both<State2, C>(_ that: Schedule<R, A, State2, C>) -> Schedule<R, A, (State, State2), (B, C)> {
+        self.and(that)
+    }
+    
+    public func bothWith<State2, C, D>(_ that: Schedule<R, A, State2, C>, _ f: @escaping (B, C) -> D) -> Schedule<R, A, (State, State2), D> {
+        self.and(that).map(f)
+    }
+    
+    public func check(_ test: @escaping (A, B) -> EnvIO<R, Never, Bool>) -> Schedule<R, A, State, B> {
+        updated { upd in
+            { a, s in
+                test(a, self.extract(a, s)).unitError().flatMap { flag in
+                    flag ?
+                        upd(a, s) :
+                        EnvIO.raiseError(.unit)
+                }^
+            }
+        }
+    }
+    
+    public func collectAll() -> Schedule<R, A, (State, [B]), [B]> {
+        fold([]) { xs, x in [x] + xs }.map { x in Array(x.reversed()) }
+    }
+    
+    public func compose<State2, C>(_ that: Schedule<R, C, State2, A>) -> Schedule<R, C, (State2, State), B> {
+        self.reversePipe(that)
+    }
+    
+    public func contramap<AA>(_ f: @escaping (AA) -> A) -> Schedule<R, AA, State, B> {
+        Schedule<R, AA, State, B>(
+            initial: self.initial,
+            extract: { a, s in self.extract(f(a), s) },
+            update: { a, s in self.update(f(a), s) })
+    }
+    
+    public func dimap<AA, C>(_ f: @escaping (AA) -> A, _ g: @escaping (B) -> C) -> Schedule<R, AA, State, C> {
+        contramap(f).map(g)
+    }
+    
+    public func either<State2, C>(_ that: Schedule<R, A, State2, C>) -> Schedule<R, A, (State, State2), (B, C)> {
+        self.or(that)
+    }
+    
+    public func eitherWith<State2, C, D>(_ that: Schedule<R, A, State2, C>, _ f: @escaping (B, C) -> D) -> Schedule<R, A, (State, State2), D> {
+        self.or(that).map(f)
+    }
+    
+    func first<C>() -> Schedule<R, (A, C), (State, Unit), (B, C)> {
+        self.split(Schedule<R, C, Unit, C>.identity())
+    }
+    
+    public func fold<Z>(_ z: Z, _ f: @escaping (Z, B) -> Z) -> Schedule<R, A, (State, Z), Z> {
+        Schedule<R, A, (State, Z), Z>(
+            initial: self.initial.map { x in (x, z) }^,
+            extract: { a, s in f(s.1, self.extract(a, s.0)) },
+            update: { a, s in
+                self.update(a, s.0).map { s1 in (s1, f(s.1, self.extract(a, s.0))) }^
+            })
+    }
+    
+    public func forever() -> Schedule<R, A, State, B> {
+        Schedule(
+            initial: self.initial,
+            extract: self.extract,
+            update: { a, s in self.update(a, s).handleErrorWith { _ in
+                self.initial.unitError().flatMap { x in self.update(a, x) }
+            }^ })
+    }
+    
+    public func initialized(_ f: @escaping (EnvIO<R, Never, State>) -> EnvIO<R, Never, State>) -> Schedule<R, A, State, B> {
+        Schedule(
+            initial: f(self.initial),
+            extract: self.extract,
+            update: self.update)
+    }
+    
+    func left<C>() -> Schedule<R, Either<A, C>, (State, Unit), Either<B, C>> {
+        self.choose(Schedule<R, C, Unit, C>.identity())
+    }
+    
+    public func map<C>(_ f: @escaping (B) -> C) -> Schedule<R, A, State, C> {
+        Schedule<R, A, State, C>(
+            initial: self.initial,
+            extract: { a, s in f(self.extract(a, s)) },
+            update: self.update)
+    }
+    
+    public func repetitions() -> Schedule<R, A, (State, Int), Int> {
+        fold(0) { n, _ in n + 1 }
+    }
+    
+    public func tapInput(_ f: @escaping (A) -> EnvIO<R, Never, Void>) -> Schedule<R, A, State, B> {
+        updated { upd in
+            { a, s in
+                f(a).unitError().flatMap { _ in upd(a, s) }^
+            }
+        }
+    }
+    
+    public func tapOutput(_ f: @escaping (B) -> EnvIO<R, Never, Void>) -> Schedule<R, A, State, B> {
+        updated { upd in
+            { a, s in
+                upd(a, s).flatMap { ss in f(self.extract(a, ss)).unitError().as(ss) }^
+            }
+        }
+    }
+    
+    func updated(_ f: @escaping (@escaping (A, State) -> EnvIO<R, Unit, State>) -> (A, State) -> EnvIO<R, Unit, State>) -> Schedule<R, A, State, B> {
+        Schedule(
+            initial: self.initial,
+            extract: self.extract,
+            update: f(self.update)
+        )
+    }
+    
+    public func void() -> Schedule<R, A, State, Void> {
+        `as`(())
+    }
+    
+    public func untilInput(_ f: @escaping (A) -> Bool) -> Schedule<R, A, State, B> {
+        untilInputM { a in EnvIO.pure(f(a))^ }
+    }
+    
+    public func untilInputM(_ f: @escaping (A) -> EnvIO<R, Never, Bool>) -> Schedule<R, A, State, B> {
+        updated { upd in
+            { a, s in
+                f(a).unitError().flatMap { flag in
+                    flag ?
+                        EnvIO.raiseError(.unit)^ :
+                        upd(a, s)
+                }^
+            }
+        }
+    }
+    
+    public func untilOutput(_ f: @escaping (B) -> Bool) -> Schedule<R, A, State, B> {
+        untilOutputM { b in EnvIO.pure(f(b))^ }
+    }
+    
+    public func untilOutputM(_ f: @escaping (B) -> EnvIO<R, Never, Bool>) -> Schedule<R, A, State, B> {
+        updated { upd in
+            { a, s in
+                f(self.extract(a, s)).unitError().flatMap { flag in
+                    flag ?
+                        EnvIO.raiseError(.unit)^ :
+                        upd(a, s)
+                }^
+            }
+        }
+    }
+    
+    public func whileInput(_ f: @escaping (A) -> Bool) -> Schedule<R, A, State, B> {
+        whileInputM { a in EnvIO.pure(f(a))^ }
+    }
+    
+    public func whileInputM(_ f: @escaping (A) -> EnvIO<R, Never, Bool>) -> Schedule<R, A, State, B> {
+        check { a, _ in f(a) }
+    }
+    
+    public func whileOutput(_ f: @escaping (B) -> Bool) -> Schedule<R, A, State, B> {
+        whileOutputM { b in EnvIO.pure(f(b))^ }
+    }
+    
+    public func whileOutputM(_ f: @escaping (B) -> EnvIO<R, Never, Bool>) -> Schedule<R, A, State, B> {
+        check { _, b in f(b) }
+    }
+    
+    public static func unfold(_ a: B, _ f: @escaping (B) -> B) -> Schedule<R, A, B, B> {
+        unfoldM(EnvIO.pure(a)^, { a in EnvIO.pure(f(a))^ })
+    }
+    
+    public static func unfoldM(_ a: EnvIO<R, Never, B>, _ f: @escaping (B) -> EnvIO<R, Never, B>) -> Schedule<R, A, B, B> {
+        Schedule<R, A, B, B>(
+            initial: a,
+            extract: { _, a in a },
+            update: { _, a in f(a).unitError() }
+        )
+    }
+}
+
+extension Schedule where B == DispatchTimeInterval {
+    public static func delayed(_ s: Schedule<R, A, State, DispatchTimeInterval>) -> Schedule<R, A, State, DispatchTimeInterval> {
+        s.addDelay(id)
+    }
+}
+
+extension Schedule where B == TimeInterval {
+    public static func delayed(_ s: Schedule<R, A, State, TimeInterval>) -> Schedule<R, A, State, TimeInterval> {
+        s.addDelay(id)
+    }
+}
+
+extension Schedule where State == (DispatchTime, DispatchTimeInterval), B == DispatchTimeInterval {
+    private static func now() -> EnvIO<R, Never, DispatchTime> {
+        EnvIO.pure(DispatchTime.now())^
+    }
+    
+    public static func elapsed() -> Schedule<R, A, (DispatchTime, DispatchTimeInterval), DispatchTimeInterval> {
+        Schedule<R, A, (DispatchTime, DispatchTimeInterval), DispatchTimeInterval>(
+            initial: now().map { s in (s, DispatchTimeInterval.seconds(0)) }^,
+            extract: { _, s in s.1 },
+            update: { _, s in now().unitError().map { currentTime in (s.0, currentTime - s.0) }^ }
+        )
+    }
+    
+    public static func duration(_ interval: DispatchTimeInterval) -> Schedule<R, A, (DispatchTime, DispatchTimeInterval), DispatchTimeInterval> {
+        elapsed().untilOutput { x in x >= interval }
+    }
+}
+
+extension Schedule where State == Int, B == Int {
+    public static func spaced(_ interval: DispatchTimeInterval) -> Schedule<R, A, State, Int> {
+        forever().addDelay { _ in interval }
+    }
+    
+    public static func spaced(_ interval: TimeInterval) -> Schedule<R, A, State, Int> {
+        forever().addDelay { _ in interval }
+    }
+}
+
+extension Schedule where State == Int, B == TimeInterval {
+    public static func exponential(_ base: DispatchTimeInterval, factor: Double = 2.0) -> Schedule<R, A, Int, TimeInterval> {
+        exponential(base.toDouble() ?? 1, factor: factor)
+    }
+    
+    public static func exponential(_ base: TimeInterval, factor: Double = 2.0) -> Schedule<R, A, Int, TimeInterval> {
+        delayed(Schedule<R, A, Int, Int>.forever().map { i in
+            base * pow(factor, Double(i + 1))
+        })
+    }
+    
+    public static func linear(_ base: DispatchTimeInterval) -> Schedule<R, A, Int, TimeInterval> {
+        linear(base.toDouble() ?? 1)
+    }
+    
+    public static func linear(_ base: TimeInterval) -> Schedule<R, A, Int, TimeInterval> {
+        delayed(Schedule<R, A, Int, Int>.forever().map { i in
+            base * Double(i + 1)
+        })
+    }
+}
+
+extension Schedule where State == (TimeInterval, TimeInterval), B == TimeInterval {
+    public static func fibonacci(_ one: DispatchTimeInterval) -> Schedule<R, A, (TimeInterval, TimeInterval), TimeInterval> {
+        delayed(
+            Schedule<R, A, (TimeInterval, TimeInterval), (TimeInterval, TimeInterval)>.unfold((one.toDouble() ?? 1, one.toDouble() ?? 1)) { x in (x.1, x.0 + x.1) }.map { x in x.0 })
+    }
+}
+
+extension Schedule where B == Void, State == Unit {
+    public static func void() -> Schedule<R, A, Unit, Void> {
+        Schedule<R, A, Unit, A>.identity().void()
+    }
+}
+
+extension Schedule where A == B, State == Unit {
+    public static func identity() -> Schedule<R, A, Unit, A> {
+        Schedule<R, A, Unit, A>(
+            initial: EnvIO.pure(.unit)^,
+            extract: { a, _ in a },
+            update: { _, _ in EnvIO.pure(.unit)^ })
+    }
+    
+    public static func doWhile(_ f: @escaping (A) -> Bool) -> Schedule<R, A, Unit, A> {
+        doWhileM { a in EnvIO.pure(f(a))^ }
+    }
+    
+    public static func doWhileM(_ f: @escaping (A) -> EnvIO<R, Never, Bool>) -> Schedule<R, A, Unit, A> {
+        identity().whileInputM(f)
+    }
+    
+    public static func doUntil(_ f: @escaping (A) -> Bool) -> Schedule<R, A, Unit, A> {
+        doUntilM { a in EnvIO.pure(f(a))^ }
+    }
+    
+    public static func doUntilM(_ f: @escaping (A) -> EnvIO<R, Never, Bool>) -> Schedule<R, A, Unit, A> {
+        identity().untilInputM(f)
+    }
+    
+    public static func tapInput(_ f: @escaping (A) -> EnvIO<R, Never, Void>) -> Schedule<R, A, Unit, A> {
+        identity().tapInput(f)
+    }
+    
+    public static func tapOutput(_ f: @escaping (A) -> EnvIO<R, Never, Void>) -> Schedule<R, A, Unit, A> {
+        identity().tapOutput(f)
+    }
+}
+
+extension Schedule where State == Unit {
+    public static func from(function: @escaping (A) -> B) -> Schedule<R, A, State, B> {
+        Schedule<R, A, Unit, A>.identity().map(function)
+    }
+}
+
+extension Schedule where A == B, State == Unit, A: Equatable {
+    public static func doWhileEquals(_ a: A) -> Schedule<R, A, Unit, A> {
+        identity().whileInput { x in x == a }
+    }
+    
+    public static func doUntilEquals(_ a: A) -> Schedule<R, A, Unit, A> {
+        identity().untilInput { x in x == a }
+    }
+}
+
+extension Schedule where B == Int, State == Int {
+    public static func forever() -> Schedule<R, A, Int, Int> {
+        Schedule<R, A, Int, Int>.unfold(0) { $0 + 1 }
+    }
+    
+    public static func recurs(_ n: Int) -> Schedule<R, A, Int, Int> {
+        forever().whileOutput { $0 < n }
+    }
+    
+    public static func once() -> Schedule<R, A, Int, Void> {
+        recurs(1).void()
+    }
+    
+    public static func stop() -> Schedule<R, A, Int, Void> {
+        recurs(0).void()
+    }
+}
+
+extension Schedule where B == Never, A == Any, State == Never {
+    public static func never() -> Schedule<R, Any, Never, Never> {
+        Schedule(
+            initial: EnvIO { _ in IO.never() },
+            extract: { _, never in never },
+            update: { _, _ in EnvIO { _ in IO.never() }})
+    }
+}
+
+extension Schedule where B == [A], State == (Unit, [A]) {
+    public static func collectAll() -> Schedule<R, A, State, [A]> {
+        Schedule<R, A, Unit, A>.identity().collectAll()
+    }
+    
+    public static func collectWhile(_ f: @escaping (A) -> Bool) -> Schedule<R, A, State, [A]> {
+        Schedule<R, A, Unit, A>.doWhile(f).collectAll()
+    }
+    
+    public static func collectWhileM(_ f: @escaping (A) -> EnvIO<R, Never, Bool>) -> Schedule<R, A, State, [A]> {
+        Schedule<R, A, Unit, A>.doWhileM(f).collectAll()
+    }
+    
+    public static func collectUntil(_ f: @escaping (A) -> Bool) -> Schedule<R, A, State, [A]> {
+        Schedule<R, A, Unit, A>.doUntil(f).collectAll()
+    }
+    
+    public static func collectUntilM(_ f: @escaping (A) -> EnvIO<R, Never, Bool>) -> Schedule<R, A, State, [A]> {
+        Schedule<R, A, Unit, A>.doUntilM(f).collectAll()
+    }
+}
+
+extension Kleisli {
+    func unitError<E: Error>() -> EnvIO<D, Unit, A> where F == IOPartial<E> {
+        self.mapError { _ in .unit }
+    }
+}


### PR DESCRIPTION
## Related issues

Current implementation does not have a mechanism to retry or repeat effectful computations based on `IO` or `EnvIO`.

## Goal

Create a composable way of specifying retrial/repeat policies to re-run effectful computations. I used [ZIO](https://github.com/zio/zio/blob/fae35db0dd8c8fb89e52a76bdf2f22d63a81a4e1/core/shared/src/main/scala/zio/Schedule.scala) as an inspiration to achieve this.

## Implementation details

Functions to `retry` and `repeat` have been added to `EnvIO` and `IO` (the latter delegates on the former). These functions receive a `Schedule` that dictates if the effect needs to be reapplied or not.

Primitive `Schedules` have been added, where the most prominent ones are:

- `Schedule.recurs(n)`: recurs `n` times.
- `Schedule.forever()`: recurs forever.
- `Schedule.spaced(time)`: recurs forever, spacing each execution the specified time.
- `Schedule.linear(time)`: recurs forever, incrementing the delay between each attempt in a linear manner, using `time` as a baseline.
- `Schedule.exponential(time)`: recurs forever, incrementing the delay between each attempt in an exponential manner, using `time` as a baseline.
- `Schedule.fibonacci(time)`: recurs forever, incrementing the delay between each attempt following the Fibonacci sequence, using `time` as a baseline.
- `Schedule.duration(time)`: recurs until the specified `time` elapses.

These primitives can be composed in different manners, always resulting in new `Schedule`s that can be subsequently composed. The most prominent composition operators are:

- `s1.and(s2)`: executes as long as both schedules want to keep recursing, using the maximum of both delays.
- `s1.or(s2)`: executes as long as one of the schedules want to keep recursing, using the minimum of both delays.
- `s1.andThen(s2)`: executes `s1` until it states to finish, and then executes `s2`.

## Usage

An example of usage:

Retries the `io` operation 8 times, waiting 2 seconds between each attempt.

```swift
io.retry(Schedule.recurs(8).and(Schedule.spaced(.seconds(2)))
```