### PR TITLE
Generalize function to convert from IO to EnvIO

### DIFF
--- a/Bow.xcodeproj/project.pbxproj
+++ b/Bow.xcodeproj/project.pbxproj
@@ -168,7 +168,9 @@
 		11BA21BC23D5EF4E00F3EE78 /* ComonadEnvLaws.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11BA21BB23D5EF4E00F3EE78 /* ComonadEnvLaws.swift */; };
 		11BA21BE23D6F74F00F3EE78 /* ComonadStoreLaws.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11BA21BD23D6F74F00F3EE78 /* ComonadStoreLaws.swift */; };
 		11BA21C023D6FA3600F3EE78 /* ComonadTracedLaws.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11BA21BF23D6FA3600F3EE78 /* ComonadTracedLaws.swift */; };
-		11BA21C223D75B5200F3EE78 /* ZipperTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11BA21C123D75B5200F3EE78 /* ZipperTest.swift */; };
+		11BA21C323D83DA200F3EE78 /* ZipperTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11BA21C123D75B5200F3EE78 /* ZipperTest.swift */; };
+		11BA21C423D83DC800F3EE78 /* Zipper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1171ED5D23C62C5E005362E0 /* Zipper.swift */; };
+		11BA21C523D83EA100F3EE78 /* Zipper+Gen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1171ED5F23C636A9005362E0 /* Zipper+Gen.swift */; };
 		11D36A19223261EC00CBD85F /* Selective.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11D36A18223261EC00CBD85F /* Selective.swift */; };
 		11D36A1C2232789900CBD85F /* SelectiveLaws.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11D36A1A2232787A00CBD85F /* SelectiveLaws.swift */; };
 		11D97EF2219EBC0F008FC004 /* AsyncLaws.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BA0F3A2217E2DEF00969984 /* AsyncLaws.swift */; };
@@ -2618,6 +2620,7 @@
 				112097D622A904AC007F3D9C /* Sum+Gen.swift in Sources */,
 				112097C522A805CE007F3D9C /* Function0+Gen.swift in Sources */,
 				112097C722A80730007F3D9C /* Function1+Gen.swift in Sources */,
+				11BA21C523D83EA100F3EE78 /* Zipper+Gen.swift in Sources */,
 				112097DF22A90972007F3D9C /* StateT+Gen.swift in Sources */,
 				113746A623435C0B00D9C1AD /* DictionaryK+Gen.swift in Sources */,
 				112097E122A90AAA007F3D9C /* WriterT+Gen.swift in Sources */,
@@ -2986,6 +2989,7 @@
 				8BA0F3ED217E2DEF00969984 /* KleisliTest.swift in Sources */,
 				8BA0F40D217E2DEF00969984 /* NonEmptyArrayTest.swift in Sources */,
 				8BA0F40B217E2DEF00969984 /* ArrayKTest.swift in Sources */,
+				11BA21C323D83DA200F3EE78 /* ZipperTest.swift in Sources */,
 				8BA0F3E8217E2DEF00969984 /* BooleanFunctionsTest.swift in Sources */,
 				8BA0F3FD217E2DEF00969984 /* CurryTest.swift in Sources */,
 			);
@@ -3009,8 +3013,8 @@
 				8BA0F4FB217E2E9200969984 /* Cokleisli.swift in Sources */,
 				110DE5CE23ACE5AD00E5DB36 /* ComonadEnv.swift in Sources */,
 				8BA0F57B217E2E9200969984 /* Reader.swift in Sources */,
+				11BA21C423D83DC800F3EE78 /* Zipper.swift in Sources */,
 				8BA0F54F217E2E9200969984 /* OptionInstances.swift in Sources */,
-				11BA21C223D75B5200F3EE78 /* ZipperTest.swift in Sources */,
 				8BA0F4EB217E2E9200969984 /* Kleisli.swift in Sources */,
 				8BA0F59B217E2E9200969984 /* Day.swift in Sources */,
 				8BA0F65B217E2E9200969984 /* FunctorFilter.swift in Sources */,

