### PR TITLE
Enhance UnsafeRun methods

### DIFF
--- a/Sources/BowEffects/Data/EnvIO.swift
+++ b/Sources/BowEffects/Data/EnvIO.swift
@@ -195,7 +195,7 @@ public extension Kleisli {
     ///   - d: Dependencies needed in this operation.
     ///   - queue: Dispatch queue used to execute the side effects. Defaults to the main queue.
     ///   - callback: A callback function to receive the results of the evaluation. Errors of other types thrown from the evaluation of this IO will cause a fatal error.
-    func unsafeRunAsync<E: Error>(with d: D, on queue: DispatchQueue = .main, _ callback: @escaping Callback<E, A>) where F == IOPartial<E> {
+    func unsafeRunAsync<E: Error>(with d: D, on queue: DispatchQueue = .main, _ callback: @escaping Callback<E, A> = { _ in }) where F == IOPartial<E> {
         self.provide(d).unsafeRunAsync(on: queue, callback)
     }
 }
@@ -233,7 +233,7 @@ public extension Kleisli where D == Any {
     /// - Parameters:
     ///   - queue: Dispatch queue used to execute the side effects. Defaults to the main queue.
     ///   - callback: A callback function to receive the results of the evaluation. Errors of other types thrown from the evaluation of this IO will cause a fatal error.
-    func unsafeRunAsync<E: Error>(on queue: DispatchQueue = .main, _ callback: @escaping Callback<E, A>) where F == IOPartial<E> {
+    func unsafeRunAsync<E: Error>(on queue: DispatchQueue = .main, _ callback: @escaping Callback<E, A> = { _ in }) where F == IOPartial<E> {
         self.provide(()).unsafeRunAsync(on: queue, callback)
     }
 }

--- a/Sources/BowEffects/Data/IO.swift
+++ b/Sources/BowEffects/Data/IO.swift
@@ -332,7 +332,7 @@ public class IO<E: Error, A>: IOOf<E, A> {
     /// - Parameters:
     ///   - queue: Dispatch queue used to execute the side effects. Defaults to the main queue.
     ///   - callback: A callback function to receive the results of the evaluation. Errors of other types thrown from the evaluation of this IO will cause a fatal error.
-    public func unsafeRunAsync(on queue: DispatchQueue = .main, _ callback: @escaping Callback<E, A>) {
+    public func unsafeRunAsync(on queue: DispatchQueue = .main, _ callback: @escaping Callback<E, A> = { _ in }) {
         queue.async {
             callback(self.unsafeRunSyncEither(on: queue))
         }

--- a/Sources/BowEffects/Typeclasses/UnsafeRun.swift
+++ b/Sources/BowEffects/Typeclasses/UnsafeRun.swift
@@ -28,21 +28,19 @@ public extension Kind where F: UnsafeRun {
     ///
     /// - Parameters:
     ///   - queue: Dispatch queue used to run the computation. Defaults to the main queue.
-    ///   - fa: Computation to be run.
     /// - Returns: Result of running the computation.
     /// - Throws: Error happened during the execution of the computation, of the error type of the underlying `MonadError`.
-    static func runBlocking(on queue: DispatchQueue = .main, _ fa: @escaping () -> Kind<F, A>) throws -> A {
-        return try F.runBlocking(on: queue, fa)
+    func runBlocking(on queue: DispatchQueue = .main) throws -> A {
+        return try F.runBlocking(on: queue, { self })
     }
 
     /// Unsafely runs a computation in an asynchronous manner.
     ///
     /// - Parameters:
     ///   - queue: Dispatch queue used to run the computation. Defaults to the main queue.
-    ///   - fa: Computation to be run.
     ///   - callback: Callback to report the result of the evaluation.
-    static func runNonBlocking(on queue: DispatchQueue = .main, _ fa: @escaping () -> Kind<F, A>, _ callback: @escaping Callback<F.E, A>) {
-        return F.runNonBlocking(on: queue, fa, callback)
+    func runNonBlocking(on queue: DispatchQueue = .main, _ callback: @escaping Callback<F.E, A> = { _ in }) {
+        return F.runNonBlocking(on: queue, { self }, callback)
     }
 }
 


### PR DESCRIPTION
## Goal

Improve the usability of the methods provided in `UnsafeRun`, moving from static to instance methods on `Kind`. This way, we can abstract over the execution of an effect. The previous version was:

```swift
Kind<F, A>.runBlocking(on: .main) { fa }
Kind<F, A>.runNonBlocking(on: .main, { fa }) { result in ... }
```

With this version, it becomes:

```swift
fa.runBlocking(on: .main)
fa.runNonBlocking(on: .main) { result in ... }
```

Callbacks are also optional in non-blocking / async executions.