### PR TITLE
Add Co Transformer and derive instances from their duals

### DIFF
--- a/Documentation.app/Contents/MacOS/Effects.playground/Pages/Handling errors.xcplaygroundpage/Contents.swift
+++ b/Documentation.app/Contents/MacOS/Effects.playground/Pages/Handling errors.xcplaygroundpage/Contents.swift
@@ -34,9 +34,9 @@ let networkError: IO<NetworkError, String> = IO.raiseError(.notFound)^
 /*:
  ## Transforming errors
  
- Similar to transforming the data inside an `IO` using the `map` operator, you can transform the error type using `mapLeft`. This is useful to handle errors at different layers of your application. For instance, you may want to map a `NetworkError` to a `DomainError` when you move from your network layer to your domain layer:
+ Similar to transforming the data inside an `IO` using the `map` operator, you can transform the error type using `mapError`. This is useful to handle errors at different layers of your application. For instance, you may want to map a `NetworkError` to a `DomainError` when you move from your network layer to your domain layer:
  */
-let domainError: IO<DomainError, String> = networkError.mapLeft { error in
+let domainError: IO<DomainError, String> = networkError.mapError { error in
     switch error {
     case .notFound: return .missingUser
     // Map other cases

--- a/Sources/Bow/Arrow/Function1.swift
+++ b/Sources/Bow/Arrow/Function1.swift
@@ -11,7 +11,7 @@ public typealias Function1Of<I, O> = Kind<Function1Partial<I>, O>
 
 /// This data type acts as a wrapper over functions. It receives two type parameters representing the input and output type of the function. The wrapper adds capabilities to use a function as a Higher Kinded Type and conform to typeclasses that have this requirement.
 public final class Function1<I, O>: Function1Of<I, O> {
-    fileprivate let f: (I) -> O
+    internal let f: (I) -> O
     
     /// Safe downcast.
     ///

--- a/Sources/Bow/Data/Co.swift
+++ b/Sources/Bow/Data/Co.swift
@@ -1,30 +1,53 @@
-// newtype Co w a = Co (forall r. w (a -> r) -> r)
+// newtype CoT w m a = Co (forall r. w (a -> m r) -> m r)
 
-public final class ForCo {}
-public final class CoPartial<W: Comonad>: Kind<ForCo, W> {}
-public typealias CoOf<W: Comonad, A> = Kind<CoPartial<W>, A>
+public final class ForCoT {}
+public final class CoTPartial<W: Comonad, M>: Kind2<ForCoT, W, M> {}
+public typealias CoTOf<W: Comonad, M, A> = Kind<CoTPartial<W, M>, A>
 
-/// (Co w) gives you "the best" pairing monad for any comonad w
+public typealias ForCo = ForCoT
+public typealias CoPartial<W: Comonad> = CoTPartial<W, ForId>
+public typealias CoOf<W: Comonad, A> = CoTOf<W, ForId, A>
+public typealias Co<W: Comonad, A> = CoT<W, ForId, A>
+
+public typealias Transition<W: Comonad, A> = Co<W, A>
+public typealias TransitionT<W: Comonad, M, A> = CoT<W, M, A>
+
+/// (CoT w) gives you "the best" pairing monad transformer for any comonad w
 /// In other words, an explorer for the state space given by w
-public class Co<W: Comonad, A>: CoOf<W, A> {
-    internal let cow: (Kind<W, (A) -> Any>) -> Any
+public class CoT<W: Comonad, M, A>: CoTOf<W, M, A> {
+    internal let cow: (Kind<W, (A) -> Kind<M, Any>>) -> Kind<M, Any>
     
-    public static func fix(_ value: CoOf<W, A>) -> Co<W, A> {
-        value as! Co<W, A>
+    public static func fix(_ value: CoTOf<W, M, A>) -> CoT<W, M, A> {
+        value as! CoT<W, M, A>
     }
     
-    public static func select<A, B>(_ co: Co<W, (A) -> B>, _ wa: Kind<W, A>) -> Kind<W, B> {
+    public init(_ cow: @escaping /*forall R.*/(Kind<W, (A) -> Kind<M, /*R*/Any>>) -> Kind<M, /*R*/Any>) {
+        self.cow = cow
+    }
+    
+    func runT<R>(_ w: Kind<W, (A) -> Kind<M, R>>) -> Kind<M, R> {
+        unsafeBitCast(self.cow, to:((Kind<W, (A) -> Kind<M, R>>) -> Kind<M, R>).self)(w)
+    }
+    
+    func hoistT<V>(_ transform: FunctionK<V, W>) -> CoT<V, M, A> {
+        CoT<V, M, A>(self.cow <<< transform.invoke)
+    }
+}
+
+public extension CoT where M == ForId {
+    static func select<A, B>(_ co: Co<W, (A) -> B>, _ wa: Kind<W, A>) -> Kind<W, B> {
         co.run(wa.coflatMap { wa in
             { f in wa.map(f) }
         })
     }
     
-    public init(_ cow: @escaping /*forall R.*/(Kind<W, (A) -> /*R*/Any>) -> /*R*/Any) {
-        self.cow = cow
+    /// - Returns: The pairing between the underlying comonad, `w`, and the monad `Co<w>`.
+    static func pair() -> Pairing<W, CoPartial<W>> {
+        Pairing { wab, cowa in cowa^.run(wab) }
     }
     
     func run<R>(_ w: Kind<W, (A) -> R>) -> R {
-        unsafeBitCast(self.cow, to:((Kind<W, (A) -> R>) -> R).self)(w)
+        self.runT(w.map { f in f >>> Id.pure })^.value
     }
     
     func hoist<V>(_ transform: FunctionK<V, W>) -> Co<V, A> {
@@ -36,21 +59,21 @@ public class Co<W: Comonad, A>: CoOf<W, A> {
 ///
 /// - Parameter value: Value in higher-kind form.
 /// - Returns: Value cast to Co.
-public postfix func ^<W, A>(_ value: CoOf<W, A>) -> Co<W, A> {
-    Co.fix(value)
+public postfix func ^<W, M, A>(_ value: CoTOf<W, M, A>) -> CoT<W, M, A> {
+    CoT.fix(value)
 }
 
-extension CoPartial: Functor {
-    public static func map<A, B>(_ fa: CoOf<W, A>, _ f: @escaping (A) -> B) -> CoOf<W, B> {
-        Co<W, B> { b in
-            fa^.run(b.map { bb in bb <<< f })
+extension CoTPartial: Functor {
+    public static func map<A, B>(_ fa: CoTOf<W, M, A>, _ f: @escaping (A) -> B) -> CoTOf<W, M, B> {
+        CoT<W, M, B> { b in
+            fa^.runT(b.map { bb in bb <<< f })
         }
     }
 }
 
-extension CoPartial: Applicative {
-    public static func ap<A, B>(_ ff: CoOf<W, (A) -> B>, _ fa: CoOf<W, A>) -> CoOf<W, B> {
-        Co<W, B> { w in
+extension CoTPartial: Applicative {
+    public static func ap<A, B>(_ ff: CoTOf<W, M, (A) -> B>, _ fa: CoTOf<W, M, A>) -> CoTOf<W, M, B> {
+        CoT<W, M, B> { w in
             ff^.cow(w.coflatMap { wf in
                 { g in
                     fa^.cow(wf.map { ff in ff <<< g})
@@ -59,27 +82,27 @@ extension CoPartial: Applicative {
         }
     }
     
-    public static func pure<A>(_ a: A) -> CoOf<W, A> {
-        Co<W, A> { w in w.extract()(a) }
+    public static func pure<A>(_ a: A) -> CoTOf<W, M, A> {
+        CoT<W, M, A> { w in w.extract()(a) }
     }
 }
 
-extension CoPartial: Monad {
-    public static func flatMap<A, B>(_ fa: CoOf<W, A>, _ f: @escaping (A) -> CoOf<W, B>) -> CoOf<W, B> {
-        Co { w in
+extension CoTPartial: Monad {
+    public static func flatMap<A, B>(_ fa: CoTOf<W, M, A>, _ f: @escaping (A) -> CoTOf<W, M, B>) -> CoTOf<W, M, B> {
+        CoT { w in
             fa^.cow(w.coflatMap { wa in
                 { a in
-                    Co<W, B>.fix(f(a)).run(wa)
+                    f(a)^.runT(wa)
                 }
             })
         }
     }
     
-    public static func tailRecM<A, B>(_ a: A, _ f: @escaping (A) -> CoOf<W, Either<A, B>>) -> CoOf<W, B> {
+    public static func tailRecM<A, B>(_ a: A, _ f: @escaping (A) -> CoTOf<W, M, Either<A, B>>) -> CoTOf<W, M, B> {
         f(a).flatMap { either in
             either.fold(
                 { aa in tailRecM(aa, f) },
-                { b in Co.pure(b) })
+                { b in CoT.pure(b) })
         }
     }
 }

--- a/Sources/Bow/Data/Co.swift
+++ b/Sources/Bow/Data/Co.swift
@@ -152,3 +152,17 @@ extension CoTPartial: MonadReader where W: ComonadEnv {
         CoT(fa^.cow <<< { wa in wa.local(f) })
     }
 }
+
+// MARK: Instance of `MonadState` for `CoT`
+
+extension CoTPartial: MonadState where W: ComonadStore {
+    public typealias S = W.S
+    
+    public static func get() -> CoTOf<W, M, W.S> {
+        CoT.liftT { wa in wa.position }
+    }
+    
+    public static func set(_ s: W.S) -> CoTOf<W, M, ()> {
+        CoT { wa in wa.peek(s)(()) }
+    }
+}

--- a/Sources/Bow/Data/Co.swift
+++ b/Sources/Bow/Data/Co.swift
@@ -184,8 +184,8 @@ extension CoTPartial: MonadWriter where W: ComonadTraced {
     }
     
     public static func pass<A>(_ fa: CoTOf<W, M, ((W.M) -> W.M, A)>) -> CoTOf<W, M, A> {
-        CoT { (wa: Kind<W, (A) -> Kind<M, Any>>) -> Kind<M, Any> in
-            let passed: Kind<W, (((W.M) -> W.M, A)) -> Kind<M, Any>> = wa.pass().map { xx in { tuple in xx(tuple.0)(tuple.1) } }
+        CoT { wa in
+            let passed: Kind<W, (((W.M) -> W.M, A)) -> Kind<M, Any>> = wa.pass().map { f in { tuple in f(tuple.0)(tuple.1) } }
             return fa^.runT(passed)
         }
     }

--- a/Sources/Bow/Data/Co.swift
+++ b/Sources/Bow/Data/Co.swift
@@ -89,7 +89,7 @@ public postfix func ^<W, M, A>(_ value: CoTOf<W, M, A>) -> CoT<W, M, A> {
     CoT.fix(value)
 }
 
-// MARK: Instance of `Functor` for `Co`
+// MARK: Instance of `Functor` for `CoT`
 
 extension CoTPartial: Functor {
     public static func map<A, B>(_ fa: CoTOf<W, M, A>, _ f: @escaping (A) -> B) -> CoTOf<W, M, B> {
@@ -99,7 +99,7 @@ extension CoTPartial: Functor {
     }
 }
 
-// MARK: Instance of `Applicative` for `Co`
+// MARK: Instance of `Applicative` for `CoT`
 
 extension CoTPartial: Applicative {
     public static func ap<A, B>(_ ff: CoTOf<W, M, (A) -> B>, _ fa: CoTOf<W, M, A>) -> CoTOf<W, M, B> {
@@ -117,7 +117,7 @@ extension CoTPartial: Applicative {
     }
 }
 
-// MARK: Instance of `Monad` for `Co`
+// MARK: Instance of `Monad` for `CoT`
 
 extension CoTPartial: Monad {
     public static func flatMap<A, B>(_ fa: CoTOf<W, M, A>, _ f: @escaping (A) -> CoTOf<W, M, B>) -> CoTOf<W, M, B> {
@@ -136,5 +136,19 @@ extension CoTPartial: Monad {
                 { aa in tailRecM(aa, f) },
                 { b in CoT.pure(b) })
         }
+    }
+}
+
+// MARK: Instance of `MonadReader` for `CoT`
+
+extension CoTPartial: MonadReader where W: ComonadEnv {
+    public typealias D = W.E
+    
+    public static func ask() -> CoTOf<W, M, W.E> {
+        CoT.liftT(W.ask)
+    }
+    
+    public static func local<A>(_ fa: CoTOf<W, M, A>, _ f: @escaping (W.E) -> W.E) -> CoTOf<W, M, A> {
+        CoT(fa^.cow <<< { wa in wa.local(f) })
     }
 }

--- a/Sources/Bow/Data/Co.swift
+++ b/Sources/Bow/Data/Co.swift
@@ -72,7 +72,7 @@ public extension CoT where M == ForId {
         self.runT(w.map { f in f >>> Id.pure })^.value
     }
     
-    func hoist<V>(_ transform: FunctionK<V, W>) -> Co<V, A> {
+    func hoist<V: Comonad>(_ transform: FunctionK<V, W>) -> Co<V, A> {
         Co<V, A>(self.cow <<< transform.invoke)
     }
     

--- a/Sources/Bow/Transformers/TracedT.swift
+++ b/Sources/Bow/Transformers/TracedT.swift
@@ -87,10 +87,6 @@ extension TracedTPartial: ComonadTraced where W: Comonad, M: Monoid {
         })
     }
     
-    public static func censor<A>(_ wa: TracedTOf<M, W, A>, _ f: @escaping (M) -> M) -> TracedTOf<M, W, A> {
-        TracedT(wa^.value.map { g in f >>> g })
-    }
-    
     public static func pass<A>(_ wa: TracedTOf<M, W, A>) -> TracedTOf<M, W, ((M) -> M) -> A> {
         TracedT(wa^.value.map { trace in
             { m in

--- a/Sources/Bow/Transformers/TracedT.swift
+++ b/Sources/Bow/Transformers/TracedT.swift
@@ -80,4 +80,24 @@ extension TracedTPartial: ComonadTraced where W: Comonad, M: Monoid {
     public static func trace<A>(_ wa: TracedTOf<M, W, A>, _ m: M) -> A {
         wa^.value.extract()(m)
     }
+
+    public static func listens<A, B>(_ wa: TracedTOf<M, W, A>, _ f: @escaping (M) -> B) -> TracedTOf<M, W, (B, A)> {
+        TracedT(wa^.value.map { g in
+            { m in (f(m), g(m)) }
+        })
+    }
+    
+    public static func censor<A>(_ wa: TracedTOf<M, W, A>, _ f: @escaping (M) -> M) -> TracedTOf<M, W, A> {
+        TracedT(wa^.value.map { g in f >>> g })
+    }
+    
+    public static func pass<A>(_ wa: TracedTOf<M, W, A>) -> TracedTOf<M, W, ((M) -> M) -> A> {
+        TracedT(wa^.value.map { trace in
+            { m in
+                { f in
+                    trace(f(m))
+                }
+            }
+        })
+    }
 }

--- a/Sources/Bow/Typeclasses/ComonadTraced.swift
+++ b/Sources/Bow/Typeclasses/ComonadTraced.swift
@@ -3,7 +3,6 @@ public protocol ComonadTraced: Comonad {
     
     static func trace<A>(_ wa: Kind<Self, A>, _ m: M) -> A
     static func listens<A, B>(_ wa: Kind<Self, A>, _ f: @escaping (M) -> B) -> Kind<Self, (B, A)>
-    static func censor<A>(_ wa: Kind<Self, A>, _ f: @escaping (M) -> M) -> Kind<Self, A>
     static func pass<A>(_ wa: Kind<Self, A>) -> Kind<Self, ((M) -> M) -> A>
 }
 
@@ -14,6 +13,10 @@ public extension ComonadTraced {
     
     static func listen<A>(_ wa: Kind<Self, A>) -> Kind<Self, (M, A)> {
         listens(wa, id)
+    }
+    
+    static func censor<A>(_ wa: Kind<Self, A>, _ f: @escaping (M) -> M) -> Kind<Self, A> {
+        pass(wa).map { trace in trace(f) }
     }
 }
 

--- a/Sources/Bow/Typeclasses/ComonadTraced.swift
+++ b/Sources/Bow/Typeclasses/ComonadTraced.swift
@@ -2,11 +2,18 @@ public protocol ComonadTraced: Comonad {
     associatedtype M
     
     static func trace<A>(_ wa: Kind<Self, A>, _ m: M) -> A
+    static func listens<A, B>(_ wa: Kind<Self, A>, _ f: @escaping (M) -> B) -> Kind<Self, (B, A)>
+    static func censor<A>(_ wa: Kind<Self, A>, _ f: @escaping (M) -> M) -> Kind<Self, A>
+    static func pass<A>(_ wa: Kind<Self, A>) -> Kind<Self, ((M) -> M) -> A>
 }
 
 public extension ComonadTraced {
     static func traces<A>(_ wa: Kind<Self, A>, _ f: @escaping (A) -> M) -> A {
         trace(wa, f(wa.extract()))
+    }
+    
+    static func listen<A>(_ wa: Kind<Self, A>) -> Kind<Self, (M, A)> {
+        listens(wa, id)
     }
 }
 
@@ -19,5 +26,21 @@ public extension Kind where F: ComonadTraced {
     
     func traces(_ f: @escaping (A) -> F.M) -> A {
         F.traces(self, f)
+    }
+    
+    func listens<B>(_ f: @escaping (F.M) -> B) -> Kind<F, (B, A)> {
+        F.listens(self, f)
+    }
+    
+    func listen() -> Kind<F, (F.M, A)> {
+        F.listen(self)
+    }
+    
+    func censor(_ f: @escaping (F.M) -> F.M) -> Kind<F, A> {
+        F.censor(self, f)
+    }
+    
+    func pass() -> Kind<F, ((F.M) -> F.M) -> A>  {
+        F.pass(self)
     }
 }

--- a/Sources/BowEffects/Data/EnvIO.swift
+++ b/Sources/BowEffects/Data/EnvIO.swift
@@ -59,7 +59,7 @@ public extension Kleisli {
     /// - Parameter f: Function transforming the error.
     /// - Returns: An EnvIO value with the new error type.
     func mapError<E: Error, EE: Error>(_ f: @escaping (E) -> EE) -> EnvIO<D, EE, A> where F == IOPartial<E> {
-        return EnvIO { env in self.run(env)^.mapLeft(f) }
+        return EnvIO { env in self.run(env)^.mapError(f) }
     }
     
     /// Provides the required environment.
@@ -166,6 +166,37 @@ public extension Kleisli {
     /// - Returns: An EnvIO with both type arguments transformed.
     func bimap<E: Error, EE: Error, B>(_ fe: @escaping (E) -> EE, _ fa: @escaping (A) -> B) -> EnvIO<D, EE, B> where F == IOPartial<E> {
         mapError(fe).map(fa)^
+    }
+    
+    /// Performs the side effects that are suspended in this IO in a synchronous manner.
+    ///
+    /// - Parameters:
+    ///   - d: Dependencies needed in this operation.
+    ///   - queue: Dispatch queue used to execute the side effects. Defaults to the main queue.
+    /// - Returns: Value produced after running the suspended side effects.
+    /// - Throws: Error of type `E` that may happen during the evaluation of the side-effects. Errors of other types thrown from the evaluation of this IO will cause a fatal error.
+    func unsafeRunSync<E: Error>(with d: D, on queue: DispatchQueue = .main) throws -> A where F == IOPartial<E> {
+        try self.provide(d).unsafeRunSync(on: queue)
+    }
+    
+    /// Performs the side effects that are suspended in this EnvIO in a synchronous manner.
+    ///
+    /// - Parameters:
+    ///   - d: Dependencies needed in this operation.
+    ///   - queue: Dispatch queue used to execute the side effects. Defaults to the main queue.
+    /// - Returns: An Either wrapping errors in the left side and values on the right side. Errors of other types thrown from the evaluation of this IO will cause a fatal error.
+    func unsafeRunSyncEither<E: Error>(with d: D, on queue: DispatchQueue = .main) -> Either<E, A> where F == IOPartial<E> {
+        self.provide(d).unsafeRunSyncEither(on: queue)
+    }
+    
+    /// Performs the side effects that are suspended in this EnvIO in an asynchronous manner.
+    ///
+    /// - Parameters:
+    ///   - d: Dependencies needed in this operation.
+    ///   - queue: Dispatch queue used to execute the side effects. Defaults to the main queue.
+    ///   - callback: A callback function to receive the results of the evaluation. Errors of other types thrown from the evaluation of this IO will cause a fatal error.
+    func unsafeRunAsync<E: Error>(with d: D, on queue: DispatchQueue = .main, _ callback: @escaping Callback<E, A>) where F == IOPartial<E> {
+        self.provide(d).unsafeRunAsync(on: queue, callback)
     }
 }
 

--- a/Sources/BowEffects/Data/IO.swift
+++ b/Sources/BowEffects/Data/IO.swift
@@ -99,7 +99,7 @@ public class IO<E: Error, A>: IOOf<E, A> {
     ///   - fa: Function to transform the output type argument.
     /// - Returns: An IO with both type arguments transformed.
     func bimap<EE: Error, B>(_ fe: @escaping (E) -> EE, _ fa: @escaping (A) -> B) -> IO<EE, B> {
-        mapLeft(fe).map(fa)^
+        mapError(fe).map(fa)^
     }
     
     /// Creates an IO from 2 side-effectful functions, tupling their results. Errors thrown from the functions must be of type `E`; otherwise, a fatal error will happen.
@@ -349,13 +349,22 @@ public class IO<E: Error, A>: IOOf<E, A> {
     ///
     /// - Parameter f: Function transforming the error.
     /// - Returns: An IO value with the new error type.
+    @available(*, deprecated, renamed: "mapError")
     public func mapLeft<EE>(_ f: @escaping (E) -> EE) -> IO<EE, A> {
+        FErrorMap(f, self)
+    }
+    
+    /// Transforms the error type of this IO.
+    ///
+    /// - Parameter f: Function transforming the error.
+    /// - Returns: An IO value with the new error type.
+    public func mapError<EE>(_ f: @escaping (E) -> EE) -> IO<EE, A> {
         FErrorMap(f, self)
     }
     
     /// Returns this `IO` erasing the error type information
     public var anyError: IO<Error, A> {
-        self.mapLeft { e in e as Error }
+        self.mapError { e in e as Error }
     }
     
     internal func fail(_ error: Error) -> Never {

--- a/Tests/BowGenerators/Data/Co+Gen.swift
+++ b/Tests/BowGenerators/Data/Co+Gen.swift
@@ -2,9 +2,9 @@ import Bow
 import SwiftCheck
 
 // MARK: Instance of `ArbitraryK` for `Co`
-extension CoPartial: ArbitraryK where W: ArbitraryK {
-    public static func generate<A: Arbitrary>() -> Kind<CoPartial<W>, A> {
+extension CoTPartial: ArbitraryK where W: ArbitraryK, M: ArbitraryK {
+    public static func generate<A: Arbitrary>() -> CoTOf<W, M, A> {
         let wa: Kind<W, A> = W.generate()
-        return Co.pure(wa.extract())
+        return CoT.pure(wa.extract())
     }
 }

--- a/Tests/BowLaws/MonadWriterLaws.swift
+++ b/Tests/BowLaws/MonadWriterLaws.swift
@@ -7,6 +7,7 @@ public class MonadWriterLaws<F: MonadWriter & EquatableK> where F.W == Int {
         tellFusion()
         listenPure()
         listenWriterProperty()
+        censorTell()
     }
     
     private static func writerPure() {
@@ -34,4 +35,12 @@ public class MonadWriterLaws<F: MonadWriter & EquatableK> where F.W == Int {
             return isEqual(F.listen(F.writer(tuple)), F.map(F.tell(tuple.0), { _ in tuple }))
         }
     }
+    
+    private static func censorTell() {
+        property("Censor tell") <~ forAll { (a: Int, w: Int, f: ArrowOf<Int, Int>) in
+            isEqual(F.writer((f.getArrow(w), a)).listen(),
+                    F.writer((w, a)).censor(f.getArrow).listen())
+        }
+    }
+    
 }

--- a/Tests/BowTests/Data/CoTest.swift
+++ b/Tests/BowTests/Data/CoTest.swift
@@ -2,6 +2,7 @@ import XCTest
 import BowLaws
 import Bow
 import BowGenerators
+import SwiftCheck
 
 extension CoTPartial: EquatableK where W: Applicative & EquatableK, M == ForId {
     public static func eq<A: Equatable>(_ lhs: CoTOf<W, M, A>, _ rhs: CoTOf<W, M, A>) -> Bool {
@@ -25,5 +26,9 @@ class CoTest: XCTestCase {
     
     func testMonadStateLaws() {
         MonadStateLaws<CoPartial<StorePartial<Int>>>.check()
+    }
+    
+    func testMonadWriterLaws() {
+        MonadWriterLaws<CoPartial<TracedPartial<Int>>>.check()
     }
 }

--- a/Tests/BowTests/Data/CoTest.swift
+++ b/Tests/BowTests/Data/CoTest.swift
@@ -3,10 +3,10 @@ import BowLaws
 import Bow
 import BowGenerators
 
-extension CoTPartial: EquatableK where W == ForId, M == ForId {
-    public static func eq<A>(_ lhs: Kind<CoTPartial<W, M>, A>, _ rhs: Kind<CoTPartial<W, M>, A>) -> Bool where A : Equatable {
-        ForId.pair().zap(Id(id), lhs^) ==
-            ForId.pair().zap(Id(id), rhs^)
+extension CoTPartial: EquatableK where W: Applicative & EquatableK, M == ForId {
+    public static func eq<A: Equatable>(_ lhs: CoTOf<W, M, A>, _ rhs: CoTOf<W, M, A>) -> Bool {
+        W.pair().zap(W.pure(id), lhs^) ==
+            W.pair().zap(W.pure(id), rhs^)
     }
 }
 
@@ -21,5 +21,9 @@ class CoTest: XCTestCase {
 
     func testMonadLaws() {
         MonadLaws<CoPartial<ForId>>.check()
+    }
+    
+    func testMonadStateLaws() {
+        MonadStateLaws<CoPartial<StorePartial<Int>>>.check()
     }
 }

--- a/Tests/BowTests/Data/CoTest.swift
+++ b/Tests/BowTests/Data/CoTest.swift
@@ -3,8 +3,8 @@ import BowLaws
 import Bow
 import BowGenerators
 
-extension CoPartial: EquatableK where W == ForId {
-    public static func eq<A: Equatable>(_ lhs: CoOf<W, A>, _ rhs: CoOf<W, A>) -> Bool {
+extension CoTPartial: EquatableK where W == ForId, M == ForId {
+    public static func eq<A>(_ lhs: Kind<CoTPartial<W, M>, A>, _ rhs: Kind<CoTPartial<W, M>, A>) -> Bool where A : Equatable {
         ForId.pair().zap(Id(id), lhs^) ==
             ForId.pair().zap(Id(id), rhs^)
     }


### PR DESCRIPTION
## Goal

Generalize `Co` to a transformer `CoT`, that provides a Monad transformer for a given `Comonad`. From there, we can derive instances based on their duals:

- Given a `ComonadEnv` instance, derive the `MonadReader` instance for `CoT`.
- Given a `ComonadStore` instance, derive the `MonadState` instance for `CoT`.
- Given a `ComonadTraced` instance, derive the `MonadWriter` instance for `CoT`.

Deriving this last instance made me realize that `ComonadTraced` needed some dual methods to the ones present in `MonadWriter`, which were added in this PR.