### PR TITLE
[WIP] Add ZipArray

### DIFF
--- a/Bow.xcodeproj/project.pbxproj
+++ b/Bow.xcodeproj/project.pbxproj
@@ -329,6 +329,9 @@
 		8BA0F657217E2E9200969984 /* MonadCombine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BA0F4AD217E2E9200969984 /* MonadCombine.swift */; };
 		8BA0F65B217E2E9200969984 /* FunctorFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BA0F4AE217E2E9200969984 /* FunctorFilter.swift */; };
 		8BB969AD2398661D005520D6 /* Queue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BB969AB239863F0005520D6 /* Queue.swift */; };
+		B53734D723C0800F00A012F3 /* ZipArray.swift in Sources */ = {isa = PBXBuildFile; fileRef = B53734D623C0800F00A012F3 /* ZipArray.swift */; };
+		B58DBFD323B964F000454CFA /* ZipArray+Gen.swift in Sources */ = {isa = PBXBuildFile; fileRef = B58DBFD223B964F000454CFA /* ZipArray+Gen.swift */; };
+		B58DBFD523B9654000454CFA /* ZipArrayTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = B58DBFD423B9654000454CFA /* ZipArrayTest.swift */; };
 		B8B910C0234D7F2600E44271 /* Semiring.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8B910BF234D7F2600E44271 /* Semiring.swift */; };
 		B8B910C4234D846900E44271 /* SemiringLaws.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8B910C3234D846900E44271 /* SemiringLaws.swift */; };
 		B8B910C6234DDA4000E44271 /* BoolInstancesTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8B910C5234DDA4000E44271 /* BoolInstancesTest.swift */; };
@@ -1065,6 +1068,9 @@
 		8BA0F4D1217E2E9200969984 /* Each+Optics.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Each+Optics.swift"; sourceTree = "<group>"; };
 		8BA0F4D2217E2E9200969984 /* Lens.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Lens.swift; sourceTree = "<group>"; };
 		8BB969AB239863F0005520D6 /* Queue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Queue.swift; sourceTree = "<group>"; };
+		B53734D623C0800F00A012F3 /* ZipArray.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ZipArray.swift; sourceTree = "<group>"; };
+		B58DBFD223B964F000454CFA /* ZipArray+Gen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ZipArray+Gen.swift"; sourceTree = "<group>"; };
+		B58DBFD423B9654000454CFA /* ZipArrayTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ZipArrayTest.swift; sourceTree = "<group>"; };
 		B8B910BF234D7F2600E44271 /* Semiring.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Semiring.swift; sourceTree = "<group>"; };
 		B8B910C3234D846900E44271 /* SemiringLaws.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SemiringLaws.swift; sourceTree = "<group>"; };
 		B8B910C5234DDA4000E44271 /* BoolInstancesTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoolInstancesTest.swift; sourceTree = "<group>"; };
@@ -1271,6 +1277,7 @@
 				112097D522A904AC007F3D9C /* Sum+Gen.swift */,
 				112097BE22A7FDEF007F3D9C /* Try+Gen.swift */,
 				112097C022A7FF37007F3D9C /* Validated+Gen.swift */,
+				B58DBFD223B964F000454CFA /* ZipArray+Gen.swift */,
 			);
 			path = Data;
 			sourceTree = "<group>";
@@ -1720,6 +1727,7 @@
 			isa = PBXGroup;
 			children = (
 				8BA0F3B6217E2DEF00969984 /* ArrayKTest.swift */,
+				B58DBFD423B9654000454CFA /* ZipArrayTest.swift */,
 				1137469A234345EE00D9C1AD /* ArrayTest.swift */,
 				8BA0F3B9217E2DEF00969984 /* ConstTest.swift */,
 				8BA0F3B7217E2DEF00969984 /* DayTest.swift */,
@@ -1856,6 +1864,7 @@
 				8BA0F483217E2E9200969984 /* Sum.swift */,
 				8BA0F480217E2E9200969984 /* Try.swift */,
 				8BA0F484217E2E9200969984 /* Validated.swift */,
+				B53734D623C0800F00A012F3 /* ZipArray.swift */,
 			);
 			path = Data;
 			sourceTree = "<group>";
