### PR TITLE
Add bimap to EnvIO + IO

### DIFF
--- a/Sources/BowEffects/Data/EnvIO.swift
+++ b/Sources/BowEffects/Data/EnvIO.swift
@@ -133,7 +133,7 @@ public extension Kleisli {
     ///   - fa: Function to transform the output type argument.
     /// - Returns: An EnvIO with both type arguments transformed.
     func bimap<E: Error, EE: Error, B>(_ fe: @escaping (E) -> EE, _ fa: @escaping (A) -> B) -> EnvIO<D, EE, B> where F == IOPartial<E> {
-        self.mapError(fe).map(fa)^
+        mapError(fe).map(fa)^
     }
 }
 

--- a/Sources/BowEffects/Data/EnvIO.swift
+++ b/Sources/BowEffects/Data/EnvIO.swift
@@ -125,6 +125,16 @@ public extension Kleisli {
                 .mapError { x in x as! E }
                 .flatMap { s in loop(a, s) }^ })
     }
+    
+    /// Transforms the type arguments of this EnvIO.
+    ///
+    /// - Parameters:
+    ///   - fe: Function to transform the error type argument.
+    ///   - fa: Function to transform the output type argument.
+    /// - Returns: An EnvIO with both type arguments transformed.
+    func bimap<E: Error, EE: Error, B>(_ fe: @escaping (E) -> EE, _ fa: @escaping (A) -> B) -> EnvIO<D, EE, B> where F == IOPartial<E> {
+        self.mapError(fe).map(fa)^
+    }
 }
 
 public extension Kleisli where D == Any {

--- a/Sources/BowEffects/Data/IO.swift
+++ b/Sources/BowEffects/Data/IO.swift
@@ -92,6 +92,16 @@ public class IO<E: Error, A>: IOOf<E, A> {
         invokeEither { try f().toEither() }
     }
     
+    /// Transforms the type arguments of this IO.
+    ///
+    /// - Parameters:
+    ///   - fe: Function to transform the error type argument.
+    ///   - fa: Function to transform the output type argument.
+    /// - Returns: An IO with both type arguments transformed.
+    func bimap<EE: Error, B>(_ fe: @escaping (E) -> EE, _ fa: @escaping (A) -> B) -> IO<EE, B> {
+        mapLeft(fe).map(fa)^
+    }
+    
     /// Creates an IO from 2 side-effectful functions, tupling their results. Errors thrown from the functions must be of type `E`; otherwise, a fatal error will happen.
     ///
     /// - Parameters:


### PR DESCRIPTION
## Implementation details

Add `bimap` to data type `EnvIO` and `IO` to transform the type arguments.
- `fe` function to transform error type argument
- `fa` function to transform output type argument.

```swift
func bimap<E: Error, EE: Error, B>(_ fe: @escaping (E) -> EE, _ fa: @escaping (A) -> B) -> EnvIO<D, EE, B>
```