### PR TITLE
Fix type aliases for State

### DIFF
--- a/Sources/Bow/Transformers/EnvT.swift
+++ b/Sources/Bow/Transformers/EnvT.swift
@@ -4,6 +4,7 @@ public typealias EnvTOf<E, W, A> = Kind<EnvTPartial<E, W>, A>
 
 public typealias ForEnv = ForEnvT
 public typealias EnvPartial<E> = EnvTPartial<E, ForId>
+public typealias EnvOf<E, A> = EnvTOf<E, ForId, A>
 public typealias Env<E, A> = EnvT<E, ForId, A>
 
 public final class EnvT<E, W, A>: EnvTOf<E, W, A> {

--- a/Sources/Bow/Transformers/StateT.swift
+++ b/Sources/Bow/Transformers/StateT.swift
@@ -41,14 +41,17 @@ public postfix func ^<F, S, A>(_ fa : StateTOf<F, S, A>) -> StateT<F, S, A> {
     StateT.fix(fa)
 }
 
+/// Witness for the `State<S, A>` data type. To be used in simulated Higher Kinded Types.
+public typealias ForState = ForStateT
+
 /// Partial application of the `StateT` type constructor, omitting the last parameter.
 public typealias StatePartial<S> = StateTPartial<ForId, S>
 
 /// Higher Kinded Type alias to improve readability over `StateT<ForId, S, A>`.
-public typealias StateOf<S, A> = StateT<ForId, S, A>
+public typealias StateOf<S, A> = StateTOf<ForId, S, A>
 
 /// State is a convenience data type over the `StateT` transformer, when the effect is `Id`.
-public typealias State<S, A> = StateOf<S, A>
+public typealias State<S, A> = StateT<ForId, S, A>
 
 // MARK: Convenience functions when the effect is `Id`
 public extension StateT where F == ForId {

--- a/Sources/Bow/Transformers/StoreT.swift
+++ b/Sources/Bow/Transformers/StoreT.swift
@@ -4,6 +4,7 @@ public typealias StoreTOf<S, W, A> = Kind<StoreTPartial<S, W>, A>
 
 public typealias ForStore = ForStoreT
 public typealias StorePartial<S> = StoreTPartial<S, ForId>
+public typealias StoreOf<S, A> = StoreTOf<S, ForId, A>
 public typealias Store<S, A> = StoreT<S, ForId, A>
 
 public final class StoreT<S, W, A>: StoreTOf<S, W, A> {

--- a/Sources/Bow/Transformers/TracedT.swift
+++ b/Sources/Bow/Transformers/TracedT.swift
@@ -4,6 +4,7 @@ public typealias TracedTOf<M, W, A> = Kind<TracedTPartial<M, W>, A>
 
 public typealias ForTraced = ForTracedT
 public typealias TracedPartial<M> = TracedTPartial<M, ForId>
+public typealias TracedOf<M, A> = TracedTOf<M, ForId, A>
 public typealias Traced<M, A> = TracedT<M, ForId, A>
 
 public final class TracedT<M, W, A>: TracedTOf<M, W, A> {


### PR DESCRIPTION
Some aliases for State are not correct with respect to their corresponding ones on StateT.
