### PR TITLE
Comonad Type classes

### DIFF
--- a/Bow.xcodeproj/project.pbxproj
+++ b/Bow.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		1104BEE422C22E47002C3F78 /* Bracket.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1104BEE122C22E47002C3F78 /* Bracket.swift */; };
 		1104BEE522C22E47002C3F78 /* Concurrent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1104BEE222C22E47002C3F78 /* Concurrent.swift */; };
 		1104BEEA22C25AAF002C3F78 /* Resource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1104BEE922C25AAF002C3F78 /* Resource.swift */; };
+		110DE5CC23ACE29D00E5DB36 /* ComonadStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 110DE5CB23ACE29D00E5DB36 /* ComonadStore.swift */; };
 		1116D4F0224E270B00507B54 /* Coproduct3.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1116D4EF224E270B00507B54 /* Coproduct3.swift */; };
 		1116D4F2224E2B1600507B54 /* Coproduct4.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1116D4F1224E2B1600507B54 /* Coproduct4.swift */; };
 		1116D4F4224E2C8A00507B54 /* Coproduct5.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1116D4F3224E2C8A00507B54 /* Coproduct5.swift */; };
@@ -700,6 +701,7 @@
 		1104BEE122C22E47002C3F78 /* Bracket.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Bracket.swift; sourceTree = "<group>"; };
 		1104BEE222C22E47002C3F78 /* Concurrent.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Concurrent.swift; sourceTree = "<group>"; };
 		1104BEE922C25AAF002C3F78 /* Resource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Resource.swift; sourceTree = "<group>"; };
+		110DE5CB23ACE29D00E5DB36 /* ComonadStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComonadStore.swift; sourceTree = "<group>"; };
 		1116D4EF224E270B00507B54 /* Coproduct3.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Coproduct3.swift; sourceTree = "<group>"; };
 		1116D4F1224E2B1600507B54 /* Coproduct4.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Coproduct4.swift; sourceTree = "<group>"; };
 		1116D4F3224E2C8A00507B54 /* Coproduct5.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Coproduct5.swift; sourceTree = "<group>"; };
@@ -1862,6 +1864,7 @@
 				8BA0F48E217E2E9200969984 /* ApplicativeError.swift */,
 				8BA0F4A2217E2E9200969984 /* Bimonad.swift */,
 				8BA0F4A9217E2E9200969984 /* Comonad.swift */,
+				110DE5CB23ACE29D00E5DB36 /* ComonadStore.swift */,
 				8BA0F493217E2E9200969984 /* Comparable.swift */,
 				8BA0F492217E2E9200969984 /* Contravariant.swift */,
 				609CC14C2365410500096D5D /* Decidable.swift */,
@@ -2991,6 +2994,7 @@
 				8BA0F5C7217E2E9200969984 /* SetK.swift in Sources */,
 				8BA0F647217E2E9200969984 /* Comonad.swift in Sources */,
 				8BA0F5A3217E2E9200969984 /* Moore.swift in Sources */,
+				110DE5CC23ACE29D00E5DB36 /* ComonadStore.swift in Sources */,
 				606B29EA23607607002334B2 /* Divide.swift in Sources */,
 				8BA0F5AF217E2E9200969984 /* Try.swift in Sources */,
 				8BA0F62B217E2E9200969984 /* NonEmptyReducible.swift in Sources */,

--- a/Bow.xcodeproj/project.pbxproj
+++ b/Bow.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		1104BEE522C22E47002C3F78 /* Concurrent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1104BEE222C22E47002C3F78 /* Concurrent.swift */; };
 		1104BEEA22C25AAF002C3F78 /* Resource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1104BEE922C25AAF002C3F78 /* Resource.swift */; };
 		110DE5CC23ACE29D00E5DB36 /* ComonadStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 110DE5CB23ACE29D00E5DB36 /* ComonadStore.swift */; };
+		110DE5CE23ACE5AD00E5DB36 /* ComonadEnv.swift in Sources */ = {isa = PBXBuildFile; fileRef = 110DE5CD23ACE5AD00E5DB36 /* ComonadEnv.swift */; };
 		1116D4F0224E270B00507B54 /* Coproduct3.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1116D4EF224E270B00507B54 /* Coproduct3.swift */; };
 		1116D4F2224E2B1600507B54 /* Coproduct4.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1116D4F1224E2B1600507B54 /* Coproduct4.swift */; };
 		1116D4F4224E2C8A00507B54 /* Coproduct5.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1116D4F3224E2C8A00507B54 /* Coproduct5.swift */; };