@@ -2582,6 +2591,7 @@
 				112097C122A7FF37007F3D9C /* Validated+Gen.swift in Sources */,
 				112097B922A7FAF6007F3D9C /* Ior+Gen.swift in Sources */,
 				112097CE22A81BE8007F3D9C /* EitherK+Gen.swift in Sources */,
+				B58DBFD323B964F000454CFA /* ZipArray+Gen.swift in Sources */,
 				112097BD22A7FD6F007F3D9C /* Option+Gen.swift in Sources */,
 				112097DD22A90899007F3D9C /* OptionT+Gen.swift in Sources */,
 				112097B122A7F0E6007F3D9C /* ArrayK+Gen.swift in Sources */,
@@ -2926,6 +2936,7 @@
 				8BA0F400217E2DEF00969984 /* EitherTest.swift in Sources */,
 				8BA0F408217E2DEF00969984 /* ValidatedTest.swift in Sources */,
 				111F84FE234DC00F003FE646 /* SetTest.swift in Sources */,
+				B58DBFD523B9654000454CFA /* ZipArrayTest.swift in Sources */,
 				8BA0F3EB217E2DEF00969984 /* Function1Test.swift in Sources */,
 				8BA0F3EC217E2DEF00969984 /* Function0Test.swift in Sources */,
 				8BA0F3F0217E2DEF00969984 /* WriterTTest.swift in Sources */,
@@ -2958,6 +2969,7 @@
 				8BA0F517217E2E9200969984 /* Predef.swift in Sources */,
 				1137469923433E5800D9C1AD /* Array.swift in Sources */,
 				8BA0F4FB217E2E9200969984 /* Cokleisli.swift in Sources */,
+				B53734D723C0800F00A012F3 /* ZipArray.swift in Sources */,
 				110DE5CE23ACE5AD00E5DB36 /* ComonadEnv.swift in Sources */,
 				8BA0F57B217E2E9200969984 /* Reader.swift in Sources */,
 				8BA0F54F217E2E9200969984 /* OptionInstances.swift in Sources */,

--- a/Sources/Bow/Data/NonEmptyArray.swift
+++ b/Sources/Bow/Data/NonEmptyArray.swift
@@ -36,6 +36,17 @@ public final class NonEmptyArray<A>: NonEmptyArrayOf<A> {
         return NonEmptyArray(head: lhs.head, tail: lhs.tail + rhs)
     }
 
+    /// Concatenates a Swift array with a non-empty array with.
+    ///
+    /// - Parameters:
+    ///   - lhs: A Swift array.
+    ///   - rhs: A non-empty array.
+    /// - Returns: A non-empty array that contains the elements of the two arguments in the same order.
+    public static func +(lhs: [A], rhs: NonEmptyArray<A>) -> NonEmptyArray<A> {
+        guard let leftArray = NonEmptyArray.fromArray(lhs).toOptional() else { return rhs }
+        return leftArray + rhs
+    }
+
     /// Appends an element to a non-empty array.
     ///
     /// - Parameters:
