### PR TITLE
Set exact versions installing Travis builds Ruby dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,8 +18,7 @@ jobs:
   include:
     - stage: compile-docs
       before_install:
-        - gem update --system --force
-        - gem install cocoapods --force
+        - gem install cocoapods -v 1.8.4
       script:
         - nef compile Documentation.app
     - stage: test
@@ -31,9 +30,8 @@ jobs:
     - stage: deploy-docs
       if: branch = master AND type != pull_request
       before_install:
-        - gem update --system --force
-        - gem install bundler --force
-        - gem install cocoapods --force
+        - gem install bundler -v 2.0.2
+        - gem install cocoapods -v 1.8.4
       script:
         - ./scripts/gen-docs.rb
       deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ jobs:
       before_install:
         - gem update --system --conservative
         - gem install bundler --conservative
-        - gem install cocoapods
+        - gem install cocoapods --conservative
       script:
         - ./scripts/gen-docs.rb
       deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,8 +18,8 @@ jobs:
   include:
     - stage: compile-docs
       before_install:
-        - gem update --system --conservative
-        - gem install cocoapods --conservative
+        - gem update --system --force
+        - gem install cocoapods --force
       script:
         - nef compile Documentation.app
     - stage: test
@@ -31,9 +31,9 @@ jobs:
     - stage: deploy-docs
       if: branch = master AND type != pull_request
       before_install:
-        - gem update --system --conservative
-        - gem install bundler --conservative
-        - gem install cocoapods --conservative
+        - gem update --system --force
+        - gem install bundler --force
+        - gem install cocoapods --force
       script:
         - ./scripts/gen-docs.rb
       deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ jobs:
     - stage: compile-docs
       before_install:
         - gem update --system --conservative
-        - gem install cocoapods
+        - gem install cocoapods --conservative
       script:
         - nef compile Documentation.app
     - stage: test

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ jobs:
   include:
     - stage: compile-docs
       before_install:
-        - gem update --system
+        - gem update --system --conservative
         - gem install cocoapods
       script:
         - nef compile Documentation.app
@@ -31,8 +31,8 @@ jobs:
     - stage: deploy-docs
       if: branch = master AND type != pull_request
       before_install:
-        - gem update --system
-        - gem install bundler
+        - gem update --system --conservative
+        - gem install bundler --conservative
         - gem install cocoapods
       script:
         - ./scripts/gen-docs.rb


### PR DESCRIPTION
## Related issues

Latest builds are failing due to an error:

```bash
$ gem update --system

Updating rubygems-update
Successfully installed rubygems-update-3.1.1
Installing RubyGems 3.1.1
  Successfully built RubyGem
  Name: bundler
  Version: 2.1.0
  File: bundler-2.1.0.gem
bundler's executable "bundle" conflicts with /Users/travis/.rvm/rubies/ruby-2.6.4/bin/bundle
Overwrite the executable? [yN]  
```

## Goal

Fix those Travis builds problems.

## Implementation details

We are using the `-v` option to try to tell the system to install an exact versions, so we don't need to update the Ruby environment globally.