### PR TITLE
Add Puller Monad as a dual of Zipper Comonad

### DIFF
--- a/Bow.xcodeproj/project.pbxproj
+++ b/Bow.xcodeproj/project.pbxproj
@@ -100,6 +100,7 @@
 		112297BB219DCFDE006D66C5 /* ObservableKTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BA0F3A4217E2DEF00969984 /* ObservableKTest.swift */; };
 		112297BC219DCFDE006D66C5 /* SingleKTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BA0F3A6217E2DEF00969984 /* SingleKTest.swift */; };
 		112297BD219DCFDE006D66C5 /* MaybeKTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BA0F3A5217E2DEF00969984 /* MaybeKTest.swift */; };
+		1123686F240FC316005D4CF4 /* Puller.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1123686E240FC316005D4CF4 /* Puller.swift */; };
 		1125054D220DD92B00861131 /* EquatableK.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1125054C220DD92B00861131 /* EquatableK.swift */; };
 		1126CA8A22B1144200F840CB /* AutoOptics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1126CA8922B1144200F840CB /* AutoOptics.swift */; };
 		1126CA8C22B115E100F840CB /* AutoLens.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1126CA8B22B115E100F840CB /* AutoLens.swift */; };
@@ -786,6 +787,7 @@
 		112297AA219DCE76006D66C5 /* Bow-Rx-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; name = "Bow-Rx-Info.plist"; path = "/Users/tomasruizlopez/Development/bow/Support Files/Bow-Rx-Info.plist"; sourceTree = "<absolute>"; };
 		112297CD219DCFDE006D66C5 /* BowRxTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = BowRxTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		112297CE219DCFDF006D66C5 /* Bow-RxTests-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; name = "Bow-RxTests-Info.plist"; path = "/Users/tomasruizlopez/Development/bow/Support Files/Bow-RxTests-Info.plist"; sourceTree = "<absolute>"; };
+		1123686E240FC316005D4CF4 /* Puller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Puller.swift; sourceTree = "<group>"; };
 		1125054C220DD92B00861131 /* EquatableK.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EquatableK.swift; sourceTree = "<group>"; };
 		1126CA8922B1144200F840CB /* AutoOptics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoOptics.swift; sourceTree = "<group>"; };
 		1126CA8B22B115E100F840CB /* AutoLens.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoLens.swift; sourceTree = "<group>"; };
@@ -1934,6 +1936,7 @@
 				8BA0F479217E2E9200969984 /* NonEmptyArray.swift */,
 				8BA0F478217E2E9200969984 /* Option.swift */,
 				09CEF850236E28680070CF43 /* Pairing.swift */,
+				1123686E240FC316005D4CF4 /* Puller.swift */,
 				8BA0F473217E2E9200969984 /* Reader.swift */,
 				8BA0F482217E2E9200969984 /* Result.swift */,
 				111F84FA234DBF95003FE646 /* Set.swift */,
@@ -3122,6 +3125,7 @@
 				8BA0F4E7217E2E9200969984 /* FunctionK.swift in Sources */,
 				8BA0F617217E2E9200969984 /* MonadReader.swift in Sources */,
 				1165E1A923F414350052F0C7 /* Trampoline.swift in Sources */,
+				1123686F240FC316005D4CF4 /* Puller.swift in Sources */,
 				8BA0F5D7217E2E9200969984 /* HigherKinds.swift in Sources */,
 				8BA0F4D3217E2E9200969984 /* Curry.swift in Sources */,
 				8BA0F653217E2E9200969984 /* Semigroup.swift in Sources */,

--- a/Sources/Bow/Data/Pairing.swift
+++ b/Sources/Bow/Data/Pairing.swift
@@ -149,6 +149,16 @@ public extension Pairing {
     }
 }
 
