### PR TITLE
[Bug] handleErrorWith IO::ApplicativeError

### DIFF
--- a/Bow.xcodeproj/project.pbxproj
+++ b/Bow.xcodeproj/project.pbxproj
@@ -327,6 +327,7 @@
 		8BA0F653217E2E9200969984 /* Semigroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BA0F4AC217E2E9200969984 /* Semigroup.swift */; };
 		8BA0F657217E2E9200969984 /* MonadCombine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BA0F4AD217E2E9200969984 /* MonadCombine.swift */; };
 		8BA0F65B217E2E9200969984 /* FunctorFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BA0F4AE217E2E9200969984 /* FunctorFilter.swift */; };
+		8BB969AD2398661D005520D6 /* Queue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BB969AB239863F0005520D6 /* Queue.swift */; };
 		B8B910C0234D7F2600E44271 /* Semiring.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8B910BF234D7F2600E44271 /* Semiring.swift */; };
 		B8B910C4234D846900E44271 /* SemiringLaws.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8B910C3234D846900E44271 /* SemiringLaws.swift */; };
 		B8B910C6234DDA4000E44271 /* BoolInstancesTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8B910C5234DDA4000E44271 /* BoolInstancesTest.swift */; };
@@ -1061,6 +1062,7 @@
 		8BA0F4D0217E2E9200969984 /* At+Optics.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "At+Optics.swift"; sourceTree = "<group>"; };
 		8BA0F4D1217E2E9200969984 /* Each+Optics.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Each+Optics.swift"; sourceTree = "<group>"; };
 		8BA0F4D2217E2E9200969984 /* Lens.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Lens.swift; sourceTree = "<group>"; };
+		8BB969AB239863F0005520D6 /* Queue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Queue.swift; sourceTree = "<group>"; };
 		B8B910BF234D7F2600E44271 /* Semiring.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Semiring.swift; sourceTree = "<group>"; };
 		B8B910C3234D846900E44271 /* SemiringLaws.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SemiringLaws.swift; sourceTree = "<group>"; };
 		B8B910C5234DDA4000E44271 /* BoolInstancesTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoolInstancesTest.swift; sourceTree = "<group>"; };
@@ -1649,6 +1651,7 @@
 				11F41C95231816AD00BD1E87 /* Dictionary+Extensions.swift */,
 				11F41C93231816AD00BD1E87 /* DispatchQueue+Extensions.swift */,
 				11912B09238C1FB4007D90A2 /* DispatchTimeInterval+Extensions.swift */,
+				8BB969AB239863F0005520D6 /* Queue.swift */,
 			);
 			path = Internal;
 			sourceTree = "<group>";
@@ -2718,6 +2721,7 @@
 				11F41C9C231816F000BD1E87 /* Dictionary+Extensions.swift in Sources */,
 				11229747219DC557006D66C5 /* MonadDefer.swift in Sources */,
 				1104BEE522C22E47002C3F78 /* Concurrent.swift in Sources */,
+				8BB969AD2398661D005520D6 /* Queue.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Bow.xcodeproj/project.pbxproj
+++ b/Bow.xcodeproj/project.pbxproj
@@ -220,7 +220,6 @@
 		11F41C9A231816D800BD1E87 /* Ref.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11F41C91231816AD00BD1E87 /* Ref.swift */; };
 		11F41C9B231816F000BD1E87 /* Atomic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11F41C94231816AD00BD1E87 /* Atomic.swift */; };
 		11F41C9C231816F000BD1E87 /* Dictionary+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11F41C95231816AD00BD1E87 /* Dictionary+Extensions.swift */; };
-		11F41C9D231816F000BD1E87 /* DispatchQueue+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11F41C93231816AD00BD1E87 /* DispatchQueue+Extensions.swift */; };
 		11F41CA2231818DB00BD1E87 /* BracketLaws.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11F41C9E231818AE00BD1E87 /* BracketLaws.swift */; };
 		11F41CA3231818DB00BD1E87 /* MonadDeferLaws.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11F41C9F231818AF00BD1E87 /* MonadDeferLaws.swift */; };
 		11FB4612238EB78200EA60BF /* EnvIO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11FB4610238EB78200EA60BF /* EnvIO.swift */; };
