### PR TITLE
Add Pairings of Functors

### DIFF
--- a/Documentation.app/Contents/MacOS/Podfile.lock
+++ b/Documentation.app/Contents/MacOS/Podfile.lock
@@ -1,18 +1,18 @@
 PODS:
-  - Bow (0.6.0)
-  - BowEffects (0.6.0):
-    - Bow (~> 0.6.0)
-  - BowFree (0.6.0):
-    - Bow (~> 0.6.0)
-  - BowGeneric (0.6.0):
-    - Bow (~> 0.6.0)
-  - BowOptics (0.6.0):
-    - Bow (~> 0.6.0)
-  - BowRecursionSchemes (0.6.0):
-    - Bow (~> 0.6.0)
-  - BowRx (0.6.0):
-    - Bow (~> 0.6.0)
-    - BowEffects (~> 0.6.0)
+  - Bow (0.7.0)
+  - BowEffects (0.7.0):
+    - Bow (~> 0.7.0)
+  - BowFree (0.7.0):
+    - Bow (~> 0.7.0)
+  - BowGeneric (0.7.0):
+    - Bow (~> 0.7.0)
+  - BowOptics (0.7.0):
+    - Bow (~> 0.7.0)
+  - BowRecursionSchemes (0.7.0):
+    - Bow (~> 0.7.0)
+  - BowRx (0.7.0):
+    - Bow (~> 0.7.0)
+    - BowEffects (~> 0.7.0)
     - RxSwift (~> 5.0.0)
   - RxSwift (5.0.1)
 
@@ -46,13 +46,13 @@ EXTERNAL SOURCES:
     :path: "../../.."
 
 SPEC CHECKSUMS:
-  Bow: 2a42ff7c2b0bf72a2f16491aff170e5069b3ebe6
-  BowEffects: 12f4e2ad8e3fb32704de2ad5c7645f265efa93e3
-  BowFree: ec5e4d71f4f8fd1bd9afea24be26962ef75b14c3
-  BowGeneric: 4477520f8be1a4ce958322c2eb74f75e8cca366a
-  BowOptics: 1bcd0d97b8f1a03e6c1314aa689e151caf07f110
-  BowRecursionSchemes: ad78f3395af32b06b72d76a081ecb9f868dd3774
-  BowRx: e21ccc42aea8a5a6b40c87cded59cec74997135d
+  Bow: 3561cae6b993e4c37f507e03dd89859538d8ec12
+  BowEffects: 235d503f2e438ab9fdf84e074f586c806d8dec31
+  BowFree: 2c0ef44f40bf12f63edc8b60ec881fada1145dfd
+  BowGeneric: 8ad67728410b2a50cf681b3bfbf92b86b6b8a07b
+  BowOptics: 1d6c742c8144117b7ff76d2ce14839aac2619d82
+  BowRecursionSchemes: a62b201be5440e95e2e514b08c163e55e5dc9195
+  BowRx: 9b0e395c92f47f2c7f6f8b4a42adf37ffd5c897a
   RxSwift: e2dc62b366a3adf6a0be44ba9f405efd4c94e0c4
 
 PODFILE CHECKSUM: c776910e1659fef526505f3385fe27e8c3a2e42d

--- a/Sources/Bow/Arrow/Kleisli.swift
+++ b/Sources/Bow/Arrow/Kleisli.swift
@@ -12,6 +12,9 @@ public typealias KleisliOf<F, D, A> = Kind<KleisliPartial<F, D>, A>
 /// Alias over `Kleisli<F, D, A>`.
 public typealias ReaderT<F, D, A> = Kleisli<F, D, A>
 
