### PR TITLE
Add tests for Pairing

### DIFF
--- a/Bow.xcodeproj/project.pbxproj
+++ b/Bow.xcodeproj/project.pbxproj
@@ -159,6 +159,7 @@
 		1191BD0E22D784630052FEA8 /* MonadComprenhensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1191BD0D22D784630052FEA8 /* MonadComprenhensions.swift */; };
 		1191BD1322D78F6D0052FEA8 /* PropertyOperatorOverload.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1191BD0F22D78C0A0052FEA8 /* PropertyOperatorOverload.swift */; };
 		1191BD1422D78F760052FEA8 /* BindingOperatorOverload.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1191BD1122D78F640052FEA8 /* BindingOperatorOverload.swift */; };
+		119D053323D9E8B400F0D559 /* PairingTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 119D053223D9E8B400F0D559 /* PairingTest.swift */; };
 		11A435622212C60A000C5E31 /* EquatableLaws.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11A435602212C59F000C5E31 /* EquatableLaws.swift */; };
 		11A4356422131ACC000C5E31 /* BoolInstances.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11A4356322131ACC000C5E31 /* BoolInstances.swift */; };
 		11A5FDD022E5C79F00FF7821 /* BindingOperator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11A5FDCF22E5C79F00FF7821 /* BindingOperator.swift */; };
@@ -839,6 +840,7 @@
 		1191BD0D22D784630052FEA8 /* MonadComprenhensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MonadComprenhensions.swift; sourceTree = "<group>"; };
 		1191BD0F22D78C0A0052FEA8 /* PropertyOperatorOverload.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PropertyOperatorOverload.swift; sourceTree = "<group>"; };
 		1191BD1122D78F640052FEA8 /* BindingOperatorOverload.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BindingOperatorOverload.swift; sourceTree = "<group>"; };
+		119D053223D9E8B400F0D559 /* PairingTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PairingTest.swift; sourceTree = "<group>"; };
 		11A435602212C59F000C5E31 /* EquatableLaws.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EquatableLaws.swift; sourceTree = "<group>"; };
 		11A4356322131ACC000C5E31 /* BoolInstances.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoolInstances.swift; sourceTree = "<group>"; };
 		11A5FDCF22E5C79F00FF7821 /* BindingOperator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BindingOperator.swift; sourceTree = "<group>"; };
@@ -1773,6 +1775,7 @@
 				8BA0F3AA217E2DEF00969984 /* MooreTest.swift */,
 				8BA0F3B8217E2DEF00969984 /* NonEmptyArrayTest.swift */,
 				8BA0F3B5217E2DEF00969984 /* OptionTest.swift */,
+				119D053223D9E8B400F0D559 /* PairingTest.swift */,
 				112296D3219DC1EF006D66C5 /* ResultTest.swift */,
 				8BA0F3AC217E2DEF00969984 /* SetKTest.swift */,
 				111F84FC234DC00C003FE646 /* SetTest.swift */,
@@ -2992,6 +2995,7 @@
 				11BA21C323D83DA200F3EE78 /* ZipperTest.swift in Sources */,
 				8BA0F3E8217E2DEF00969984 /* BooleanFunctionsTest.swift in Sources */,
 				8BA0F3FD217E2DEF00969984 /* CurryTest.swift in Sources */,
+				119D053323D9E8B400F0D559 /* PairingTest.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Documentation.app/Contents/MacOS/Effects.playground/Pages/Handling errors.xcplaygroundpage/Contents.swift
+++ b/Documentation.app/Contents/MacOS/Effects.playground/Pages/Handling errors.xcplaygroundpage/Contents.swift
@@ -34,9 +34,9 @@ let networkError: IO<NetworkError, String> = IO.raiseError(.notFound)^
 /*:
  ## Transforming errors
  
- Similar to transforming the data inside an `IO` using the `map` operator, you can transform the error type using `mapLeft`. This is useful to handle errors at different layers of your application. For instance, you may want to map a `NetworkError` to a `DomainError` when you move from your network layer to your domain layer:
+ Similar to transforming the data inside an `IO` using the `map` operator, you can transform the error type using `mapError`. This is useful to handle errors at different layers of your application. For instance, you may want to map a `NetworkError` to a `DomainError` when you move from your network layer to your domain layer:
  */
