### PR TITLE
Add Comonad Transformer Laws

### DIFF
--- a/Bow.xcodeproj/project.pbxproj
+++ b/Bow.xcodeproj/project.pbxproj
@@ -167,6 +167,7 @@
 		11A5FDD822E5F0C300FF7821 /* WriterBindingExpression.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11A5FDD722E5F0C300FF7821 /* WriterBindingExpression.swift */; };
 		11BA21BC23D5EF4E00F3EE78 /* ComonadEnvLaws.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11BA21BB23D5EF4E00F3EE78 /* ComonadEnvLaws.swift */; };
 		11BA21BE23D6F74F00F3EE78 /* ComonadStoreLaws.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11BA21BD23D6F74F00F3EE78 /* ComonadStoreLaws.swift */; };
+		11BA21C023D6FA3600F3EE78 /* ComonadTracedLaws.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11BA21BF23D6FA3600F3EE78 /* ComonadTracedLaws.swift */; };
 		11D36A19223261EC00CBD85F /* Selective.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11D36A18223261EC00CBD85F /* Selective.swift */; };
 		11D36A1C2232789900CBD85F /* SelectiveLaws.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11D36A1A2232787A00CBD85F /* SelectiveLaws.swift */; };
 		11D97EF2219EBC0F008FC004 /* AsyncLaws.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BA0F3A2217E2DEF00969984 /* AsyncLaws.swift */; };
@@ -841,6 +842,7 @@
 		11A5FDD722E5F0C300FF7821 /* WriterBindingExpression.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WriterBindingExpression.swift; sourceTree = "<group>"; };
 		11BA21BB23D5EF4E00F3EE78 /* ComonadEnvLaws.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComonadEnvLaws.swift; sourceTree = "<group>"; };
 		11BA21BD23D6F74F00F3EE78 /* ComonadStoreLaws.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComonadStoreLaws.swift; sourceTree = "<group>"; };
+		11BA21BF23D6FA3600F3EE78 /* ComonadTracedLaws.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComonadTracedLaws.swift; sourceTree = "<group>"; };
 		11D36A18223261EC00CBD85F /* Selective.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Selective.swift; sourceTree = "<group>"; };
 		11D36A1A2232787A00CBD85F /* SelectiveLaws.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectiveLaws.swift; sourceTree = "<group>"; };
 		11D97EEA219EBAA1008FC004 /* BowEffectsLaws.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = BowEffectsLaws.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -1601,6 +1603,7 @@
 				11BA21BB23D5EF4E00F3EE78 /* ComonadEnvLaws.swift */,
 				8BA0F3D2217E2DEF00969984 /* ComonadLaws.swift */,
 				11BA21BD23D6F74F00F3EE78 /* ComonadStoreLaws.swift */,
+				11BA21BF23D6FA3600F3EE78 /* ComonadTracedLaws.swift */,
 				8BA0F3C2217E2DEF00969984 /* ComparableLaws.swift */,
 				8BA0F3C9217E2DEF00969984 /* ContravariantLaws.swift */,
 				8BA0F3D1217E2DEF00969984 /* CustomStringConvertibleLaws.swift */,
@@ -2639,6 +2642,7 @@
 				1122941F219D8BDE006D66C5 /* AlternativeLaws.swift in Sources */,
 				11229420219D8BDE006D66C5 /* ApplicativeErrorLaws.swift in Sources */,
 				11229421219D8BDE006D66C5 /* ApplicativeLaws.swift in Sources */,
+				11BA21C023D6FA3600F3EE78 /* ComonadTracedLaws.swift in Sources */,
 				1191BD1422D78F760052FEA8 /* BindingOperatorOverload.swift in Sources */,
 				11BA21BC23D5EF4E00F3EE78 /* ComonadEnvLaws.swift in Sources */,
 				11229423219D8BDE006D66C5 /* BimonadLaws.swift in Sources */,

--- a/Bow.xcodeproj/project.pbxproj
+++ b/Bow.xcodeproj/project.pbxproj
@@ -166,6 +166,7 @@
 		11A5FDD622E5ECB300FF7821 /* ReaderBindingExpression.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11A5FDD522E5ECB300FF7821 /* ReaderBindingExpression.swift */; };
 		11A5FDD822E5F0C300FF7821 /* WriterBindingExpression.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11A5FDD722E5F0C300FF7821 /* WriterBindingExpression.swift */; };
 		11BA21BC23D5EF4E00F3EE78 /* ComonadEnvLaws.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11BA21BB23D5EF4E00F3EE78 /* ComonadEnvLaws.swift */; };