+/// Alias over `KleisliPartial<F, D>`
+public typealias ReaderTPartial<F, D> = KleisliPartial<F, D>
+
 /// Kleisli represents a function with the signature `(D) -> Kind<F, A>`.
 public final class Kleisli<F, D, A>: KleisliOf<F, D, A> {
     internal let run: (D) -> Kind<F, A>

--- a/Sources/Bow/Data/Co.swift
+++ b/Sources/Bow/Data/Co.swift
@@ -21,7 +21,7 @@ public class Co<W: Comonad, A>: CoOf<W, A> {
     
     /// - Returns: The pairing between the underlying comonad, `w`, and the monad `Co<w>`.
     public static func pair() -> Pairing<W, CoPartial<W>> {
-        Pairing { wab in { cowa in cowa^.run(wab) } }
+        Pairing { wab, cowa in cowa^.run(wab) }
     }
     
     public init(_ cow: @escaping /*forall R.*/(Kind<W, (A) -> /*R*/Any>) -> /*R*/Any) {

--- a/Sources/Bow/Data/Pairing.swift
+++ b/Sources/Bow/Data/Pairing.swift
@@ -70,6 +70,20 @@ public extension Pairing {
     }
     
     static func pairWriterTraced<W>() -> Pairing<WriterPartial<W>, TracedPartial<W>> where F == WriterPartial<W>, G == TracedPartial<W> {
-        Pairing<WriterTPartial<ForId, W>, TracedTPartial<W, ForId>>.pairWriterTTracedT(.pairId())
+        Pairing.pairWriterTTracedT(.pairId())
+    }
+}
+
+// MARK: Pairing for Reader and Env
+
+public extension Pairing {
+    static func pairReaderTEnvT<R, FF, GG>(_ pairing: Pairing<FF, GG>) -> Pairing<ReaderTPartial<FF, R>, EnvTPartial<R, GG>> where F == ReaderTPartial<FF, R>, G == EnvTPartial<R, GG> {
+        Pairing { reader, env, f in
+            pairing.pair(reader^.run(env^.runT().0), env^.runT().1, f)
+        }
+    }
+    
+    static func pairReaderEnv<R>() -> Pairing<ReaderPartial<R>, EnvPartial<R>> where F == ReaderPartial<R>, G == EnvPartial<R> {
+        Pairing.pairReaderTEnvT(.pairId())
     }
 }

--- a/Sources/Bow/Data/Pairing.swift
+++ b/Sources/Bow/Data/Pairing.swift
@@ -40,6 +40,18 @@ public class Pairing<F: Functor, G: Functor>: PairingOf<F, G> {
     public func pairFlipped<A, B, C>(_ ga: Kind<G, A>, _ fb: Kind<F, B>, _ f: @escaping (A, B) -> C) -> C {
         pair(fb, ga, flip(f))
     }
+    
+    public func pairStateTStoreT<S>() -> Pairing<StateTPartial<F, S>, StoreTPartial<S, G>> {
+        Pairing<StateTPartial<F, S>, StoreTPartial<S, G>>.pairStateTStoreT(self)
+    }
+    
+    public func pairWriterTTracedT<W>() -> Pairing<WriterTPartial<F, W>, TracedTPartial<W, G>> {
+        Pairing<WriterTPartial<F, W>, TracedTPartial<W, G>>.pairWriterTTracedT(self)
+    }
+    
+    public func pairReaderTEnvT<R>() -> Pairing<ReaderTPartial<F, R>, EnvTPartial<R, G>> {
+        Pairing<ReaderTPartial<F, R>, EnvTPartial<R, G>>.pairReaderTEnvT(self)
+    }
 }
 
 /// Safe downcast.

--- a/Sources/Bow/Data/Pairing.swift
+++ b/Sources/Bow/Data/Pairing.swift
@@ -20,12 +20,20 @@ public class Pairing<F: Functor, G: Functor>: PairingOf<F, G> {
     /// - Parameter fab: An `F`-effectful `A -> B`
     /// - Parameter ga: A `G`-effectful `A`
     /// - Returns: A pure `B`
-    public func zap<A, B>(_ fab: Kind<F, (A) -> B>, ga: Kind<G, A>) -> B {
+    public func zap<A, B>(_ fab: Kind<F, (A) -> B>, _ ga: Kind<G, A>) -> B {
         let gany = ga.map{ $0 as Any }
         let fany =
             fab.map{ aArrb in { (any: Any) in
                 aArrb(any as! A) as Any}}
         return self.pair(fany)(gany) as! B
+    }
+    
+    public func pair<A, B, C>(_ fa: Kind<F, A>, _ gb: Kind<G, B>, _ f: @escaping (A, B) -> C) -> C {
+        zap(fa.map(curry(f)), (gb))
+    }
+    
+    public func pairFlipped<A, B, C>(_ ga: Kind<G, A>, _ fb: Kind<F, B>, _ f: @escaping (A, B) -> C) -> C {
+        pair(fb, ga, flip(f))
     }
 }
 

--- a/Sources/Bow/Data/Pairing.swift
+++ b/Sources/Bow/Data/Pairing.swift
@@ -44,3 +44,11 @@ public class Pairing<F: Functor, G: Functor>: PairingOf<F, G> {
 public postfix func ^<F, G>(_ value: PairingOf<F, G>) -> Pairing<F, G> {
     Pairing.fix(value)
 }
+
+public extension Pairing where F == ForId, G == ForId {
+    static func pairId() -> Pairing<ForId, ForId> {
+        Pairing { fa, gb in
+            fa^.value(gb^.value)
+        }
+    }
+}

--- a/Sources/Bow/Data/Pairing.swift
+++ b/Sources/Bow/Data/Pairing.swift
@@ -5,7 +5,6 @@ public final class PairingPartial<F: Functor>: Kind<ForPairing, F> {}
 public typealias PairingOf<F: Functor, G: Functor> =  Kind<PairingPartial<F>, G>
 
 public class Pairing<F: Functor, G: Functor>: PairingOf<F, G> {
-    // internal let pair: (Kind<F, (/*A*/Any) -> /*B*/Any>, Kind<G, /*A*/Any>) -> /*B*/Any
     internal let pairing: (Kind<F, /*A*/Any>,
                            Kind<G, /*B*/Any>,
                            @escaping (/*A*/Any, /*B*/Any) -> /*C*/Any) -> /*C*/Any

--- a/Sources/Bow/Data/Pairing.swift
+++ b/Sources/Bow/Data/Pairing.swift
@@ -50,10 +50,26 @@ public postfix func ^<F, G>(_ value: PairingOf<F, G>) -> Pairing<F, G> {
     Pairing.fix(value)
 }
 
+// MARK: Pairing for Id
+
 public extension Pairing where F == ForId, G == ForId {
     static func pairId() -> Pairing<ForId, ForId> {
         Pairing { fa, gb in
             fa^.value(gb^.value)
         }
+    }
+}
+
+// MARK: Pairing for Writer and Traced
+
+public extension Pairing {
+    static func pairWriterTTracedT<W, FF, GG>(_ pairing: Pairing<FF, GG>) -> Pairing<WriterTPartial<FF, W>, TracedTPartial<W, GG>> where F == WriterTPartial<FF, W>, G == TracedTPartial<W, GG> {
+        Pairing { writer, traced, f in
+            pairing.pair(writer^.runT, traced^.value) { a, b in f(a.1, b(a.0)) }
+        }
+    }
+    
+    static func pairWriterTraced<W>() -> Pairing<WriterPartial<W>, TracedPartial<W>> where F == WriterPartial<W>, G == TracedPartial<W> {
+        Pairing<WriterTPartial<ForId, W>, TracedTPartial<W, ForId>>.pairWriterTTracedT(.pairId())
     }
 }

--- a/Sources/Bow/Data/Pairing.swift
+++ b/Sources/Bow/Data/Pairing.swift
@@ -60,6 +60,22 @@ public extension Pairing where F == ForId, G == ForId {
     }
 }
 
+// MARK: Pairing for State and Store
+
+public extension Pairing {
+    static func pairStateTStoreT<S, FF, GG>(_ pairing: Pairing<FF, GG>) -> Pairing<StateTPartial<FF, S>, StoreTPartial<S, GG>> where F == StateTPartial<FF, S>, G == StoreTPartial<S, GG> {
+        Pairing { state, store, f in
+            pairing.pair(state^.runM(store^.state), store^.render) { a, b in
+                f(a.1, b(a.0))
+            }
+        }
+    }
+    
+    static func pairStateStore<S>() -> Pairing<StatePartial<S>, StorePartial<S>> where F == StatePartial<S>, G == StorePartial<S> {
+        .pairStateTStoreT(.pairId())
+    }
+}
+
 // MARK: Pairing for Writer and Traced
 
 public extension Pairing {
@@ -70,7 +86,7 @@ public extension Pairing {
     }
     
     static func pairWriterTraced<W>() -> Pairing<WriterPartial<W>, TracedPartial<W>> where F == WriterPartial<W>, G == TracedPartial<W> {
-        Pairing.pairWriterTTracedT(.pairId())
+        .pairWriterTTracedT(.pairId())
     }
 }
 
@@ -84,6 +100,6 @@ public extension Pairing {
     }
     
     static func pairReaderEnv<R>() -> Pairing<ReaderPartial<R>, EnvPartial<R>> where F == ReaderPartial<R>, G == EnvPartial<R> {
-        Pairing.pairReaderTEnvT(.pairId())
+        .pairReaderTEnvT(.pairId())
     }
 }

--- a/Sources/Bow/Data/Pairing.swift
+++ b/Sources/Bow/Data/Pairing.swift
@@ -5,13 +5,13 @@ public final class PairingPartial<F: Functor>: Kind<ForPairing, F> {}
 public typealias PairingOf<F: Functor, G: Functor> =  Kind<PairingPartial<F>, G>
 
 public class Pairing<F: Functor, G: Functor>: PairingOf<F, G> {
-    internal let pair: (Kind<F, (/*A*/Any) -> /*B*/Any>) -> (Kind<G, /*A*/Any>) -> /*B*/Any
+    internal let pair: (Kind<F, (/*A*/Any) -> /*B*/Any>, Kind<G, /*A*/Any>) -> /*B*/Any
     
     public static func fix(_ value : PairingOf<F, G>) -> Pairing<F, G> {
         value as! Pairing<F, G>
     }
     
-    public init(_ pair: @escaping (Kind<F, (/*A*/Any) -> /*B*/Any>) -> (Kind<G, /*A*/Any>) -> /*B*/Any) {
+    public init(_ pair: @escaping (Kind<F, (/*A*/Any) -> /*B*/Any>, Kind<G, /*A*/Any>) -> /*B*/Any) {
         self.pair = pair
     }
     
@@ -25,7 +25,7 @@ public class Pairing<F: Functor, G: Functor>: PairingOf<F, G> {
         let fany =
             fab.map{ aArrb in { (any: Any) in
                 aArrb(any as! A) as Any}}
-        return self.pair(fany)(gany) as! B
+        return self.pair(fany, gany) as! B
     }
     
     public func pair<A, B, C>(_ fa: Kind<F, A>, _ gb: Kind<G, B>, _ f: @escaping (A, B) -> C) -> C {

--- a/Sources/Bow/Data/Reader.swift
+++ b/Sources/Bow/Data/Reader.swift
@@ -2,3 +2,6 @@ import Foundation
 
 /// Reader is a special case of ReaderT / Kleisli where F is `Id`, so it is equivalent to functions `(D) -> A`.
 public typealias Reader<D, A> = ReaderT<ForId, D, A>
+
+/// Alias over `ReaderTPartial<ForId, D>`
+public typealias ReaderPartial<D> = ReaderTPartial<ForId, D>

--- a/Sources/Bow/Syntax/Predef.swift
+++ b/Sources/Bow/Syntax/Predef.swift
@@ -446,3 +446,10 @@ public func <<<<A, B, C>(_ g : @escaping (B) throws -> C, _ f : @escaping (A) th
     return f >>> g
 }
 
+/// Flips the arguments of a binary function.
+///
+/// - Parameter f: Function whose arguments must be flipped.
+/// - Returns: A function with the same behavior as the input, but with arguments flipped.
+public func flip<A, B, C>(_ f: @escaping (A, B) -> C) -> (B, A) -> C {
+    { b, a in f(a, b) }
+}

--- a/Sources/Bow/Transformers/StateT.swift
+++ b/Sources/Bow/Transformers/StateT.swift
@@ -15,20 +15,20 @@ public typealias StateTOf<F, S, A> = Kind<StateTPartial<F, S>, A>
 ///     - For read-only state, see `ReaderT` / `Kleisli`.
 ///     - To accumulate a value without using it on the way, see `WriterT`.
 public final class StateT<F, S, A>: StateTOf<F, S, A> {
-    fileprivate let runF: Kind<F, (S) -> Kind<F, (S, A)>>
+    fileprivate let runF: (S) -> Kind<F, (S, A)>
 
     /// Safe downcast.
     ///
     /// - Parameter fa: Value in the higher-kind form.
     /// - Returns: Value cast to StateT.
     public static func fix(_ fa: StateTOf<F, S, A>) -> StateT<F, S, A> {
-        return fa as! StateT<F, S, A>
+        fa as! StateT<F, S, A>
     }
 
     /// Initializes a `StateT`.
     ///
     /// - Parameter runF: An effect describing a function that receives a state and produces an effect that updates the state and productes a value.
-    public init(_ runF: Kind<F, (S) -> Kind<F, (S, A)>>) {
+    public init(_ runF: @escaping (S) -> Kind<F, (S, A)>) {
         self.runF = runF
     }
 }
@@ -38,7 +38,7 @@ public final class StateT<F, S, A>: StateTOf<F, S, A> {
 /// - Parameter fa: Value in higher-kind form.
 /// - Returns: Value cast to StateT.
 public postfix func ^<F, S, A>(_ fa : StateTOf<F, S, A>) -> StateT<F, S, A> {
-    return StateT.fix(fa)
+    StateT.fix(fa)
 }
 
 /// Partial application of the `StateT` type constructor, omitting the last parameter.
@@ -56,7 +56,7 @@ public extension StateT where F == ForId {
     ///
     /// - Parameter run: A function that depends on a state and produces a new state and a value.
     convenience init(_ run: @escaping (S) -> (S, A)) {
-        self.init(Id.pure({ s in Id.pure(run(s)) }))
+        self.init { s in Id(run(s)) }
     }
     
     /// Runs this computation provided an initial state.
@@ -64,7 +64,7 @@ public extension StateT where F == ForId {
     /// - Parameter initialState: Initial state for this computation.
     /// - Returns: A pair with the updated state and the produced value.
     func run(_ initialState: S) -> (S, A) {
-        return Id.fix(self.runM(initialState)).value
+        Id.fix(self.runM(initialState)).value
     }
 
     /// Runs this computation provided an initial state.
@@ -72,7 +72,7 @@ public extension StateT where F == ForId {
     /// - Parameter s: Initial state for this computation.
     /// - Returns: Produced value from this computation.
     func runA(_ s: S) -> A {
-        return run(s).1
+        run(s).1
     }
 
     /// Runs this computation provided an initial state.
@@ -80,7 +80,7 @@ public extension StateT where F == ForId {
     /// - Parameter s: Initial state for this computation.
     /// - Returns: Updated state after running the computation.
     func runS(_ s: S) -> S {
-        return run(s).0
+        run(s).0
     }
 }
 
@@ -92,21 +92,20 @@ extension StateT where F: Functor {
     /// - Returns: An `StateT` where the final state and produced value have been transformed using the provided function.
     public func transform<B>(_ f: @escaping (S, A) -> (S, B)) -> StateT<F, S, B> {
         return StateT<F, S, B>(
-            runF.map { sfsa in
-                sfsa >>> F.lift(f)
-            }
+            runF >>> F.lift(f)
         )
     }
 }
 
-// MARK: Functions for `StateT` when the effect has an instance of `Monad`
-extension StateT where F: Monad {
+// MARK: Functions for `StateT` when the effect has an instance of `Functor`
+
+extension StateT where F: Functor {
     /// Lifts an effect by wrapping the contained value into a function that depends on some state.
     ///
     /// - Parameter fa: Value to be lifted.
     /// - Returns: A `StateT` that produces the contained value in the original effect, preserving the state.
     public static func liftF(_ fa: Kind<F, A>) -> StateT<F, S, A> {
-        return StateT(F.pure({ s in fa.map { a in (s, a) } }))
+        StateT { s in fa.map { a in (s, a) } }
     }
 
     /// Runs this computation using the provided initial state.
@@ -114,7 +113,7 @@ extension StateT where F: Monad {
     /// - Parameter s: Initial state to run this computation.
     /// - Returns: Result of running this computation with the provided state, wrapped in the effect.
     public func runA(_ s: S) -> Kind<F, A> {
-        return runM(s).map{ (_, a) in a }
+        runM(s).map{ (_, a) in a }
     }
 
     /// Runs this computation using the provided initial state.
@@ -122,7 +121,7 @@ extension StateT where F: Monad {
     /// - Parameter s: Initial state to run this computation.
     /// - Returns: New state after running this computation with the provided state, wrapped in the effect.
     public func runS(_ s: S) -> Kind<F, S> {
-        return runM(s).map { (s, _) in s }
+        runM(s).map { (s, _) in s }
     }
 
     /// Runs this computation using the provided initial state.
@@ -130,39 +129,7 @@ extension StateT where F: Monad {
     /// - Parameter initial: Initial state to run this computation.
     /// - Returns: A pair with the new state and produced value, wrapped in the effect.
     public func runM(_ initial: S) -> Kind<F, (S, A)> {
-        return runF.flatMap { f in f(initial) }
-    }
-
-    /// Zips this computation with another one depending on the same state and effect types and combines the produced values using the provided function.
-    ///
-    /// - Parameters:
-    ///   - sb: Another state computation.
-    ///   - f: Combining function.
-    /// - Returns: An `StateT` with the combination of the results of the two state computations, using the provided function.
-    public func map2<B, Z>(_ sb: StateT<F, S, B>, _ f: @escaping (A, B) -> Z) -> StateT<F, S, Z> {
-        return StateT<F, S, Z>(F.map(runF, sb.runF, { ssa, ssb in
-            ssa >>> { fsa in
-                F.flatMap(fsa) { (s, a) in
-                    F.map(ssb(s), { (s, b) in (s, f(a, b)) })
-                }
-            }
-        }))
-    }
-
-    /// Flatmaps a function that produces an effect and lifts if back to `StateT`.
-    ///
-    /// - Parameter f: A function producing an effect.
-    /// - Returns: Result of flatmapping and lifting the function to this value.
-    public func semiflatMap<B>(_ f: @escaping (A) -> Kind<F, B>) -> StateT<F, S, B> {
-        return StateT<F, S, B>(
-            runF.map { sfsa in
-                sfsa >>> { fsa in
-                    fsa.flatMap { (s, a) in
-                        f(a).map { b in (s, b) }
-                    }
-                }
-            }
-        )
+        runF(initial)
     }
     
     /// Modifies the state with a function and returns unit.
@@ -170,7 +137,7 @@ extension StateT where F: Monad {
     /// - Parameter f: Function to modify the state.
     /// - Returns: A StateT value with a modified state and unit as result value.
     public func modifyF(_ f: @escaping (S) -> Kind<F, S>) -> StateT<F, S, ()> {
-        return StateT<F, S, ()>(F.pure({ s in f(s).map { ss in (ss, ()) } }))
+        StateT<F, S, ()> { s in f(s).map { ss in (ss, ()) } }
     }
     
     /// Sets the state to a specific value and returns unit.
@@ -178,7 +145,25 @@ extension StateT where F: Monad {
     /// - Parameter fs: Value to set the state.
     /// - Returns: A StateT value with a modified state and unit as result value.
     public func setF(_ fs: Kind<F, S>) -> StateT<F, S, ()> {
-        return self.modifyF { _ in fs }
+        self.modifyF { _ in fs }
+    }
+}
+
+// MARK: Functions for `StateT` when the effect has an instance of `Functor`
+
+extension StateT where F: Monad {
+    /// Flatmaps a function that produces an effect and lifts if back to `StateT`.
+    ///
+    /// - Parameter f: A function producing an effect.
+    /// - Returns: Result of flatmapping and lifting the function to this value.
+    public func semiflatMap<B>(_ f: @escaping (A) -> Kind<F, B>) -> StateT<F, S, B> {
+        StateT<F, S, B>(
+            runF >>> { fsa in
+                fsa.flatMap { (s, a) in
+                    f(a).map { b in (s, b) }
+                }
+            }
+        )
     }
 }
 
@@ -188,14 +173,14 @@ extension StateTPartial: Invariant where F: Functor {}
 // MARK: Instance of `Functor` for `StateT`
 extension StateTPartial: Functor where F: Functor {
     public static func map<A, B>(_ fa: Kind<StateTPartial<F, S>, A>, _ f: @escaping (A) -> B) -> Kind<StateTPartial<F, S>, B> {
-        return StateT.fix(fa).transform({ (s, a) in (s, f(a)) })
+        fa^.transform({ (s, a) in (s, f(a)) })
     }
 }
 
 // MARK: Instance of `Applicative` for `StateT`
 extension StateTPartial: Applicative where F: Monad {
     public static func pure<A>(_ a: A) -> Kind<StateTPartial<F, S>, A> {
-        return StateT(F.pure({ s in F.pure((s, a)) }))
+        StateT { s in F.pure((s, a)) }
     }
 }
 
@@ -205,53 +190,47 @@ extension StateTPartial: Selective where F: Monad {}
 // MARK: Instance of `Monad` for `StateT`
 extension StateTPartial: Monad where F: Monad {
     public static func flatMap<A, B>(_ fa: Kind<StateTPartial<F, S>, A>, _ f: @escaping (A) -> Kind<StateTPartial<F, S>, B>) -> Kind<StateTPartial<F, S>, B> {
-        let sta = StateT.fix(fa)
-        return StateT<F, S, B>(
-            sta.runF.map { sfsa in
-                sfsa >>> { fsa in
-                    fsa.flatMap { (s, a) in
-                        StateT.fix(f(a)).runM(s)
-                    }
+        StateT<F, S, B>(
+            fa^.runF >>> { fsa in
+                fsa.flatMap { (s, a) in
+                    f(a)^.runM(s)
                 }
-            }
-        )
+            })
     }
 
     public static func tailRecM<A, B>(_ a: A, _ f: @escaping (A) -> Kind<StateTPartial<F, S>, Either<A, B>>) -> Kind<StateTPartial<F, S>, B> {
-        return StateT<F, S, B>(F.pure({ s in
+        StateT<F, S, B> { s in
             F.tailRecM((s, a), { pair in
                 F.map(StateT.fix(f(pair.1)).runM(pair.0), { sss, ab in
                     ab.bimap({ left in (sss, left) }, { right in (sss, right) })
                 })
             })
-        }))
+        }
     }
 }
 
 // MARK: Instance of `MonadState` for `StateT`
 extension StateTPartial: MonadState where F: Monad {
     public static func get() -> Kind<StateTPartial<F, S>, S> {
-        return StateT(F.pure({ s in F.pure((s, s)) }))
+        StateT { s in F.pure((s, s)) }
     }
 
     public static func set(_ s: S) -> Kind<StateTPartial<F, S>, ()> {
-        return StateT(F.pure({ _ in F.pure((s, ())) } ))
+        StateT { _ in F.pure((s, ())) }
     }
 }
 
 // MARK: Instance of `SemigroupK` for `StateT`
 extension StateTPartial: SemigroupK where F: Monad & SemigroupK {
     public static func combineK<A>(_ x: Kind<StateTPartial<F, S>, A>, _ y: Kind<StateTPartial<F, S>, A>) -> Kind<StateTPartial<F, S>, A> {
-        let stx = StateT.fix(x)
-        let sty = StateT.fix(y)
-        return StateT(F.pure({ s in stx.runM(s).combineK(sty.runM(s)) }))
+        StateT { s in x^.runM(s).combineK(y^.runM(s)) }
     }
 }
 
 // MARK: Instance of `MonoidK` for `StateT`
 extension StateTPartial: MonoidK where F: MonadCombine {
     public static func emptyK<A>() -> Kind<StateTPartial<F, S>, A> {
-        return StateT.liftF(F.empty())
+        StateT.liftF(F.empty())
     }
 }
 
@@ -267,7 +246,7 @@ extension StateTPartial: MonadFilter where F: MonadCombine {}
 // MARK: Instance of `MonadCombine` for `StateT`
 extension StateTPartial: MonadCombine where F: MonadCombine {
     public static func empty<A>() -> Kind<StateTPartial<F, S>, A> {
-        return StateT.liftF(F.empty())
+        StateT.liftF(F.empty())
     }
 }
 
@@ -276,15 +255,15 @@ extension StateTPartial: ApplicativeError where F: MonadError {
     public typealias E = F.E
 
     public static func raiseError<A>(_ e: F.E) -> Kind<StateTPartial<F, S>, A> {
-        return StateT.liftF(F.raiseError(e))
+        StateT.liftF(F.raiseError(e))
     }
 
     public static func handleErrorWith<A>(_ fa: Kind<StateTPartial<F, S>, A>, _ f: @escaping (F.E) -> Kind<StateTPartial<F, S>, A>) -> Kind<StateTPartial<F, S>, A> {
-        return StateT(F.pure({ s in
+        StateT { s in
             StateT.fix(fa).runM(s).handleErrorWith { e in
                 StateT.fix(f(e)).runM(s)
             }
-        }))
+        }
     }
 }
 

--- a/Sources/BowOptics/Getter.swift
+++ b/Sources/BowOptics/Getter.swift
@@ -221,7 +221,7 @@ public class Getter<S, A>: GetterOf<S, A> {
     ///
     /// - Returns: A `State` of the source and target.
     public func extract() -> State<S, A> {
-        return State({ s in (s, self.get(s)) })
+        return State { s in (s, self.get(s)) } 
     }
     
     /// Extracts the focus view through the `Getter`.

--- a/Sources/BowOptics/Lens.swift
+++ b/Sources/BowOptics/Lens.swift
@@ -383,10 +383,7 @@ public extension Lens where S == T, A == B {
     /// - Parameter f: Updating function.
     /// - Returns: A `State` with the new value.
     func update(_ f: @escaping (A) -> A) -> State<S, A> {
-        return State { s in
-            let b = f(self.get(s))
-            return (self.set(s, b), b)
-        }
+        State { s in (self.set(s, f(self.get(s))), f(self.get(s))) }
     }
     
     /// Updates the focus viewed through the `Lens` and returns its old value.

--- a/Tests/BowGenerators/Transformers/StateT+Gen.swift
+++ b/Tests/BowGenerators/Transformers/StateT+Gen.swift
@@ -15,6 +15,6 @@ extension StateTPartial: ArbitraryK where F: ArbitraryK & Applicative, S: Arbitr
     public static func generate<A: Arbitrary>() -> Kind<StateTPartial<F, S>, A> {
         let a = A.arbitrary.generate
         let f: (S) -> Kind<F, (S, A)> = { s in F.pure((s, a)) }
-        return StateT(F.pure(f))
+        return StateT(f)
     }
 }

--- a/Tests/BowTests/Data/CoTest.swift
+++ b/Tests/BowTests/Data/CoTest.swift
@@ -5,8 +5,8 @@ import BowGenerators
 
 extension CoPartial: EquatableK where W == ForId {
     public static func eq<A: Equatable>(_ lhs: CoOf<W, A>, _ rhs: CoOf<W, A>) -> Bool {
-        Co<W, A>.pair().zap(Id(id), ga: lhs^) ==
-            Co<W, A>.pair().zap(Id(id), ga: rhs^)
+        Co<W, A>.pair().zap(Id(id), lhs^) ==
+            Co<W, A>.pair().zap(Id(id), rhs^)
     }
 }
 

--- a/Tests/BowTests/Transformers/StateTTest.swift
+++ b/Tests/BowTests/Transformers/StateTTest.swift
@@ -3,10 +3,9 @@ import XCTest
 import Bow
 
 extension StateTPartial: EquatableK where F: EquatableK & Monad, S == Int {
-    public static func eq<A>(_ lhs: Kind<StateTPartial<F, S>, A>, _ rhs: Kind<StateTPartial<F, S>, A>) -> Bool where A : Equatable {
-        let x = StateT.fix(lhs).runM(1)
-        let y = StateT.fix(rhs).runM(1)
-        return isEqual(x, y)
+    public static func eq<A: Equatable>(_ lhs: Kind<StateTPartial<F, S>, A>, _ rhs: Kind<StateTPartial<F, S>, A>) -> Bool {
+        isEqual(lhs^.runM(1),
+                rhs^.runM(1))
     }
 }
 


### PR DESCRIPTION
## Goal

Add instances for known pairings of functors:

- Id / Id
- StateT / StoreT
- WriterT / TracedT
- ReaderT / EnvT

The implementation of these pairings is based on their implementation in PureScript that can be checked [here](https://github.com/arthurxavierx/purescript-comonad-ui-todos/blob/master/src/Data/Functor/Pairing.purs).

This PR also refactors the `StateT` transformer to remove the extra wrapping of the stateful function in an `F` context and makes it like the Haskell or PureScript implementations. Without this change, the pairing with StoreT would not be possible.