### PR TITLE
Enhace Sum Comonad with its dual Monad

### DIFF
--- a/Bow.xcodeproj/project.pbxproj
+++ b/Bow.xcodeproj/project.pbxproj
@@ -156,6 +156,7 @@
 		1186E15122BA395D001F8A5D /* Index+Optics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1186E14E22BA38CD001F8A5D /* Index+Optics.swift */; };
 		1186E15722BA8A77001F8A5D /* Cons.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1186E15622BA8A77001F8A5D /* Cons.swift */; };
 		1186E15922BA8ECA001F8A5D /* Snoc.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1186E15822BA8ECA001F8A5D /* Snoc.swift */; };
+		118C35DD240E5C2200113C66 /* CoSum.swift in Sources */ = {isa = PBXBuildFile; fileRef = 118C35DC240E5C2200113C66 /* CoSum.swift */; };
 		11912B0B238C2068007D90A2 /* DispatchTimeInterval+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11912B09238C1FB4007D90A2 /* DispatchTimeInterval+Extensions.swift */; };
 		1191BD0A22D77C510052FEA8 /* BoundVar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1191BD0922D77C510052FEA8 /* BoundVar.swift */; };
 		1191BD0C22D77FED0052FEA8 /* BindingExpression.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1191BD0B22D77FED0052FEA8 /* BindingExpression.swift */; };
@@ -843,6 +844,7 @@
 		1186E14E22BA38CD001F8A5D /* Index+Optics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Index+Optics.swift"; sourceTree = "<group>"; };
 		1186E15622BA8A77001F8A5D /* Cons.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Cons.swift; sourceTree = "<group>"; };
 		1186E15822BA8ECA001F8A5D /* Snoc.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Snoc.swift; sourceTree = "<group>"; };
+		118C35DC240E5C2200113C66 /* CoSum.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoSum.swift; sourceTree = "<group>"; };
 		11912B09238C1FB4007D90A2 /* DispatchTimeInterval+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DispatchTimeInterval+Extensions.swift"; sourceTree = "<group>"; };
 		1191BD0922D77C510052FEA8 /* BoundVar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoundVar.swift; sourceTree = "<group>"; };
 		1191BD0B22D77FED0052FEA8 /* BindingExpression.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BindingExpression.swift; sourceTree = "<group>"; };
@@ -1907,6 +1909,7 @@
 				09CEF84D236E28150070CF43 /* Co.swift */,
 				8BA0F489217E2E9200969984 /* Const.swift */,
 				8BA0F485217E2E9200969984 /* Coreader.swift */,
+				118C35DC240E5C2200113C66 /* CoSum.swift */,
 				8BA0F47B217E2E9200969984 /* Day.swift */,
 				1137469D2343592300D9C1AD /* Dictionary.swift */,
 				8BA0F476217E2E9200969984 /* DictionaryK.swift */,
@@ -3135,6 +3138,7 @@
 				8BA0F58B217E2E9200969984 /* Ior.swift in Sources */,
 				8BA0F5BF217E2E9200969984 /* Coreader.swift in Sources */,
 				1171ED4B23C48985005362E0 /* StoreT.swift in Sources */,
+				118C35DD240E5C2200113C66 /* CoSum.swift in Sources */,
 				11DDCD23217F1E2B00844D9D /* Reverse.swift in Sources */,
 				609CC1472364F9A200096D5D /* Divisible.swift in Sources */,
 				8BA0F5DB217E2E9200969984 /* Alternative.swift in Sources */,

--- a/Sources/Bow/Data/CoSum.swift
+++ b/Sources/Bow/Data/CoSum.swift
@@ -2,12 +2,46 @@ public typealias CoSumPartial<F: Comonad, G: Comonad> = CoPartial<SumPartial<F, 
 public typealias CoSumOf<F: Comonad, G: Comonad, A> = CoOf<SumPartial<F, G>, A>
 public typealias CoSum<F: Comonad, G: Comonad, A> = Co<SumPartial<F, G>, A>
 