+		11BA21BE23D6F74F00F3EE78 /* ComonadStoreLaws.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11BA21BD23D6F74F00F3EE78 /* ComonadStoreLaws.swift */; };
 		11D36A19223261EC00CBD85F /* Selective.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11D36A18223261EC00CBD85F /* Selective.swift */; };
 		11D36A1C2232789900CBD85F /* SelectiveLaws.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11D36A1A2232787A00CBD85F /* SelectiveLaws.swift */; };
 		11D97EF2219EBC0F008FC004 /* AsyncLaws.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BA0F3A2217E2DEF00969984 /* AsyncLaws.swift */; };
@@ -839,6 +840,7 @@
 		11A5FDD522E5ECB300FF7821 /* ReaderBindingExpression.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderBindingExpression.swift; sourceTree = "<group>"; };
 		11A5FDD722E5F0C300FF7821 /* WriterBindingExpression.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WriterBindingExpression.swift; sourceTree = "<group>"; };
 		11BA21BB23D5EF4E00F3EE78 /* ComonadEnvLaws.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComonadEnvLaws.swift; sourceTree = "<group>"; };
+		11BA21BD23D6F74F00F3EE78 /* ComonadStoreLaws.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComonadStoreLaws.swift; sourceTree = "<group>"; };
 		11D36A18223261EC00CBD85F /* Selective.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Selective.swift; sourceTree = "<group>"; };
 		11D36A1A2232787A00CBD85F /* SelectiveLaws.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectiveLaws.swift; sourceTree = "<group>"; };
 		11D97EEA219EBAA1008FC004 /* BowEffectsLaws.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = BowEffectsLaws.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -1598,6 +1600,7 @@
 				1191BD1122D78F640052FEA8 /* BindingOperatorOverload.swift */,
 				11BA21BB23D5EF4E00F3EE78 /* ComonadEnvLaws.swift */,
 				8BA0F3D2217E2DEF00969984 /* ComonadLaws.swift */,
+				11BA21BD23D6F74F00F3EE78 /* ComonadStoreLaws.swift */,
 				8BA0F3C2217E2DEF00969984 /* ComparableLaws.swift */,
 				8BA0F3C9217E2DEF00969984 /* ContravariantLaws.swift */,
 				8BA0F3D1217E2DEF00969984 /* CustomStringConvertibleLaws.swift */,
@@ -2660,6 +2663,7 @@
 				11229433219D8BDE006D66C5 /* MonoidLaws.swift in Sources */,
 				1166A07A22119F720032CD4E /* EqualityFunctions.swift in Sources */,
 				609CC1492364FC5B00096D5D /* DivisibleLaws.swift in Sources */,
+				11BA21BE23D6F74F00F3EE78 /* ComonadStoreLaws.swift in Sources */,
 				11229434219D8BDE006D66C5 /* ComparableLaws.swift in Sources */,
 				11229436219D8BDE006D66C5 /* SemigroupKLaws.swift in Sources */,
 				11229437219D8BDE006D66C5 /* SemigroupLaws.swift in Sources */,

--- a/Bow.xcodeproj/project.pbxproj
+++ b/Bow.xcodeproj/project.pbxproj
@@ -165,6 +165,7 @@
 		11A5FDD422E5CF1600FF7821 /* StateBindingExpression.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11A5FDD322E5CF1600FF7821 /* StateBindingExpression.swift */; };
 		11A5FDD622E5ECB300FF7821 /* ReaderBindingExpression.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11A5FDD522E5ECB300FF7821 /* ReaderBindingExpression.swift */; };
 		11A5FDD822E5F0C300FF7821 /* WriterBindingExpression.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11A5FDD722E5F0C300FF7821 /* WriterBindingExpression.swift */; };
+		11BA21BC23D5EF4E00F3EE78 /* ComonadEnvLaws.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11BA21BB23D5EF4E00F3EE78 /* ComonadEnvLaws.swift */; };
 		11D36A19223261EC00CBD85F /* Selective.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11D36A18223261EC00CBD85F /* Selective.swift */; };
 		11D36A1C2232789900CBD85F /* SelectiveLaws.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11D36A1A2232787A00CBD85F /* SelectiveLaws.swift */; };
 		11D97EF2219EBC0F008FC004 /* AsyncLaws.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BA0F3A2217E2DEF00969984 /* AsyncLaws.swift */; };
