### PR TITLE
Bracket's guarantee does not work for errors

### DIFF
--- a/Sources/Bow/Syntax/Predef.swift
+++ b/Sources/Bow/Syntax/Predef.swift
@@ -26,7 +26,7 @@ public func constant<A>(_ a: @autoclosure @escaping () -> A) -> () -> A {
 /// - Parameter a: Constant value to return.
 /// - Returns: A 1-ary function that constantly return the value provided as argument, regardless of its input parameter.
 public func constant<A, B>(_ a: @autoclosure @escaping () -> A) -> (B) -> A {
-    return { _ in return a() }
+    return { _ in a() }
 }
 
 /// Provides a constant function.

--- a/Sources/BowEffects/Typeclasses/Bracket.swift
+++ b/Sources/BowEffects/Typeclasses/Bracket.swift
@@ -91,7 +91,7 @@ public extension Bracket {
     /// - Returns: A computation describing the resouce that will invoke the finalizer when it is released.
     static func guarantee<A>(_ fa: Kind<Self, A>,
                              finalizer: Kind<Self, ()>) -> Kind<Self, A> {
-        return bracket(acquire: fa, release: constant(finalizer), use: constant(fa))
+        return guaranteeCase(fa, finalizer: constant(finalizer))
     }
     
     /// Executes the given finalizer when the source is finished, either in success, error or cancelation, alowing to differentiate between exit conditions.
@@ -102,7 +102,7 @@ public extension Bracket {
     /// - Returns: A computation describing the resource that will invoke the finalizer when it is released.
     static func guaranteeCase<A>(_ fa: Kind<Self, A>,
                                  finalizer: @escaping (ExitCase<Self.E>) -> Kind<Self, ()>) -> Kind<Self, A> {
-        return bracketCase(acquire: fa, release: { _, e in finalizer(e) }, use: constant(fa))
+        return bracketCase(acquire: pure(()), release: { _, e in finalizer(e) }, use: { fa })
     }
 }
 

--- a/Tests/BowEffectsLaws/BracketLaws.swift
+++ b/Tests/BowEffectsLaws/BracketLaws.swift
@@ -94,7 +94,7 @@ public class BracketLaws<F: Bracket & EquatableK> where F.E: Equatable & Arbitra
     private static func bracketMustRunReleaseTask() {
         property("bracketMustRunReleaseTask") <~ forAll { (a: Int, e: F.E) in
             var msg = 0
-            return F.pure(a).bracket(release: { i in msg = i; return F.pure(()) }, use: { _ -> Kind<F, Int> in throw e })
+            return F.pure(a).bracket(release: { i in F.pure(()).map { msg = i } }, use: { _ -> Kind<F, Int> in throw e })
                 .attempt()
                 .map { _ in msg } == F.pure(a)
         }

--- a/Tests/BowEffectsLaws/BracketLaws.swift
+++ b/Tests/BowEffectsLaws/BracketLaws.swift
@@ -94,7 +94,7 @@ public class BracketLaws<F: Bracket & EquatableK> where F.E: Equatable & Arbitra
     private static func bracketMustRunReleaseTask() {
         property("bracketMustRunReleaseTask") <~ forAll { (a: Int, e: F.E) in
             var msg = 0
-            return F.pure(a).bracket(release: { i in F.pure(()).map { msg = i } }, use: { _ -> Kind<F, Int> in throw e })
+            return F.pure(a).bracket(release: { i in F.pure(msg = i) }, use: { _ -> Kind<F, Int> in throw e })
                 .attempt()
                 .map { _ in msg } == F.pure(a)
         }
@@ -103,7 +103,7 @@ public class BracketLaws<F: Bracket & EquatableK> where F.E: Equatable & Arbitra
     private static func guaranteeMustRunFinalizerOnError() {
         property("guaranteeMustRunReleaseOnError") <~ forAll { (a: Int, e: F.E) in
             var msg = 0
-            let finalizer: Kind<F, ()> = F.pure(()).map { msg = a }
+            let finalizer: Kind<F, ()> = F.pure(msg = a)
             return Kind<F, Int>.raiseError(e).guarantee(finalizer)
                 .attempt()
                 .map { _ in msg } == F.pure(a)


### PR DESCRIPTION
As per [this issue in Arrow](https://github.com/arrow-kt/arrow/issues/1996) I just checked and it seems that Bow suffers from the same issue (unless I messed up with the tests 😅).

What changed:
- [x] Add test to BracketLaws to specifically check for guarantee working with an explicit error
- [ ] Add fix for Bracket, ideally fixing the above test