-public extension CoSum {
+public typealias CoSumOptPartial<G: Comonad> = CoSumPartial<ForId, G>
+public typealias CoSumOptOf<G: Comonad, A> = CoSumOf<ForId, G, A>
+public typealias CoSumOpt<G: Comonad, A> = CoSum<ForId, G, A>
+
+public extension CoSum where M == ForId {
     static func moveLeft<F, G>() -> CoSum<F, G, Void> where W == SumPartial<F, G>, A == Void {
         CoSum { cow in cow^.lowerLeft().extract()(()) }
     }
     
     static func moveRight<F, G>() -> CoSum<F, G, Void> where W == SumPartial<F, G>, A == Void {
         CoSum { cow in cow^.lowerRight().extract()(()) }
+    }
+}
+
+public extension Co where M == ForId {
+    func liftLeft<G>() -> CoSum<W, G, A> {
+        CoSum(self.run <<< { sum in sum^.lowerLeft() })
+    }
+    
+    func liftRight<F>() -> CoSum<F, W, A> {
+        CoSum(self.run <<< { sum in sum^.lowerRight() })
+    }
+}
+
+public extension CoSumOpt where M == ForId {
+    static func hide<G>() -> CoSumOpt<G, Void> where W == SumOptPartial<G>, A == Void {
+        moveLeft()
+    }
+    
+    static func show<G>() -> CoSumOpt<G, Void> where W == SumOptPartial<G>, A == Void {
+        moveRight()
+    }
+    
+    static func toggle<G>() -> CoSumOpt<G, Void> where W == SumOptPartial<G>, A == Void {
+        CoSumOpt { cow in cow^.extractOther()(()) }
+    }
+}
+
+public extension Co where M == ForId {
+    func liftSumOpt() -> CoSumOpt<W, A> {
+        self.liftRight()
     }
 }

--- a/Sources/Bow/Data/CoSum.swift
+++ b/Sources/Bow/Data/CoSum.swift
@@ -1,0 +1,13 @@
+public typealias CoSumPartial<F: Comonad, G: Comonad> = CoPartial<SumPartial<F, G>>
+public typealias CoSumOf<F: Comonad, G: Comonad, A> = CoOf<SumPartial<F, G>, A>
+public typealias CoSum<F: Comonad, G: Comonad, A> = Co<SumPartial<F, G>, A>
+
+public extension CoSum {
+    static func moveLeft<F, G>() -> CoSum<F, G, Void> where W == SumPartial<F, G>, A == Void {
+        CoSum { cow in cow^.lowerLeft().extract()(()) }
+    }
+    
+    static func moveRight<F, G>() -> CoSum<F, G, Void> where W == SumPartial<F, G>, A == Void {
+        CoSum { cow in cow^.lowerRight().extract()(()) }
+    }
+}

--- a/Sources/Bow/Data/Pairing.swift
+++ b/Sources/Bow/Data/Pairing.swift
@@ -129,6 +129,16 @@ public extension Pairing {
     }
 }
 
+// MARK: Pairing for CoSum and Sum
+
+public extension Pairing {
+    static func pairCoSumSum<FF, GG>() -> Pairing<CoSumPartial<FF, GG>, SumPartial<FF, GG>> where F == CoSumPartial<FF, GG>, G == SumPartial<FF, GG> {
+        Pairing { cosum, sum, f in
+            SumPartial<FF, GG>.pair().pairFlipped(cosum, sum, f)
+        }
+    }
+}
+
 // MARK: Pairing for any Comonad
 
 public extension Comonad {

--- a/Sources/Bow/Data/Pairing.swift
+++ b/Sources/Bow/Data/Pairing.swift
@@ -139,6 +139,16 @@ public extension Pairing {
     }
 }
 