@@ -702,6 +703,7 @@
 		1104BEE222C22E47002C3F78 /* Concurrent.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Concurrent.swift; sourceTree = "<group>"; };
 		1104BEE922C25AAF002C3F78 /* Resource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Resource.swift; sourceTree = "<group>"; };
 		110DE5CB23ACE29D00E5DB36 /* ComonadStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComonadStore.swift; sourceTree = "<group>"; };
+		110DE5CD23ACE5AD00E5DB36 /* ComonadEnv.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComonadEnv.swift; sourceTree = "<group>"; };
 		1116D4EF224E270B00507B54 /* Coproduct3.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Coproduct3.swift; sourceTree = "<group>"; };
 		1116D4F1224E2B1600507B54 /* Coproduct4.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Coproduct4.swift; sourceTree = "<group>"; };
 		1116D4F3224E2C8A00507B54 /* Coproduct5.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Coproduct5.swift; sourceTree = "<group>"; };
@@ -1864,6 +1866,7 @@
 				8BA0F48E217E2E9200969984 /* ApplicativeError.swift */,
 				8BA0F4A2217E2E9200969984 /* Bimonad.swift */,
 				8BA0F4A9217E2E9200969984 /* Comonad.swift */,
+				110DE5CD23ACE5AD00E5DB36 /* ComonadEnv.swift */,
 				110DE5CB23ACE29D00E5DB36 /* ComonadStore.swift */,
 				8BA0F493217E2E9200969984 /* Comparable.swift */,
 				8BA0F492217E2E9200969984 /* Contravariant.swift */,
@@ -2952,6 +2955,7 @@
 				8BA0F517217E2E9200969984 /* Predef.swift in Sources */,
 				1137469923433E5800D9C1AD /* Array.swift in Sources */,
 				8BA0F4FB217E2E9200969984 /* Cokleisli.swift in Sources */,
+				110DE5CE23ACE5AD00E5DB36 /* ComonadEnv.swift in Sources */,
 				8BA0F57B217E2E9200969984 /* Reader.swift in Sources */,
 				8BA0F54F217E2E9200969984 /* OptionInstances.swift in Sources */,
 				8BA0F4EB217E2E9200969984 /* Kleisli.swift in Sources */,

--- a/Bow.xcodeproj/project.pbxproj
+++ b/Bow.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		1104BEEA22C25AAF002C3F78 /* Resource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1104BEE922C25AAF002C3F78 /* Resource.swift */; };
 		110DE5CC23ACE29D00E5DB36 /* ComonadStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 110DE5CB23ACE29D00E5DB36 /* ComonadStore.swift */; };
 		110DE5CE23ACE5AD00E5DB36 /* ComonadEnv.swift in Sources */ = {isa = PBXBuildFile; fileRef = 110DE5CD23ACE5AD00E5DB36 /* ComonadEnv.swift */; };
+		110DE5D023ACE6B800E5DB36 /* ComonadTraced.swift in Sources */ = {isa = PBXBuildFile; fileRef = 110DE5CF23ACE6B800E5DB36 /* ComonadTraced.swift */; };
 		1116D4F0224E270B00507B54 /* Coproduct3.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1116D4EF224E270B00507B54 /* Coproduct3.swift */; };
 		1116D4F2224E2B1600507B54 /* Coproduct4.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1116D4F1224E2B1600507B54 /* Coproduct4.swift */; };
 		1116D4F4224E2C8A00507B54 /* Coproduct5.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1116D4F3224E2C8A00507B54 /* Coproduct5.swift */; };
@@ -704,6 +705,7 @@
 		1104BEE922C25AAF002C3F78 /* Resource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Resource.swift; sourceTree = "<group>"; };
 		110DE5CB23ACE29D00E5DB36 /* ComonadStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComonadStore.swift; sourceTree = "<group>"; };
 		110DE5CD23ACE5AD00E5DB36 /* ComonadEnv.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComonadEnv.swift; sourceTree = "<group>"; };
+		110DE5CF23ACE6B800E5DB36 /* ComonadTraced.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComonadTraced.swift; sourceTree = "<group>"; };
 		1116D4EF224E270B00507B54 /* Coproduct3.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Coproduct3.swift; sourceTree = "<group>"; };
 		1116D4F1224E2B1600507B54 /* Coproduct4.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Coproduct4.swift; sourceTree = "<group>"; };
 		1116D4F3224E2C8A00507B54 /* Coproduct5.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Coproduct5.swift; sourceTree = "<group>"; };
@@ -1868,6 +1870,7 @@
 				8BA0F4A9217E2E9200969984 /* Comonad.swift */,
 				110DE5CD23ACE5AD00E5DB36 /* ComonadEnv.swift */,
 				110DE5CB23ACE29D00E5DB36 /* ComonadStore.swift */,