@@ -102,6 +113,11 @@ public final class NonEmptyArray<A>: NonEmptyArrayOf<A> {
     /// - Returns: A Swift array with the elements in this value.
     public func all() -> [A] {
         return [head] + tail
+    }
+
+    /// Last element of the array.
+    public var last: A {
+        return tail.last ?? head
     }
 
     /// Obtains an element from its position in this non-empty array.

--- a/Sources/Bow/Data/ZipArray.swift
+++ b/Sources/Bow/Data/ZipArray.swift
@@ -1,0 +1,243 @@
+import Foundation
+
+public final class ForZipArray {}
+
+public typealias ZipArrayOf<A> = Kind<ForZipArray, A>
+
+public final class ZipArray<A>: ZipArrayOf<A> {
+    internal indirect enum Data: Semigroup {
+        case finite([A])
+        case infinite(NonEmptyArray<A>)
+
+        var isFinite: Bool {
+            if case .finite = self {
+                return true
+            }
+            return false
+        }
+
+        func combine(_ other: ZipArray<A>.Data) -> ZipArray<A>.Data {
+            switch (self, other) {
+            case (.infinite, _):
+                return self
+            case let (.finite(lhs), .finite(rhs)):
+                return .finite(lhs + rhs)
+            case let (.finite(lhs), .infinite(rhs)):
+                return .infinite(lhs + rhs)
+            }
+        }
+
+        var asSequence: LazySequence<AnySequence<A>> {
+            switch self {
+            case let .finite(array):
+                return AnySequence(array).lazy
+            case let .infinite(array):
+                return AnySequence([
+                    AnySequence(array.all()),
+                    AnySequence(Swift.sequence(first: array.last, next: { _ in array.last}))
+                ].joined()).lazy
+            }
+        }
+
+        var description: String {
+            switch self {
+            case let .finite(array):
+                return array.description
+            case let .infinite(array):
+                return array.description + ", \(array.last), ..."
+            }
+        }
+
+        func map<B>(_ f: @escaping (A) -> B) -> ZipArray<B>.Data {
+            switch self {
+            case let .finite(array):
+                return .finite(array.map(f))
+            case let .infinite(array):
+                return .infinite(array.map(f)^)
+            }
+        }
+
+        func ap<B>(_ ff: ZipArray<(A) -> B>.Data) -> ZipArray<B>.Data {
+
+            func extend<T>(array: NonEmptyArray<T>, with t: T, untilLength length: Int64) -> NonEmptyArray<T> {
+                let nExtraElements = Int(length - array.count)
+                guard nExtraElements > 0 else { return array }
+                return array + Array(repeating: t, count: nExtraElements)
+            }
+
+            switch (self, ff) {
+            case let (.finite(arrayA), .finite(arrayF)):
+                return .finite(Swift.zip(arrayA, arrayF).map(|>))
+
+            case let (.finite(arrayA), .infinite(arrayF)):
+                let result = Swift.zip(
+                    arrayA,
+                    extend(array: arrayF, with: arrayF.last, untilLength: Int64(arrayA.count)).all()
+                ).map(|>)
+                return ZipArray<B>.Data.finite(result)
+
+            case let (.infinite(arrayA), .finite(arrayF)):
+                return .finite(Swift.zip(
+                    extend(array: arrayA, with: arrayA.last, untilLength: Int64(arrayF.count)).all(),
+                    arrayF
+                ).map(|>))
+
+            case let (.infinite(arrayA), .infinite(arrayF)):
+                return .infinite(NonEmptyArray.fromArrayUnsafe(Swift.zip(
+                    extend(array: arrayA, with: arrayA.last, untilLength: arrayF.count).all(),
+                    extend(array: arrayF, with: arrayF.last, untilLength: arrayA.count).all()
+                ).map(|>))^)
+            }
+        }
+
+        public func foldLeft<B>(_ b: B, _ f: @escaping (B, A) -> B) -> B? {
+            switch self {
+            case .finite(let array):
+                return ArrayK(array).foldLeft(b, f)
+            case .infinite:
+                return nil
+            }
+        }
+
+        public func foldRight<B>(_ b: Eval<B>, _ f: @escaping (A, Eval<B>) -> Eval<B>) -> Eval<B>? {
+            switch self {
+            case .finite(let array):
+                return ArrayK(array).foldRight(b, f)
+            default:
+                return nil
+            }
+        }
+    }
+
+    internal var data: Data
+
+    internal init(_ data: Data) {
+        self.data = data
+    }
+
+    /// Concatenates two ZipArrays
+    ///
+    /// - Parameters:
+    ///   - lhs: Left hand side of the concatenation.
+    ///   - rhs: Right hand side of the concatenation.
+    /// - Returns: A ZipArray that contains the elements of the two ZipArrays in the order they appear in the original ones.
+    public static func +(lhs: ZipArray<A>, rhs: ZipArray<A>) -> ZipArray<A> {
+        return ZipArray(lhs.data.combine(rhs.data))
+    }
+
+    /// Prepends an element to a ZipArray.
+    ///
+    /// - Parameters:
+    ///   - lhs: Element to prepend.
+    ///   - rhs: Array.
+    /// - Returns: A ZipArray containing the prepended element at the head and the other ZipArray as the tail.
+    public static func +(lhs: A, rhs: ZipArray<A>) -> ZipArray<A> {
+        return ZipArray(lhs) + rhs
+    }
+
+    /// Appends an element to a ZipArray.
+    ///
+    /// - Parameters:
+    ///   - lhs: Array.
+    ///   - rhs: Element to append.
+    /// - Returns: A ZipArrays containing all elements of the first ZipArrays and the appended element as the last element.
+    public static func +(lhs: ZipArray<A>, rhs: A) -> ZipArray<A> {
+        return lhs + ZipArray(rhs)
+    }
+
+    /// Initializes a `ZipArray`.
+    ///
+    /// - Parameter array: A Swift array of values.
+    public convenience init(_ array: [A]) {
+        self.init(.finite(array))
+    }
+
+    /// Initializes a `ZipArray`.
+    ///
+    /// - Parameter arrayk: An array of values.
+    public convenience init(_ arrayk: ArrayKOf<A>) {
+        self.init(arrayk^.asArray)
+    }
+
+    /// Initializes a `ZipArray`.
+    ///
+    /// - Parameter values: A variable number of values.
+    public convenience init(_ values: A...) {
+        self.init(values)
+    }
+
+    /// Obtains the wrapped sequence.
+    ///
+    /// This sequence needs to be lazy because it can be an infinite sequence.
+    public var asSequence: LazySequence<AnySequence<A>> {
+        data.asSequence
+    }
+
+    /// Obtains the wrapped sequence converted into an Array if the sequence is finite.
+    public var asArrayK: ArrayK<A>? {
+        switch data {
+        case .finite(let array):
+            return ArrayK(array)
+        case .infinite:
+            return nil
+        }
+    }
+
+    public static func fix(_ fa: ZipArrayOf<A>) -> ZipArray<A> {
+        fa as! ZipArray<A>
+    }
+}
+
+extension ZipArray: CustomStringConvertible {
+    public var description: String {
+        return data.description
+    }
+}
+
+public postfix func ^<A>(_ fa: ZipArrayOf<A>) -> ZipArray<A> {
+    ZipArray.fix(fa)
+}
+
+// MARK: Instance of `EquatableK` for `ZipArray`
+extension ForZipArray: EquatableK {
+    public static func eq<A>(_ lhs: Kind<ForZipArray, A>, _ rhs: Kind<ForZipArray, A>) -> Bool where A : Equatable {
+        switch (lhs^.data, rhs^.data) {
+        case let (.finite(l), .finite(r)):
+            return l == r
+        case (.finite, .infinite), (.infinite, .finite):
+            return false
+        case let (.infinite(l), .infinite(r)):
+            return l == r
+        }
+    }
+}
+
+// MARK: Instance of `MonoidK` for `ZipArray`
+extension ForZipArray: MonoidK {
+    public static func emptyK<A>() -> Kind<ForZipArray, A> {
+        return ZipArray([])
+    }
+
+    public static func combineK<A>(_ x: Kind<ForZipArray, A>, _ y: Kind<ForZipArray, A>) -> Kind<ForZipArray, A> {
+        return ZipArray(x^.data.combine(y^.data))
+    }
+}
+
+// MARK: Instance of `Functor` for `ZipArray`
+extension ForZipArray: Functor {
+    public static func map<A, B>(_ fa: Kind<ForZipArray, A>, _ f: @escaping (A) -> B) -> Kind<ForZipArray, B> {
+        return ZipArray(fa^.data.map(f))
+    }
+}
+
+// MARK: Instance of `Applicative` for `ZipArray`
+extension ForZipArray: Applicative {
+    public static func pure<A>(_ a: A) -> Kind<ForZipArray, A> {
+        ZipArray(.infinite(NonEmptyArray(head: a, tail: [])))
+    }
+
+    public static func ap<A, B>(_ ff: Kind<ForZipArray, (A) -> B>, _ fa: Kind<ForZipArray, A>) -> Kind<ForZipArray, B> {
+        ZipArray(fa^.data.ap(ff^.data))
+    }
+}
+

--- a/Tests/BowGenerators/Data/ZipArray+Gen.swift
+++ b/Tests/BowGenerators/Data/ZipArray+Gen.swift
@@ -1,0 +1,21 @@
+@testable import Bow
+import SwiftCheck
+
+// MARK: Generator for Property-based Testing
+
+extension ZipArray: Arbitrary where A: Arbitrary {
+    public static var arbitrary: Gen<ZipArray<A>> {
+        return Gen<ZipArray<A>>.one(of: [
+            Array<A>.arbitrary.map { ZipArray(ZipArray.Data.finite($0)) },
+            NonEmptyArray<A>.arbitrary.map { ZipArray(ZipArray.Data.infinite($0)) }
+        ])
+    }
+}
+
+// MARK: Instance of `ArbitraryK` for `ZipArray`
+
+extension ForZipArray: ArbitraryK {
+    public static func generate<A: Arbitrary>() -> Kind<ForZipArray, A> {
+        return ZipArray.arbitrary.generate
+    }
+}

--- a/Tests/BowTests/Data/ZipArrayTest.swift
+++ b/Tests/BowTests/Data/ZipArrayTest.swift
@@ -1,0 +1,27 @@
+import XCTest
+import SwiftCheck
+import BowLaws
+import Bow
+
+class ZipArrayTest: XCTestCase {
+    func testEquatableKLaws() {
+        EquatableKLaws<ForZipArray, Int>.check()
+    }
+
+    func testSemiGroupKLaws() {
+        SemigroupKLaws<ForZipArray>.check()
+    }
+
+    func testMonoidKLaws() {
+        MonoidKLaws<ForZipArray>.check()
+    }
+
+    func testFunctorLaws() {
+        FunctorLaws<ForZipArray>.check()
+    }
+
+    func testApplicativeLaws() {
+        ApplicativeLaws<ForZipArray>.check()
+    }
+
+}


### PR DESCRIPTION
## Related issues

I didn't open an issue because I thought it would be easier to discuss this looking at the whole code. Please feel free to close if you decide this does not belong in Bow.

This is experimental, I just aim for discussion, feedback, ideas...

Please let me know if anything is not clear enough.

## Goal

Have a ZipList-like type with applicative and traverse instances that never gets caught in an infinite loop.

The usual ZipList implementation relies on laziness and infinite lists. The problem with this approach is that it's tricky to tell whether a computation will terminate or not. In this PR I explore an approach that should allow us the query whether a list is infinite or not.

## Implementation details

`ZipArray` is a finite-lenght version of haskell's ZipList, where some operations might escape finiteness, but we can always check whether this has happened or not.

For applicative, ZipList (as implemented in Haskell) needs to implement `pure` by creating an infinite list with the argument. The trick here is to realize that the infinite list is used like an 'unknown length list': when you `ap` an infinite list with a finite list, you can then fix the length of the infinite list.

Thus, `ZipArray` has two cases: `.finite` and `.infinite`. The former indicates that we have a list of known length, the later indicates that we have a list of unknown length.

Furthermore, `ZipArray` can only be initialized with an array (i.e. a finite list). The only way you can create an infinite list is with `pure`. Thus, you cannot create a ZipList from an arbitrary swift infinite list (e.g. `sequence(first:next:)`). Thus, a `ZipArray` can always be expressed as a finite number of transformation of a `pure` *[insert proof here]*. This means a `ZipArray` is either finite, or a finite list followed by a single repeating element ad infinitum (e.g. `[a, b, c, d, d, d, d, ...]`)*[insert proof here]*.

Thus, the `.finite` case takes an array as parameter, the actual finite list of elements forming the `ZipArray`. The `.infinite` case takes a non-empty list as a paramater. This list represents the finite list where the last element is repeated ad-infinitum.

## What works
I could write implementations for `EquatableK`, `MonoidK`, `Functor` and `Applicative`.

## Problems
I don't know how to implement `Foldable`. I can fold the `.finite`, but not the `.infinite` case. Thus fold should have an `Option` return type, for the cases where we have an infinite list. Shall we create a new `MaybeFoldable`type class with such a signature? [1]

It'd be interesting to be able to implement `Traverse`, because then the transpose of a `matrix: ZipArray<ZipArray<A>>` can be expressed as `matrix.traverse(id)`.

## Alternatives
We could actually implement ZipList with lazy infinite lists. I actually did this [here](https://github.com/ferranpujolcamins/bow/tree/ziparray) using swift built-in LazySequences.

The drawbacks are that it's not nice to debug why your code is now stuck in an infinite loop. With the built-in lazy sequences, you need to remember to add `.lazy` all the time.

Maybe another option is to write a Bow type for infinite sequences base on `Eval` that offers better ergonomics, but if we want to be able to check for finiteness at runtime, we will most likely stumble with the same problems when trying to implement `Foldable` and `Traverse`.

---

[1] [I asked on stackoverflow about this](https://stackoverflow.com/questions/59603865/is-ther-a-type-class-for-fallible-fold)

We could add something like this:

```swift
public protocol FoldableT {
    associatedtype F

    static func foldLeft<A, B>(_ fa: Kind<Self, A>, _ b: B, _ f: @escaping (B, A) -> B) -> Kind<F, B>

    static func foldRight<A, B>(_ fa: Kind<Self, A>, _ b: Eval<B>, _ f: @escaping (A, Eval<B>) -> Eval<B>) -> Eval<Kind<F, B>>
}

public protocol Foldable: FoldableT where F == ForId {
    static func foldLeft<A, B>(_ fa: Kind<Self, A>, _ b: B, _ f: @escaping (B, A) -> B) -> B

    static func foldRight<A, B>(_ fa: Kind<Self, A>, _ b: Eval<B>, _ f: @escaping (A, Eval<B>) -> Eval<B>) -> Eval<B>
}

public extension Foldable {
    static func foldLeft<A, B>(_ fa: Kind<Self, A>, _ b: B, _ f: @escaping (B, A) -> B) -> Kind<F, B> {
        let r: B = foldLeft(fa, b, f)
        return Id(r)
    }

    static func foldRight<A, B>(_ fa: Kind<Self, A>, _ b: Eval<B>, _ f: @escaping (A, Eval<B>) -> Eval<B>) -> Eval<Kind<F, B>> {
        let r: Eval<B> = foldRight(fa, b, f)
        return r.map { Id($0) as Kind<ForId, B> }^
    }
}
```

Then:

```swift
extension ForZipArray: FoldableT {
     typealias F = ForOption

     static func foldLeft<A, B>(_ fa: Kind<Self, A>, _ b: B, _ f: @escaping (B, A) -> B) -> Kind<F, B> {
        switch fa^.data {
            case .finite(let array):
                return Option<B>.some(ForArrayK.foldLeft(ArrayK(array), b , f))
            case .infinite:
                return nil
        }
    }
}
```

`Foldable` adds the regular fold functions without the F embedding. With them, we can provide default implementations for the `FoldableT` functions that embed the result in `Id`. Thus, this new `Foldable` as a special case of `FoldableT` is a drop-in replacement of the normal `Foldable`, no code using it needs to be changed.