+// MARK: Pairing for CoSumOpt and SumOpt
+
+public extension Pairing {
+    static func pairCoSumOptSumOpt<FF>() -> Pairing<CoSumOptPartial<FF>, SumOptPartial<FF>> where F == CoSumOptPartial<FF>, G == SumOptPartial<FF> {
+        Pairing { cosumopt, sumopt, f in
+            SumOptPartial<FF>.pair().pairFlipped(cosumopt, sumopt, f)
+        }
+    }
+}
+
 // MARK: Pairing for any Comonad
 
 public extension Comonad {

--- a/Sources/Bow/Data/Sum.swift
+++ b/Sources/Bow/Data/Sum.swift
@@ -15,15 +15,15 @@ public final class Sum<F, G, V> : SumOf<F, G, V> {
     public let side: Side
     
     public static func fix(_ value: SumOf<F, G, V>) -> Sum<F, G, V> {
-        return value as! Sum<F, G, V>
+        value as! Sum<F, G, V>
     }
     
     public static func left(_ left: Kind<F, V>, _ right: Kind<G, V>) -> Sum<F, G, V> {
-        return Sum(left: left, right: right, side: .left)
+        Sum(left: left, right: right, side: .left)
     }
     
     public static func right(_ left: Kind<F, V>, _ right: Kind<G, V>) -> Sum<F, G, V> {
-        return Sum(left: left, right: right, side: .right)
+        Sum(left: left, right: right, side: .right)
     }
 
     public init(left: Kind<F, V>, right: Kind<G, V>, side: Side = .left) {
@@ -33,7 +33,7 @@ public final class Sum<F, G, V> : SumOf<F, G, V> {
     }
     
     public func change(side: Side) -> Sum<F, G, V> {
-        return Sum(left: self.left, right: self.right, side: side)
+        Sum(left: self.left, right: self.right, side: side)
     }
 }
 
@@ -42,33 +42,30 @@ public final class Sum<F, G, V> : SumOf<F, G, V> {
 /// - Parameter value: Value in higher-kind form.
 /// - Returns: Value cast to Sum.
 public postfix func ^<F, G, V>(_ value: SumOf<F, G, V>) -> Sum<F, G, V> {
-    return Sum.fix(value)
+    Sum.fix(value)
 }
 
 extension SumPartial: Invariant where F: Functor, G: Functor {}
 
 extension SumPartial: Functor where F: Functor, G: Functor {
     public static func map<A, B>(_ fa: Kind<SumPartial<F, G>, A>, _ f: @escaping (A) -> B) -> Kind<SumPartial<F, G>, B> {
-        let sum = Sum.fix(fa)
-        return Sum(left: sum.left.map(f),
-                   right: sum.right.map(f),
-                   side: sum.side)
+        Sum(left: fa^.left.map(f),
+            right: fa^.right.map(f),
+            side: fa^.side)
     }
 }
 
 extension SumPartial: Comonad where F: Comonad, G: Comonad {
     public static func coflatMap<A, B>(_ fa: Kind<SumPartial<F, G>, A>, _ f: @escaping (Kind<SumPartial<F, G>, A>) -> B) -> Kind<SumPartial<F, G>, B> {
-        let sum = Sum.fix(fa)
-        return Sum(left: F.coflatMap(sum.left, { _ in f(Sum(left: sum.left, right: sum.right, side: .left)) }),
-                   right: G.coflatMap(sum.right, { _ in f(Sum(left: sum.left, right: sum.right, side: .right)) }),
-                   side: sum.side)
+        Sum(left: fa^.left.coflatMap { l in f(Sum(left: l, right: fa^.right, side: .left)) },
+            right: fa^.right.coflatMap { r in f(Sum(left: fa^.left, right: r, side: .right)) },
+            side: fa^.side)
     }
 
     public static func extract<A>(_ fa: Kind<SumPartial<F, G>, A>) -> A {
-        let sum = Sum.fix(fa)
-        switch sum.side {
-        case .left: return F.extract(sum.left)
-        case .right: return G.extract(sum.right)
+        switch fa^.side {
+        case .left: return fa^.left.extract()
+        case .right: return fa^.right.extract()
         }
     }
 }

--- a/Sources/Bow/Data/Sum.swift
+++ b/Sources/Bow/Data/Sum.swift
@@ -4,6 +4,10 @@ public final class ForSum {}
 public final class SumPartial<F, G>: Kind2<ForSum, F, G> {}
 public typealias SumOf<F, G, V> = Kind<SumPartial<F, G>, V>
 
+public typealias SumOptPartial<G> = SumPartial<ForId, G>
+public typealias SumOptOf<G, A> = SumOf<ForId, G, A>
+public typealias SumOpt<G, A> = Sum<ForId, G, A>
+
 public enum Side {
     case left
     case right

--- a/Sources/Bow/Data/Sum.swift
+++ b/Sources/Bow/Data/Sum.swift
@@ -35,6 +35,30 @@ public final class Sum<F, G, V> : SumOf<F, G, V> {
     public func change(side: Side) -> Sum<F, G, V> {
         Sum(left: self.left, right: self.right, side: side)
     }
+    
+    public func lower() -> EitherK<F, G, V> {
+        switch side {
+        case .left: return .init(left)
+        case .right: return .init(right)
+        }
+    }
+    
+    public func lowerLeft() -> Kind<F, V> {
+        left
+    }
+    
+    public func lowerRight() -> Kind<G, V> {
+        right
+    }
+}
+
+public extension Sum where F: Comonad, G: Comonad {
+    func extractOther() -> V {
+        switch side {
+        case .left: return right.extract()
+        case .right: return left.extract()
+        }
+    }
 }
 
 /// Safe downcast.

--- a/Tests/BowTests/Data/PairingTest.swift
+++ b/Tests/BowTests/Data/PairingTest.swift
@@ -88,4 +88,20 @@ class PairingTest: XCTestCase {
         
         XCTAssertEqual(w2.view, "3 is odd")
     }
+    
+    func testPairingCoSumSum() {
+        let w = Sum<ForId, ForId, Int>(left: Id(10), right: Id(20))
+        
+        let actions: CoSum<ForId, ForId, Void> = binding(
+            |<-CoSum.moveRight(),
+            |<-CoSum.moveLeft(),
+            |<-CoSum.moveLeft(),
+            |<-CoSum.moveRight(),
+            yield: ()
+        )^
+        
+        let w2 = Pairing.pairCoSumSum().select(actions, w.duplicate())^
+        
+        XCTAssertEqual(w2.extract(), 20)
+    }
 }

--- a/Tests/BowTests/Data/PairingTest.swift
+++ b/Tests/BowTests/Data/PairingTest.swift
@@ -104,4 +104,18 @@ class PairingTest: XCTestCase {
         
         XCTAssertEqual(w2.extract(), 20)
     }
+    
+    func testPairingCoSumOptSumOpt() {
+        let w = SumOpt<ForId, Int>(left: Id(0), right: Id(25))
+        
+        let actions: CoSumOpt<ForId, Void> = binding(
+            |<-CoSumOpt.show(),
+            |<-CoSumOpt.hide(),
+            |<-CoSumOpt.toggle(),
+            yield: ())^
+        
+        let w2 = Pairing.pairCoSumOptSumOpt().select(actions, w.duplicate())^
+        
+        XCTAssertEqual(w2.extract(), 25)
+    }
 }


### PR DESCRIPTION
## Goal

- Fix an issue with the implementation of `coflatMap` for Sum.
- Provide missing methods for Sum.
- Provide its dual Monad, CoSum.
- Provide convenience aliases for SumOpt and CoSumOpt.
- Provide Pairings between Sum and CoSum.