### PR TITLE
Semigroup and Monoid enhancements

### DIFF
--- a/Sources/Bow/Typeclasses/Monoid.swift
+++ b/Sources/Bow/Typeclasses/Monoid.swift
@@ -14,3 +14,24 @@ public protocol Monoid: Semigroup {
     /// - Returns: A value of the implementing type satisfying the monoid laws.
     static func empty() -> Self
 }
+
+// MARK: Monoid syntax
+public extension Monoid {
+    /// Combines a variable number of values of the implementing type, in the order provided in the call.
+    ///
+    /// - Parameters:
+    ///     - elems: Values of the implementing type.
+    /// - Returns: A single value of the implementing type representing the combination of all the parameter values.
+    static func combineAll(_ elems: Self...) -> Self {
+        combineAll(elems)
+    }
+
+    /// Combines an array of values of the implementing type, in the order provided in the call.
+    ///
+    /// - Parameters:
+    ///     - elems: Values of the implementing type.
+    /// - Returns: A single value of the implementing type representing the combination of all the parameter values.
+    static func combineAll(_ elems: [Self]) -> Self {
+        elems.reduce(empty(), Self.combine)
+    }
+}

--- a/Sources/Bow/Typeclasses/Semigroup.swift
+++ b/Sources/Bow/Typeclasses/Semigroup.swift
@@ -23,22 +23,26 @@ public extension Semigroup {
     ///   - b: Value of the implementing type.
     /// - Returns: Combination of `a` and `b`.
     static func combine(_ a: Self, _ b: Self) -> Self {
-        return a.combine(b)
+        a.combine(b)
     }
 
-    /// Combines a variable number of values of the implementing type, in the order provided in the call.
+    /// Combines a variable number of values (at least one) of the implementing type, in the order provided in the call.
     ///
-    /// - Parameter elems: Values of the implementing type.
+    /// - Parameters:
+    ///     - first: First value of the implementing type.
+    ///     - elems: Values of the implementing type.
     /// - Returns: A single value of the implementing type representing the combination of all the parameter values.
-    static func combineAll(_ elems: Self...) -> Self {
-        return combineAll(elems)
+    static func combineAll(_ first: Self, _ elems: Self...) -> Self {
+        combineAll(first, elems)
     }
 
     /// Combines an array of values of the implementing type, in the order provided in the call.
     ///
-    /// - Parameter elems: Array of values of the implementing type.
+    /// - Parameters:
+    ///     - first: First value of the implementing type.
+    ///     - elems: Values of the implementing type.
     /// - Returns: A single value of the implementing type representing the combination of all the parameter values.
-    static func combineAll(_ elems: [Self]) -> Self {
-        return elems[1 ..< elems.count].reduce(elems[0], { partial, next in partial.combine(next) })
+    static func combineAll(_ first: Self, _ elems: [Self]) -> Self {
+        elems.reduce(first, Self.combine)
     }
 }


### PR DESCRIPTION
## Related issues

The implementation of `combineAll` for Semigroup is not safe, as passing 0 values will make it crash. Semigroup always needs at least one value.

## Goal

- Force having at least one element in `combineAll` in the signature of the function.
- Provide an additional `combineAll` function in Monoid that can accept 0 or more values, using the `empty` value in case no values are combined.