### PR TITLE
Improve type inference in some type classes

### DIFF
--- a/Sources/Bow/Data/Array.swift
+++ b/Sources/Bow/Data/Array.swift
@@ -72,7 +72,7 @@ public extension Array {
     ///
     /// - Returns: Results collected under the context of the effects.
     func sequence<G: Applicative, A>() -> Kind<G, [A]> where Element: Kind<G, A> {
-        self.k().map { x in x.map(id) }.sequence().map { array in array^.asArray }
+        self.k().sequence().map { array in array^.asArray }
     }
     
     /// A traverse followed by flattening the inner result.

--- a/Sources/Bow/Data/Array.swift
+++ b/Sources/Bow/Data/Array.swift
@@ -71,8 +71,8 @@ public extension Array {
     /// Evaluate each effect in this array of values and collects the results.
     ///
     /// - Returns: Results collected under the context of the effects.
-    func sequence<G: Applicative, A>() -> Kind<G, [A]> where Element == Kind<G, A> {
-        self.k().sequence().map { array in array^.asArray }
+    func sequence<G: Applicative, A>() -> Kind<G, [A]> where Element: Kind<G, A> {
+        self.k().map { x in x.map(id) }.sequence().map { array in array^.asArray }
     }
     
     /// A traverse followed by flattening the inner result.

--- a/Sources/Bow/Data/Array.swift
+++ b/Sources/Bow/Data/Array.swift
@@ -55,7 +55,7 @@ public extension Array {
     ///
     /// - Parameter fga: Structure to be reduced.
     /// - Returns: A value in the context providing the `MonoidK` instance.
-    func reduceK<G: MonoidK, A>() -> Kind<G, A> where Element == Kind<G, A> {
+    func reduceK<G: MonoidK, A>() -> Kind<G, A> where Element: Kind<G, A> {
         self.k().reduceK()
     }
     

--- a/Sources/Bow/Typeclasses/Applicative.swift
+++ b/Sources/Bow/Typeclasses/Applicative.swift
@@ -741,9 +741,9 @@ public extension Kind where F: Applicative {
     ///   - b: 2nd computation.
     ///   - f: Combination function.
     /// - Returns: Result of combining the provided computations, in the context implementing this instance.
-    static func map<A, B, Z>(_ a: Kind<F, Z>,
-                             _ b: Kind<F, B>,
-                             _ f: @escaping (Z, B) -> A) -> Kind<F, A> {
+    static func map<B, Z>(_ a: Kind<F, Z>,
+                          _ b: Kind<F, B>,
+                          _ f: @escaping (Z, B) -> A) -> Kind<F, A> {
         return F.map(a, b, f)
     }
 
@@ -757,10 +757,10 @@ public extension Kind where F: Applicative {
     ///   - c: 3rd computation.
     ///   - f: Combination function.
     /// - Returns: Result of combining the provided computations, in the context implementing this instance.
-    static func map<A, B, C, Z>(_ a: Kind<F, Z>,
-                                _ b: Kind<F, B>,
-                                _ c: Kind<F, C>,
-                                _ f: @escaping (Z, B, C) -> A) -> Kind<F, A> {
+    static func map<B, C, Z>(_ a: Kind<F, Z>,
+                             _ b: Kind<F, B>,
+                             _ c: Kind<F, C>,
+                             _ f: @escaping (Z, B, C) -> A) -> Kind<F, A> {
         return F.map(a, b, c, f)
     }
 
@@ -775,11 +775,11 @@ public extension Kind where F: Applicative {
     ///   - d: 4th computation.
     ///   - f: Combination function.
     /// - Returns: Result of combining the provided computations, in the context implementing this instance.
-    static func map<A, B, C, D, Z>(_ a: Kind<F, Z>,
-                                   _ b: Kind<F, B>,
-                                   _ c: Kind<F, C>,
-                                   _ d: Kind<F, D>,
-                                   _ f: @escaping (Z, B, C, D) -> A) -> Kind<F, A> {
+    static func map<B, C, D, Z>(_ a: Kind<F, Z>,
+                                _ b: Kind<F, B>,
+                                _ c: Kind<F, C>,
+                                _ d: Kind<F, D>,
+                                _ f: @escaping (Z, B, C, D) -> A) -> Kind<F, A> {
         return F.map(a, b, c, d, f)
     }
 
@@ -795,12 +795,12 @@ public extension Kind where F: Applicative {
     ///   - e: 5th computation.
     ///   - f: Combination function.
     /// - Returns: Result of combining the provided computations, in the context implementing this instance.
-    static func map<A, B, C, D, E, Z>(_ a: Kind<F, Z>,
-                                      _ b: Kind<F, B>,
-                                      _ c: Kind<F, C>,
-                                      _ d: Kind<F, D>,
-                                      _ e: Kind<F, E>,
-                                      _ f: @escaping (Z, B, C, D, E) -> A) -> Kind<F, A> {
+    static func map<B, C, D, E, Z>(_ a: Kind<F, Z>,
+                                   _ b: Kind<F, B>,
+                                   _ c: Kind<F, C>,
+                                   _ d: Kind<F, D>,
+                                   _ e: Kind<F, E>,
+                                   _ f: @escaping (Z, B, C, D, E) -> A) -> Kind<F, A> {
         return F.map(a, b, c, d, e, f)
     }
 
@@ -817,13 +817,13 @@ public extension Kind where F: Applicative {
     ///   - g: 6th computation.
     ///   - f: Combination function.
     /// - Returns: Result of combining the provided computations, in the context implementing this instance.
-    static func map<A, B, C, D, E, G, Z>(_ a: Kind<F, Z>,
-                                         _ b: Kind<F, B>,
-                                         _ c: Kind<F, C>,
-                                         _ d: Kind<F, D>,
-                                         _ e: Kind<F, E>,
-                                         _ g: Kind<F, G>,
-                                         _ f: @escaping (Z, B, C, D, E, G) -> A) -> Kind<F, A> {
+    static func map<B, C, D, E, G, Z>(_ a: Kind<F, Z>,
+                                      _ b: Kind<F, B>,
+                                      _ c: Kind<F, C>,
+                                      _ d: Kind<F, D>,
+                                      _ e: Kind<F, E>,
+                                      _ g: Kind<F, G>,
+                                      _ f: @escaping (Z, B, C, D, E, G) -> A) -> Kind<F, A> {
         return F.map(a, b, c, d, e, g, f)
     }
 
@@ -841,14 +841,14 @@ public extension Kind where F: Applicative {
     ///   - h: 7th computation.
     ///   - f: Combination function.
     /// - Returns: Result of combining the provided computations, in the context implementing this instance.
-    static func map<A, B, C, D, E, G, H, Z>(_ a: Kind<F, Z>,
-                                            _ b: Kind<F, B>,
-                                            _ c: Kind<F, C>,
-                                            _ d: Kind<F, D>,
-                                            _ e: Kind<F, E>,
-                                            _ g: Kind<F, G>,
-                                            _ h: Kind<F, H>,
-                                            _ f: @escaping (Z, B, C, D, E, G, H) -> A) -> Kind<F, A> {
+    static func map<B, C, D, E, G, H, Z>(_ a: Kind<F, Z>,
+                                         _ b: Kind<F, B>,
+                                         _ c: Kind<F, C>,
+                                         _ d: Kind<F, D>,
+                                         _ e: Kind<F, E>,
+                                         _ g: Kind<F, G>,
+                                         _ h: Kind<F, H>,
+                                         _ f: @escaping (Z, B, C, D, E, G, H) -> A) -> Kind<F, A> {
         return F.map(a, b, c, d, e, g, h, f)
     }
 
@@ -867,15 +867,15 @@ public extension Kind where F: Applicative {
     ///   - i: 8th computation.
     ///   - f: Combination function.
     /// - Returns: Result of combining the provided computations, in the context implementing this instance.
-    static func map<A, B, C, D, E, G, H, I, Z>(_ a: Kind<F, Z>,
-                                               _ b: Kind<F, B>,
-                                               _ c: Kind<F, C>,
-                                               _ d: Kind<F, D>,
-                                               _ e: Kind<F, E>,
-                                               _ g: Kind<F, G>,
-                                               _ h: Kind<F, H>,
-                                               _ i: Kind<F, I>,
-                                               _ f: @escaping (Z, B, C, D, E, G, H, I) -> A) -> Kind<F, A> {
+    static func map<B, C, D, E, G, H, I, Z>(_ a: Kind<F, Z>,
+                                            _ b: Kind<F, B>,
+                                            _ c: Kind<F, C>,
+                                            _ d: Kind<F, D>,
+                                            _ e: Kind<F, E>,
+                                            _ g: Kind<F, G>,
+                                            _ h: Kind<F, H>,
+                                            _ i: Kind<F, I>,
+                                            _ f: @escaping (Z, B, C, D, E, G, H, I) -> A) -> Kind<F, A> {
         return F.map(a, b, c, d, e, g, h, i, f)
     }
 
@@ -895,16 +895,16 @@ public extension Kind where F: Applicative {
     ///   - j: 9th computation.
     ///   - f: Combination function.
     /// - Returns: Result of combining the provided computations, in the context implementing this instance.
-    static func map<A, B, C, D, E, G, H, I, J, Z>(_ a: Kind<F, Z>,
-                                                  _ b: Kind<F, B>,
-                                                  _ c: Kind<F, C>,
-                                                  _ d: Kind<F, D>,
-                                                  _ e: Kind<F, E>,
-                                                  _ g: Kind<F, G>,
-                                                  _ h: Kind<F, H>,
-                                                  _ i: Kind<F, I>,
-                                                  _ j: Kind<F, J>,
-                                                  _ f: @escaping (Z, B, C, D, E, G, H, I, J) -> A) -> Kind<F, A> {
+    static func map<B, C, D, E, G, H, I, J, Z>(_ a: Kind<F, Z>,
+                                               _ b: Kind<F, B>,
+                                               _ c: Kind<F, C>,
+                                               _ d: Kind<F, D>,
+                                               _ e: Kind<F, E>,
+                                               _ g: Kind<F, G>,
+                                               _ h: Kind<F, H>,
+                                               _ i: Kind<F, I>,
+                                               _ j: Kind<F, J>,
+                                               _ f: @escaping (Z, B, C, D, E, G, H, I, J) -> A) -> Kind<F, A> {
         return F.map(a, b, c, d, e, g, h, i, j, f)
     }
 }

--- a/Sources/Bow/Typeclasses/ComonadTrans.swift
+++ b/Sources/Bow/Typeclasses/ComonadTrans.swift
@@ -4,7 +4,7 @@ public protocol ComonadTrans {
     ///
     /// - Parameter twa: Value containing another comonadic value.
     /// - Returns: Contained comonadic value within the transformer.
-    static func lower<W: Comonad, A>(_ twa: Kind<Self, Kind<W, A>>) -> Kind<W, A>
+    static func lower<W: Comonad, A, B>(_ twa: Kind<Self, B>) -> Kind<W, A> where B: Kind<W, A>
 }
 
 // MARK: Syntax for ComonadTrans
@@ -13,7 +13,7 @@ public extension Kind where F: ComonadTrans {
     /// Obtains the comonadic value contained in the provided comonad transformer.
     ///
     /// - Returns: Contained comonadic value within the transformer.
-    func lower<W: Comonad, B>() -> Kind<W, B> where A == Kind<W, B> {
+    func lower<W: Comonad, B>() -> Kind<W, B> where A: Kind<W, B> {
         F.lower(self)
     }
 }

--- a/Sources/Bow/Typeclasses/Foldable.swift
+++ b/Sources/Bow/Typeclasses/Foldable.swift
@@ -118,7 +118,7 @@ public extension Foldable {
     ///
     /// - Parameter fga: Structure of effects.
     /// - Returns: Unit in the context of the effects contained in the structure.
-    static func sequence_<G: Applicative, A>(_ fga: Kind<Self, Kind<G, A>>) -> Kind<G, Unit> {
+    static func sequence_<G: Applicative, A, B>(_ fga: Kind<Self, B>) -> Kind<G, Unit> where B: Kind<G, A> {
         return traverse_(fga, id)
     }
 
@@ -222,7 +222,7 @@ public extension Foldable {
     /// 
     /// - Parameter fga: Structure to be reduced.
     /// - Returns: A value in the context providing the `MonoidK` instance.
-    static func foldK<A, G: MonoidK>(_ fga: Kind<Self, Kind<G, A>>) -> Kind<G, A> {
+    static func foldK<A, G: MonoidK, B>(_ fga: Kind<Self, B>) -> Kind<G, A> where B: Kind<G, A> {
         return reduceK(fga)
     }
     
@@ -230,7 +230,7 @@ public extension Foldable {
     ///
     /// - Parameter fga: Structure to be reduced.
     /// - Returns: A value in the context providing the `MonoidK` instance.
-    static func reduceK<A, G: MonoidK>(_ fga: Kind<Self, Kind<G, A>>) -> Kind<G, A> {
+    static func reduceK<A, G: MonoidK, B>(_ fga: Kind<Self, B>) -> Kind<G, A> where B: Kind<G, A> {
         return foldLeft(fga, Kind<G, A>.emptyK(), { b, a in b.combineK(a) })
     }
 }
@@ -318,7 +318,7 @@ public extension Kind where F: Foldable {
     /// Traverses this structure of effects, performing them and discarding their result.
     ///
     /// - Returns: Unit in the context of the effects contained in the structure.
-    func sequence_<G: Applicative, AA>() -> Kind<G, Unit> where A == Kind<G, AA> {
+    func sequence_<G: Applicative, AA>() -> Kind<G, Unit> where A: Kind<G, AA> {
         return F.sequence_(self)
     }
 
@@ -398,11 +398,11 @@ public extension Kind where F: Foldable {
         return F.count(self)
     }
     
-    func foldK<G: MonoidK, B>() -> Kind<G, B> where A == Kind<G, B> {
+    func foldK<G: MonoidK, B>() -> Kind<G, B> where A: Kind<G, B> {
         return F.foldK(self)
     }
     
-    func reduceK<G: MonoidK, B>() -> Kind<G, B> where A == Kind<G, B> {
+    func reduceK<G: MonoidK, B>() -> Kind<G, B> where A: Kind<G, B> {
         return F.reduceK(self)
     }
 }

--- a/Sources/Bow/Typeclasses/Traverse.swift
+++ b/Sources/Bow/Typeclasses/Traverse.swift
@@ -16,7 +16,7 @@ public extension Traverse {
     ///
     /// - Parameter fga: A structure of values.
     /// - Returns: Results collected under the context of the effects.
-    static func sequence<G: Applicative, A>(_ fga: Kind<Self, Kind<G, A>>) -> Kind<G, Kind<Self, A>> {
+    static func sequence<G: Applicative, A, B>(_ fga: Kind<Self, B>) -> Kind<G, Kind<Self, A>> where B: Kind<G, A> {
         return traverse(fga, id)
     }
 }
@@ -48,7 +48,7 @@ public extension Kind where F: Traverse {
     /// Evaluate each effect in this structure of values and collects the results.
     ///
     /// - Returns: Results collected under the context of the effects.
-    func sequence<G: Applicative, AA>() -> Kind<G, Kind<F, AA>> where A == Kind<G, AA>{
+    func sequence<G: Applicative, AA>() -> Kind<G, Kind<F, AA>> where A: Kind<G, AA>{
         return F.sequence(self)
     }
 }

--- a/Tests/BowTests/Data/ArrayTest.swift
+++ b/Tests/BowTests/Data/ArrayTest.swift
@@ -10,4 +10,12 @@ class ArrayTest: XCTestCase {
     func testMonoidLaws() {
         MonoidLaws<[Int]>.check()
     }
+    
+    func testSequence() {
+        let x: Array<Option<Int>> = [.some(1), .none(), .some(2)]
+        XCTAssertEqual(x.sequence()^, .none())
+        
+        let y: Array<Option<Int>> = [.some(1), .some(2)]
+        XCTAssertEqual(y.sequence()^, .some([1, 2]))
+    }
 }


### PR DESCRIPTION
## Goal

Some type classes, especially the ones dealing with multiple effects, were having inference problems as the nested effects are fixed to `Kind` and therefore we cannot pass subclasses of them (their fixed form). This PR relaxes those constraints to ease type inference and have a more flexible API that is more ergonomic.