### PR TITLE
Set version 0.7.0 as the current version for docs

### DIFF
--- a/scripts/gen-docs.rb
+++ b/scripts/gen-docs.rb
@@ -6,7 +6,7 @@ require 'json'
 # If you want a specific version to be served as default, set this value to the
 # branch/tag you want. Otherwise it will be the latest version on alphabetical order.
 # If there's no tags, then `master` branch content will be served at root path.
-$default_version = "0.6.0"
+$default_version = "0.7.0"
 
 # If you want to build the current branch (usually `master`) and serve it,
 # set the path/name in here. If you leave it empty no site will be built for it.
@@ -15,7 +15,7 @@ $current_branch_path = "next"
 # This is a list to filter -out- tags we know are not valuable to generate docs
 # for. If you set one tag in the default_version, you can add it here, so it's
 # not generated twice. Unless you want to have the same content at two paths.
-$invalid_tags = ["0.1.0", "0.2.0", "0.3.0", "0.6.0"]
+$invalid_tags = ["0.1.0", "0.2.0", "0.3.0", "0.4.0", "0.7.0"]
 
 # This is a list to filter -in- tags. Unless it's empty, where it will be ignored.
 # If you want an empty tags list in the end (for some reason ¯\_(ツ)_/¯)


### PR DESCRIPTION
## Related issues

After the last release, we didn't update the version selector for docs.

## Goal

Set version 0.7.0 as the current version.