@@ -846,7 +845,6 @@
 		11F036832327E1C900B39A80 /* ConsoleIO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConsoleIO.swift; sourceTree = "<group>"; };
 		11F036852327EA1F00B39A80 /* FileManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileManager.swift; sourceTree = "<group>"; };
 		11F41C91231816AD00BD1E87 /* Ref.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Ref.swift; sourceTree = "<group>"; };
-		11F41C93231816AD00BD1E87 /* DispatchQueue+Extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "DispatchQueue+Extensions.swift"; sourceTree = "<group>"; };
 		11F41C94231816AD00BD1E87 /* Atomic.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Atomic.swift; sourceTree = "<group>"; };
 		11F41C95231816AD00BD1E87 /* Dictionary+Extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Dictionary+Extensions.swift"; sourceTree = "<group>"; };
 		11F41C9E231818AE00BD1E87 /* BracketLaws.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BracketLaws.swift; sourceTree = "<group>"; };
@@ -1649,7 +1647,6 @@
 			isa = PBXGroup;
 			children = (
 				11F41C95231816AD00BD1E87 /* Dictionary+Extensions.swift */,
-				11F41C93231816AD00BD1E87 /* DispatchQueue+Extensions.swift */,
 				11912B09238C1FB4007D90A2 /* DispatchTimeInterval+Extensions.swift */,
 				8BB969AB239863F0005520D6 /* Queue.swift */,
 			);
@@ -2714,7 +2711,6 @@
 				1104BEE322C22E47002C3F78 /* UnsafeRun.swift in Sources */,
 				11229745219DC557006D66C5 /* ConcurrentEffect.swift in Sources */,
 				1104BEE422C22E47002C3F78 /* Bracket.swift in Sources */,
-				11F41C9D231816F000BD1E87 /* DispatchQueue+Extensions.swift in Sources */,
 				11FDD68F23867D9800EA8A4D /* Schedule.swift in Sources */,
 				11F0367F2327D08900B39A80 /* EffectComprehensions.swift in Sources */,
 				11229746219DC557006D66C5 /* Effect.swift in Sources */,