+// MARK: Pairing for Puller and Zipper
+
+public extension Pairing where F == ForPuller, G == ForZipper {
+    static func pairPullerZipper() -> Pairing<ForPuller, ForZipper>  {
+        Pairing { puller, zipper, f in
+            ForZipper.pair().pairFlipped(puller, zipper, f)
+        }
+    }
+}
+
 // MARK: Pairing for any Comonad
 
 public extension Comonad {

--- a/Sources/Bow/Data/Puller.swift
+++ b/Sources/Bow/Data/Puller.swift
@@ -4,7 +4,7 @@ public typealias ForPuller = CoPartial<ForZipper>
 public typealias PullerOf<A> = CoOf<ForZipper, A>
 public typealias Puller<A> = Co<ForZipper, A>
 
-public extension Puller where M == ForId {
+public extension Puller where M == ForId, W == ForZipper, A == Void  {
     static func moveLeft() -> Puller<Void> {
         Puller { cow in cow^.moveLeft().extract()(()) }
     }

--- a/Sources/Bow/Data/Puller.swift
+++ b/Sources/Bow/Data/Puller.swift
@@ -1,0 +1,23 @@
+// A Puller is the dual Monad of a Zipper
+
+public typealias ForPuller = CoPartial<ForZipper>
+public typealias PullerOf<A> = CoOf<ForZipper, A>
+public typealias Puller<A> = Co<ForZipper, A>
+
+public extension Puller where M == ForId {
+    static func moveLeft() -> Puller<Void> {
+        Puller { cow in cow^.moveLeft().extract()(()) }
+    }
+    
+    static func moveRight() -> Puller<Void> {
+        Puller { cow in cow^.moveRight().extract()(()) }
+    }
+    
+    static func moveToFirst() -> Puller<Void> {
+        Puller { cow in cow^.moveToFirst().extract()(()) }
+    }
+    
+    static func moveToLast() -> Puller<Void> {
+        Puller { cow in cow^.moveToLast().extract()(()) }
+    }
+}

--- a/Sources/Bow/Data/Zipper.swift
+++ b/Sources/Bow/Data/Zipper.swift
@@ -29,9 +29,9 @@ public final class Zipper<A>: ZipperOf<A> {
         self.init(left: [], focus: array[0], right: Array(array[1...]))
     }
     
-    public func moveLeft() -> Zipper<A>? {
+    public func moveLeft() -> Zipper<A> {
         guard !left.isEmpty else {
-            return nil
+            return self
         }
         
         return Zipper(left: Array(left[0 ..< left.count - 1]),
@@ -39,14 +39,30 @@ public final class Zipper<A>: ZipperOf<A> {
                       right: [focus] + right)
     }
     
-    public func moveRight() -> Zipper<A>? {
+    public func moveRight() -> Zipper<A> {
         guard !right.isEmpty else {
-            return nil
+            return self
         }
         
         return Zipper(left: left + [focus],
                       focus: right[0],
                       right: Array(right[1...]))
+    }
+    
+    public func moveToFirst() -> Zipper<A> {
+        if isBeginning() {
+            return self
+        } else {
+            return self.moveLeft().moveToFirst()
+        }
+    }
+    
+    public func moveToLast() -> Zipper<A> {
+        if isEnding() {
+            return self
+        } else {
+            return self.moveRight().moveToLast()
+        }
     }
     
     public func asArray() -> [A] {

--- a/Tests/BowTests/Data/PairingTest.swift
+++ b/Tests/BowTests/Data/PairingTest.swift
@@ -118,4 +118,20 @@ class PairingTest: XCTestCase {
         
         XCTAssertEqual(w2.extract(), 25)
     }
+    
+    func testPairingPullerZipper() {
+        let w = Zipper(left: [1, 2, 3], focus: 4, right: [5, 6, 7])
+        
+        let actions: Puller<Void> = binding(
+            |<-Puller.moveToFirst(),
+            |<-Puller.moveToLast(),
+            |<-Puller.moveLeft(),
+            |<-Puller.moveLeft(),
+            |<-Puller.moveRight(),
+            yield: ())^
+        
+        let w2 = Pairing.pairPullerZipper().select(actions, w.duplicate())^
+        
+        XCTAssertEqual(w2.extract(), 6)
+    }
 }

--- a/Tests/BowTests/Data/ZipperTest.swift
+++ b/Tests/BowTests/Data/ZipperTest.swift
@@ -38,13 +38,25 @@ class ZipperTest: XCTestCase {
         XCTAssertEqual(moved, expected, "Focus should be 5")
     }
     
+    func testMoveToFirst() {
+        property("After moving to first, zipper must be at beginning") <~ forAll { (zipper: Zipper<Int>) in
+            zipper.moveToFirst().isBeginning()
+        }
+    }
+    
+    func testMoveToLast() {
+        property("After moving to last, zipper must be at end") <~ forAll { (zipper: Zipper<Int>) in
+            zipper.moveToLast().isEnding()
+        }
+    }
+    
     func testCoflatMap() {
         let zipper = Zipper(left: [1, 2, 3], focus: 4, right: [5, 6])
         // f computes each element plus its neighbors
         let f = { (zipper: ZipperOf<Int>) -> Int in
             zipper.extract()
-                + (zipper^.moveLeft()?.extract() ?? 0)
-                + (zipper^.moveRight()?.extract() ?? 0)
+                + (zipper^.isBeginning() ? 0 : zipper^.moveLeft().extract())
+                + (zipper^.isEnding() ? 0 : zipper^.moveRight().extract())
         }
         let expected = Zipper(left: [3, 6, 9], focus: 12, right: [15, 11])
         let result = zipper.coflatMap(f)


### PR DESCRIPTION
## Goal

- Provide a dual monad for Zipper, named Puller.
- Provide methods to construct Puller actions.
- Provide a pairing between both.

## Implementation details

The implementation is obtained for free using `Co`.