### PR TITLE
Comonad Transformers Type Classes API Reference

### DIFF
--- a/Sources/Bow/Typeclasses/ComonadEnv.swift
+++ b/Sources/Bow/Typeclasses/ComonadEnv.swift
@@ -1,11 +1,29 @@
+/// The ComonadEnv type class represents a Comonad that support a global environment that can be provided and transformed into a local environment.
 public protocol ComonadEnv: Comonad {
+    /// Type of the associated environment
     associatedtype E
     
+    /// Gets the underlying global environment from the provided value.
+    /// - Parameter wa: Value to obtain the environment from.
+    /// - Returns: Global environment.
     static func ask<A>(_ wa: Kind<Self, A>) -> E
+    
+    /// Transforms the environment into a local one.
+    ///
+    /// - Parameters:
+    ///   - wa: Value containing the environment.
+    ///   - f: Transforming function.
+    /// - Returns: A value with the transformed environment.
     static func local<A>(_ wa: Kind<Self, A>, _ f: @escaping (E) -> E) -> Kind<Self, A>
 }
 
 public extension ComonadEnv {
+    /// Obtains a value that depends on the environment.
+    ///
+    /// - Parameters:
+    ///   - wa: Value containing the environment.
+    ///   - f: Function to obtain a value from the environment.
+    /// - Returns: A value that depends on the environment.
     static func asks<A, EE>(_ wa: Kind<Self, A>, _ f: @escaping (E) -> EE) -> EE {
         f(ask(wa))
     }
@@ -14,14 +32,26 @@ public extension ComonadEnv {
 // MARK: Syntax for ComonadEnv
 
 public extension Kind where F: ComonadEnv {
+    /// Gets the underlying global environment from this value.
+    /// - Returns: Global environment.
     func ask() -> F.E {
         F.ask(self)
     }
     
+    /// Obtains a value that depends on the environment.
+    ///
+    /// - Parameters:
+    ///   - f: Function to obtain a value from the environment.
+    /// - Returns: A value that depends on the environment.
     func asks<EE>(_ f: @escaping (F.E) -> EE) -> EE {
         F.asks(self, f)
     }
     
+    /// Transforms the environment into a local one.
+    ///
+    /// - Parameters:
+    ///   - f: Transforming function.
+    /// - Returns: A value with the transformed environment.
     func local(_ f: @escaping (F.E) -> F.E) -> Kind<F, A> {
         F.local(self, f)
     }

--- a/Sources/Bow/Typeclasses/ComonadStore.swift
+++ b/Sources/Bow/Typeclasses/ComonadStore.swift
@@ -1,23 +1,59 @@
+/// The ComonadStore type class represents those Comonads that support local position information.
 public protocol ComonadStore: Comonad {
+    /// Type of the position within the ComonadStore
     associatedtype S
     
+    /// Obtains the current position of the store.
+    /// - Parameter wa: Value from which the store is retrieved.
+    /// - Returns: Current position.
     static func position<A>(_ wa: Kind<Self, A>) -> S
+    
+    /// Obtains the value stored in the provided position.
+    ///
+    /// - Parameters:
+    ///   - wa: Store.
+    ///   - s: Position within the Store.
+    /// - Returns: Value stored in the provided position.
     static func peek<A>(_ wa: Kind<Self, A>, _ s: S) -> A
 }
 
 public extension ComonadStore {
+    /// Obtains a value in a position relative to the current position.
+    ///
+    /// - Parameters:
+    ///   - wa: Store.
+    ///   - f: Function to compute the relative position.
+    /// - Returns: Value located in a relative position to the current one.
     static func peeks<A>(_ wa: Kind<Self, A>, _ f: @escaping (S) -> S) -> A {
         peek(wa, f(position(wa)))
     }
     
+    /// Moves to a new position.
+    ///
+    /// - Parameters:
+    ///   - wa: Store.
+    ///   - s: New position.
+    /// - Returns: Store focused into the new position.
     static func seek<A>(_ wa: Kind<Self, A>, _ s: S) -> Kind<Self, A> {
         wa.coflatMap { fa in peek(fa, s) }
     }
     
+    /// Moves to a new position relative to the current one.
+    ///
+    /// - Parameters:
+    ///   - wa: Store.
+    ///   - f: Function to compute the new position, relative to the current one.
+    /// - Returns: Store focused into the new position.
     static func seeks<A>(_ wa: Kind<Self, A>, _ f: @escaping (S) -> S) -> Kind<Self, A> {
         wa.coflatMap { fa in peeks(fa, f) }
     }
     
+    /// Extracts a collection of values from positions that depend on the current one.
+    ///
+    /// - Parameters:
+    ///   - wa: Store.
+    ///   - f: Effectful function computing new positions based on the current one.
+    /// - Returns: A collection of values located a the specified positions.
     static func experiment<F: Functor, A>(_ wa: Kind<Self, A>, _ f: @escaping (S) -> Kind<F, S>) -> Kind<F, A> {
         F.map(f(position(wa))) { s in peek(wa, s) }
     }
@@ -26,26 +62,52 @@ public extension ComonadStore {
 // MARK: Syntax for ComonadStore
 
 public extension Kind where F: ComonadStore {
+    /// Obtains the current position of the store.
     var position: F.S {
         F.position(self)
     }
     
+    /// Obtains the value stored in the provided position.
+    ///
+    /// - Parameters:
+    ///   - s: Position within the Store.
+    /// - Returns: Value stored in the provided position.
     func peek(_ s: F.S) -> A {
         F.peek(self, s)
     }
     
+    /// Obtains a value in a position relative to the current position.
+    ///
+    /// - Parameters:
+    ///   - f: Function to compute the relative position.
+    /// - Returns: Value located in a relative position to the current one.
     func peeks(_ f: @escaping (F.S) -> F.S) -> A {
         F.peeks(self, f)
     }
     
+    /// Moves to a new position.
+    ///
+    /// - Parameters:
+    ///   - s: New position.
+    /// - Returns: Store focused into the new position.
     func seek(_ s: F.S) -> Kind<F, A> {
         F.seek(self, s)
     }
     
+    /// Moves to a new position relative to the current one.
+    ///
+    /// - Parameters:
+    ///   - f: Function to compute the new position, relative to the current one.
+    /// - Returns: Store focused into the new position.
     func seeks(_ f: @escaping (F.S) -> F.S) -> Kind<F, A> {
         F.seeks(self, f)
     }
     
+    /// Extracts a collection of values from positions that depend on the current one.
+    ///
+    /// - Parameters:
+    ///   - f: Effectful function computing new positions based on the current one.
+    /// - Returns: A collection of values located a the specified positions.
     func experiment<G: Functor>(_ f: @escaping (F.S) -> Kind<G, F.S>) -> Kind<G, A> {
         F.experiment(self, f)
     }

--- a/Sources/Bow/Typeclasses/ComonadTraced.swift
+++ b/Sources/Bow/Typeclasses/ComonadTraced.swift
@@ -1,20 +1,56 @@
+/// The ComonadTraced type class represents those comonads which support relative (monoidal) position information.
 public protocol ComonadTraced: Comonad {
+    /// Index type to access values inside the Comonad
     associatedtype M
     
+    /// Extracts a value at the specified relative position.
+    ///
+    /// - Parameters:
+    ///   - wa: Trace.
+    ///   - m: Relative position.
+    /// - Returns: Value corresponding to the specified position.
     static func trace<A>(_ wa: Kind<Self, A>, _ m: M) -> A
+    
+    /// Gets a value that depends on the current position.
+    ///
+    /// - Parameters:
+    ///   - wa: Trace.
+    ///   - f: Function to compute a value from the current position.
+    /// - Returns: A tuple with the current and computed value in the context of this ComonadTraced.
     static func listens<A, B>(_ wa: Kind<Self, A>, _ f: @escaping (M) -> B) -> Kind<Self, (B, A)>
+    
+    /// Obtains a Trace that can modify the current position.
+    ///
+    /// - Parameter wa: Trace.
+    /// - Returns: Trace that can modify the current position.
     static func pass<A>(_ wa: Kind<Self, A>) -> Kind<Self, ((M) -> M) -> A>
 }
 
 public extension ComonadTraced {
+    /// Extracts a value at a relative position which depends on the current value.
+    ///
+    /// - Parameters:
+    ///   - wa: Trace.
+    ///   - f: Function to compute the position based on the current value.
+    /// - Returns: Value corresponding to the new position.
     static func traces<A>(_ wa: Kind<Self, A>, _ f: @escaping (A) -> M) -> A {
         trace(wa, f(wa.extract()))
     }
     
+    /// Obtains the current position together with the current value.
+    ///
+    /// - Parameter wa: Trace.
+    /// - Returns: A tuple with the current position and value in the context of this ComonadTraced.
     static func listen<A>(_ wa: Kind<Self, A>) -> Kind<Self, (M, A)> {
         listens(wa, id)
     }
     
+    /// Apply a function to the current position.
+    ///
+    /// - Parameters:
+    ///   - wa: Trace.
+    ///   - f: Function to transform the current position.
+    /// - Returns: Trace focused in the new position.
     static func censor<A>(_ wa: Kind<Self, A>, _ f: @escaping (M) -> M) -> Kind<Self, A> {
         pass(wa).map { trace in trace(f) }
     }
@@ -23,26 +59,52 @@ public extension ComonadTraced {
 // MARK: Syntax for ComonadTraced
 
 public extension Kind where F: ComonadTraced {
+    /// Extracts a value at the specified relative position.
+    ///
+    /// - Parameters:
+    ///   - m: Relative position.
+    /// - Returns: Value corresponding to the specified position.
     func trace(_ m: F.M) -> A {
         F.trace(self, m)
     }
     
+    /// Extracts a value at a relative position which depends on the current value.
+    ///
+    /// - Parameters:
+    ///   - f: Function to compute the position based on the current value.
+    /// - Returns: Value corresponding to the new position.
     func traces(_ f: @escaping (A) -> F.M) -> A {
         F.traces(self, f)
     }
     
+    /// Gets a value that depends on the current position.
+    ///
+    /// - Parameters:
+    ///   - f: Function to compute a value from the current position.
+    /// - Returns: A tuple with the current and computed value in the context of this ComonadTraced.
     func listens<B>(_ f: @escaping (F.M) -> B) -> Kind<F, (B, A)> {
         F.listens(self, f)
     }
     
+    /// Obtains the current position together with the current value.
+    ///
+    /// - Returns: A tuple with the current position and value in the context of this ComonadTraced.
     func listen() -> Kind<F, (F.M, A)> {
         F.listen(self)
     }
     
+    /// Apply a function to the current position.
+    ///
+    /// - Parameters:
+    ///   - f: Function to transform the current position.
+    /// - Returns: Trace focused in the new position.
     func censor(_ f: @escaping (F.M) -> F.M) -> Kind<F, A> {
         F.censor(self, f)
     }
     
+    /// Obtains a Trace that can modify the current position.
+    ///
+    /// - Returns: Trace that can modify the current position.
     func pass() -> Kind<F, ((F.M) -> F.M) -> A>  {
         F.pass(self)
     }

--- a/Sources/Bow/Typeclasses/ComonadTrans.swift
+++ b/Sources/Bow/Typeclasses/ComonadTrans.swift
@@ -1,10 +1,18 @@
+/// The ComonadTrans type class represents Comonad Transformers.
 public protocol ComonadTrans {
+    /// Obtains the comonadic value contained in the provided comonad transformer.
+    ///
+    /// - Parameter twa: Value containing another comonadic value.
+    /// - Returns: Contained comonadic value within the transformer.
     static func lower<W: Comonad, A>(_ twa: Kind<Self, Kind<W, A>>) -> Kind<W, A>
 }
 
 // MARK: Syntax for ComonadTrans
 
 public extension Kind where F: ComonadTrans {
+    /// Obtains the comonadic value contained in the provided comonad transformer.
+    ///
+    /// - Returns: Contained comonadic value within the transformer.
     func lower<W: Comonad, B>() -> Kind<W, B> where A == Kind<W, B> {
         F.lower(self)
     }


### PR DESCRIPTION
## Related issues

- Closes #526.
- Closes #527.
- Closes #528.
- Closes #529.

## Goal

Document API Reference for the type classes for Comonad Transformers.