@@ -837,6 +838,7 @@
 		11A5FDD322E5CF1600FF7821 /* StateBindingExpression.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StateBindingExpression.swift; sourceTree = "<group>"; };
 		11A5FDD522E5ECB300FF7821 /* ReaderBindingExpression.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderBindingExpression.swift; sourceTree = "<group>"; };
 		11A5FDD722E5F0C300FF7821 /* WriterBindingExpression.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WriterBindingExpression.swift; sourceTree = "<group>"; };
+		11BA21BB23D5EF4E00F3EE78 /* ComonadEnvLaws.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComonadEnvLaws.swift; sourceTree = "<group>"; };
 		11D36A18223261EC00CBD85F /* Selective.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Selective.swift; sourceTree = "<group>"; };
 		11D36A1A2232787A00CBD85F /* SelectiveLaws.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectiveLaws.swift; sourceTree = "<group>"; };
 		11D97EEA219EBAA1008FC004 /* BowEffectsLaws.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = BowEffectsLaws.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -1594,6 +1596,7 @@
 				8BA0F3CE217E2DEF00969984 /* ApplicativeLaws.swift */,
 				8BA0F3CA217E2DEF00969984 /* BimonadLaws.swift */,
 				1191BD1122D78F640052FEA8 /* BindingOperatorOverload.swift */,
+				11BA21BB23D5EF4E00F3EE78 /* ComonadEnvLaws.swift */,
 				8BA0F3D2217E2DEF00969984 /* ComonadLaws.swift */,
 				8BA0F3C2217E2DEF00969984 /* ComparableLaws.swift */,
 				8BA0F3C9217E2DEF00969984 /* ContravariantLaws.swift */,
@@ -2634,6 +2637,7 @@
 				11229420219D8BDE006D66C5 /* ApplicativeErrorLaws.swift in Sources */,
 				11229421219D8BDE006D66C5 /* ApplicativeLaws.swift in Sources */,
 				1191BD1422D78F760052FEA8 /* BindingOperatorOverload.swift in Sources */,
+				11BA21BC23D5EF4E00F3EE78 /* ComonadEnvLaws.swift in Sources */,
 				11229423219D8BDE006D66C5 /* BimonadLaws.swift in Sources */,
 				11229425219D8BDE006D66C5 /* ComonadLaws.swift in Sources */,
 				11229426219D8BDE006D66C5 /* ContravariantLaws.swift in Sources */,

--- a/Sources/Bow/Transformers/EnvT.swift
+++ b/Sources/Bow/Transformers/EnvT.swift
@@ -81,7 +81,7 @@ extension EnvTPartial: Comonad where W: Comonad {
         EnvT(fa^.e, fa^.wa.coflatMap { a in f(EnvT(fa^.e, a)) })
     }
     
-    public static func extract<A>(_ fa: Kind<EnvTPartial<E, W>, A>) -> A {
+    public static func extract<A>(_ fa: EnvTOf<E, W, A>) -> A {
         fa^.wa.extract()
     }
 }
