### PR TITLE
EnvIO utilities to run an operation

### DIFF
--- a/Documentation.app/Contents/MacOS/Effects.playground/Pages/Handling errors.xcplaygroundpage/Contents.swift
+++ b/Documentation.app/Contents/MacOS/Effects.playground/Pages/Handling errors.xcplaygroundpage/Contents.swift
@@ -34,9 +34,9 @@ let networkError: IO<NetworkError, String> = IO.raiseError(.notFound)^
 /*:
  ## Transforming errors
  
- Similar to transforming the data inside an `IO` using the `map` operator, you can transform the error type using `mapLeft`. This is useful to handle errors at different layers of your application. For instance, you may want to map a `NetworkError` to a `DomainError` when you move from your network layer to your domain layer:
+ Similar to transforming the data inside an `IO` using the `map` operator, you can transform the error type using `mapError`. This is useful to handle errors at different layers of your application. For instance, you may want to map a `NetworkError` to a `DomainError` when you move from your network layer to your domain layer:
  */
-let domainError: IO<DomainError, String> = networkError.mapLeft { error in
+let domainError: IO<DomainError, String> = networkError.mapError { error in
     switch error {
     case .notFound: return .missingUser
     // Map other cases

--- a/Sources/BowEffects/Data/EnvIO.swift
+++ b/Sources/BowEffects/Data/EnvIO.swift
@@ -167,6 +167,37 @@ public extension Kleisli {
     func bimap<E: Error, EE: Error, B>(_ fe: @escaping (E) -> EE, _ fa: @escaping (A) -> B) -> EnvIO<D, EE, B> where F == IOPartial<E> {
         mapError(fe).map(fa)^
     }
+    
+    /// Performs the side effects that are suspended in this IO in a synchronous manner.
+    ///
+    /// - Parameters:
+    ///   - d: Dependencies needed in this operation.
+    ///   - queue: Dispatch queue used to execute the side effects. Defaults to the main queue.
+    /// - Returns: Value produced after running the suspended side effects.
+    /// - Throws: Error of type `E` that may happen during the evaluation of the side-effects. Errors of other types thrown from the evaluation of this IO will cause a fatal error.
+    func unsafeRunSync<E: Error>(with d: D, on queue: DispatchQueue = .main) throws -> A where F == IOPartial<E> {
+        try self.provide(d).unsafeRunSync(on: queue)
+    }
+    
+    /// Performs the side effects that are suspended in this EnvIO in a synchronous manner.
+    ///
+    /// - Parameters:
+    ///   - d: Dependencies needed in this operation.
+    ///   - queue: Dispatch queue used to execute the side effects. Defaults to the main queue.
+    /// - Returns: An Either wrapping errors in the left side and values on the right side. Errors of other types thrown from the evaluation of this IO will cause a fatal error.
+    func unsafeRunSyncEither<E: Error>(with d: D, on queue: DispatchQueue = .main) -> Either<E, A> where F == IOPartial<E> {
+        self.provide(d).unsafeRunSyncEither(on: queue)
+    }
+    
+    /// Performs the side effects that are suspended in this EnvIO in an asynchronous manner.
+    ///
+    /// - Parameters:
+    ///   - d: Dependencies needed in this operation.
+    ///   - queue: Dispatch queue used to execute the side effects. Defaults to the main queue.
+    ///   - callback: A callback function to receive the results of the evaluation. Errors of other types thrown from the evaluation of this IO will cause a fatal error.
+    func unsafeRunAsync<E: Error>(with d: D, on queue: DispatchQueue = .main, _ callback: @escaping Callback<E, A>) where F == IOPartial<E> {
+        self.provide(d).unsafeRunAsync(on: queue, callback)
+    }
 }
 
 public extension Kleisli where F == IOPartial<Error> {

--- a/Sources/BowEffects/Data/EnvIO.swift
+++ b/Sources/BowEffects/Data/EnvIO.swift
@@ -59,7 +59,7 @@ public extension Kleisli {
     /// - Parameter f: Function transforming the error.
     /// - Returns: An EnvIO value with the new error type.
     func mapError<E: Error, EE: Error>(_ f: @escaping (E) -> EE) -> EnvIO<D, EE, A> where F == IOPartial<E> {
-        return EnvIO { env in self.run(env)^.mapLeft(f) }
+        return EnvIO { env in self.run(env)^.mapError(f) }
     }
     
     /// Provides the required environment.

--- a/Sources/BowEffects/Data/IO.swift
+++ b/Sources/BowEffects/Data/IO.swift
@@ -99,7 +99,7 @@ public class IO<E: Error, A>: IOOf<E, A> {
     ///   - fa: Function to transform the output type argument.
     /// - Returns: An IO with both type arguments transformed.
     func bimap<EE: Error, B>(_ fe: @escaping (E) -> EE, _ fa: @escaping (A) -> B) -> IO<EE, B> {
-        mapLeft(fe).map(fa)^
+        mapError(fe).map(fa)^
     }
     
     /// Creates an IO from 2 side-effectful functions, tupling their results. Errors thrown from the functions must be of type `E`; otherwise, a fatal error will happen.
@@ -349,13 +349,22 @@ public class IO<E: Error, A>: IOOf<E, A> {
     ///
     /// - Parameter f: Function transforming the error.
     /// - Returns: An IO value with the new error type.
+    @available(*, deprecated, renamed: "mapError")
     public func mapLeft<EE>(_ f: @escaping (E) -> EE) -> IO<EE, A> {
+        FErrorMap(f, self)
+    }
+    
+    /// Transforms the error type of this IO.
+    ///
+    /// - Parameter f: Function transforming the error.
+    /// - Returns: An IO value with the new error type.
+    public func mapError<EE>(_ f: @escaping (E) -> EE) -> IO<EE, A> {
         FErrorMap(f, self)
     }
     
     /// Returns this `IO` erasing the error type information
     public var anyError: IO<Error, A> {
-        self.mapLeft { e in e as Error }
+        self.mapError { e in e as Error }
     }
     
     internal func fail(_ error: Error) -> Never {


### PR DESCRIPTION
## Goal

Provide a convenience method to run an `EnvIO` operation, providing its dependencies. It is a wrapper of two calls (`provide` + `unsafeRun`).

This PR also deprecates `IO.mapLeft` in favor of `IO.mapError`. Both are maintained until the next version is released.