--- a/Documentation.app/Contents/MacOS/Documentation.xcodeproj/xcshareddata/xcschemes/Documentation.xcscheme
+++ b/Documentation.app/Contents/MacOS/Documentation.xcodeproj/xcshareddata/xcschemes/Documentation.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1130"
+   LastUpgradeVersion = "1120"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Documentation.app/Contents/MacOS/Effects.playground/Pages/Retrying and repeating effects.xcplaygroundpage/Contents.swift
+++ b/Documentation.app/Contents/MacOS/Effects.playground/Pages/Retrying and repeating effects.xcplaygroundpage/Contents.swift
@@ -12,10 +12,10 @@ import BowEffects
 let formatter = DateFormatter()
 formatter.dateFormat = "HH:mm:ss"
 
-let io = Task<String>.invoke {
+let io = RIO<Any, String>.invoke { _ in
     let date = Date()
     return formatter.string(from: date)
-}.env
+}
 
 enum AnyError: Error {
     case unknown

--- a/Sources/BowEffects/Data/IO.swift
+++ b/Sources/BowEffects/Data/IO.swift
@@ -379,7 +379,7 @@ public class IO<E: Error, A>: IOOf<E, A> {
     /// - Parameter policy: Retrial policy.
     /// - Returns: A computation that is retried based on the provided policy when it fails.
     public func retry<S, O>(_ policy: Schedule<Any, E, S, O>) -> IO<E, A> {
-        self.env.retry(policy).provide(())
+        self.env().retry(policy).provide(())
     }
     
     /// Retries this computation if it fails based on the provided retrial policy, providing a default computation to handle failures after retrial.
@@ -391,7 +391,7 @@ public class IO<E: Error, A>: IOOf<E, A> {
     ///   - orElse: Function to handle errors after retrying.
     /// - Returns: A computation that is retried based on the provided policy when it fails.
     public func retry<S, O, B>(_ policy: Schedule<Any, E, S, O>, orElse: @escaping (E, O) -> IO<E, B>) -> IO<E, Either<B, A>> {
-        self.env.retry(policy, orElse: { e, o in orElse(e, o).env }).provide(())
+        self.env().retry(policy, orElse: { e, o in orElse(e, o).env() }).provide(())
     }
     
     /// Repeats this computation until the provided repeating policy completes, or until it fails.
@@ -403,7 +403,7 @@ public class IO<E: Error, A>: IOOf<E, A> {
     ///   - onUpdateError: A function providing an error in case the policy fails to update properly.
     /// - Returns: A computation that is repeated based on the provided policy when it succeeds.
     public func `repeat`<S, O>(_ policy: Schedule<Any, A, S, O>, onUpdateError: @escaping () -> E) -> IO<E, O> {
-        self.env.repeat(policy, onUpdateError: onUpdateError).provide(())
+        self.env().repeat(policy, onUpdateError: onUpdateError).provide(())
     }
     
     /// Repeats this computation until the provided repeating policy completes, or until it fails, with a function to handle potential failures.
@@ -414,7 +414,7 @@ public class IO<E: Error, A>: IOOf<E, A> {
     ///   - orElse: A function to return a computation in case of error.
     /// - Returns: A computation that is repeated based on the provided policy when it succeeds.
     public func `repeat`<S, O, B>(_ policy: Schedule<Any, A, S, O>, onUpdateError: @escaping () -> E, orElse: @escaping (E, O?) -> IO<E, B>) -> IO<E, Either<B, O>> {
-        self.env.repeat(policy, onUpdateError: onUpdateError, orElse: { e, o in orElse(e, o).env }).provide(())
+        self.env().repeat(policy, onUpdateError: onUpdateError, orElse: { e, o in orElse(e, o).env() }).provide(())
     }
 }
 

--- a/Sources/BowEffects/Data/IO.swift
+++ b/Sources/BowEffects/Data/IO.swift
@@ -40,7 +40,7 @@ public class IO<E: Error, A>: IOOf<E, A> {
     }
     
     /// Creates an EnvIO with no dependencies from this IO.
-    public var env: EnvIO<Any, E, A> {
+    public func env<D>() -> EnvIO<D, E, A> {
         EnvIO { _ in self }
     }
     


### PR DESCRIPTION
## Goal

`IO` has a property to wrap it into an `EnvIO` that sets `Any` as dependency type, but this limits type inference and composability.

## Implementation details

Instead of using `Any`, a generic type `D` is used, so the caller determines this type, making it easier to compose.