@@ -89,8 +89,12 @@ extension EnvTPartial: Comonad where W: Comonad {
 // MARK: Instance of `ComonadEnv` for `EnvT`
 
 extension EnvTPartial: ComonadEnv where W: Comonad {
-    public static func ask<A>(_ wa: Kind<EnvTPartial<E, W>, A>) -> E {
+    public static func ask<A>(_ wa: EnvTOf<E, W, A>) -> E {
         wa^.e
+    }
+    
+    public static func local<A>(_ wa: EnvTOf<E, W, A>, _ f: @escaping (E) -> E) -> EnvTOf<E, W, A> {
+        EnvT(f(wa^.e), wa^.wa)
     }
 }
 

--- a/Sources/Bow/Typeclasses/ComonadEnv.swift
+++ b/Sources/Bow/Typeclasses/ComonadEnv.swift
@@ -2,6 +2,7 @@ public protocol ComonadEnv: Comonad {
     associatedtype E
     
     static func ask<A>(_ wa: Kind<Self, A>) -> E
+    static func local<A>(_ wa: Kind<Self, A>, _ f: @escaping (E) -> E) -> Kind<Self, A>
 }
 
 public extension ComonadEnv {
@@ -19,5 +20,9 @@ public extension Kind where F: ComonadEnv {
     
     func asks<EE>(_ f: @escaping (F.E) -> EE) -> EE {
         F.asks(self, f)
+    }
+    
+    func local(_ f: @escaping (F.E) -> F.E) -> Kind<F, A> {
+        F.local(self, f)
     }
 }

--- a/Tests/BowLaws/ComonadEnvLaws.swift
+++ b/Tests/BowLaws/ComonadEnvLaws.swift
@@ -2,7 +2,7 @@ import SwiftCheck
 import Bow
 import BowGenerators
 
-public class ComonadEnvLaws<F: ComonadEnv & EquatableK & ArbitraryK> where F.E == Int {
+public class ComonadEnvLaws<F: ComonadEnv & EquatableK & ArbitraryK, A: Arbitrary & CoArbitrary & Hashable> where F.E == A {
     public static func check() {
         askLocal()
         extractLocal()
@@ -10,21 +10,21 @@ public class ComonadEnvLaws<F: ComonadEnv & EquatableK & ArbitraryK> where F.E =
     }
     
     static func askLocal() {
-        property("Ask followed by local is equivalent to applying a function to ask") <~ forAll { (fa: KindOf<F, Int>, f: ArrowOf<Int, Int>) in
+        property("Ask followed by local is equivalent to applying a function to ask") <~ forAll { (fa: KindOf<F, Int>, f: ArrowOf<A, A>) in
             fa.value.local(f.getArrow).ask() ==
                 f.getArrow(fa.value.ask())
         }
     }
     
     static func extractLocal() {
-        property("Local does not affect extract") <~ forAll { (fa: KindOf<F, Int>, f: ArrowOf<Int, Int>) in
+        property("Local does not affect extract") <~ forAll { (fa: KindOf<F, Int>, f: ArrowOf<A, A>) in
             fa.value.local(f.getArrow).extract() ==
                 fa.value.extract()
         }
     }
     
     static func coflatMapLocal() {
-        property("CoflatMap Local") <~ forAll { (fa: KindOf<F, Int>, f: ArrowOf<Int, Int>, g: ArrowOf<Int, Int>) in
+        property("CoflatMap Local") <~ forAll { (fa: KindOf<F, Int>, f: ArrowOf<A, A>, g: ArrowOf<Int, Int>) in
             let h: (Kind<F, Int>) -> Int = { wa in g.getArrow(wa.extract()) }
 
             return fa.value.local(f.getArrow).coflatMap(h) ==

--- a/Tests/BowLaws/ComonadEnvLaws.swift
+++ b/Tests/BowLaws/ComonadEnvLaws.swift
@@ -1,0 +1,34 @@
+import SwiftCheck
+import Bow
+import BowGenerators
+
+public class ComonadEnvLaws<F: ComonadEnv & EquatableK & ArbitraryK> where F.E == Int {
+    public static func check() {
+        askLocal()
+        extractLocal()
+        coflatMapLocal()
+    }
+    
+    static func askLocal() {
+        property("Ask followed by local is equivalent to applying a function to ask") <~ forAll { (fa: KindOf<F, Int>, f: ArrowOf<Int, Int>) in
+            fa.value.local(f.getArrow).ask() ==
+                f.getArrow(fa.value.ask())
+        }
+    }
+    
+    static func extractLocal() {
+        property("Local does not affect extract") <~ forAll { (fa: KindOf<F, Int>, f: ArrowOf<Int, Int>) in
+            fa.value.local(f.getArrow).extract() ==
+                fa.value.extract()
+        }
+    }
+    
+    static func coflatMapLocal() {
+        property("CoflatMap Local") <~ forAll { (fa: KindOf<F, Int>, f: ArrowOf<Int, Int>, g: ArrowOf<Int, Int>) in
+            let h: (Kind<F, Int>) -> Int = { wa in g.getArrow(wa.extract()) }
+
+            return fa.value.local(f.getArrow).coflatMap(h) ==
+                fa.value.coflatMap(h).local(f.getArrow)
+        }
+    }
+}

--- a/Tests/BowLaws/ComonadStoreLaws.swift
+++ b/Tests/BowLaws/ComonadStoreLaws.swift
@@ -2,7 +2,7 @@ import SwiftCheck
 import Bow
 import BowGenerators
 
-public class ComonadStoreLaws<F: ComonadStore & EquatableK & ArbitraryK> where F.S == Int {
+public class ComonadStoreLaws<F: ComonadStore & EquatableK & ArbitraryK, A: Arbitrary & CoArbitrary & Hashable> where F.S == A {
 
     public static func check() {
         positionCoflatMap()

--- a/Tests/BowLaws/ComonadStoreLaws.swift
+++ b/Tests/BowLaws/ComonadStoreLaws.swift
@@ -1,0 +1,26 @@
+import SwiftCheck
+import Bow
+import BowGenerators
+
+public class ComonadStoreLaws<F: ComonadStore & EquatableK & ArbitraryK> where F.S == Int {
+
+    public static func check() {
+        positionCoflatMap()
+        peekPosition()
+    }
+    
+    static func positionCoflatMap() {
+        property("coflatMap does not change position") <~ forAll { (fa: KindOf<F, Int>, f: ArrowOf<Int, Int>) in
+            let ff: (Kind<F, Int>) -> Int = { wa in f.getArrow(wa.extract()) }
+            
+            return fa.value.coflatMap(ff).position ==
+                fa.value.position
+        }
+    }
+    
+    static func peekPosition() {
+        property("peek at position is equal to extract") <~ forAll { (fa: KindOf<F, Int>) in
+            fa.value.peek(fa.value.position) == fa.value.extract()
+        }
+    }
+}

--- a/Tests/BowLaws/ComonadTracedLaws.swift
+++ b/Tests/BowLaws/ComonadTracedLaws.swift
@@ -1,0 +1,24 @@
+import SwiftCheck
+import Bow
+import BowGenerators
+
+public class ComonadTracedLaws<F: ComonadTraced & EquatableK & ArbitraryK, M: Equatable & Arbitrary & Monoid> where F.M == M {
+    
+    public static func check() {
+        traceEmpty()
+        sequentialTracing()
+    }
+    
+    static func traceEmpty() {
+        property("trace empty is equal to extract") <~ forAll { (fa: KindOf<F, Int>) in
+            fa.value.trace(.empty()) == fa.value.extract()
+        }
+    }
+    
+    static func sequentialTracing() {
+        property("tracing twice is equal to tracing combination of values") <~ forAll { (fa: KindOf<F, Int>, s: M, t: M) in
+            fa.value.coflatMap { wa in wa.trace(t) }.trace(s) ==
+                fa.value.trace(s.combine(t))
+        }
+    }
+}

--- a/Tests/BowTests/Transformers/EnvTTest.swift
+++ b/Tests/BowTests/Transformers/EnvTTest.swift
@@ -23,4 +23,8 @@ class EnvTTest: XCTestCase {
     func testComonadLaws() {
         ComonadLaws<EnvPartial<Int>>.check()
     }
+    
+    func testComonadEnvLaws() {
+        ComonadEnvLaws<EnvPartial<Int>>.check()
+    }
 }

--- a/Tests/BowTests/Transformers/EnvTTest.swift
+++ b/Tests/BowTests/Transformers/EnvTTest.swift
@@ -25,6 +25,6 @@ class EnvTTest: XCTestCase {
     }
     
     func testComonadEnvLaws() {
-        ComonadEnvLaws<EnvPartial<Int>>.check()
+        ComonadEnvLaws<EnvPartial<Int>, Int>.check()
     }
 }

--- a/Tests/BowTests/Transformers/StoreTTest.swift
+++ b/Tests/BowTests/Transformers/StoreTTest.swift
@@ -23,7 +23,7 @@ class StoreTTest: XCTestCase {
     }
     
     func testComonadStoreLaws() {
-        ComonadStoreLaws<StorePartial<Int>>.check()
+        ComonadStoreLaws<StorePartial<Int>, Int>.check()
     }
     
     let greetingStore = { (name: String) in Store(name, { name in "Hi \(name)!"}) }

--- a/Tests/BowTests/Transformers/StoreTTest.swift
+++ b/Tests/BowTests/Transformers/StoreTTest.swift
@@ -22,6 +22,10 @@ class StoreTTest: XCTestCase {
         ComonadLaws<StorePartial<Int>>.check()
     }
     
+    func testComonadStoreLaws() {
+        ComonadStoreLaws<StorePartial<Int>>.check()
+    }
+    
     let greetingStore = { (name: String) in Store(name, { name in "Hi \(name)!"}) }
     
     func testExtractRendersCurrentState() {

--- a/Tests/BowTests/Transformers/TracedTTest.swift
+++ b/Tests/BowTests/Transformers/TracedTTest.swift
@@ -21,4 +21,8 @@ class TracedTTest: XCTestCase {
     func testComonadLaws() {
         ComonadLaws<TracedPartial<Int>>.check()
     }
+    
+    func testComonadTraced() {
+        ComonadTracedLaws<TracedPartial<String>, String>.check()
+    }
 }


### PR DESCRIPTION
## Goal

Being able to test instances of Comonad Transformer type classes (namely `ComonadEnv`, `ComonadStore` and `ComonadTraced`) satisfy their laws.

## Implementation details

We use Property-based Tests to encode the properties these implementations must have. Making use of arbitrary generators, we create inputs for these functions that we can verify later for each implementation (`EnvT`, `StoreT` and `TracedT`  respectively).