-let domainError: IO<DomainError, String> = networkError.mapLeft { error in
+let domainError: IO<DomainError, String> = networkError.mapError { error in
     switch error {
     case .notFound: return .missingUser
     // Map other cases

--- a/Sources/Bow/Arrow/Function1.swift
+++ b/Sources/Bow/Arrow/Function1.swift
@@ -11,7 +11,7 @@ public typealias Function1Of<I, O> = Kind<Function1Partial<I>, O>
 
 /// This data type acts as a wrapper over functions. It receives two type parameters representing the input and output type of the function. The wrapper adds capabilities to use a function as a Higher Kinded Type and conform to typeclasses that have this requirement.
 public final class Function1<I, O>: Function1Of<I, O> {
-    fileprivate let f: (I) -> O
+    internal let f: (I) -> O
     
     /// Safe downcast.
     ///

--- a/Sources/Bow/Data/Co.swift
+++ b/Sources/Bow/Data/Co.swift
@@ -19,11 +19,6 @@ public class Co<W: Comonad, A>: CoOf<W, A> {
         })
     }
     
-    /// - Returns: The pairing between the underlying comonad, `w`, and the monad `Co<w>`.
-    public static func pair() -> Pairing<W, CoPartial<W>> {
-        Pairing { wab, cowa in cowa^.run(wab) }
-    }
-    
     public init(_ cow: @escaping /*forall R.*/(Kind<W, (A) -> /*R*/Any>) -> /*R*/Any) {
         self.cow = cow
     }

--- a/Sources/Bow/Data/Co.swift
+++ b/Sources/Bow/Data/Co.swift
@@ -26,6 +26,10 @@ public class Co<W: Comonad, A>: CoOf<W, A> {
     func run<R>(_ w: Kind<W, (A) -> R>) -> R {
         unsafeBitCast(self.cow, to:((Kind<W, (A) -> R>) -> R).self)(w)
     }
+    
+    func hoist<V>(_ transform: FunctionK<V, W>) -> Co<V, A> {
+        Co<V, A>(self.cow <<< transform.invoke)
+    }
 }
 
 /// Safe downcast.

--- a/Sources/Bow/Data/Co.swift
+++ b/Sources/Bow/Data/Co.swift
@@ -1,34 +1,83 @@
-// newtype Co w a = Co (forall r. w (a -> r) -> r)
+// newtype CoT w m a = Co (forall r. w (a -> m r) -> m r)
 
-public final class ForCo {}
-public final class CoPartial<W: Comonad>: Kind<ForCo, W> {}
-public typealias CoOf<W: Comonad, A> = Kind<CoPartial<W>, A>
+public final class ForCoT {}
+public final class CoTPartial<W: Comonad, M>: Kind2<ForCoT, W, M> {}
+public typealias CoTOf<W: Comonad, M, A> = Kind<CoTPartial<W, M>, A>
 
-/// (Co w) gives you "the best" pairing monad for any comonad w
+public typealias ForCo = ForCoT
+public typealias CoPartial<W: Comonad> = CoTPartial<W, ForId>
+public typealias CoOf<W: Comonad, A> = CoTOf<W, ForId, A>
+public typealias Co<W: Comonad, A> = CoT<W, ForId, A>
+
+public typealias Transition<W: Comonad, A> = Co<W, A>
+public typealias TransitionT<W: Comonad, M, A> = CoT<W, M, A>
+
+/// (CoT w) gives you "the best" pairing monad transformer for any comonad w
 /// In other words, an explorer for the state space given by w
-public class Co<W: Comonad, A>: CoOf<W, A> {
-    internal let cow: (Kind<W, (A) -> Any>) -> Any
+public class CoT<W: Comonad, M, A>: CoTOf<W, M, A> {
+    internal let cow: (Kind<W, (A) -> Kind<M, Any>>) -> Kind<M, Any>
     
-    public static func fix(_ value: CoOf<W, A>) -> Co<W, A> {
-        value as! Co<W, A>
+    public static func fix(_ value: CoTOf<W, M, A>) -> CoT<W, M, A> {
+        value as! CoT<W, M, A>
     }
     
-    public static func select<A, B>(_ co: Co<W, (A) -> B>, _ wa: Kind<W, A>) -> Kind<W, B> {
+    public static func liftT(_ f: @escaping (Kind<W, Any/*S*/>) -> A) -> CoT<W, M, A> {
+        let extract = Function1<Kind<W, (Any) -> Kind<M, Any>>, (Any) -> Kind<M, Any>> { x in x.extract() }
+        let ff = Function1<Kind<W, (Any) -> Kind<M, Any>>, A> { x in f(x.map { xx in xx as Any }) }.map { a in a as Any }
+        let g: (Any) -> A = { a in a as! A }
+        let adapt: (Kind<W, (A) -> Kind<M, Any>>) -> Kind<W, (Any) -> Kind<M, Any>> = { wf in
+            wf.map { f in g >>> f }
+        }
+        let ap: (Kind<W, (Any) -> Kind<M, Any>>) -> Kind<M, Any> = extract.ap(ff)^.f
+        
+        return CoT(adapt >>> ap)
+    }
+    
+    public init(_ cow: @escaping /*forall R.*/(Kind<W, (A) -> Kind<M, /*R*/Any>>) -> Kind<M, /*R*/Any>) {
+        self.cow = cow
+    }
+    
+    func runT<R>(_ w: Kind<W, (A) -> Kind<M, R>>) -> Kind<M, R> {
+        unsafeBitCast(self.cow, to:((Kind<W, (A) -> Kind<M, R>>) -> Kind<M, R>).self)(w)
+    }
+    
+    func hoistT<V: Comonad>(_ transform: FunctionK<V, W>) -> CoT<V, M, A> {
+        CoT<V, M, A>(self.cow <<< transform.invoke)
+    }
+}
+
+public extension CoT where M: Applicative {
+    func lowerT<B>(_ input: Kind<W, B>) -> Kind<M, A> {
+        (self.runT <<< { wbma in wbma.as(M.pure) })(input)
+    }
+}
+
+public extension CoT where M == ForId {
+    static func select<A, B>(_ co: Co<W, (A) -> B>, _ wa: Kind<W, A>) -> Kind<W, B> {
         co.run(wa.coflatMap { wa in
             { f in wa.map(f) }
         })
     }
     
-    public init(_ cow: @escaping /*forall R.*/(Kind<W, (A) -> /*R*/Any>) -> /*R*/Any) {
-        self.cow = cow
+    static func lift(_ f: @escaping (Kind<W, Any>) -> A) -> Co<W, A> {
+        liftT(f)
+    }
+    
+    /// - Returns: The pairing between the underlying comonad, `w`, and the monad `Co<w>`.
+    static func pair() -> Pairing<W, CoPartial<W>> {
+        Pairing { wab, cowa in cowa^.run(wab) }
     }
     
     func run<R>(_ w: Kind<W, (A) -> R>) -> R {
-        unsafeBitCast(self.cow, to:((Kind<W, (A) -> R>) -> R).self)(w)
+        self.runT(w.map { f in f >>> Id.pure })^.value
     }
     
-    func hoist<V>(_ transform: FunctionK<V, W>) -> Co<V, A> {
+    func hoist<V: Comonad>(_ transform: FunctionK<V, W>) -> Co<V, A> {
         Co<V, A>(self.cow <<< transform.invoke)
+    }
+    
+    func lower<B>(_ input: Kind<W, B>) -> A {
+        lowerT(input)^.value
     }
 }
 
@@ -36,21 +85,25 @@ public class Co<W: Comonad, A>: CoOf<W, A> {
 ///
 /// - Parameter value: Value in higher-kind form.
 /// - Returns: Value cast to Co.
-public postfix func ^<W, A>(_ value: CoOf<W, A>) -> Co<W, A> {
-    Co.fix(value)
+public postfix func ^<W, M, A>(_ value: CoTOf<W, M, A>) -> CoT<W, M, A> {
+    CoT.fix(value)
 }
 
-extension CoPartial: Functor {
-    public static func map<A, B>(_ fa: CoOf<W, A>, _ f: @escaping (A) -> B) -> CoOf<W, B> {
-        Co<W, B> { b in
-            fa^.run(b.map { bb in bb <<< f })
+// MARK: Instance of `Functor` for `CoT`
+
+extension CoTPartial: Functor {
+    public static func map<A, B>(_ fa: CoTOf<W, M, A>, _ f: @escaping (A) -> B) -> CoTOf<W, M, B> {
+        CoT<W, M, B> { b in
+            fa^.runT(b.map { bb in bb <<< f })
         }
     }
 }
 
-extension CoPartial: Applicative {
-    public static func ap<A, B>(_ ff: CoOf<W, (A) -> B>, _ fa: CoOf<W, A>) -> CoOf<W, B> {
-        Co<W, B> { w in
+// MARK: Instance of `Applicative` for `CoT`
+
+extension CoTPartial: Applicative {
+    public static func ap<A, B>(_ ff: CoTOf<W, M, (A) -> B>, _ fa: CoTOf<W, M, A>) -> CoTOf<W, M, B> {
+        CoT<W, M, B> { w in
             ff^.cow(w.coflatMap { wf in
                 { g in
                     fa^.cow(wf.map { ff in ff <<< g})
@@ -59,27 +112,81 @@ extension CoPartial: Applicative {
         }
     }
     
-    public static func pure<A>(_ a: A) -> CoOf<W, A> {
-        Co<W, A> { w in w.extract()(a) }
+    public static func pure<A>(_ a: A) -> CoTOf<W, M, A> {
+        CoT<W, M, A> { w in w.extract()(a) }
     }
 }
 
-extension CoPartial: Monad {
-    public static func flatMap<A, B>(_ fa: CoOf<W, A>, _ f: @escaping (A) -> CoOf<W, B>) -> CoOf<W, B> {
-        Co { w in
+// MARK: Instance of `Monad` for `CoT`
+
+extension CoTPartial: Monad {
+    public static func flatMap<A, B>(_ fa: CoTOf<W, M, A>, _ f: @escaping (A) -> CoTOf<W, M, B>) -> CoTOf<W, M, B> {
+        CoT { w in
             fa^.cow(w.coflatMap { wa in
                 { a in
-                    Co<W, B>.fix(f(a)).run(wa)
+                    f(a)^.runT(wa)
                 }
             })
         }
     }
     
-    public static func tailRecM<A, B>(_ a: A, _ f: @escaping (A) -> CoOf<W, Either<A, B>>) -> CoOf<W, B> {
+    public static func tailRecM<A, B>(_ a: A, _ f: @escaping (A) -> CoTOf<W, M, Either<A, B>>) -> CoTOf<W, M, B> {
         f(a).flatMap { either in
             either.fold(
                 { aa in tailRecM(aa, f) },
-                { b in Co.pure(b) })
+                { b in CoT.pure(b) })
+        }
+    }
+}
+
+// MARK: Instance of `MonadReader` for `CoT`
+
+extension CoTPartial: MonadReader where W: ComonadEnv {
+    public typealias D = W.E
+    
+    public static func ask() -> CoTOf<W, M, W.E> {
+        CoT.liftT(W.ask)
+    }
+    
+    public static func local<A>(_ fa: CoTOf<W, M, A>, _ f: @escaping (W.E) -> W.E) -> CoTOf<W, M, A> {
+        CoT(fa^.cow <<< { wa in wa.local(f) })
+    }
+}
+
+// MARK: Instance of `MonadState` for `CoT`
+
+extension CoTPartial: MonadState where W: ComonadStore {
+    public typealias S = W.S
+    
+    public static func get() -> CoTOf<W, M, W.S> {
+        CoT.liftT { wa in wa.position }
+    }
+    
+    public static func set(_ s: W.S) -> CoTOf<W, M, ()> {
+        CoT { wa in wa.peek(s)(()) }
+    }
+}
+
+// MARK: Instance of `MonadWriter` for `CoT`
+
+extension CoTPartial: MonadWriter where W: ComonadTraced {
+    public typealias W = W.M
+    
+    public static func writer<A>(_ aw: (W.M, A)) -> CoTOf<W, M, A> {
+        CoT { wa in wa.trace(aw.0)(aw.1) }
+    }
+    
+    public static func listen<A>(_ fa: CoTOf<W, M, A>) -> CoTOf<W, M, (W.M, A)> {
+        CoT { wa in
+            let listened = wa.listen().map { tuple in { a in tuple.1((tuple.0, a)) } }
+            return fa^.runT(listened)
+        }
+    }
+    
+    public static func pass<A>(_ fa: CoTOf<W, M, ((W.M) -> W.M, A)>) -> CoTOf<W, M, A> {
+        CoT { wa in
+            let passed: Kind<W, (((W.M) -> W.M, A)) -> Kind<M, Any>> = wa.pass().map { f in { tuple in f(tuple.0)(tuple.1) } }
+            return fa^.runT(passed)
         }
     }
 }

--- a/Sources/Bow/Data/Pairing.swift
+++ b/Sources/Bow/Data/Pairing.swift
@@ -118,3 +118,17 @@ public extension Pairing {
         .pairReaderTEnvT(.pairId())
     }
 }
+
+// MARK: Pairing for any Comonad
+
+public extension Comonad {
+    static func pair() -> Pairing<Self, CoPartial<Self>> {
+        Pairing { wab, cowa in cowa^.run(wab) }
+    }
+}
+
+public extension Kind where F: Comonad {
+    static func pair() -> Pairing<F, CoPartial<F>> {
+        F.pair()
+    }
+}

--- a/Sources/Bow/Data/Pairing.swift
+++ b/Sources/Bow/Data/Pairing.swift
@@ -36,6 +36,10 @@ public class Pairing<F: Functor, G: Functor>: PairingOf<F, G> {
                 gb.map { b in b as Any }) { a, b in f(a as! A, b as! B) } as! C
     }
     
+    public func select<A, B>(_ fa: Kind<F, A>, _ ggb: Kind<G, Kind<G, B>>) -> Kind<G, B> {
+        pair(fa, ggb) { _, gb in gb }
+    }
+    
     public func pairFlipped<A, B, C>(_ ga: Kind<G, A>, _ fb: Kind<F, B>, _ f: @escaping (A, B) -> C) -> C {
         pair(fb, ga, flip(f))
     }

--- a/Sources/Bow/Transformers/TracedT.swift
+++ b/Sources/Bow/Transformers/TracedT.swift
@@ -80,4 +80,20 @@ extension TracedTPartial: ComonadTraced where W: Comonad, M: Monoid {
     public static func trace<A>(_ wa: TracedTOf<M, W, A>, _ m: M) -> A {
         wa^.value.extract()(m)
     }
+
+    public static func listens<A, B>(_ wa: TracedTOf<M, W, A>, _ f: @escaping (M) -> B) -> TracedTOf<M, W, (B, A)> {
+        TracedT(wa^.value.map { g in
+            { m in (f(m), g(m)) }
+        })
+    }
+    
+    public static func pass<A>(_ wa: TracedTOf<M, W, A>) -> TracedTOf<M, W, ((M) -> M) -> A> {
+        TracedT(wa^.value.map { trace in
+            { m in
+                { f in
+                    trace(f(m))
+                }
+            }
+        })
+    }
 }

--- a/Sources/Bow/Transformers/WriterT.swift
+++ b/Sources/Bow/Transformers/WriterT.swift
@@ -127,14 +127,6 @@ extension WriterT where F: Applicative {
         return WriterT.putT(F.pure(a), w)
     }
 
-    /// Creates a `WriterT` from an initial value for the accumulator.
-    ///
-    /// - Parameter l: Initial value for the accumulator.
-    /// - Returns: A `WriterT` wrapping the provided value and unit for the result value.
-    public static func tell(_ l: W) -> WriterT<F, W, Unit>  {
-        return WriterT<F, W, Unit>.put(unit, l)
-    }
-
     /// Lifts an effect using the accumulator value of this `WriterT`.
     ///
     /// - Parameter fb: Effect to be lifted.
@@ -207,17 +199,6 @@ extension WriterT where F: Monad {
                 (l, (l, a))
             }
         })
-    }
-}
-
-// MARK: Functions for `WriterT` when the effect has an instance of `Monad` and the accumulator type has an instance of `Semigroup`
-extension WriterT where F: Monad, W: Semigroup {
-    /// Combines the accumulator with a new value.
-    ///
-    /// - Parameter w: New value to combine the accumulator with.
-    /// - Returns: A `WriterT` with the same result and combined accumulator.
-    public func tell(_ w: W) -> WriterT<F, W, A> {
-        return mapAcc({ inW in inW.combine(w) })
     }
 }
 

--- a/Sources/Bow/Typeclasses/ComonadTraced.swift
+++ b/Sources/Bow/Typeclasses/ComonadTraced.swift
@@ -2,11 +2,21 @@ public protocol ComonadTraced: Comonad {
     associatedtype M
     
     static func trace<A>(_ wa: Kind<Self, A>, _ m: M) -> A
+    static func listens<A, B>(_ wa: Kind<Self, A>, _ f: @escaping (M) -> B) -> Kind<Self, (B, A)>
+    static func pass<A>(_ wa: Kind<Self, A>) -> Kind<Self, ((M) -> M) -> A>
 }
 
 public extension ComonadTraced {
     static func traces<A>(_ wa: Kind<Self, A>, _ f: @escaping (A) -> M) -> A {
         trace(wa, f(wa.extract()))
+    }
+    
+    static func listen<A>(_ wa: Kind<Self, A>) -> Kind<Self, (M, A)> {
+        listens(wa, id)
+    }
+    
+    static func censor<A>(_ wa: Kind<Self, A>, _ f: @escaping (M) -> M) -> Kind<Self, A> {
+        pass(wa).map { trace in trace(f) }
     }
 }
 
@@ -19,5 +29,21 @@ public extension Kind where F: ComonadTraced {
     
     func traces(_ f: @escaping (A) -> F.M) -> A {
         F.traces(self, f)
+    }
+    
+    func listens<B>(_ f: @escaping (F.M) -> B) -> Kind<F, (B, A)> {
+        F.listens(self, f)
+    }
+    
+    func listen() -> Kind<F, (F.M, A)> {
+        F.listen(self)
+    }
+    
+    func censor(_ f: @escaping (F.M) -> F.M) -> Kind<F, A> {
+        F.censor(self, f)
+    }
+    
+    func pass() -> Kind<F, ((F.M) -> F.M) -> A>  {
+        F.pass(self)
     }
 }

--- a/Sources/Bow/Typeclasses/MonadReader.swift
+++ b/Sources/Bow/Typeclasses/MonadReader.swift
@@ -31,7 +31,7 @@ public extension MonadReader {
 
 // MARK: Syntax for MonadReader
 
-public extension Kind where F: MonadReader {
+public extension Kind where F: MonadReader, A == F.D {
     /// Retrieves the shared environment.
     ///
     /// This is a convenience method to call `MonadReader.ask` as a static method of this type.
@@ -40,7 +40,9 @@ public extension Kind where F: MonadReader {
     static func ask() -> Kind<F, F.D> {
         return F.ask()
     }
+}
 
+public extension Kind where F: MonadReader {
     /// Executes this computation in a modified environment.
     ///
     /// This is a convenience method to call `MonadReader.local` as an instance method of this type.

--- a/Sources/Bow/Typeclasses/MonadState.swift
+++ b/Sources/Bow/Typeclasses/MonadState.swift
@@ -48,16 +48,7 @@ public extension MonadState {
 
 // MARK: Syntax for MonadState
 
-public extension Kind where F: MonadState {
-    /// Retrieves the state from the internals of the monad.
-    ///
-    /// This is a convenience method to call `MonadState.get` as a static method of this type.
-    ///
-    /// - Returns: Maintained state.
-    static func get() -> Kind<F, F.S> {
-        return F.get()
-    }
-
+public extension Kind where F: MonadState, A == Void {
     /// Replaces the state inside the monad.
     ///
     /// This is a convenience method to call `MonadState.set` as a static method of this type.
@@ -67,17 +58,7 @@ public extension Kind where F: MonadState {
     static func set(_ s: F.S) -> Kind<F, ()> {
         return F.set(s)
     }
-
-    /// Embeds a state action into the monad.
-    ///
-    /// This is a convenience method to call `MonadState.state` as a static method of this type.
-    ///
-    /// - Parameter f: A function that receives the state and computes a value and a new state.
-    /// - Returns: A value with the output of the function and the new state.
-    static func state(_ f: @escaping (F.S) -> (F.S, A)) -> Kind<F, A> {
-        return F.state(f)
-    }
-
+    
     /// Modifies the internal state.
     ///
     /// This is a convenience method to call `MonadState.modify` as a static method of this type.
@@ -86,6 +67,29 @@ public extension Kind where F: MonadState {
     /// - Returns: Unit.
     static func modify(_ f: @escaping (F.S) -> F.S) -> Kind<F, ()> {
         return F.modify(f)
+    }
+}
+
+public extension Kind where F: MonadState, A == F.S {
+    /// Retrieves the state from the internals of the monad.
+    ///
+    /// This is a convenience method to call `MonadState.get` as a static method of this type.
+    ///
+    /// - Returns: Maintained state.
+    static func get() -> Kind<F, F.S> {
+        return F.get()
+    }
+}
+
+public extension Kind where F: MonadState {
+    /// Embeds a state action into the monad.
+    ///
+    /// This is a convenience method to call `MonadState.state` as a static method of this type.
+    ///
+    /// - Parameter f: A function that receives the state and computes a value and a new state.
+    /// - Returns: A value with the output of the function and the new state.
+    static func state(_ f: @escaping (F.S) -> (F.S, A)) -> Kind<F, A> {
+        return F.state(f)
     }
 
     /// Retrieves a specific component of the state.

--- a/Sources/Bow/Typeclasses/MonadWriter.swift
+++ b/Sources/Bow/Typeclasses/MonadWriter.swift
@@ -56,6 +56,18 @@ public extension MonadWriter {
 
 // MARK: Syntax for MonadWriter
 
+public extension Kind where F: MonadWriter, A == Void {
+    /// Produces a new value of the side stream of data.
+    ///
+    /// This is a convenience method to call `MonadWriter.tell` as a static method of this type.
+    ///
+    /// - Parameter w: New value.
+    /// - Returns: Unit.
+    static func tell(_ w: F.W) -> Kind<F, ()> {
+        return F.tell(w)
+    }
+}
+
 public extension Kind where F: MonadWriter {
     /// Embeds a writer action.
     ///
@@ -84,16 +96,6 @@ public extension Kind where F: MonadWriter {
     /// - Returns: Result of the computation.
     static func pass(_ fa: Kind<F, ((F.W) -> F.W, A)>) -> Kind<F, A> {
         return F.pass(fa)
-    }
-
-    /// Produces a new value of the side stream of data.
-    ///
-    /// This is a convenience method to call `MonadWriter.tell` as a static method of this type.
-    ///
-    /// - Parameter w: New value.
-    /// - Returns: Unit.
-    static func tell(_ w: F.W) -> Kind<F, ()> {
-        return F.tell(w)
     }
 
     /// Performs this computation and transforms the side stream of data, pairing it with the result of this computation.

--- a/Sources/BowEffects/Data/EnvIO.swift
+++ b/Sources/BowEffects/Data/EnvIO.swift
@@ -59,7 +59,7 @@ public extension Kleisli {
     /// - Parameter f: Function transforming the error.
     /// - Returns: An EnvIO value with the new error type.
     func mapError<E: Error, EE: Error>(_ f: @escaping (E) -> EE) -> EnvIO<D, EE, A> where F == IOPartial<E> {
-        return EnvIO { env in self.run(env)^.mapLeft(f) }
+        return EnvIO { env in self.run(env)^.mapError(f) }
     }
     
     /// Provides the required environment.
@@ -166,6 +166,37 @@ public extension Kleisli {
     /// - Returns: An EnvIO with both type arguments transformed.
     func bimap<E: Error, EE: Error, B>(_ fe: @escaping (E) -> EE, _ fa: @escaping (A) -> B) -> EnvIO<D, EE, B> where F == IOPartial<E> {
         mapError(fe).map(fa)^
+    }
+    
+    /// Performs the side effects that are suspended in this IO in a synchronous manner.
+    ///
+    /// - Parameters:
+    ///   - d: Dependencies needed in this operation.
+    ///   - queue: Dispatch queue used to execute the side effects. Defaults to the main queue.
+    /// - Returns: Value produced after running the suspended side effects.
+    /// - Throws: Error of type `E` that may happen during the evaluation of the side-effects. Errors of other types thrown from the evaluation of this IO will cause a fatal error.
+    func unsafeRunSync<E: Error>(with d: D, on queue: DispatchQueue = .main) throws -> A where F == IOPartial<E> {
+        try self.provide(d).unsafeRunSync(on: queue)
+    }
+    
+    /// Performs the side effects that are suspended in this EnvIO in a synchronous manner.
+    ///
+    /// - Parameters:
+    ///   - d: Dependencies needed in this operation.
+    ///   - queue: Dispatch queue used to execute the side effects. Defaults to the main queue.
+    /// - Returns: An Either wrapping errors in the left side and values on the right side. Errors of other types thrown from the evaluation of this IO will cause a fatal error.
+    func unsafeRunSyncEither<E: Error>(with d: D, on queue: DispatchQueue = .main) -> Either<E, A> where F == IOPartial<E> {
+        self.provide(d).unsafeRunSyncEither(on: queue)
+    }
+    
+    /// Performs the side effects that are suspended in this EnvIO in an asynchronous manner.
+    ///
+    /// - Parameters:
+    ///   - d: Dependencies needed in this operation.
+    ///   - queue: Dispatch queue used to execute the side effects. Defaults to the main queue.
+    ///   - callback: A callback function to receive the results of the evaluation. Errors of other types thrown from the evaluation of this IO will cause a fatal error.
+    func unsafeRunAsync<E: Error>(with d: D, on queue: DispatchQueue = .main, _ callback: @escaping Callback<E, A>) where F == IOPartial<E> {
+        self.provide(d).unsafeRunAsync(on: queue, callback)
     }
 }
 

--- a/Sources/BowEffects/Data/IO.swift
+++ b/Sources/BowEffects/Data/IO.swift
@@ -99,7 +99,7 @@ public class IO<E: Error, A>: IOOf<E, A> {
     ///   - fa: Function to transform the output type argument.
     /// - Returns: An IO with both type arguments transformed.
     func bimap<EE: Error, B>(_ fe: @escaping (E) -> EE, _ fa: @escaping (A) -> B) -> IO<EE, B> {
-        mapLeft(fe).map(fa)^
+        mapError(fe).map(fa)^
     }
     
     /// Creates an IO from 2 side-effectful functions, tupling their results. Errors thrown from the functions must be of type `E`; otherwise, a fatal error will happen.
@@ -349,13 +349,22 @@ public class IO<E: Error, A>: IOOf<E, A> {
     ///
     /// - Parameter f: Function transforming the error.
     /// - Returns: An IO value with the new error type.
+    @available(*, deprecated, renamed: "mapError")
     public func mapLeft<EE>(_ f: @escaping (E) -> EE) -> IO<EE, A> {
+        FErrorMap(f, self)
+    }
+    
+    /// Transforms the error type of this IO.
+    ///
+    /// - Parameter f: Function transforming the error.
+    /// - Returns: An IO value with the new error type.
+    public func mapError<EE>(_ f: @escaping (E) -> EE) -> IO<EE, A> {
         FErrorMap(f, self)
     }
     
     /// Returns this `IO` erasing the error type information
     public var anyError: IO<Error, A> {
-        self.mapLeft { e in e as Error }
+        self.mapError { e in e as Error }
     }
     
     internal func fail(_ error: Error) -> Never {

--- a/Tests/BowGenerators/Data/Co+Gen.swift
+++ b/Tests/BowGenerators/Data/Co+Gen.swift
@@ -2,9 +2,9 @@ import Bow
 import SwiftCheck
 
 // MARK: Instance of `ArbitraryK` for `Co`
-extension CoPartial: ArbitraryK where W: ArbitraryK {
-    public static func generate<A: Arbitrary>() -> Kind<CoPartial<W>, A> {
+extension CoTPartial: ArbitraryK where W: ArbitraryK, M: ArbitraryK {
+    public static func generate<A: Arbitrary>() -> CoTOf<W, M, A> {
         let wa: Kind<W, A> = W.generate()
-        return Co.pure(wa.extract())
+        return CoT.pure(wa.extract())
     }
 }

--- a/Tests/BowLaws/MonadWriterLaws.swift
+++ b/Tests/BowLaws/MonadWriterLaws.swift
@@ -7,6 +7,7 @@ public class MonadWriterLaws<F: MonadWriter & EquatableK> where F.W == Int {
         tellFusion()
         listenPure()
         listenWriterProperty()
+        censorTell()
     }
     
     private static func writerPure() {
@@ -34,4 +35,12 @@ public class MonadWriterLaws<F: MonadWriter & EquatableK> where F.W == Int {
             return isEqual(F.listen(F.writer(tuple)), F.map(F.tell(tuple.0), { _ in tuple }))
         }
     }
+    
+    private static func censorTell() {
+        property("Censor tell") <~ forAll { (a: Int, w: Int, f: ArrowOf<Int, Int>) in
+            isEqual(F.writer((f.getArrow(w), a)).listen(),
+                    F.writer((w, a)).censor(f.getArrow).listen())
+        }
+    }
+    
 }

--- a/Tests/BowTests/Data/CoTest.swift
+++ b/Tests/BowTests/Data/CoTest.swift
@@ -2,11 +2,12 @@ import XCTest
 import BowLaws
 import Bow
 import BowGenerators
+import SwiftCheck
 
-extension CoPartial: EquatableK where W == ForId {
-    public static func eq<A: Equatable>(_ lhs: CoOf<W, A>, _ rhs: CoOf<W, A>) -> Bool {
-        ForId.pair().zap(Id(id), lhs^) ==
-            ForId.pair().zap(Id(id), rhs^)
+extension CoTPartial: EquatableK where W: Applicative & EquatableK, M == ForId {
+    public static func eq<A: Equatable>(_ lhs: CoTOf<W, M, A>, _ rhs: CoTOf<W, M, A>) -> Bool {
+        W.pair().zap(W.pure(id), lhs^) ==
+            W.pair().zap(W.pure(id), rhs^)
     }
 }
 
@@ -21,5 +22,13 @@ class CoTest: XCTestCase {
 
     func testMonadLaws() {
         MonadLaws<CoPartial<ForId>>.check()
+    }
+    
+    func testMonadStateLaws() {
+        MonadStateLaws<CoPartial<StorePartial<Int>>>.check()
+    }
+    
+    func testMonadWriterLaws() {
+        MonadWriterLaws<CoPartial<TracedPartial<Int>>>.check()
     }
 }

--- a/Tests/BowTests/Data/CoTest.swift
+++ b/Tests/BowTests/Data/CoTest.swift
@@ -5,8 +5,8 @@ import BowGenerators
 
 extension CoPartial: EquatableK where W == ForId {
     public static func eq<A: Equatable>(_ lhs: CoOf<W, A>, _ rhs: CoOf<W, A>) -> Bool {
-        Co<W, A>.pair().zap(Id(id), lhs^) ==
-            Co<W, A>.pair().zap(Id(id), rhs^)
+        ForId.pair().zap(Id(id), lhs^) ==
+            ForId.pair().zap(Id(id), rhs^)
     }
 }
 

--- a/Tests/BowTests/Data/PairingTest.swift
+++ b/Tests/BowTests/Data/PairingTest.swift
@@ -1,0 +1,20 @@
+import XCTest
+import Bow
+
+class PairingTest: XCTestCase {
+    func testPairingStateStore() {
+        let w = Store<Int, Int>(0, id)
+        let s = State<Int, Int>.var()
+        
+        let actions: State<Int, Void> = binding(
+            |<-.set(5),
+            |<-.modify { x in x + 5 },
+            s <- .get(),
+            |<-.set(s.get * 3 + 1),
+            yield: ())^
+        
+        let w2 = Pairing.pairStateStore().select(actions, w.duplicate())
+        
+        XCTAssertEqual(w2.extract(), 31)
+    }
+}

--- a/Tests/BowTests/Data/PairingTest.swift
+++ b/Tests/BowTests/Data/PairingTest.swift
@@ -17,4 +17,20 @@ class PairingTest: XCTestCase {
         
         XCTAssertEqual(w2.extract(), 31)
     }
+    
+    func testPairingWriterTraced() {
+        let w = Traced<Int, String> { x in Array(repeating: "*", count: x).joined() }
+        
+        let m = Writer<Int, Int>.var()
+        let a = Writer<Int, Void>.var()
+        
+        let actions: Writer<Int, Void> = binding(
+            (m, a) <- Writer.tell(3).censor { x in 2 * x }.listens(id),
+            |<-.tell(m.get + 1),
+            yield: ())^
+        
+        let w2 = Pairing.pairWriterTraced().select(actions, w.duplicate())
+        
+        XCTAssertEqual(w2.extract(), "*************")
+    }
 }

--- a/Tests/BowTests/Data/PairingTest.swift
+++ b/Tests/BowTests/Data/PairingTest.swift
@@ -33,4 +33,25 @@ class PairingTest: XCTestCase {
         
         XCTAssertEqual(w2.extract(), "*************")
     }
+    
+    func testPairingReaderEnv() {
+        let w = Env<Int, Double>(10, .pi)
+        
+        let e1 = Reader<Int, Int>.var()
+        let e2 = Reader<Int, Int>.var()
+        var res = 0
+        
+        let actions: Reader<Int, Int> = binding(
+            e1 <- Reader.ask().local { x in 2 * x },
+            e2 <- Reader.pure(e1.get * 3),
+            |<-Reader<Int, Void> { _ in
+                res = e2.get
+                return Id(())
+            },
+            yield: e2.get)^
+        
+        let _ = Pairing.pairReaderEnv().select(actions, w.duplicate())
+        
+        XCTAssertEqual(res, 60)
+    }
 }


### PR DESCRIPTION
## Goal

This PR tests the Pairing combinations for State/Store, Writer/Traced and Reader/Env. While writing the tests, some improvements to the ergonomics of the projected methods of MonadReader, MonadWriter and MonadState were found and applied. Also, some utility methods for Co and Pairing were added.

Tests are based on examples found on [this paper](https://pdfs.semanticscholar.org/31b9/1969215a46f5d44298e1c1e67872edd7ae77.pdf).