--- a/Sources/BowEffects/Data/IO.swift
+++ b/Sources/BowEffects/Data/IO.swift
@@ -36,7 +36,7 @@ public class IO<E: Error, A>: IOOf<E, A> {
     /// - Parameter fa: Value in higher-kind form.
     /// - Returns: Value casted to IO.
     public static func fix(_ fa: IOOf<E, A>) -> IO<E, A> {
-        return fa as! IO<E, A>
+        fa as! IO<E, A>
     }
     
     /// Creates an EnvIO with no dependencies from this IO.
@@ -49,7 +49,7 @@ public class IO<E: Error, A>: IOOf<E, A> {
     /// - Parameter f: Side-effectful function. Errors thrown from this function must be of type `E`; otherwise, a fatal error will happen.
     /// - Returns: An IO function suspending the execution of the side effect.
     public static func invoke(_ f: @escaping () throws -> A) -> IO<E, A> {
-        return IO.defer {
+        IO.defer {
             do {
                 return Pure<E, A>(try f())
             } catch let error as E {
@@ -65,7 +65,7 @@ public class IO<E: Error, A>: IOOf<E, A> {
     /// - Parameter f: Side-effectful function returning an `Either`. Errors thrown from this function must be of type `E`; otherwise, a fatal error will happen.
     /// - Returns: An IO suspending the execution of the side effect.
     public static func invokeEither(_ f: @escaping () throws -> Either<E, A>) -> IO<E, A> {
-        return IO.defer {
+        IO.defer {
             do {
                 return try f().fold(IO.raiseError, IO.pure)
             } catch let error as E {
@@ -81,7 +81,7 @@ public class IO<E: Error, A>: IOOf<E, A> {
     /// - Parameter f: Side-effectful function returning a `Result`. Errors thrown from this function must be of type `E`; otherwise, a fatal error will happen.
     /// - Returns: An IO suspending the execution of the side effect.
     public static func invokeResult(_ f: @escaping () throws -> Result<A, E>) -> IO<E, A> {
-        return invokeEither { try f().toEither() }
+        invokeEither { try f().toEither() }
     }
     
     /// Creates an IO from a side-effectful function.
@@ -89,7 +89,7 @@ public class IO<E: Error, A>: IOOf<E, A> {
     /// - Parameter f: Side-effectful function returning an `Validated`. Errors thrown from this function must be of type `E`; otherwise, a fatal error will happen.
     /// - Returns: An IO suspending the execution of the side effect.
     public static func invokeValidated(_ f: @escaping () throws -> Validated<E, A>) -> IO<E, A> {
-        return invokeEither { try f().toEither() }
+        invokeEither { try f().toEither() }
     }
     
     /// Creates an IO from 2 side-effectful functions, tupling their results. Errors thrown from the functions must be of type `E`; otherwise, a fatal error will happen.
@@ -100,9 +100,8 @@ public class IO<E: Error, A>: IOOf<E, A> {
     /// - Returns: An IO suspending the execution of the side effects.
     public static func merge<Z, B>(_ fa: @escaping () throws -> Z,
                                    _ fb: @escaping () throws -> B) -> IO<E, (Z, B)> where A == (Z, B) {
-        return IO.zip(
-            IO<E, Z>.invoke(fa),
-            IO<E, B>.invoke(fb))^
+        IO.zip(IO<E, Z>.invoke(fa),
+               IO<E, B>.invoke(fb))^
     }
     
     /// Creates an IO from 3 side-effectful functions, tupling their results. Errors thrown from the functions must be of type `E`; otherwise, a fatal error will happen.
@@ -115,10 +114,9 @@ public class IO<E: Error, A>: IOOf<E, A> {
     public static func merge<Z, B, C>(_ fa: @escaping () throws -> Z,
                                       _ fb: @escaping () throws -> B,
                                       _ fc: @escaping () throws -> C) -> IO<E, (Z, B, C)> where A == (Z, B, C) {
-        return IO.zip(
-            IO<E, Z>.invoke(fa),
-            IO<E, B>.invoke(fb),
-            IO<E, C>.invoke(fc))^
+        IO.zip(IO<E, Z>.invoke(fa),
+               IO<E, B>.invoke(fb),
+               IO<E, C>.invoke(fc))^
     }
     
     /// Creates an IO from 4 side-effectful functions, tupling their results. Errors thrown from the functions must be of type `E`; otherwise, a fatal error will happen.
@@ -133,11 +131,10 @@ public class IO<E: Error, A>: IOOf<E, A> {
                                          _ fb: @escaping () throws -> B,
                                          _ fc: @escaping () throws -> C,
                                          _ fd: @escaping () throws -> D) -> IO<E, (Z, B, C, D)> where A == (Z, B, C, D) {
-        return IO.zip(
-            IO<E, Z>.invoke(fa),
-            IO<E, B>.invoke(fb),
-            IO<E, C>.invoke(fc),
-            IO<E, D>.invoke(fd))^
+        IO.zip(IO<E, Z>.invoke(fa),
+               IO<E, B>.invoke(fb),
+               IO<E, C>.invoke(fc),
+               IO<E, D>.invoke(fd))^
     }
     
     /// Creates an IO from 5 side-effectful functions, tupling their results. Errors thrown from the functions must be of type `E`; otherwise, a fatal error will happen.
@@ -154,12 +151,11 @@ public class IO<E: Error, A>: IOOf<E, A> {
                                             _ fc: @escaping () throws -> C,
                                             _ fd: @escaping () throws -> D,
                                             _ ff: @escaping () throws -> F) -> IO<E, (Z, B, C, D, F)> where A == (Z, B, C, D, F) {
-        return IO.zip(
-            IO<E, Z>.invoke(fa),
-            IO<E, B>.invoke(fb),
-            IO<E, C>.invoke(fc),
-            IO<E, D>.invoke(fd),
-            IO<E, F>.invoke(ff))^
+        IO.zip(IO<E, Z>.invoke(fa),
+               IO<E, B>.invoke(fb),
+               IO<E, C>.invoke(fc),
+               IO<E, D>.invoke(fd),
+               IO<E, F>.invoke(ff))^
     }
     
     /// Creates an IO from 6 side-effectful functions, tupling their results. Errors thrown from the functions must be of type `E`; otherwise, a fatal error will happen.
@@ -178,13 +174,12 @@ public class IO<E: Error, A>: IOOf<E, A> {
                                                _ fd: @escaping () throws -> D,
                                                _ ff: @escaping () throws -> F,
                                                _ fg: @escaping () throws -> G) -> IO<E, (Z, B, C, D, F, G)> where A == (Z, B, C, D, F, G){
-        return IO.zip(
-            IO<E, Z>.invoke(fa),
-            IO<E, B>.invoke(fb),
-            IO<E, C>.invoke(fc),
-            IO<E, D>.invoke(fd),
-            IO<E, F>.invoke(ff),
-            IO<E, G>.invoke(fg))^
+        IO.zip(IO<E, Z>.invoke(fa),
+               IO<E, B>.invoke(fb),
+               IO<E, C>.invoke(fc),
+               IO<E, D>.invoke(fd),
+               IO<E, F>.invoke(ff),
+               IO<E, G>.invoke(fg))^
     }
     
     /// Creates an IO from 7 side-effectful functions, tupling their results. Errors thrown from the functions must be of type `E`; otherwise, a fatal error will happen.
@@ -205,14 +200,13 @@ public class IO<E: Error, A>: IOOf<E, A> {
                                                   _ ff: @escaping () throws -> F,
                                                   _ fg: @escaping () throws -> G,
                                                   _ fh: @escaping () throws -> H ) -> IO<E, (Z, B, C, D, F, G, H)> where A == (Z, B, C, D, F, G, H) {
-        return IO.zip(
-            IO<E, Z>.invoke(fa),
-            IO<E, B>.invoke(fb),
-            IO<E, C>.invoke(fc),
-            IO<E, D>.invoke(fd),
-            IO<E, F>.invoke(ff),
-            IO<E, G>.invoke(fg),
-            IO<E, H>.invoke(fh))^
+        IO.zip(IO<E, Z>.invoke(fa),
+               IO<E, B>.invoke(fb),
+               IO<E, C>.invoke(fc),
+               IO<E, D>.invoke(fd),
+               IO<E, F>.invoke(ff),
+               IO<E, G>.invoke(fg),
+               IO<E, H>.invoke(fh))^
     }
     
     /// Creates an IO from 8 side-effectful functions, tupling their results. Errors thrown from the functions must be of type `E`; otherwise, a fatal error will happen.
@@ -235,15 +229,14 @@ public class IO<E: Error, A>: IOOf<E, A> {
                                                      _ fg: @escaping () throws -> G,
                                                      _ fh: @escaping () throws -> H,
                                                      _ fi: @escaping () throws -> I) -> IO<E, (Z, B, C, D, F, G, H, I)> where A == (Z, B, C, D, F, G, H, I) {
-        return IO.zip(
-            IO<E, Z>.invoke(fa),
-            IO<E, B>.invoke(fb),
-            IO<E, C>.invoke(fc),
-            IO<E, D>.invoke(fd),
-            IO<E, F>.invoke(ff),
-            IO<E, G>.invoke(fg),
-            IO<E, H>.invoke(fh),
-            IO<E, I>.invoke(fi))^
+        IO.zip(IO<E, Z>.invoke(fa),
+               IO<E, B>.invoke(fb),
+               IO<E, C>.invoke(fc),
+               IO<E, D>.invoke(fd),
+               IO<E, F>.invoke(ff),
+               IO<E, G>.invoke(fg),
+               IO<E, H>.invoke(fh),
+               IO<E, I>.invoke(fi))^
     }
     
     /// Creates an IO from 9 side-effectful functions, tupling their results. Errors thrown from the functions must be of type `E`; otherwise, a fatal error will happen.
@@ -268,16 +261,15 @@ public class IO<E: Error, A>: IOOf<E, A> {
                                                         _ fh: @escaping () throws -> H,
                                                         _ fi: @escaping () throws -> I,
                                                         _ fj: @escaping () throws -> J ) -> IO<E, (Z, B, C, D, F, G, H, I, J)> where A == (Z, B, C, D, F, G, H, I, J) {
-        return IO.zip(
-            IO<E, Z>.invoke(fa),
-            IO<E, B>.invoke(fb),
-            IO<E, C>.invoke(fc),
-            IO<E, D>.invoke(fd),
-            IO<E, F>.invoke(ff),
-            IO<E, G>.invoke(fg),
-            IO<E, H>.invoke(fh),
-            IO<E, I>.invoke(fi),
-            IO<E, J>.invoke(fj))^
+        IO.zip(IO<E, Z>.invoke(fa),
+               IO<E, B>.invoke(fb),
+               IO<E, C>.invoke(fc),
+               IO<E, D>.invoke(fd),
+               IO<E, F>.invoke(ff),
+               IO<E, G>.invoke(fg),
+               IO<E, H>.invoke(fh),
+               IO<E, I>.invoke(fi),
+               IO<E, J>.invoke(fj))^
     }
     
     /// Performs the side effects that are suspended in this IO in a synchronous manner.
@@ -286,7 +278,7 @@ public class IO<E: Error, A>: IOOf<E, A> {
     /// - Returns: Value produced after running the suspended side effects.
     /// - Throws: Error of type `E` that may happen during the evaluation of the side-effects. Errors of other types thrown from the evaluation of this IO will cause a fatal error.
     public func unsafeRunSync(on queue: DispatchQueue = .main) throws -> A {
-        return try self._unsafeRunSync(on: .queue(queue)).0
+        try self._unsafeRunSync(on: .queue(queue)).0
     }
     
     /// Performs the side effects that are suspended in this IO in a synchronous manner.
@@ -308,9 +300,7 @@ public class IO<E: Error, A>: IOOf<E, A> {
     }
     
     internal func on<T>(queue: Queue, perform: @escaping () throws -> T) throws -> T {
-        return try queue.sync {
-            try perform()
-        }
+        try queue.sync { try perform() }
     }
     
     /// Flattens the internal structure of this IO by performing the side effects and wrapping them again in an IO structure containing the result or the error produced.
@@ -328,7 +318,7 @@ public class IO<E: Error, A>: IOOf<E, A> {
         }
     }
     
-    internal func _attempt(on queue: Queue = .queue()) -> IO<E, A> {
+    internal func _attempt(on queue: Queue) -> IO<E, A> {
         do {
             let result = try self._unsafeRunSync(on: queue).0
             return IO.pure(result)^
@@ -361,12 +351,12 @@ public class IO<E: Error, A>: IOOf<E, A> {
     /// - Parameter f: Function transforming the error.
     /// - Returns: An IO value with the new error type.
     public func mapLeft<EE>(_ f: @escaping (E) -> EE) -> IO<EE, A> {
-        return FErrorMap(f, self)
+        FErrorMap(f, self)
     }
     
     /// Returns this `IO` erasing the error type information
     public var anyError: IO<Error, A> {
-        return self.mapLeft { e in e as Error }
+        self.mapLeft { e in e as Error }
     }
     
     internal func fail(_ error: Error) -> Never {
@@ -434,7 +424,7 @@ public class IO<E: Error, A>: IOOf<E, A> {
 /// - Parameter fa: Value in higher-kind form.
 /// - Returns: Value cast to IO.
 public postfix func ^<E, A>(_ fa: IOOf<E, A>) -> IO<E, A> {
-    return IO.fix(fa)
+    IO.fix(fa)
 }
 
 public extension IO where A == Void {
@@ -471,7 +461,7 @@ public extension IO where E == Error {
     /// - Parameter f: Side-effectful function returning a `Try`. Errors thrown from this function must be of type `E`; otherwise, a fatal error will happen.
     /// - Returns: An IO suspending the execution of the side effect.
     static func invokeTry(_ f: @escaping () throws -> Try<A>) -> IO<Error, A> {
-        return invokeEither { try f().toEither() }
+        invokeEither { try f().toEither() }
     }
 }
 
@@ -483,7 +473,7 @@ internal class Pure<E: Error, A>: IO<E, A> {
     }
     
     override internal func _unsafeRunSync(on queue: Queue = .queue()) throws -> (A, Queue) {
-        return (try on(queue: queue) { self.a }, queue)
+        (try on(queue: queue) { self.a }, queue)
     }
 }
 
@@ -495,7 +485,7 @@ internal class RaiseError<E: Error, A> : IO<E, A> {
     }
     
     override internal func _unsafeRunSync(on queue: Queue = .queue()) throws -> (A, Queue) {
-        return (try on(queue: queue) { throw self.error }, queue)
+        (try on(queue: queue) { throw self.error }, queue)
     }
 }
 
@@ -582,7 +572,7 @@ internal class ContinueOn<E: Error, A>: IO<E, A> {
     }
     
     override internal func _unsafeRunSync(on queue: Queue = .queue()) throws -> (A, Queue) {
-        return (try io._unsafeRunSync(on: queue).0, .queue(self.queue))
+        (try io._unsafeRunSync(on: queue).0, .queue(self.queue))
     }
 }
 
@@ -628,8 +618,8 @@ internal class Race<E: Error, A, B>: IO<E, Either<A, B>> {
         let result = Atomic<Either<A, B>?>(nil)
         let atomic = Atomic<E?>(nil)
         let group = DispatchGroup()
-        let parQueue1 = Queue.queue(label: queue.label + "raceA", qos: queue.qos)
-        let parQueue2 = Queue.queue(label: queue.label + "raceB", qos: queue.qos)
+        let parQueue1: Queue = .queue(label: queue.label + "raceA", qos: queue.qos)
+        let parQueue2: Queue = .queue(label: queue.label + "raceB", qos: queue.qos)
         
         group.enter()
         parQueue1.async {
@@ -687,8 +677,8 @@ internal class ParMap2<E: Error, A, B, Z>: IO<E, Z> {
         var b: B?
         let atomic = Atomic<E?>(nil)
         let group = DispatchGroup()
-        let parQueue1 = Queue.queue(label: queue.label + "parMap1", qos: queue.qos)
-        let parQueue2 = Queue.queue(label: queue.label + "parMap2", qos: queue.qos)
+        let parQueue1: Queue = .queue(label: queue.label + "parMap1", qos: queue.qos)
+        let parQueue2: Queue = .queue(label: queue.label + "parMap2", qos: queue.qos)
         
         group.enter()
         parQueue1.async {
@@ -742,9 +732,9 @@ internal class ParMap3<E: Error, A, B, C, Z>: IO<E, Z> {
         var c: C?
         let atomic = Atomic<E?>(nil)
         let group = DispatchGroup()
-        let parQueue1 = Queue.queue(label: queue.label + "parMap1", qos: queue.qos)
-        let parQueue2 = Queue.queue(label: queue.label + "parMap2", qos: queue.qos)
-        let parQueue3 = Queue.queue(label: queue.label + "parMap3", qos: queue.qos)
+        let parQueue1: Queue = .queue(label: queue.label + "parMap1", qos: queue.qos)
+        let parQueue2: Queue = .queue(label: queue.label + "parMap2", qos: queue.qos)
+        let parQueue3: Queue = .queue(label: queue.label + "parMap3", qos: queue.qos)
         
         group.enter()
         parQueue1.async {
@@ -823,7 +813,7 @@ internal class Suspend<E: Error, A>: IO<E, A> {
     }
     
     override func _unsafeRunSync(on queue: Queue = .queue()) throws -> (A, Queue) {
-        return try on(queue: queue) {
+        try on(queue: queue) {
             try self.thunk()^._unsafeRunSync(on: queue)
         }
     }
@@ -832,14 +822,14 @@ internal class Suspend<E: Error, A>: IO<E, A> {
 // MARK: Instance of `Functor` for `IO`
 extension IOPartial: Functor {
     public static func map<A, B>(_ fa: IOOf<E, A>, _ f: @escaping (A) -> B) -> IOOf<E, B> {
-        return FMap(f, IO.fix(fa))
+        FMap(f, IO.fix(fa))
     }
 }
 
 // MARK: Instance of `Applicative` for `IO`
 extension IOPartial: Applicative {
     public static func pure<A>(_ a: A) -> IOOf<E, A> {
-        return Pure(a)
+        Pure(a)
     }
 }
 
@@ -849,11 +839,11 @@ extension IOPartial: Selective {}
 // MARK: Instance of `Monad` for `IO`
 extension IOPartial: Monad {
     public static func flatMap<A, B>(_ fa: IOOf<E, A>, _ f: @escaping (A) -> IOOf<E, B>) -> IOOf<E, B> {
-        return Join(IO.fix(IO.fix(fa).map { x in IO.fix(f(x)) }))
+        Join(IO.fix(IO.fix(fa).map { x in IO.fix(f(x)) }))
     }
     
     public static func tailRecM<A, B>(_ a: A, _ f: @escaping (A) -> IOOf<E, Either<A, B>>) -> IOOf<E, B> {
-        return IO.fix(f(a)).flatMap { either in
+        IO.fix(f(a)).flatMap { either in
             either.fold({ a in tailRecM(a, f) },
                         { b in IO.pure(b) })
         }
@@ -863,7 +853,7 @@ extension IOPartial: Monad {
 // MARK: Instance of `ApplicativeError` for `IO`
 extension IOPartial: ApplicativeError {
     public static func raiseError<A>(_ e: E) -> IOOf<E, A> {
-        return RaiseError(e)
+        RaiseError(e)
     }
     
     private static func fold<A, B>(_ io: IO<E, A>, _ fe: @escaping (E) -> B, _ fa: @escaping (A) -> B) -> B {
@@ -885,25 +875,25 @@ extension IOPartial: MonadError {}
 // MARK: Instance of `Bracket` for `IO`
 extension IOPartial: Bracket {
     public static func bracketCase<A, B>(acquire fa: IOOf<E, A>, release: @escaping (A, ExitCase<E>) -> IOOf<E, ()>, use: @escaping (A) throws -> IOOf<E, B>) -> IOOf<E, B> {
-        return BracketIO<E, A, B>(fa^, release, use)
+        BracketIO<E, A, B>(fa^, release, use)
     }
 }
 
 // MARK: Instance of `MonadDefer` for `IO`
 extension IOPartial: MonadDefer {
     public static func `defer`<A>(_ fa: @escaping () -> IOOf<E, A>) -> IOOf<E, A> {
-        return Suspend(fa)
+        Suspend(fa)
     }
 }
 
 // MARK: Instance of `Async` for `IO`
 extension IOPartial: Async {
     public static func asyncF<A>(_ procf: @escaping (@escaping (Either<E, A>) -> ()) -> IOOf<E, ()>) -> IOOf<E, A> {
-        return AsyncIO(procf)
+        AsyncIO(procf)
     }
     
     public static func continueOn<A>(_ fa: IOOf<E, A>, _ queue: DispatchQueue) -> IOOf<E, A> {
-        return ContinueOn(fa^, queue)
+        ContinueOn(fa^, queue)
     }
 }
 
@@ -914,25 +904,25 @@ extension IOPartial: Concurrent {
     }
     
     public static func parMap<A, B, Z>(_ fa: Kind<IOPartial<E>, A>, _ fb: Kind<IOPartial<E>, B>, _ f: @escaping (A, B) -> Z) -> Kind<IOPartial<E>, Z> {
-        return ParMap2<E, A, B, Z>(fa^, fb^, f)
+        ParMap2<E, A, B, Z>(fa^, fb^, f)
     }
     
     public static func parMap<A, B, C, Z>(_ fa: Kind<IOPartial<E>, A>, _ fb: Kind<IOPartial<E>, B>, _ fc: Kind<IOPartial<E>, C>, _ f: @escaping (A, B, C) -> Z) -> Kind<IOPartial<E>, Z> {
-        return ParMap3<E, A, B, C, Z>(fa^, fb^, fc^, f)
+        ParMap3<E, A, B, C, Z>(fa^, fb^, fc^, f)
     }
 }
 
 // MARK: Instance of `Effect` for `IO`
 extension IOPartial: Effect {
     public static func runAsync<A>(_ fa: IOOf<E, A>, _ callback: @escaping (Either<E, A>) -> IOOf<E, ()>) -> IOOf<E, ()> {
-        return IOEffect(fa^, callback)
+        IOEffect(fa^, callback)
     }
 }
 
 // MARK: Instance of `UnsafeRun` for `IO`
 extension IOPartial: UnsafeRun {
     public static func runBlocking<A>(on queue: DispatchQueue, _ fa: @escaping () -> Kind<IOPartial<E>, A>) throws -> A {
-        return try fa()^.unsafeRunSync(on: queue)
+        try fa()^.unsafeRunSync(on: queue)
     }
     
     public static func runNonBlocking<A>(on queue: DispatchQueue, _ fa: @escaping () -> Kind<IOPartial<E>, A>, _ callback: @escaping (Either<E, A>) -> ()) {

--- a/Sources/BowEffects/Data/IO.swift
+++ b/Sources/BowEffects/Data/IO.swift
@@ -287,7 +287,7 @@ public class IO<E: Error, A>: IOOf<E, A> {
     /// - Returns: An Either wrapping errors in the left side and values on the right side. Errors of other types thrown from the evaluation of this IO will cause a fatal error.
     public func unsafeRunSyncEither(on queue: DispatchQueue = .main) -> Either<E, A> {
         do {
-            return .right(try self.unsafeRunSync())
+            return .right(try self.unsafeRunSync(on: queue))
         } catch let e as E {
             return .left(e)
         } catch {

--- a/Sources/BowEffects/Data/Internal/DispatchQueue+Extensions.swift
+++ b/Sources/BowEffects/Data/Internal/DispatchQueue+Extensions.swift
@@ -1,7 +1,0 @@
-import Foundation
-
-extension DispatchQueue {
-    public static var currentLabel: String {
-        String(validatingUTF8: __dispatch_queue_get_label(nil)) ?? ""
-    }
-}

--- a/Sources/BowEffects/Data/Internal/DispatchQueue+Extensions.swift
+++ b/Sources/BowEffects/Data/Internal/DispatchQueue+Extensions.swift
@@ -2,6 +2,6 @@ import Foundation
 
 extension DispatchQueue {
     public static var currentLabel: String {
-        return String(validatingUTF8: __dispatch_queue_get_label(nil)) ?? ""
+        String(validatingUTF8: __dispatch_queue_get_label(nil)) ?? ""
     }
 }

--- a/Sources/BowEffects/Data/Internal/Queue.swift
+++ b/Sources/BowEffects/Data/Internal/Queue.swift
@@ -1,0 +1,70 @@
+import Foundation
+
+internal enum Queue {
+    case queue(DispatchQueue = .main)
+    case current
+    
+    // MARK: properties
+    var dispatchQueue: DispatchQueue {
+        switch self {
+        case .queue(let queue):
+            return queue
+        case .current:
+            fatalError("can not extract queue from current context")
+        }
+    }
+    
+    var label: String {
+        switch self {
+        case .queue(let queue):
+            return queue.label
+        case .current:
+            return DispatchQueue.currentLabel
+        }
+    }
+    
+    var qos: DispatchQoS {
+        switch self {
+        case .queue(let queue):
+            return queue.qos
+        case .current:
+            return .default
+        }
+    }
+    
+    // Mark: constructors
+    static func queue(label: String, qos: DispatchQoS = .default) -> Queue {
+        .queue(DispatchQueue(label: label, qos: qos))
+    }
+    
+    // MARK: operations
+    func async(execute work: @escaping () -> Void) {
+        switch self {
+        case .queue(let queue):
+            queue.async(execute: work)
+        default:
+            fatalError("can not execute async work in current queue")
+        }
+    }
+    
+    func sync<T>(execute work: () throws -> T) rethrows -> T {
+        switch self {
+        case .queue(let queue):
+            if DispatchQueue.currentLabel == queue.label {
+                return try work()
+            } else {
+                return try queue.sync(execute: work)
+            }
+        case .current:
+            return try work()
+        }
+    }
+}
+
+
+// MARK: - helpers
+internal extension DispatchQueue {
+    var queue: Queue {
+        .queue(self)
+    }
+}

--- a/Sources/BowEffects/Data/Internal/Queue.swift
+++ b/Sources/BowEffects/Data/Internal/Queue.swift
@@ -5,15 +5,6 @@ internal enum Queue {
     case current
     
     // MARK: properties
-    var dispatchQueue: DispatchQueue {
-        switch self {
-        case .queue(let queue):
-            return queue
-        case .current:
-            fatalError("can not extract queue from current context")
-        }
-    }
-    
     var label: String {
         switch self {
         case .queue(let queue):
@@ -66,5 +57,11 @@ internal enum Queue {
 internal extension DispatchQueue {
     var queue: Queue {
         .queue(self)
+    }
+}
+
+fileprivate extension DispatchQueue {
+    static var currentLabel: String {
+        String(validatingUTF8: __dispatch_queue_get_label(nil)) ?? ""
     }
 }


### PR DESCRIPTION
## Goal

We have detected when the user uses `IO.handleErrorWith` execution always continue on the main thread and it is performed at this moment.

## Implementation details

It is happening because internally `IO.handleErrorWith` is using `attempt(on: .main)` to perform the side effects and resolve the handle at this moment.