+				110DE5CF23ACE6B800E5DB36 /* ComonadTraced.swift */,
 				8BA0F493217E2E9200969984 /* Comparable.swift */,
 				8BA0F492217E2E9200969984 /* Contravariant.swift */,
 				609CC14C2365410500096D5D /* Decidable.swift */,
@@ -2972,6 +2975,7 @@
 				09CEF851236E28680070CF43 /* Pairing.swift in Sources */,
 				8BA0F593217E2E9200969984 /* NonEmptyArray.swift in Sources */,
 				8BA0F58F217E2E9200969984 /* Option.swift in Sources */,
+				110DE5D023ACE6B800E5DB36 /* ComonadTraced.swift in Sources */,
 				8BA0F5F3217E2E9200969984 /* Comparable.swift in Sources */,
 				8BA0F5E7217E2E9200969984 /* MonadFilter.swift in Sources */,
 				8BA0F5B7217E2E9200969984 /* Sum.swift in Sources */,

--- a/Sources/Bow/Typeclasses/ComonadEnv.swift
+++ b/Sources/Bow/Typeclasses/ComonadEnv.swift
@@ -1,0 +1,18 @@
+public protocol ComonadEnv: Comonad {
+    associatedtype E
+    
+    static func ask<A>(_ wa: Kind<Self, A>) -> E
+    static func asks<A, EE>(_ wa: Kind<Self, A>, _ f: @escaping (E) -> EE) -> EE
+}
+
+// MARK: Syntax for ComonadEnv
+
+public extension Kind where F: ComonadEnv {
+    func ask() -> F.E {
+        F.ask(self)
+    }
+    
+    func asks<EE>(_ f: @escaping (F.E) -> EE) -> EE {
+        F.asks(self, f)
+    }
+}

--- a/Sources/Bow/Typeclasses/ComonadEnv.swift
+++ b/Sources/Bow/Typeclasses/ComonadEnv.swift
@@ -2,7 +2,12 @@ public protocol ComonadEnv: Comonad {
     associatedtype E
     
     static func ask<A>(_ wa: Kind<Self, A>) -> E
-    static func asks<A, EE>(_ wa: Kind<Self, A>, _ f: @escaping (E) -> EE) -> EE
+}
+
+public extension ComonadEnv {
+    static func asks<A, EE>(_ wa: Kind<Self, A>, _ f: @escaping (E) -> EE) -> EE {
+        f(ask(wa))
+    }
 }
 
 // MARK: Syntax for ComonadEnv

--- a/Sources/Bow/Typeclasses/ComonadStore.swift
+++ b/Sources/Bow/Typeclasses/ComonadStore.swift
@@ -1,0 +1,38 @@
+public protocol ComonadStore: Comonad {
+    associatedtype S
+    
+    static func position<A>(_ wa: Kind<Self, A>) -> S
+    static func peek<A>(_ wa: Kind<Self, A>, _ s: S) -> A
+    static func peeks<A>(_ wa: Kind<Self, A>, _ f: @escaping (S) -> S) -> A
+    static func seek<A>(_ wa: Kind<Self, A>, _ s: S) -> Kind<Self, A>
+    static func seeks<A>(_ wa: Kind<Self, A>, _ f: @escaping (S) -> S) -> Kind<Self, A>
+    static func experiment<F: Functor, A>(_ wa: Kind<Self, A>, _ f: @escaping (S) -> Kind<F, S>) -> Kind<F, A>
+}
+
+// MARK: Syntax for ComonadStore
+
+public extension Kind where F: ComonadStore {
+    var position: F.S {
+        F.position(self)
+    }
+    
+    func peek(_ s: F.S) -> A {
+        F.peek(self, s)
+    }
+    
+    func peeks(_ f: @escaping (F.S) -> F.S) -> A {
+        F.peeks(self, f)
+    }
+    
+    func seek(_ s: F.S) -> Kind<F, A> {
+        F.seek(self, s)
+    }
+    
+    func seeks(_ f: @escaping (F.S) -> F.S) -> Kind<F, A> {
+        F.seeks(self, f)
+    }
+    
+    func experiment<G: Functor>(_ f: @escaping (F.S) -> Kind<G, F.S>) -> Kind<G, A> {
+        F.experiment(self, f)
+    }
+}

