### PR TITLE
EnvIO constructors

### DIFF
--- a/Sources/BowEffects/Data/EnvIO.swift
+++ b/Sources/BowEffects/Data/EnvIO.swift
@@ -22,6 +22,38 @@ public typealias URIO<D, A> = EnvIO<D, Never, A>
 // MARK: Functions for EnvIO
 
 public extension Kleisli {
+    /// Creates an EnvIO from a side-effectful function that has a dependency.
+    ///
+    /// - Parameter f: Side-effectful function. Errors thrown from this function must be of type `E`; otherwise, a fatal error will happen.
+    /// - Returns: An EnvIO value suspending the execution of the side effect.
+    static func invoke<E: Error>(_ f: @escaping (D) throws -> A) -> EnvIO<D, E, A> where F == IOPartial<E> {
+        EnvIO { env in IO.invoke { try f(env) } }
+    }
+    
+    /// Creates an EnvIO from a side-effectful function returning an Either that has a dependency.
+    ///
+    /// - Parameter f: Side-effectful function.
+    /// - Returns: An EnvIO value suspending the execution of the side effect.
+    static func invokeEither<E: Error>(_ f: @escaping (D) -> Either<E, A>) -> EnvIO<D, E, A> where F == IOPartial<E> {
+        EnvIO { env in IO.invokeEither { f(env) } }
+    }
+    
+    /// Creates an EnvIO from a side-effectful function returning a Result that has a dependency.
+    ///
+    /// - Parameter f: Side-effectful function.
+    /// - Returns: An EnvIO value suspending the execution of the side effect.
+    static func invokeResult<E: Error>(_ f: @escaping (D) -> Result<A, E>) -> EnvIO<D, E, A> where F == IOPartial<E> {
+        EnvIO { env in IO.invokeResult { f(env) } }
+    }
+    
+    /// Creates an EnvIO from a side-effectful function returning a Validated that has a dependency.
+    ///
+    /// - Parameter f: Side-effectful function.
+    /// - Returns: An EnvIO value suspending the execution of the side effect.
+    static func invokeValidated<E: Error>(_ f: @escaping (D) -> Validated<E, A>) -> EnvIO<D, E, A> {
+        EnvIO { env in IO.invokeValidated { f(env) } }
+    }
+    
     /// Transforms the error type of this EnvIO
     ///
     /// - Parameter f: Function transforming the error.
@@ -134,6 +166,16 @@ public extension Kleisli {
     /// - Returns: An EnvIO with both type arguments transformed.
     func bimap<E: Error, EE: Error, B>(_ fe: @escaping (E) -> EE, _ fa: @escaping (A) -> B) -> EnvIO<D, EE, B> where F == IOPartial<E> {
         mapError(fe).map(fa)^
+    }
+}
+
+public extension Kleisli where F == IOPartial<Error> {
+    /// Creates an EnvIO from a side-effectful function returning a Try that has a dependency.
+    ///
+    /// - Parameter f: Side-effectful function.
+    /// - Returns: An EnvIO value suspending the execution of the side effect.
+    static func invokeTry(_ f: @escaping (D) -> Try<A>) -> EnvIO<D, Error, A> {
+        EnvIO { env in IO.invokeTry { f(env) } }
     }
 }
 

--- a/Sources/BowEffects/Data/IO.swift
+++ b/Sources/BowEffects/Data/IO.swift
@@ -47,7 +47,7 @@ public class IO<E: Error, A>: IOOf<E, A> {
     /// Creates an IO from a side-effectful function.
     ///
     /// - Parameter f: Side-effectful function. Errors thrown from this function must be of type `E`; otherwise, a fatal error will happen.
-    /// - Returns: An IO function suspending the execution of the side effect.
+    /// - Returns: An IO suspending the execution of the side effect.
     public static func invoke(_ f: @escaping () throws -> A) -> IO<E, A> {
         IO.defer {
             do {

--- a/Tests/BowLaws/MonadLaws.swift
+++ b/Tests/BowLaws/MonadLaws.swift
@@ -32,14 +32,14 @@ public class MonadLaws<F: Monad & EquatableK & ArbitraryK> {
     private static func kleisliLeftIdentity() {
         property("Kleisli left identity") <~ forAll { (a: Int, f: ArrowOf<Int, Int>) in
             let g = f.getArrow >>> F.pure
-            return Kleisli({ (n : Int) in F.pure(n) }).andThen(Kleisli(g)).invoke(a) == g(a)
+            return Kleisli({ (n : Int) in F.pure(n) }).andThen(Kleisli(g)).run(a) == g(a)
         }
     }
     
     private static func kleisliRightIdentity() {
         property("Kleisli right identity") <~ forAll { (a: Int, f: ArrowOf<Int, Int>) in
             let g = f.getArrow >>> F.pure
-            return Kleisli(g).andThen(F.pure).invoke(a) == g(a)
+            return Kleisli(g).andThen(F.pure).run(a) == g(a)
         }
     }
     


### PR DESCRIPTION
## Goal

Oftentimes we have to write the following boilerplate to create an `EnvIO`:

```swift
EnvIO { env in
  IO.invoke { 
    // Do some side-effectful operation using env
  }
}
```

This PR lifts the `invoke*` constructors in `IO` to `EnvIO`, in order to avoid that double nesting to perform the side effects, improving ergonomics of the library.