### PR TITLE
Add Action and its Pairing with Moore

### DIFF
--- a/Bow.xcodeproj/project.pbxproj
+++ b/Bow.xcodeproj/project.pbxproj
@@ -50,6 +50,7 @@
 		112097DD22A90899007F3D9C /* OptionT+Gen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 112097DC22A90899007F3D9C /* OptionT+Gen.swift */; };
 		112097DF22A90972007F3D9C /* StateT+Gen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 112097DE22A90972007F3D9C /* StateT+Gen.swift */; };
 		112097E122A90AAA007F3D9C /* WriterT+Gen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 112097E022A90AAA007F3D9C /* WriterT+Gen.swift */; };
+		1122486023FD362D0082B839 /* Action.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1122485F23FD362D0082B839 /* Action.swift */; };
 		1122941F219D8BDE006D66C5 /* AlternativeLaws.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BA0F3C6217E2DEF00969984 /* AlternativeLaws.swift */; };
 		11229420219D8BDE006D66C5 /* ApplicativeErrorLaws.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BA0F3C4217E2DEF00969984 /* ApplicativeErrorLaws.swift */; };
 		11229421219D8BDE006D66C5 /* ApplicativeLaws.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BA0F3CE217E2DEF00969984 /* ApplicativeLaws.swift */; };
@@ -758,6 +759,7 @@
 		112097DC22A90899007F3D9C /* OptionT+Gen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OptionT+Gen.swift"; sourceTree = "<group>"; };
 		112097DE22A90972007F3D9C /* StateT+Gen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "StateT+Gen.swift"; sourceTree = "<group>"; };
 		112097E022A90AAA007F3D9C /* WriterT+Gen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WriterT+Gen.swift"; sourceTree = "<group>"; };
+		1122485F23FD362D0082B839 /* Action.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Action.swift; sourceTree = "<group>"; };
 		1122941B219D8B86006D66C5 /* BowLaws.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = BowLaws.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		1122947B219D8DF3006D66C5 /* BowFreeTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = BowFreeTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		112294EE219D8EF4006D66C5 /* BowRecursionSchemes.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = BowRecursionSchemes.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -1891,6 +1893,7 @@
 		8BA0F472217E2E9200969984 /* Data */ = {
 			isa = PBXGroup;
 			children = (
+				1122485F23FD362D0082B839 /* Action.swift */,
 				1137469823433E5800D9C1AD /* Array.swift */,
 				8BA0F48A217E2E9200969984 /* ArrayK.swift */,
 				09CEF84D236E28150070CF43 /* Co.swift */,
@@ -3128,6 +3131,7 @@
 				8BA0F54B217E2E9200969984 /* StringInstances.swift in Sources */,
 				8BA0F5C7217E2E9200969984 /* SetK.swift in Sources */,
 				8BA0F647217E2E9200969984 /* Comonad.swift in Sources */,
+				1122486023FD362D0082B839 /* Action.swift in Sources */,
 				115488CF23BF9FEF00A6DE92 /* ComonadTrans.swift in Sources */,
 				8BA0F5A3217E2E9200969984 /* Moore.swift in Sources */,
 				110DE5CC23ACE29D00E5DB36 /* ComonadStore.swift in Sources */,

--- a/Sources/Bow/Data/Action.swift
+++ b/Sources/Bow/Data/Action.swift
@@ -1,0 +1,21 @@
+// Action is the dual pairing monad of Moore
+public typealias Action<I, A> = Co<MoorePartial<I>, A>
+public typealias ActionOf<I, A> = CoOf<MoorePartial<I>, A>
+public typealias ForAction = ForCo
+public typealias ActionPartial<I> = CoPartial<MoorePartial<I>>
+
+public extension Co {
+    static func liftAction<I>(_ input: I, _ a: A) -> Action<I, A> where W == MoorePartial<I>, M == ForId {
+        Action { moore in
+            moore^.handle(input).extract()(a)
+        }
+    }
+    
+    static func from<I>(_ input: I) -> Action<I, Void> where W == MoorePartial<I>, M == ForId, A == Void {
+        liftAction(input, ())
+    }
+    
+    func mapAction<I, J>(_ f: @escaping (I) -> J) -> Action<J, A> where W == MoorePartial<I>, M == ForId {
+        Action<J, A> { moore in self.cow(moore^.contramapInput(f)) }
+    }
+}

--- a/Sources/Bow/Data/Moore.swift
+++ b/Sources/Bow/Data/Moore.swift
@@ -12,9 +12,39 @@ public final class Moore<E, V>: MooreOf<E, V> {
         return value as! Moore<E, V>
     }
     
+    public static func unfold<S>(_ state: S, _ next: @escaping (S) -> (V, (E) -> S)) -> Moore<E, V> {
+        let (a, transition) = next(state)
+        return Moore(view: a) { input in
+            unfold(transition(input), next)
+        }
+    }
+    
+    public static func from<S>(initialState: S, render: @escaping (S) -> V, update: @escaping (S, E) -> S) -> Moore<E, V> {
+        unfold(initialState) { state in
+            (render(state), { input in update(state, input) })
+        }
+    }
+    
+    public static func from<S>(initialState: S, render: @escaping (S) -> V, update: @escaping (E) -> State<S, S>) -> Moore<E, V> {
+        from(initialState: initialState, render: render, update: { s, e in update(e).run(s).0 })
+    }
+    
     public init(view: V, handle: @escaping (E) -> Moore<E, V>) {
         self.view = view
         self.handle = handle
+    }
+    
+    public func contramapInput<EE>(_ f: @escaping (EE) -> E) -> Moore<EE, V> {
+        Moore<EE, V>(view: self.view, handle: f >>> { x in self.handle(x).contramapInput(f) })
+    }
+}
+
+public extension Moore where E == V, E: Monoid {
+    static var log: Moore<E, E> {
+        func h(_ m: E) -> Moore<E, E> {
+            Moore(view: m) { a in h(m.combine(a)) }
+        }
+        return h(.empty())
     }
 }
 

--- a/Sources/Bow/Data/Pairing.swift
+++ b/Sources/Bow/Data/Pairing.swift
@@ -119,6 +119,16 @@ public extension Pairing {
     }
 }
 