--- a/Sources/Bow/Typeclasses/ComonadStore.swift
+++ b/Sources/Bow/Typeclasses/ComonadStore.swift
@@ -3,10 +3,24 @@ public protocol ComonadStore: Comonad {
     
     static func position<A>(_ wa: Kind<Self, A>) -> S
     static func peek<A>(_ wa: Kind<Self, A>, _ s: S) -> A
-    static func peeks<A>(_ wa: Kind<Self, A>, _ f: @escaping (S) -> S) -> A
-    static func seek<A>(_ wa: Kind<Self, A>, _ s: S) -> Kind<Self, A>
-    static func seeks<A>(_ wa: Kind<Self, A>, _ f: @escaping (S) -> S) -> Kind<Self, A>
-    static func experiment<F: Functor, A>(_ wa: Kind<Self, A>, _ f: @escaping (S) -> Kind<F, S>) -> Kind<F, A>
+}
+
+public extension ComonadStore {
+    static func peeks<A>(_ wa: Kind<Self, A>, _ f: @escaping (S) -> S) -> A {
+        peek(wa, f(position(wa)))
+    }
+    
+    static func seek<A>(_ wa: Kind<Self, A>, _ s: S) -> Kind<Self, A> {
+        wa.coflatMap { fa in peek(fa, s) }
+    }
+    
+    static func seeks<A>(_ wa: Kind<Self, A>, _ f: @escaping (S) -> S) -> Kind<Self, A> {
+        wa.coflatMap { fa in peeks(fa, f) }
+    }
+    
+    static func experiment<F: Functor, A>(_ wa: Kind<Self, A>, _ f: @escaping (S) -> Kind<F, S>) -> Kind<F, A> {
+        F.map(f(position(wa))) { s in peek(wa, s) }
+    }
 }
 
 // MARK: Syntax for ComonadStore

--- a/Sources/Bow/Typeclasses/ComonadTraced.swift
+++ b/Sources/Bow/Typeclasses/ComonadTraced.swift
@@ -1,0 +1,18 @@
+public protocol ComonadTraced: Comonad {
+    associatedtype W
+    
+    static func trace<M, A>(_ wa: Kind<Self, A>, _ m: M) -> A
+    static func traces<M, A>(_ wa: Kind<Self, A>, _ f: @escaping (A) -> M) -> A
+}
+
+// MARK: Syntax for ComonadTraced
+
+public extension Kind where F: ComonadTraced {
+    func trace<M>(_ m: M) -> A {
+        F.trace(self, m)
+    }
+    
+    func traces<M>(_ f: @escaping (A) -> M) -> A {
+        F.traces(self, f)
+    }
+}

--- a/Sources/Bow/Typeclasses/ComonadTraced.swift
+++ b/Sources/Bow/Typeclasses/ComonadTraced.swift
@@ -2,7 +2,12 @@ public protocol ComonadTraced: Comonad {
     associatedtype W
     
     static func trace<M, A>(_ wa: Kind<Self, A>, _ m: M) -> A
-    static func traces<M, A>(_ wa: Kind<Self, A>, _ f: @escaping (A) -> M) -> A
+}
+
+public extension ComonadTraced {
+    static func traces<M, A>(_ wa: Kind<Self, A>, _ f: @escaping (A) -> M) -> A {
+        trace(wa, f(wa.extract()))
+    }
 }
 
 // MARK: Syntax for ComonadTraced


### PR DESCRIPTION
Creates the following type classes for Comonads:

- [ComonadStore](http://support.hfm.io/1.6/api/comonad-5.0.2/Control-Comonad-Store.html)
- [ComonadEnv](http://support.hfm.io/1.6/api/comonad-5.0.2/Control-Comonad-Env.html)
- [ComonadTraced](http://support.hfm.io/1.6/api/comonad-5.0.2/Control-Comonad-Traced.html)

Implementation is based on the Haskell package for Comonads that you can check in the links above.