+// MARK: Pairing for Action and Moore
+
+public extension Pairing {
+    static func pairActionMoore<I>() -> Pairing<ActionPartial<I>, MoorePartial<I>> where F == ActionPartial<I>, G == MoorePartial<I> {
+        Pairing { action, moore, f in
+            MoorePartial<I>.pair().pairFlipped(action, moore, f)
+        }
+    }
+}
+
 // MARK: Pairing for any Comonad
 
 public extension Comonad {

--- a/Tests/BowTests/Data/PairingTest.swift
+++ b/Tests/BowTests/Data/PairingTest.swift
@@ -54,4 +54,38 @@ class PairingTest: XCTestCase {
         
         XCTAssertEqual(res, 60)
     }
+    
+    func testPairingActionMoore() {
+        func render(_ n: Int) -> String {
+            (n % 2 == 0) ?
+                "\(n) is even" :
+                "\(n) is odd"
+        }
+        
+        func update(_ state: Int, _ action: Input) -> Int {
+            switch action {
+            case .increment: return state + 1
+            case .decrement: return state - 1
+            }
+        }
+        
+        enum Input {
+            case increment
+            case decrement
+        }
+        
+        let w = Moore<Input, String>.from(initialState: 0, render: render, update: update)
+        
+        let actions: Action<Input, Void> = binding(
+            |<-Action.from(.increment),
+            |<-Action.from(.increment),
+            |<-Action.from(.decrement),
+            |<-Action.from(.increment),
+            |<-Action.from(.increment),
+            yield: ())^
+        
+        let w2 = Pairing.pairActionMoore().select(actions, w.duplicate())^
+        
+        XCTAssertEqual(w2.view, "3 is odd")
+    }
 }


### PR DESCRIPTION
## Goal

Add Action (dual monad of Moore comonad) and its corresponding Pairing instance.

## Implementation details

Action is implemented using Co for Moore, which automatically provides a pairing dual monad for a given comonad. Convenience constructors are added in order to work nicely with Actions.
