### PR TITLE
Bring consistency across HKT with partial application

### DIFF
--- a/Documentation.app/Contents/MacOS/Composition.playground/Pages/Composing functions.xcplaygroundpage/Contents.swift
+++ b/Documentation.app/Contents/MacOS/Composition.playground/Pages/Composing functions.xcplaygroundpage/Contents.swift
@@ -95,9 +95,9 @@ func nextTalk(at conference: Conference) -> Option<Talk>
 /*:
  Both functions are Kleisli functions, as their result are effectful, with Option being the effect. We can compose them into a function that provides the next Talk after a certain date, if it exists:
  */
-// Kleisli<ForOption, Date, Talk> is equivalent to a function:
+// Kleisli<OptionPartial, Date, Talk> is equivalent to a function:
 // (Date) -> Option<Talk>
-let nextTalkAfterDate: Kleisli<ForOption, Date, Talk> = Kleisli(nextConference(after:))
+let nextTalkAfterDate: Kleisli<OptionPartial, Date, Talk> = Kleisli(nextConference(after:))
     .andThen(Kleisli(nextTalk(at:)))
 /*:
  And we can invoke this function as:

--- a/Documentation.app/Contents/MacOS/FP concepts.playground/Pages/Higher Kinded Types.xcplaygroundpage/Contents.swift
+++ b/Documentation.app/Contents/MacOS/FP concepts.playground/Pages/Higher Kinded Types.xcplaygroundpage/Contents.swift
@@ -121,17 +121,17 @@ class Xor<Left, Right>: XorOf<Left, Right> {}
 
  | Data type        | Witness          | Partial application | Type alias         |
  | ---------------- | ---------------- | ------------------- | ------------------ |
- | Function0&lt;A&gt;     | ForFunction0     |                     | Function0Of&lt;A&gt;     |
- | Function1<I, O>  | ForFunction1     | Function1Partial<I> | Function1Of<I, O>  |
- | ArrayK&lt;A&gt;        | ForArrayK        |                     | ArrayKOf&lt;A&gt;        |
- | Const<A, T>      | ForConst         | ConstPartial&lt;A&gt;     | ConstOf<A, T>      |
- | Either<L, R>     | ForEither        | EitherPartial<L>    | EitherOf<L, R>     |
- | Id&lt;A&gt;            | ForId            |                     | IdOf&lt;A&gt;            |
- | Ior<L, R>        | ForIor           | IorPartial<L>       | IorOf<L, R>        |
- | NonEmptyArray&lt;A&gt; | ForNonEmptyArray |                     | NonEmptyArrayOf&lt;A&gt; |
- | Option&lt;A&gt;        | ForOption        |                     | OptionOf&lt;A&gt;        |
- | Try&lt;A&gt;           | ForTry           |                     | TryOf&lt;A&gt;           |
- | Validated<E, A>  | ForValidated     | ValidatedPartial<E> | ValidatedOf<E, A>  |
+ | Function0&lt;A&gt; | ForFunction0 | Function0Partial | Function0Of&lt;A&gt; |
+ | Function1<I, O>  | ForFunction1 | Function1Partial<I> | Function1Of<I, O> |
+ | ArrayK&lt;A&gt; | ForArrayK | ArrayKPartial | ArrayKOf&lt;A&gt; |
+ | Const<A, T> | ForConst | ConstPartial&lt;A&gt; | ConstOf<A, T> |
+ | Either<L, R> | ForEither | EitherPartial<L> | EitherOf<L, R> |
+ | Id&lt;A&gt; | ForId | IdPartial | IdOf&lt;A&gt; |
+ | Ior<L, R> | ForIor | IorPartial<L> | IorOf<L, R> |
+ | NonEmptyArray&lt;A&gt; | ForNonEmptyArray | NonEmptyArrayPartial | NonEmptyArrayOf&lt;A&gt; |
+ | Option&lt;A&gt; | ForOption | OptionPartial | OptionOf&lt;A&gt; |
+ | Try&lt;A&gt; | ForTry | TryPartial | TryOf&lt;A&gt; |
+ | Validated<E, A> | ForValidated | ValidatedPartial<E> | ValidatedOf<E, A> |
 
  ### Casting and the ^ operator
 
@@ -141,14 +141,14 @@ class Xor<Left, Right>: XorOf<Left, Right> {}
  */
 extension Xor {
     static func fix(_ value: XorOf<Left, Right>) -> Xor<Left, Right> {
-        return value as! Xor<Left, Right>
+        value as! Xor<Left, Right>
     }
 }
 /*:
  To simplify things even further, Bow has introduced the `^` postfix operator, that calls `fix` to avoid boilerplate. In our example:
  */
 postfix func ^<A, B>(_ value: XorOf<A, B>) -> Xor<A, B> {
-    return Xor.fix(value)
+    Xor.fix(value)
 }
 /*:
  This operator can be used with any of the existing types in Bow and lets us chain method calls in a similar manner as we do with the `?.` operator. For instance, consider the `Either` type and its `map` combinator. `map` is defined to operate at the kind level, so an invocation to this combinator returns something of type `Kind`, instead of `Either`.

--- a/Documentation.app/Contents/MacOS/FP concepts.playground/Pages/Type classes.xcplaygroundpage/Contents.swift
+++ b/Documentation.app/Contents/MacOS/FP concepts.playground/Pages/Type classes.xcplaygroundpage/Contents.swift
@@ -30,7 +30,7 @@ func allEqual<A: Equatable>(_ array: [A]) -> Bool {
     return array.reduce(true) { partial, next in partial && next == first }
 }
 /*:
- The function above is parametrically polymorphic; it operates of values of type `A`. Valid types to fill this type parameter need to conform to `Equatable` and enable the possibility to use the `==` operator.
+ The function above is parametrically polymorphic; it operates on values of type `A`. Valid types to fill this type parameter need to conform to `Equatable` and enable the possibility to use the `==` operator.
 
  ## Type classes of higher kind
 
@@ -45,12 +45,14 @@ func allEqual<A: Equatable>(_ array: [A]) -> Bool {
  Therefore, the definition of the type class may be:
  */
 protocol Transformer {
-    static func transform<A, B>(_ fa: Kind<Self, A>, _ f: (A) -> B) -> Kind<Self, B>
+    static func transform<A, B>(
+        _ fa: Kind<Self, A>,
+        _ f: (A) -> B) -> Kind<Self, B>
 }
 /*:
  ## Type class laws
 
- As we mentioned above, type classes are governed by **algebraic laws**. This means that all implementations of the type class must behave on a certain and satisfy some properties. Each type class has its own laws, as the ones we presented for `Equatable` above.
+ As we mentioned above, type classes are governed by **algebraic laws**. This means that all implementations of the type class must behave on a certain manner and satisfy some properties. Each type class has its own laws, as the ones we presented for `Equatable` above.
 
  For the `Transformer` type class that we are defining, we can consider some laws as well:
 
@@ -65,27 +67,27 @@ protocol Transformer {
 
  A **type class instance** is a concrete implementation of a type class for a given type. Instances are usually created through the extension mechanisms that Swift provides. For instance, let us provide an instance of `Transformer` for the `Option` data type in Bow:
  */
-extension ForOption: Transformer {
-    static func transform<A, B>(_ fa: Kind<ForOption, A>, _ f: (A) -> B) -> Kind<ForOption, B> {
-        return fa^.fold(Option<B>.none,                // It is empty, no transformation
-                        { a in Option<B>.some(f(a)) }) // Transformed with f and wrapped in an Option<B>
+extension OptionPartial: Transformer {
+    static func transform<A, B>(_ fa: OptionOf<A>, _ f: (A) -> B) -> OptionOf<B> {
+        fa^.fold(Option<B>.none,                // It is empty, no transformation
+                 { a in Option<B>.some(f(a)) }) // Transformed with f and wrapped in an Option<B>
     }
 }
 /*:
- Notice that, since the type class works at the kind level, it is not an extension of `Option`, but an extension of `ForOption`. Revisiting the definition of `Transformer`, the `Self` requirement is used in `Kind<Self, A>`. If we dissect the definition of `Option<A>`, it extends `Kind<ForOption, A>`. By doing some sort of pattern matching between `Kind<Self, A>` and `Kind<ForOption, A>`, we can see that it must be `ForOption` the candidate to do the extension.
+ Notice that, since the type class works at the kind level, it is not an extension of `Option`, but an extension of `OptionPartial`. Revisiting the definition of `Transformer`, the `Self` requirement is used in `Kind<Self, A>`. Therefore, it must be implemented by the `Partial` version of the type, omitting the last parameter. In the case of Option, as it only has one type argument, it should be `OptionPartial`, with no type arguments.
 
  In the case of types with a higher kind, like `Either`, we can resort to the same strategy: `Either<L, R>` is equivalent to Kind<EitherPartial<L>, R>`, so the extension should be made on `EitherPartial<L>`. Take a look at the following table for examples on some of the types in the core module for Bow.
 
  | Type          | What to extend for a type class like Transformer? |
  | ------------- | ------------------------------------------------- |
- | ArrayK        | extension ForArrayK: Transformer { ... }          |
+ | ArrayK        | extension ArrayKPartial: Transformer { ... }          |
  | Const         | extension ConstPartial: Transformer { ... }       |
  | Either        | extension EitherPartial: Transformer { ... }      |
- | Id            | extension ForId: Transformer { ... }              |
+ | Id            | extension IdPartial: Transformer { ... }              |
  | Ior           | extension IorPartial: Transformer { ... }         |
- | NonEmptyArray | extension ForNonEmptyArray : Transformer { ... }  |
- | Option        | extension ForOption: Transformer { ... }          |
- | Try           | extension ForTry: Transformer { ... }             |
+ | NonEmptyArray | extension NonEmptyArrayPartial : Transformer { ... }  |
+ | Option        | extension OptionPartial: Transformer { ... }          |
+ | Try           | extension TryPartial: Transformer { ... }             |
  | Validated     | extension ValidatedPartial: Transformer { ... }   |
 
  ## Projecting syntax on `Kind`
@@ -94,28 +96,28 @@ extension ForOption: Transformer {
  */
 extension Kind where F: Transformer {
     func transform<B>(_ f: (A) -> B) -> Kind<F, B> {
-        return F.transform(self, f)
+        F.transform(self, f)
     }
 }
 /*:
  This way, every type that its witness has an instance of `Transformer`, will be able to use `transform` as an instance method. We have two ways of using this type class; consider a function to multiply by two the values contained in some structure:
  */
-func multiplyByTwo_firstVersion<F: Transformer>(_ value: Kind<F, Int>) -> Kind<F, Int> {
-    return F.transform(value, { x in 2 * x })
+func multiplyByTwo_v1<F: Transformer>(_ value: Kind<F, Int>) -> Kind<F, Int> {
+    F.transform(value, { x in 2 * x })
 }
 
-func multiplyByTwo_secondVersion<F: Transformer>(_ value: Kind<F, Int>) -> Kind<F, Int> {
-    return value.transform { x in 2 * x }
+func multiplyByTwo_v2<F: Transformer>(_ value: Kind<F, Int>) -> Kind<F, Int> {
+    value.transform { x in 2 * x }
 }
 /*:
  Both versions are equivalent. Type classes defined in Bow project their methods as instance or static methods in Kind to make them easier to find and use. Notice that the compiler is able to resolve which instance it needs to provide based on the type that we use to call the function:
  */
-let some = multiplyByTwo_firstVersion(Option.some(1))
-let none = multiplyByTwo_secondVersion(Option.none())
+let some = multiplyByTwo_v1(Option.some(1))
+let none = multiplyByTwo_v2(Option.none())
 /*:
  ## Existing type classes in Bow
 
- The reader may have guessed that the `Transformer` type class that we have created above is, in fact, the `Functor` type class, and `transform` corresponds to `map`. Bow modules include multiple type classes, like `Functor`, with their corresponding instances. The following tables summarize some of them; for further information, refer to the API reference for each one of them.
+ The reader may have guessed that the `Transformer` type class that we have created above is, in fact, the `Functor` type class, and `transform` corresponds to `map`. Bow modules include multiple type classes, like `Functor`, with their corresponding instances. The following table summarizes some of them; for further information, refer to the API reference for each one of them.
 
  | Type class | Purpose |
  | ---------- | ------- |

--- a/Sources/Bow/Arrow/Function0.swift
+++ b/Sources/Bow/Arrow/Function0.swift
@@ -3,6 +3,9 @@ import Foundation
 /// Witness for the `Function0<A>` data type. To be used in simulated Higher Kinded Types.
 public final class ForFunction0 {}
 
+/// Partial application of the Function0 type constructor, omitting the last type parameter.
+public typealias Function0Partial = ForFunction0
+
 /// Higher Kinded Type alias to improve readability of `Kind<ForFunction0, A>`.
 public typealias Function0Of<A> = Kind<ForFunction0, A>
 
@@ -15,7 +18,7 @@ public final class Function0<A>: Function0Of<A> {
     /// - Parameter fa: Value in the higher-kind form.
     /// - Returns: Value cast to `Function0`.
     public static func fix(_ fa: Function0Of<A>) -> Function0<A> {
-        return fa as! Function0
+        fa as! Function0
     }
     
     /// Constructs a value of `Function0`.
@@ -29,7 +32,7 @@ public final class Function0<A>: Function0Of<A> {
     ///
     /// - Returns: Value produced by this function.
     public func invoke() -> A {
-        return f()
+        f()
     }
 }
 
@@ -38,39 +41,39 @@ public final class Function0<A>: Function0Of<A> {
 /// - Parameter fa: Value in the higher-kind form.
 /// - Returns: Value cast to `Function0`.
 public postfix func ^<A>(_ fa: Function0Of<A>) -> Function0<A> {
-    return Function0.fix(fa)
+    Function0.fix(fa)
 }
 
 // MARK: Protocol conformances
 
 // MARK: Instance of `EquatableK` for `Function0`
-extension ForFunction0: EquatableK {
-    public static func eq<A>(_ lhs: Kind<ForFunction0, A>, _ rhs: Kind<ForFunction0, A>) -> Bool where A : Equatable {
-        return Function0.fix(lhs).extract() == Function0.fix(rhs).extract()
+extension Function0Partial: EquatableK {
+    public static func eq<A: Equatable>(_ lhs: Function0Of<A>, _ rhs: Function0Of<A>) -> Bool {
+        Function0.fix(lhs).extract() == Function0.fix(rhs).extract()
     }
 }
 
 // MARK: Instance of `Functor` for `Function0`
-extension ForFunction0: Functor {
-    public static func map<A, B>(_ fa: Kind<ForFunction0, A>, _ f: @escaping (A) -> B) -> Kind<ForFunction0, B> {
-        return Function0(Function0.fix(fa).f >>> f)
+extension Function0Partial: Functor {
+    public static func map<A, B>(_ fa: Function0Of<A>, _ f: @escaping (A) -> B) -> Function0Of<B> {
+        Function0(Function0.fix(fa).f >>> f)
     }
 }
 
 // MARK: Instance of `Applicative` for `Function0`
-extension ForFunction0: Applicative {
-    public static func pure<A>(_ a: A) -> Kind<ForFunction0, A> {
-        return Function0(constant(a))
+extension Function0Partial: Applicative {
+    public static func pure<A>(_ a: A) -> Function0Of<A> {
+        Function0(constant(a))
     }
 }
 
 // MARK: Instance of `Selective` for `Function0`
-extension ForFunction0: Selective {}
+extension Function0Partial: Selective {}
 
 // MARK: Instance of `Monad` for `Function0`
-extension ForFunction0: Monad {
-    public static func flatMap<A, B>(_ fa: Kind<ForFunction0, A>, _ f: @escaping (A) -> Kind<ForFunction0, B>) -> Kind<ForFunction0, B> {
-        return f(Function0.fix(fa).f())
+extension Function0Partial: Monad {
+    public static func flatMap<A, B>(_ fa: Function0Of<A>, _ f: @escaping (A) -> Function0Of<B>) -> Function0Of<B> {
+        f(fa^.f())
     }
 
     private static func loop<A, B>(_ a: A, _ f: @escaping (A) -> Function0Of<Either<A, B>>) -> Trampoline<B> {
@@ -80,35 +83,35 @@ extension ForFunction0: Monad {
         }
     }
 
-    public static func tailRecM<A, B>(_ a: A, _ f: @escaping (A) -> Kind<ForFunction0, Either<A, B>>) -> Kind<ForFunction0, B> {
-        return Function0<B>({ loop(a, f).run() })
+    public static func tailRecM<A, B>(_ a: A, _ f: @escaping (A) -> Function0Of<Either<A, B>>) -> Function0Of<B> {
+        Function0<B>({ loop(a, f).run() })
     }
 }
 
 // MARK: Instance of `Comonad` for `Function0`
-extension ForFunction0: Comonad {
-    public static func coflatMap<A, B>(_ fa: Kind<ForFunction0, A>, _ f: @escaping (Kind<ForFunction0, A>) -> B) -> Kind<ForFunction0, B> {
-        return Function0<B>({ f(Function0.fix(fa)) })
+extension Function0Partial: Comonad {
+    public static func coflatMap<A, B>(_ fa: Function0Of<A>, _ f: @escaping (Function0Of<A>) -> B) -> Function0Of<B> {
+        Function0<B> { f(fa^) }
     }
 
-    public static func extract<A>(_ fa: Kind<ForFunction0, A>) -> A {
-        return Function0.fix(fa).f()
+    public static func extract<A>(_ fa: Function0Of<A>) -> A {
+        fa^.f()
     }
 }
 
 // MARK: Instance of `Bimonad` for `Function0`
-extension ForFunction0: Bimonad {}
+extension Function0Partial: Bimonad {}
 
 // MARK: Instance of `Semigroup` for `Function0`
 extension Function0: Semigroup where A: Semigroup {
     public func combine(_ other: Function0<A>) -> Function0<A> {
-        return Function0 { self.invoke().combine(other.invoke()) }
+        Function0 { self.invoke().combine(other.invoke()) }
     }
 }
 
 // MARK: Instance of `Monoid` for `Function0`
 extension Function0: Monoid where A: Monoid {
     public static func empty() -> Function0<A> {
-        return Function0(constant(A.empty()))
+        Function0(constant(A.empty()))
     }
 }

--- a/Sources/Bow/Data/Endo.swift
+++ b/Sources/Bow/Data/Endo.swift
@@ -1,6 +1,9 @@
 /// Witness for the `Endo<A>` data type. To be used in simulated Higher Kinded Types.
 public final class ForEndo {}
 
+/// Partial application of the Endo type constructor, omitting the last type parameter.
+public typealias EndoPartial = ForEndo
+
 /// Higher Kinded Type alias to improve readability over `Kind<ForEndo, A>`.
 public typealias EndoOf<A> = Kind<ForEndo, A>
 

--- a/Sources/Bow/Data/Eval.swift
+++ b/Sources/Bow/Data/Eval.swift
@@ -3,6 +3,9 @@ import Foundation
 /// Witness for the `Eval<A>` data type. To be used in simulated Higher Kinded Types.
 public final class ForEval {}
 
+/// Partial application of the Eval type constructor, omitting the last type parameter.
+public typealias EvalPartial = ForEval
+
 /// Higher-Kinded Type alias to improve readability over `Kind<ForEval, A>`.
 public typealias EvalOf<A> = Kind<ForEval, A>
 
@@ -20,7 +23,7 @@ public class Eval<A>: EvalOf<A> {
     /// - Parameter a: Value to be wrapped in the Eval.
     /// - Returns: An Eval value.
     public static func now(_ a: A) -> Eval<A> {
-        return Now<A>(a)
+        Now<A>(a)
     }
 
     /// Creates an Eval value that will be evaluated using the Later evaluation strategy.
@@ -28,7 +31,7 @@ public class Eval<A>: EvalOf<A> {
     /// - Parameter f: Function producing the value to be wrapped in an Eval.
     /// - Returns: An Eval value.
     public static func later(_ f: @escaping () -> A) -> Eval<A> {
-        return Later<A>(f)
+        Later<A>(f)
     }
 
     /// Creates an Eval value that will be evaluated using the Always evaluation strategy.
@@ -36,7 +39,7 @@ public class Eval<A>: EvalOf<A> {
     /// - Parameter f: Function producing the value to be wrapped in an Eval.
     /// - Returns: An Eval value.
     public static func always(_ f: @escaping () -> A) -> Eval<A> {
-        return Always<A>(f)
+        Always<A>(f)
     }
 
     /// Creates an Eval value that defers a computation that produces another Eval.
@@ -44,7 +47,7 @@ public class Eval<A>: EvalOf<A> {
     /// - Parameter f: Function producing an Eval.
     /// - Returns: An Eval value.
     public static func `defer`(_ f: @escaping () -> Eval<A>) -> Eval<A> {
-        return Defer<A>(f)
+        Defer<A>(f)
     }
 
     /// Safe downcast.
@@ -52,7 +55,7 @@ public class Eval<A>: EvalOf<A> {
     /// - Parameter fa: Value in the higher-kind form.
     /// - Returns: Value cast to `Eval`.
     public static func fix(_ fa: EvalOf<A>) -> Eval<A> {
-        return fa as! Eval<A>
+        fa as! Eval<A>
     }
 
     /// Computes the value wrapped in this Eval.
@@ -77,31 +80,31 @@ public class Eval<A>: EvalOf<A> {
 public extension Eval where A == () {
     /// Provides a unit in an Eval.
     static var unit: Eval<()> {
-        return Now<()>(())
+        Now<()>(())
     }
 }
 
 public extension Eval where A == Bool {
     /// Provides a true value in an Eval.
     static var `true`: Eval<Bool> {
-        return Now<Bool>(true)
+        Now<Bool>(true)
     }
     
     /// Provides a false value in an Eval.
     static var `false`: Eval<Bool> {
-        return Now<Bool>(false)
+        Now<Bool>(false)
     }
 }
 
 public extension Eval where A == Int {
     /// Provides a zero value in an Eval.
     static var zero: Eval<Int> {
-        return Now<Int>(0)
+        Now<Int>(0)
     }
     
     /// Provides a one value in an Eval.
     static var one: Eval<Int> {
-        return Now<Int>(1)
+        Now<Int>(1)
     }
 }
 
@@ -110,7 +113,7 @@ public extension Eval where A == Int {
 /// - Parameter fa: Value in higher-kind form.
 /// - Returns: Value cast to Eval.
 public postfix func ^<A>(_ fa: EvalOf<A>) -> Eval<A> {
-    return Eval.fix(fa)
+    Eval.fix(fa)
 }
 
 private class Now<A>: Eval<A> {
@@ -121,11 +124,11 @@ private class Now<A>: Eval<A> {
     }
 
     override func _value() -> Trampoline<A> {
-        return .done(a)
+        .done(a)
     }
 
     override func memoize() -> Eval<A> {
-        return self
+        self
     }
 }
 
@@ -138,27 +141,27 @@ private class Later<A>: Eval<A> {
     }
 
     override func _value() -> Trampoline<A> {
-        return .done(a)
+        .done(a)
     }
 
     override func memoize() -> Eval<A> {
-        return self
+        self
     }
 }
 
 private class Always<A>: Eval<A> {
-    private  let f: () -> A
+    private let f: () -> A
 
     init(_ f: @escaping () -> A) {
         self.f = f
     }
 
     override func _value() -> Trampoline<A> {
-        return .later(f)
+        .later(f)
     }
 
     override func memoize() -> Eval<A> {
-        return Eval<A>.later(f)
+        Eval<A>.later(f)
     }
 }
 
@@ -170,11 +173,11 @@ private class Defer<A>: Eval<A> {
     }
 
     override func memoize() -> Eval<A> {
-        return Eval<A>.later(value)
+        Eval<A>.later(value)
     }
 
     override func _value() -> Trampoline<A> {
-        return .defer { self.thunk()._value() }
+        .defer { self.thunk()._value() }
     }
 }
 
@@ -188,11 +191,11 @@ private class FMap<A, B>: Eval<B> {
     }
     
     override func memoize() -> Eval<B> {
-        return Eval<B>.later { self.value() }
+        Eval<B>.later { self.value() }
     }
     
     override func _value() -> Trampoline<B> {
-        return .later { self.f(self.eval.value()) }
+        .later { self.f(self.eval.value()) }
     }
 }
 
@@ -206,38 +209,38 @@ private class Bind<A, B>: Eval<B> {
     }
     
     override func memoize() -> Eval<B> {
-        return Eval.later { self.value() }
+        Eval.later { self.value() }
     }
     
     override func _value() -> Trampoline<B> {
-        return .later { self.f(self.eval.value())^.value() }
+        .later { self.f(self.eval.value())^.value() }
     }
 }
 
 // MARK: Instance of `Functor` for `Eval`
-extension ForEval: Functor {
-    public static func map<A, B>(_ fa: Kind<ForEval, A>, _ f: @escaping (A) -> B) -> Kind<ForEval, B> {
-        return FMap(fa^, f)
+extension EvalPartial: Functor {
+    public static func map<A, B>(_ fa: EvalOf<A>, _ f: @escaping (A) -> B) -> EvalOf<B> {
+        FMap(fa^, f)
     }
 }
 
 // MARK: Instance of `Applicative` for `Eval`
-extension ForEval: Applicative {
-    public static func pure<A>(_ a: A) -> Kind<ForEval, A> {
-        return Eval.now(a)
+extension EvalPartial: Applicative {
+    public static func pure<A>(_ a: A) -> EvalOf<A> {
+        Eval.now(a)
     }
 }
 
 // MARK: Instance of `Selective` for `Eval`
-extension ForEval: Selective {}
+extension EvalPartial: Selective {}
 
 // MARK: Instance of `Monad` for `Eval`
-extension ForEval: Monad {
-    public static func flatMap<A, B>(_ fa: Kind<ForEval, A>, _ f: @escaping (A) -> Kind<ForEval, B>) -> Kind<ForEval, B> {
-        return Bind(fa^, f)
+extension EvalPartial: Monad {
+    public static func flatMap<A, B>(_ fa: EvalOf<A>, _ f: @escaping (A) -> EvalOf<B>) -> EvalOf<B> {
+        Bind(fa^, f)
     }
 
-    public static func tailRecM<A, B>(_ a: A, _ f: @escaping (A) -> Kind<ForEval, Either<A, B>>) -> Kind<ForEval, B> {
+    public static func tailRecM<A, B>(_ a: A, _ f: @escaping (A) -> EvalOf<Either<A, B>>) -> EvalOf<B> {
         _tailRecM(a, f).run()
     }
     
@@ -250,22 +253,22 @@ extension ForEval: Monad {
 }
 
 // MARK: Instance of `Comonad` for `Eval`
-extension ForEval: Comonad {
-    public static func coflatMap<A, B>(_ fa: Kind<ForEval, A>, _ f: @escaping (Kind<ForEval, A>) -> B) -> Kind<ForEval, B> {
-        return Eval.later { f(fa) }
+extension EvalPartial: Comonad {
+    public static func coflatMap<A, B>(_ fa: EvalOf<A>, _ f: @escaping (EvalOf<A>) -> B) -> EvalOf<B> {
+        Eval.later { f(fa) }
     }
     
-    public static func extract<A>(_ fa: Kind<ForEval, A>) -> A {
-        return fa^.value()
+    public static func extract<A>(_ fa: EvalOf<A>) -> A {
+        fa^.value()
     }
 }
 
 // MARK: Instance of `Bimonad` for `Eval`
-extension ForEval: Bimonad {}
+extension EvalPartial: Bimonad {}
 
 // MARK: Instance of `EquatableK` for `Eval`
-extension ForEval: EquatableK {
-    public static func eq<A: Equatable>(_ lhs: Kind<ForEval, A>, _ rhs: Kind<ForEval, A>) -> Bool {
-        return Eval.fix(lhs).value() == Eval.fix(rhs).value()
+extension EvalPartial: EquatableK {
+    public static func eq<A: Equatable>(_ lhs: EvalOf<A>, _ rhs: EvalOf<A>) -> Bool {
+        lhs^.value() == rhs^.value()
     }
 }

--- a/Sources/Bow/Data/Id.swift
+++ b/Sources/Bow/Data/Id.swift
@@ -111,7 +111,7 @@ extension IdPartial: Bimonad {}
 
 // MARK: Instance of `Foldable` for `Id`
 extension IdPartial: Foldable {
-    public static func foldLeft<A, B>(_ fa: Kind<ForId, A>, _ b: B, _ f: @escaping (B, A) -> B) -> B {
+    public static func foldLeft<A, B>(_ fa: IdOf<A>, _ b: B, _ f: @escaping (B, A) -> B) -> B {
         f(b, fa^.value)
     }
 

--- a/Sources/Bow/Data/Id.swift
+++ b/Sources/Bow/Data/Id.swift
@@ -3,6 +3,9 @@ import Foundation
 /// Witness for the `Id<A>` data type. To be used in simulated Higher Kinded Types.
 public final class ForId {}
 
+/// Partial application of the Id type constructor, omitting the last type parameter.
+public typealias IdPartial = ForId
+
 /// Higher Kinded Type alias to improve readability of `Kind<ForId, A>`.
 public typealias IdOf<A> = Kind<ForId, A>
 
@@ -16,7 +19,7 @@ public final class Id<A>: IdOf<A> {
     /// - Parameter fa: Value in the higher-kind form.
     /// - Returns: Value cast to `Id`.
     public static func fix(_ fa: IdOf<A>) -> Id<A> {
-        return fa as! Id<A>
+        fa as! Id<A>
     }
     
     /// Constructs a value of `Id`.
@@ -32,55 +35,54 @@ public final class Id<A>: IdOf<A> {
 /// - Parameter fa: Value in the higher-kind form.
 /// - Returns: Value cast to `Id`.
 public postfix func ^<A>(_ fa: IdOf<A>) -> Id<A> {
-    return Id.fix(fa)
+    Id.fix(fa)
 }
 
 // MARK: Conformance of `Id` to `CustomStringConvertible`.
 extension Id: CustomStringConvertible {
     public var description: String {
-        return "Id(\(value))"
+        "Id(\(value))"
     }
 }
 
 // MARK: Conformance of `Id` to `CustomDebugStringConvertible`, given that type parameter also conforms to `CustomDebugStringConvertible`.
 extension Id: CustomDebugStringConvertible where A : CustomDebugStringConvertible {
     public var debugDescription: String {
-        return "Id(\(value.debugDescription))"
+        "Id(\(value.debugDescription))"
     }
 }
 
 // MARK: Instance of `EquatableK` for `Id`
-extension ForId: EquatableK {
-    public static func eq<A>(_ lhs: Kind<ForId, A>, _ rhs: Kind<ForId, A>) -> Bool where A : Equatable {
-        return Id.fix(lhs).value == Id.fix(rhs).value
+extension IdPartial: EquatableK {
+    public static func eq<A: Equatable>(_ lhs: IdOf<A>, _ rhs: IdOf<A>) -> Bool {
+        lhs^.value == rhs^.value
     }
 }
 
 // MARK: Instance of `Functor` for `Id`
-extension ForId: Functor {
-    public static func map<A, B>(_ fa: Kind<ForId, A>, _ f: @escaping (A) -> B) -> Kind<ForId, B> {
-        return Id(f(Id.fix(fa).value))
+extension IdPartial: Functor {
+    public static func map<A, B>(_ fa: IdOf<A>, _ f: @escaping (A) -> B) -> IdOf<B> {
+        Id(f(fa^.value))
     }
 }
 
 // MARK: Instance of `Applicative` for `Id`
-extension ForId: Applicative {
-    public static func pure<A>(_ a: A) -> Kind<ForId, A> {
-        return Id(a)
+extension IdPartial: Applicative {
+    public static func pure<A>(_ a: A) -> IdOf<A> {
+        Id(a)
     }
 }
 
 // MARK: Instance of `Selective` for `Id`
-extension ForId: Selective {}
+extension IdPartial: Selective {}
 
 // MARK: Instance of `Monad` for `Id`
-extension ForId: Monad {
-    public static func flatMap<A, B>(_ fa: Kind<ForId, A>, _ f: @escaping (A) -> Kind<ForId, B>) -> Kind<ForId, B> {
-        let id = Id<A>.fix(fa)
-        return f(id.value)
+extension IdPartial: Monad {
+    public static func flatMap<A, B>(_ fa: IdOf<A>, _ f: @escaping (A) -> IdOf<B>) -> IdOf<B> {
+        f(fa^.value)
     }
 
-    public static func tailRecM<A, B>(_ a: A, _ f: @escaping (A) -> Kind<ForId, Either<A, B>>) -> Kind<ForId, B> {
+    public static func tailRecM<A, B>(_ a: A, _ f: @escaping (A) -> IdOf<Either<A, B>>) -> IdOf<B> {
         _tailRecM(a, f).run()
     }
     
@@ -94,50 +96,47 @@ extension ForId: Monad {
 }
 
 // MARK: Instance of `Comonad` for `Id`
-extension ForId: Comonad {
-    public static func coflatMap<A, B>(_ fa: Kind<ForId, A>, _ f: @escaping (Kind<ForId, A>) -> B) -> Kind<ForId, B> {
-        return fa.map{ _ in f(fa) }
+extension IdPartial: Comonad {
+    public static func coflatMap<A, B>(_ fa: IdOf<A>, _ f: @escaping (IdOf<A>) -> B) -> IdOf<B> {
+        fa.map { a in f(Id(a)) }
     }
 
-    public static func extract<A>(_ fa: Kind<ForId, A>) -> A {
-        return Id.fix(fa).value
+    public static func extract<A>(_ fa: IdOf<A>) -> A {
+        fa^.value
     }
 }
 
 // MARK: Instance of `Bimonad` for `Id`
-extension ForId: Bimonad {}
+extension IdPartial: Bimonad {}
 
 // MARK: Instance of `Foldable` for `Id`
-extension ForId: Foldable {
+extension IdPartial: Foldable {
     public static func foldLeft<A, B>(_ fa: Kind<ForId, A>, _ b: B, _ f: @escaping (B, A) -> B) -> B {
-        let id = Id<A>.fix(fa)
-        return f(b, id.value)
+        f(b, fa^.value)
     }
 
-    public static func foldRight<A, B>(_ fa: Kind<ForId, A>, _ b: Eval<B>, _ f: @escaping (A, Eval<B>) -> Eval<B>) -> Eval<B> {
-        let id = Id<A>.fix(fa)
-        return f(id.value, b)
+    public static func foldRight<A, B>(_ fa: IdOf<A>, _ b: Eval<B>, _ f: @escaping (A, Eval<B>) -> Eval<B>) -> Eval<B> {
+        f(fa^.value, b)
     }
 }
 
 // MARK: Instance of `Traverse` for `Id`
-extension ForId: Traverse {
-    public static func traverse<G: Applicative, A, B>(_ fa: Kind<ForId, A>, _ f: @escaping (A) -> Kind<G, B>) -> Kind<G, Kind<ForId, B>> {
-        let id = Id<A>.fix(fa)
-        return G.map(f(id.value), Id<B>.init)
+extension IdPartial: Traverse {
+    public static func traverse<G: Applicative, A, B>(_ fa: IdOf<A>, _ f: @escaping (A) -> Kind<G, B>) -> Kind<G, IdOf<B>> {
+        G.map(f(fa^.value), Id<B>.init)
     }
 }
 
 // MARK: Instance of `Semigroup` for `Id`
 extension Id: Semigroup where A: Semigroup {
     public func combine(_ other: Id<A>) -> Id<A> {
-        return Id(self.value.combine(other.value))
+        Id(self.value.combine(other.value))
     }
 }
 
 // MARK: Instance of `Monoid` for `Id`
 extension Id: Monoid where A: Monoid {
     public static func empty() -> Id<A> {
-        return Id(A.empty())
+        Id(A.empty())
     }
 }

--- a/Sources/Bow/Data/NonEmptyArray.swift
+++ b/Sources/Bow/Data/NonEmptyArray.swift
@@ -3,11 +3,17 @@ import Foundation
 /// Witness for the `NonEmptyArray<A>` data type. To be used in simulated Higher Kinded Types.
 public final class ForNonEmptyArray {}
 
+/// Partial application of the NonEmptyArray type constructor, omitting the last type parameter.
+public typealias NonEmptyArrayPartial = ForNonEmptyArray
+
 /// Higher Kinded Type alias to improve readability over `Kind<ForNonEmptyArray, A>`.
 public typealias NonEmptyArrayOf<A> = Kind<ForNonEmptyArray, A>
 
 /// Abbreviation for `NonEmptyArray`.
 public typealias NEA<A> = NonEmptyArray<A>
+
+/// Abbrebiation for `NonEmptyArrayPartial`.
+public typealias NEAPartial = NonEmptyArrayPartial
 
 /// A NonEmptyArray is an array of elements that guarantees to have at least one element.
 public final class NonEmptyArray<A>: NonEmptyArrayOf<A> {
@@ -23,7 +29,7 @@ public final class NonEmptyArray<A>: NonEmptyArrayOf<A> {
     ///   - rhs: Right hand side of the concatenation.
     /// - Returns: A non-empty array that contains the elements of the two arguments in the same order.
     public static func +(lhs: NonEmptyArray<A>, rhs: NonEmptyArray<A>) -> NonEmptyArray<A> {
-        return NonEmptyArray(head: lhs.head, tail: lhs.tail + [rhs.head] + rhs.tail)
+        NonEmptyArray(head: lhs.head, tail: lhs.tail + [rhs.head] + rhs.tail)
     }
 
     /// Concatenates a non-empty array with a Swift array.
@@ -33,7 +39,7 @@ public final class NonEmptyArray<A>: NonEmptyArrayOf<A> {
     ///   - rhs: A Swift array.
     /// - Returns: A non-empty array that contains the elements of the two arguments in the same order.
     public static func +(lhs: NonEmptyArray<A>, rhs: [A]) -> NonEmptyArray<A> {
-        return NonEmptyArray(head: lhs.head, tail: lhs.tail + rhs)
+        NonEmptyArray(head: lhs.head, tail: lhs.tail + rhs)
     }
 
     /// Appends an element to a non-empty array.
@@ -43,7 +49,7 @@ public final class NonEmptyArray<A>: NonEmptyArrayOf<A> {
     ///   - rhs: An element.
     /// - Returns: A non-empty array that has the new element at the end.
     public static func +(lhs: NonEmptyArray<A>, rhs: A) -> NonEmptyArray<A> {
-        return NonEmptyArray(head: lhs.head, tail: lhs.tail + [rhs])
+        NonEmptyArray(head: lhs.head, tail: lhs.tail + [rhs])
     }
 
     /// Creates a non-empty array from several values.
@@ -53,7 +59,7 @@ public final class NonEmptyArray<A>: NonEmptyArrayOf<A> {
     ///   - tail: Variable number of values for the rest of the non-empty array.
     /// - Returns: A non-empty array that contains all elements in the specified order.
     public static func of(_ head: A, _ tail: A...) -> NonEmptyArray<A> {
-        return NonEmptyArray(head: head, tail: tail)
+        NonEmptyArray(head: head, tail: tail)
     }
 
     /// Creates a non-empty array from a Swift array.
@@ -61,7 +67,7 @@ public final class NonEmptyArray<A>: NonEmptyArrayOf<A> {
     /// - Parameter array: A Swift array.
     /// - Returns: An optional non-empty array with the contents of the argument, or `Option.none` if it was empty.
     public static func fromArray(_ array: [A]) -> Option<NonEmptyArray<A>> {
-        return array.isEmpty ? Option<NonEmptyArray<A>>.none() : Option<NonEmptyArray<A>>.some(NonEmptyArray(all: array))
+        array.isEmpty ? Option<NonEmptyArray<A>>.none() : Option<NonEmptyArray<A>>.some(NonEmptyArray(all: array))
     }
 
     /// Unsafely creates a non-empty array from a Swift array.
@@ -71,7 +77,7 @@ public final class NonEmptyArray<A>: NonEmptyArrayOf<A> {
     /// - Parameter array: A Swift array.
     /// - Returns: A non-empty array with the contents of the argument.
     public static func fromArrayUnsafe(_ array: [A]) -> NonEmptyArray<A> {
-        return NonEmptyArray(all: array)
+        NonEmptyArray(all: array)
     }
 
     /// Safe downcast.
@@ -79,7 +85,7 @@ public final class NonEmptyArray<A>: NonEmptyArrayOf<A> {
     /// - Parameter fa: Value in higher-kind form.
     /// - Returns: Value cast to NonEmptyArray.
     public static func fix(_ fa: NonEmptyArrayOf<A>) -> NonEmptyArray<A> {
-        return fa as! NonEmptyArray<A>
+        fa as! NonEmptyArray<A>
     }
 
     /// Initializes a non-empty array.
@@ -101,7 +107,7 @@ public final class NonEmptyArray<A>: NonEmptyArrayOf<A> {
     ///
     /// - Returns: A Swift array with the elements in this value.
     public func all() -> [A] {
-        return [head] + tail
+        [head] + tail
     }
 
     /// Obtains an element from its position in this non-empty array.
@@ -121,7 +127,7 @@ public final class NonEmptyArray<A>: NonEmptyArrayOf<A> {
     ///
     /// - Parameter index: Index of the object to obtain.
     public subscript(index: Int) -> Option<A> {
-        return getOrNone(index)
+        getOrNone(index)
     }
 }
 
@@ -130,7 +136,7 @@ public final class NonEmptyArray<A>: NonEmptyArrayOf<A> {
 /// - Parameter fa: Value in higher-kind form.
 /// - Returns: Value cast to NonEmptyArray.
 public postfix func ^<A>(_ fa: NonEmptyArrayOf<A>) -> NonEmptyArray<A> {
-    return NonEmptyArray.fix(fa)
+    NonEmptyArray.fix(fa)
 }
 
 // MARK: Functions for `NonEmptyArray` when the type conforms to `Equatable`
@@ -139,8 +145,8 @@ public extension NonEmptyArray where A: Equatable {
     ///
     /// - Parameter element: Element to look for in the array.
     /// - Returns: Boolean value indicating if the element appears in the array or not.
-    func contains(element : A) -> Bool {
-        return head == element || tail.contains(where: { $0 == element })
+    func contains(element: A) -> Bool {
+        head == element || tail.contains(where: { $0 == element })
     }
 
     /// Checks if all the elements of an array appear in this array.
@@ -148,14 +154,14 @@ public extension NonEmptyArray where A: Equatable {
     /// - Parameter elements: Elements to look for in the array.
     /// - Returns: Boolean value indicating if all elements appear in the array or not.
     func containsAll(elements: [A]) -> Bool {
-        return elements.map(contains).reduce(true, and)
+        elements.map(contains).reduce(true, and)
     }
 }
 
 // Conformance of `NonEmptyArray` to `CustomStringConvertible`
 extension NonEmptyArray: CustomStringConvertible {
     public var description: String {
-        return "NonEmptyArray(\(self.all()))"
+        "NonEmptyArray(\(self.all()))"
     }
 }
 
@@ -168,34 +174,33 @@ extension NonEmptyArray: CustomDebugStringConvertible where A: CustomDebugString
 }
 
 // MARK: Instance of `EquatableK` for `NonEmptyArray`
-extension ForNonEmptyArray: EquatableK {
-    public static func eq<A>(_ lhs: Kind<ForNonEmptyArray, A>, _ rhs: Kind<ForNonEmptyArray, A>) -> Bool where A : Equatable {
-        return NEA.fix(lhs).all() == NEA.fix(rhs).all()
+extension NonEmptyArrayPartial: EquatableK {
+    public static func eq<A: Equatable>(_ lhs: NonEmptyArrayOf<A>, _ rhs: NonEmptyArrayOf<A>) -> Bool {
+        lhs^.all() == rhs^.all()
     }
 }
 
 // MARK: Instance of `Functor` for `NonEmptyArray`
-extension ForNonEmptyArray: Functor {
-    public static func map<A, B>(_ fa: Kind<ForNonEmptyArray, A>, _ f: @escaping (A) -> B) -> Kind<ForNonEmptyArray, B> {
-        return NonEmptyArray.fromArrayUnsafe(NonEmptyArray.fix(fa).all().map(f))
+extension NonEmptyArrayPartial: Functor {
+    public static func map<A, B>(_ fa: NonEmptyArrayOf<A>, _ f: @escaping (A) -> B) -> NonEmptyArrayOf<B> {
+        NonEmptyArray.fromArrayUnsafe(fa^.all().map(f))
     }
 }
 
 // MARK: Instance of `Applicative` for `NonEmptyArray`
-extension ForNonEmptyArray: Applicative {
-    public static func pure<A>(_ a: A) -> Kind<ForNonEmptyArray, A> {
-        return NonEmptyArray(head: a, tail: [])
+extension NonEmptyArrayPartial: Applicative {
+    public static func pure<A>(_ a: A) -> NonEmptyArrayOf<A> {
+        NonEmptyArray(head: a, tail: [])
     }
 }
 
 // MARK: Instance of `Selective` for `NonEmptyArray`
-extension ForNonEmptyArray: Selective {}
+extension NonEmptyArrayPartial: Selective {}
 
 // MARK: Instance of `Monad` for `NonEmptyArray`
-extension ForNonEmptyArray: Monad {
-    public static func flatMap<A, B>(_ fa: Kind<ForNonEmptyArray, A>, _ f: @escaping (A) -> Kind<ForNonEmptyArray, B>) -> Kind<ForNonEmptyArray, B> {
-        let nea = NonEmptyArray.fix(fa)
-        return NEA.fix(f(nea.head)) + nea.tail.flatMap{ a in NEA.fix(f(a)).all() }
+extension NonEmptyArrayPartial: Monad {
+    public static func flatMap<A, B>(_ fa: NonEmptyArrayOf<A>, _ f: @escaping (A) -> NonEmptyArrayOf<B>) -> NonEmptyArrayOf<B> {
+        f(fa^.head)^ + fa^.tail.flatMap{ a in f(a)^.all() }
     }
 
     private static func go<A, B>(_ buf: [B],
@@ -213,15 +218,15 @@ extension ForNonEmptyArray: Monad {
         }
     }
 
-    public static func tailRecM<A, B>(_ a: A, _ f: @escaping (A) -> Kind<ForNonEmptyArray, Either<A, B>>) -> Kind<ForNonEmptyArray, B> {
-        return NonEmptyArray.fromArrayUnsafe(go([], f, f(a)^).run())
+    public static func tailRecM<A, B>(_ a: A, _ f: @escaping (A) -> NonEmptyArrayOf<Either<A, B>>) -> NonEmptyArrayOf<B> {
+        NonEmptyArray.fromArrayUnsafe(go([], f, f(a)^).run())
     }
 }
 
 // MARK: Instance of `Comonad` for `NonEmptyArray`
-extension ForNonEmptyArray: Comonad {
-    public static func coflatMap<A, B>(_ fa: Kind<ForNonEmptyArray, A>, _ f: @escaping (Kind<ForNonEmptyArray, A>) -> B) -> Kind<ForNonEmptyArray, B> {
-        func consume(_ array : [A], _ buf : [B] = []) -> [B] {
+extension NonEmptyArrayPartial: Comonad {
+    public static func coflatMap<A, B>(_ fa: NonEmptyArrayOf<A>, _ f: @escaping (NonEmptyArrayOf<A>) -> B) -> NonEmptyArrayOf<B> {
+        func consume(_ array: [A], _ buf: [B] = []) -> [B] {
             if array.isEmpty {
                 return buf
             } else {
@@ -230,37 +235,33 @@ extension ForNonEmptyArray: Comonad {
                 return consume(tail, newBuf)
             }
         }
-        let nea = NonEmptyArray.fix(fa)
-        return NonEmptyArray(head: f(nea), tail: consume(nea.tail))
+        return NonEmptyArray(head: f(fa^), tail: consume(fa^.tail))
     }
 
-    public static func extract<A>(_ fa: Kind<ForNonEmptyArray, A>) -> A {
-        return NonEmptyArray.fix(fa).head
+    public static func extract<A>(_ fa: NonEmptyArrayOf<A>) -> A {
+        fa^.head
     }
 }
 
 // MARK: Instance of `Bimonad` for `NonEmptyArray`
-extension ForNonEmptyArray: Bimonad {}
+extension NonEmptyArrayPartial: Bimonad {}
 
 // MARK: Instance of `Foldable` for `NonEmptyArray`
-extension ForNonEmptyArray: Foldable {
-    public static func foldLeft<A, B>(_ fa: Kind<ForNonEmptyArray, A>, _ b: B, _ f: @escaping (B, A) -> B) -> B {
-        let nea = NonEmptyArray.fix(fa)
-        return nea.tail.reduce(f(b, nea.head), f)
+extension NonEmptyArrayPartial: Foldable {
+    public static func foldLeft<A, B>(_ fa: NonEmptyArrayOf<A>, _ b: B, _ f: @escaping (B, A) -> B) -> B {
+        fa^.tail.reduce(f(b, fa^.head), f)
     }
 
-    public static func foldRight<A, B>(_ fa: Kind<ForNonEmptyArray, A>, _ b: Eval<B>, _ f: @escaping (A, Eval<B>) -> Eval<B>) -> Eval<B> {
-        let nea = NonEmptyArray.fix(fa)
-        return nea.all().k().foldRight(b, f)
+    public static func foldRight<A, B>(_ fa: NonEmptyArrayOf<A>, _ b: Eval<B>, _ f: @escaping (A, Eval<B>) -> Eval<B>) -> Eval<B> {
+        fa^.all().k().foldRight(b, f)
     }
 }
 
 // MARK: Instance of `Traverse` for `NonEmptyArray`
-extension ForNonEmptyArray: Traverse {
-    public static func traverse<G: Applicative, A, B>(_ fa: Kind<ForNonEmptyArray, A>, _ f: @escaping (A) -> Kind<G, B>) -> Kind<G, Kind<ForNonEmptyArray, B>> {
-        let nea = NonEmptyArray.fix(fa)
-        let arrayTraverse = nea.all().k().traverse(f)
-        return G.map(arrayTraverse, { x in NonEmptyArray.fromArrayUnsafe(ArrayK.fix(x).asArray) })
+extension NonEmptyArrayPartial: Traverse {
+    public static func traverse<G: Applicative, A, B>(_ fa: NonEmptyArrayOf<A>, _ f: @escaping (A) -> Kind<G, B>) -> Kind<G, NonEmptyArrayOf<B>> {
+        let arrayTraverse = fa^.all().k().traverse(f)
+        return G.map(arrayTraverse, { x in NonEmptyArray.fromArrayUnsafe(x^.asArray) })
     }
 }
 
@@ -271,15 +272,15 @@ public extension NEA {
 }
 
 // MARK: Instance of `SemigroupK` for `NonEmptyArray`
-extension ForNonEmptyArray: SemigroupK {
-    public static func combineK<A>(_ x: Kind<ForNonEmptyArray, A>, _ y: Kind<ForNonEmptyArray, A>) -> Kind<ForNonEmptyArray, A> {
-        return NonEmptyArray.fix(x) + NonEmptyArray.fix(y)
+extension NonEmptyArrayPartial: SemigroupK {
+    public static func combineK<A>(_ x: NonEmptyArrayOf<A>, _ y: NonEmptyArrayOf<A>) -> NonEmptyArrayOf<A> {
+        x^ + y^
     }
 }
 
 // MARK: Instance of `Semigroup` for `NonEmptyArray`
 extension NonEmptyArray: Semigroup {
     public func combine(_ other: NonEmptyArray<A>) -> NonEmptyArray<A> {
-        return self + other
+        self + other
     }
 }

--- a/Sources/Bow/Data/Option.swift
+++ b/Sources/Bow/Data/Option.swift
@@ -280,7 +280,7 @@ extension Option: Semigroup where A: Semigroup {
 
 // MARK: Instance of `Semigroupal` for `Option`,
 extension OptionPartial: Semigroupal {
-    public static func product<A, B>(_ a: OptionOf<A>, _ b: Kind<ForOption, B>) -> OptionOf<(A, B)> {
+    public static func product<A, B>(_ a: OptionOf<A>, _ b: OptionOf<B>) -> OptionOf<(A, B)> {
         ForOption.zip(a, b)
     }
 }

--- a/Sources/Bow/Data/Option.swift
+++ b/Sources/Bow/Data/Option.swift
@@ -71,7 +71,7 @@ public final class Option<A>: OptionOf<A> {
     ///
     /// - Parameter predicate: Boolean predicate to test the wrapped value.
     /// - Returns: This value if it does not match the predicate, or none otherwise.
-    public func filterNot(_ predicate: @escaping (A) -> Bool) -> Kind<ForOption, A> {
+    public func filterNot(_ predicate: @escaping (A) -> Bool) -> OptionOf<A> {
         filter(predicate >>> not)
     }
 

--- a/Sources/Bow/Data/Option.swift
+++ b/Sources/Bow/Data/Option.swift
@@ -3,6 +3,9 @@ import Foundation
 /// Witness for the `Option<A>` data type. To be used in simulated Higher Kinded Types.
 public final class ForOption {}
 
+/// Partial application of the Option type constructor, omitting the last type parameter.
+public typealias OptionPartial = ForOption
+
 /// Higher Kinded Type alias to improve readability of `Kind<ForOption, A>`.
 public typealias OptionOf<A> = Kind<ForOption, A>
 
@@ -11,12 +14,12 @@ public final class Option<A>: OptionOf<A> {
     private let value: A?
     /// Constructs an instance of `Option` with presence of a value of the type parameter.
     ///
-    /// It is an alias for `Option<A>.pure(_:)`
+    /// It equivalent to `Option<A>.pure(_:)`.
     ///
     /// - Parameter a: Value to be wrapped in an `Option`.
     /// - Returns: An option wrapping the value passed as an argument.
     public static func some(_ a: A) -> Option<A> {
-        return Option(a)
+        Option(a)
     }
 
     /// Constucts an instance of `Option` with absence of a value.
@@ -25,7 +28,7 @@ public final class Option<A>: OptionOf<A> {
     ///
     /// - Returns: An option with no present value
     public static func none() -> Option<A> {
-        return Option(nil)
+        Option(nil)
     }
 
     /// Converts a native Swift optional into a value of `Option<A>`.
@@ -33,7 +36,7 @@ public final class Option<A>: OptionOf<A> {
     /// - Parameter a: Optional value to be converted.
     /// - Returns: An Option with the same structure as the argument.
     public static func fromOptional(_ a: A?) -> Option<A> {
-        return Option(a)
+        Option(a)
     }
 
     private init(_ value: A?) {
@@ -45,12 +48,12 @@ public final class Option<A>: OptionOf<A> {
     /// - Parameter fa: Option in higher-kind form.
     /// - Returns: Value cast to Option.
     public static func fix(_ fa: OptionOf<A>) -> Option<A> {
-        return fa as! Option<A>
+        fa as! Option<A>
     }
 
     /// Checks if this option contains a value
     public var isDefined: Bool {
-        return !isEmpty
+        !isEmpty
     }
 
     /// Applies a function based on the presence or absence of a value.
@@ -69,7 +72,7 @@ public final class Option<A>: OptionOf<A> {
     /// - Parameter predicate: Boolean predicate to test the wrapped value.
     /// - Returns: This value if it does not match the predicate, or none otherwise.
     public func filterNot(_ predicate: @escaping (A) -> Bool) -> Kind<ForOption, A> {
-        return filter(predicate >>> not)
+        filter(predicate >>> not)
     }
 
     /// Obtains the wrapped value, or a default value if absent.
@@ -77,7 +80,7 @@ public final class Option<A>: OptionOf<A> {
     /// - Parameter defaultValue: Value to be returned if this option is empty.
     /// - Returns: The value wrapped in this Option, if present, or the value provided as an argument, otherwise.
     public func getOrElse(_ defaultValue: A) -> A {
-        return getOrElse(constant(defaultValue))
+        getOrElse(constant(defaultValue))
     }
     
     /// Obtains the wrapped value, or a default value if absent.
@@ -85,7 +88,7 @@ public final class Option<A>: OptionOf<A> {
     /// - Parameter defaultValue: Closure to be evaluated if there is no wrapped value in this option.
     /// - Returns: The value wrapped in this Option, if present, or the result of running the closure provided as an argument, otherwise.
     public func getOrElse(_ defaultValue: () -> A) -> A {
-        return fold(defaultValue, id)
+        fold(defaultValue, id)
     }
 
     /// Obtains this option, or a default value if this option is empty.
@@ -93,7 +96,7 @@ public final class Option<A>: OptionOf<A> {
     /// - Parameter defaultValue: Default option value to be returned if this option is empty.
     /// - Returns: This option, if has a present value, or the value provided as an argument, otherwise.
     public func orElse(_ defaultValue: Option<A>) -> Option<A> {
-        return orElse(constant(defaultValue))
+        orElse(constant(defaultValue))
     }
 
     /// Obtains this option, or a default value if this option is empty.
@@ -101,26 +104,26 @@ public final class Option<A>: OptionOf<A> {
     /// - Parameter defaultValue: Closure returning an option for the empty case.
     /// - Returns: This option, if has a present value, or the result of running the closure provided as an argument, otherwise.
     public func orElse(_ defaultValue: () -> Option<A>) -> Option<A> {
-        return fold(defaultValue, Option.some)
+        fold(defaultValue, Option.some)
     }
 
     /// Converts this option into a native Swift optional `A?`.
     ///
     /// - Returns: A Swift Optional with the same structure as this value.
     public func toOptional() -> A? {
-        return fold(constant(nil), id)
+        fold(constant(nil), id)
     }
 
     /// Converts this option into an array.
     ///
     /// - Returns: An empty array if this value is absent, or a singleton array, if present.
     public func toArray() -> [A] {
-        return fold(constant([]), { a in [a] })
+        fold(constant([]), { a in [a] })
     }
     
     /// Converts this option into a native Swift optional `A?`
     public var orNil: A? {
-        return toOptional()
+        toOptional()
     }
 }
 
@@ -129,60 +132,57 @@ public final class Option<A>: OptionOf<A> {
 /// - Parameter fa: Option in higher-kind form.
 /// - Returns: Value cast to Option.
 public postfix func ^<A>(_ fa: OptionOf<A>) -> Option<A> {
-    return Option.fix(fa)
+    Option.fix(fa)
 }
 
 // MARK: Conformance of `Option` to `CustomStringConvertible`.
 extension Option: CustomStringConvertible {
     public var description: String {
-        return fold({ "None" },
-                    { a in "Some(\(a))" })
+        fold({ "None" },
+             { a in "Some(\(a))" })
     }
 }
 
 // MARK: Conformance of `Option` to `CustomDebugStringConvertible`.
 extension Option: CustomDebugStringConvertible where A: CustomDebugStringConvertible {
     public var debugDescription : String {
-        return fold(constant("None"),
-                    { a in "Some(\(a.debugDescription))" })
+        fold(constant("None"),
+             { a in "Some(\(a.debugDescription))" })
     }
 }
 
 // MARK: Instance of `EquatableK` for `Option`.
-extension ForOption: EquatableK {
-    public static func eq<A>(_ lhs: Kind<ForOption, A>, _ rhs: Kind<ForOption, A>) -> Bool where A : Equatable {
-        let ol = Option.fix(lhs)
-        let or = Option.fix(rhs)
-        return ol.fold({ or.fold(constant(true), constant(false)) },
-                       { a in or.fold(constant(false), { b in a == b })})
+extension OptionPartial: EquatableK {
+    public static func eq<A: Equatable>(_ lhs: OptionOf<A>, _ rhs: OptionOf<A>) -> Bool {
+        lhs^.fold({ rhs^.fold(constant(true), constant(false)) },
+                  { a in rhs^.fold(constant(false), { b in a == b })})
     }
 }
 
 // MARK: Instance of `Functor` for `Option`.
-extension ForOption: Functor {
-    public static func map<A, B>(_ fa: Kind<ForOption, A>, _ f: @escaping (A) -> B) -> Kind<ForOption, B> {
-        return Option.fix(fa).fold(Option.none, Option.some <<< f)
+extension OptionPartial: Functor {
+    public static func map<A, B>(_ fa: OptionOf<A>, _ f: @escaping (A) -> B) -> OptionOf<B> {
+        fa^.fold(Option.none, Option.some <<< f)
     }
 }
 
 // MARK: Instance of `Applicative` for `Option`.
-extension ForOption: Applicative {
-    public static func pure<A>(_ a: A) -> Kind<ForOption, A> {
-        return Option.some(a)
+extension OptionPartial: Applicative {
+    public static func pure<A>(_ a: A) -> OptionOf<A> {
+        Option.some(a)
     }
 }
 
 // MARK: Instance of `Selective` for `Option`
-extension ForOption: Selective {}
+extension OptionPartial: Selective {}
 
 // MARK: Instance of `Monad` for `Option`.
-extension ForOption: Monad {
-    public static func flatMap<A, B>(_ fa: Kind<ForOption, A>, _ f: @escaping (A) -> Kind<ForOption, B>) -> Kind<ForOption, B> {
-        let option = Option.fix(fa)
-        return option.fold(Option<B>.none, f)
+extension OptionPartial: Monad {
+    public static func flatMap<A, B>(_ fa: OptionOf<A>, _ f: @escaping (A) -> OptionOf<B>) -> OptionOf<B> {
+        fa^.fold(Option<B>.none, f)
     }
 
-    public static func tailRecM<A, B>(_ a: A, _ f: @escaping (A) -> Kind<ForOption, Either<A, B>>) -> Kind<ForOption, B> {
+    public static func tailRecM<A, B>(_ a: A, _ f: @escaping (A) -> OptionOf<Either<A, B>>) -> OptionOf<B> {
         _tailRecM(a, f).run()
     }
     
@@ -198,100 +198,96 @@ extension ForOption: Monad {
 }
 
 // MARK: Instance of `ApplicativeError` for `Option`.
-extension ForOption: ApplicativeError {
+extension OptionPartial: ApplicativeError {
     public typealias E = Unit
 
-    public static func raiseError<A>(_ e: Unit) -> Kind<ForOption, A> {
-        return Option.none()
+    public static func raiseError<A>(_ e: Unit) -> OptionOf<A> {
+        Option.none()
     }
 
-    public static func handleErrorWith<A>(_ fa: Kind<ForOption, A>, _ f: @escaping (Unit) -> Kind<ForOption, A>) -> Kind<ForOption, A> {
-        return Option<A>.fix(fa).orElse(Option<A>.fix(f(unit)))
+    public static func handleErrorWith<A>(_ fa: OptionOf<A>, _ f: @escaping (Unit) -> OptionOf<A>) -> OptionOf<A> {
+        fa^.orElse(f(unit)^)
     }
 }
 
 // MARK: Instance of `MonadError` for `Option`.
-extension ForOption: MonadError {}
+extension OptionPartial: MonadError {}
 
 // MARK: Instance of `FunctorFilter` for `Option`.
-extension ForOption: FunctorFilter {}
+extension OptionPartial: FunctorFilter {}
 
 // MARK: Instance of `MonadFilter` for `Option`.
-extension ForOption: MonadFilter {
-    public static func empty<A>() -> Kind<ForOption, A> {
-        return Option.none()
+extension OptionPartial: MonadFilter {
+    public static func empty<A>() -> OptionOf<A> {
+        Option.none()
     }
 }
 
 // MARK: Instance of `Foldable` for `Option`.
-extension ForOption: Foldable {
-    public static func foldLeft<A, B>(_ fa: Kind<ForOption, A>, _ b: B, _ f: @escaping (B, A) -> B) -> B {
-        let option = Option.fix(fa)
-        return option.fold({ b },
-                           { a in f(b, a) })
+extension OptionPartial: Foldable {
+    public static func foldLeft<A, B>(_ fa: OptionOf<A>, _ b: B, _ f: @escaping (B, A) -> B) -> B {
+        fa^.fold({ b },
+                 { a in f(b, a) })
     }
 
-    public static func foldRight<A, B>(_ fa: Kind<ForOption, A>, _ b: Eval<B>, _ f: @escaping (A, Eval<B>) -> Eval<B>) -> Eval<B> {
-        let option = Option.fix(fa)
-        return option.fold(constant(b),
-                           { a in f(a, b) })
+    public static func foldRight<A, B>(_ fa: OptionOf<A>, _ b: Eval<B>, _ f: @escaping (A, Eval<B>) -> Eval<B>) -> Eval<B> {
+        fa^.fold(constant(b),
+                 { a in f(a, b) })
     }
 }
 
 // MARK: Instance of `Traverse` for `Option`.
-extension ForOption: Traverse {
-    public static func traverse<G: Applicative, A, B>(_ fa: Kind<ForOption, A>, _ f: @escaping (A) -> Kind<G, B>) -> Kind<G, Kind<ForOption, B>> {
-        let option = Option.fix(fa)
-        return option.fold({ G.pure(Option<B>.none()) },
-                           { a in G.map(f(a), Option<B>.some)})
+extension OptionPartial: Traverse {
+    public static func traverse<G: Applicative, A, B>(_ fa: OptionOf<A>, _ f: @escaping (A) -> Kind<G, B>) -> Kind<G, OptionOf<B>> {
+        fa^.fold({ G.pure(Option<B>.none()) },
+                 { a in G.map(f(a), Option<B>.some)})
     }
 }
 
 // MARK: Instance of `TraverseFilter` for `Option`.
-extension ForOption: TraverseFilter {
-    public static func traverseFilter<A, B, G: Applicative>(_ fa: Kind<ForOption, A>, _ f: @escaping (A) -> Kind<G, Kind<ForOption, B>>) -> Kind<G, Kind<ForOption, B>> {
-        let option = Option.fix(fa)
-        return option.fold({ G.pure(Option<B>.none()) }, f)
+extension OptionPartial: TraverseFilter {
+    public static func traverseFilter<A, B, G: Applicative>(_ fa: OptionOf<A>, _ f: @escaping (A) -> Kind<G, OptionOf<B>>) -> Kind<G, OptionOf<B>> {
+        fa^.fold({ G.pure(Option<B>.none()) }, f)
     }
 }
 
 // MARK: Instance of `SemigroupK` for `Option`
-extension ForOption: SemigroupK {
-    public static func combineK<A>(_ x: Kind<ForOption, A>, _ y: Kind<ForOption, A>) -> Kind<ForOption, A> {
-        return x^.fold(constant(y), Option.some)
+extension OptionPartial: SemigroupK {
+    public static func combineK<A>(_ x: OptionOf<A>, _ y: OptionOf<A>) -> OptionOf<A> {
+        x^.fold(constant(y), Option.some)
     }
 }
 
 // MARK: Instance of `MonoidK` for `Option`
-extension ForOption: MonoidK {
-    public static func emptyK<A>() -> Kind<ForOption, A> {
-        return Option.none()
+extension OptionPartial: MonoidK {
+    public static func emptyK<A>() -> OptionOf<A> {
+        Option.none()
     }
 }
 
 // MARK: Instance of `MonadCombine` for `Option`
-extension ForOption: MonadCombine {}
+extension OptionPartial: MonadCombine {}
 
 // MARK: Instance of `Semigroup` for `Option`, provided that `A` has an instance of `Semigroup`.
 extension Option: Semigroup where A: Semigroup {
     public func combine(_ other: Option<A>) -> Option<A> {
-        return self.fold(constant(other),
-                         { x in other.fold(constant(self),
-                                           { y in .some(x.combine(y)) })
+        self.fold(constant(other),
+                  { x in other.fold(constant(self),
+                                    { y in .some(x.combine(y)) })
         })
     }
 }
 
 // MARK: Instance of `Semigroupal` for `Option`,
-extension ForOption: Semigroupal {
-    public static func product<A, B>(_ a: Kind<ForOption, A>, _ b: Kind<ForOption, B>) -> Kind<ForOption, (A, B)> {
+extension OptionPartial: Semigroupal {
+    public static func product<A, B>(_ a: OptionOf<A>, _ b: Kind<ForOption, B>) -> OptionOf<(A, B)> {
         ForOption.zip(a, b)
     }
 }
 
 // MARK: Instance of `Monoidal` for `Option`,
-extension ForOption: Monoidal {
-    public static func identity<A>() -> Kind<ForOption, A> {
+extension OptionPartial: Monoidal {
+    public static func identity<A>() -> OptionOf<A> {
         Option.none()
     }
 }
@@ -299,7 +295,7 @@ extension ForOption: Monoidal {
 // MARK: Instance of `Monoid` for `Option`, provided that `A` has an instance of `Monoid`.
 extension Option: Monoid where A: Monoid {
     public static func empty() -> Option<A> {
-        return Option.none()
+        .none()
     }
 }
 
@@ -312,7 +308,7 @@ extension Optional {
     ///
     /// - Returns: An Option value with the same structure as this value.
     public func toOption() -> Option<Wrapped> {
-        return Option<Wrapped>.fromOptional(self)
+        Option<Wrapped>.fromOptional(self)
     }
 
     /// Converts this Optional value into a `Bow.Option`.
@@ -321,14 +317,14 @@ extension Optional {
     ///
     /// - Returns: An Option value with the same structure as this value.
     public func k() -> Option<Wrapped> {
-        return toOption()
+        toOption()
     }
 }
 
 extension Collection {
     /// Obtains the first element of this collection or `Option.none`.
     public var firstOrNone: Option<Element> {
-        return self.first.toOption()
+        self.first.toOption()
     }
     
     /// Obtains the first element of this collection that matches a predicate.
@@ -336,12 +332,12 @@ extension Collection {
     /// - Parameter predicate: Filtering predicate.
     /// - Returns: First element that matches the predicate or `Option.none`.
     public func firstOrNone(_ predicate: (Element) -> Bool) -> Option<Element> {
-        return self.first(where: predicate).toOption()
+        self.first(where: predicate).toOption()
     }
     
     /// Returns an element if it is the single one in this collection or `Option.none`
     public var singleOrNone: Option<Element> {
-        return self.count == 1 ? self.first.toOption() : .none()
+        self.count == 1 ? self.first.toOption() : .none()
     }
     
     /// Returns an element if it is the single one matching a predicate.
@@ -349,14 +345,14 @@ extension Collection {
     /// - Parameter predicate: Filtering predicate.
     /// - Returns: A value if it is the single one matching the predicate, or `Option.none`.
     public func singleOrNone(_ predicate: (Element) -> Bool) -> Option<Element> {
-        return self.filter(predicate).singleOrNone
+        self.filter(predicate).singleOrNone
     }
 }
 
 extension Sequence {
     /// Obtains the first element of this sequence or `Option.none`.
     public var firstOrNone: Option<Element> {
-        return self.first(where: constant(true)).toOption()
+        self.first(where: constant(true)).toOption()
     }
     
     /// Obtains the first element of this sequence that matches a predicate.
@@ -364,14 +360,14 @@ extension Sequence {
     /// - Parameter predicate: Filtering predicate.
     /// - Returns: First element that matches the predicate or `Option.none`.
     public func firstOrNone(_ predicate: (Element) -> Bool) -> Option<Element> {
-        return self.first(where: predicate).toOption()
+        self.first(where: predicate).toOption()
     }
 }
 
 extension BidirectionalCollection {
     /// Obtains the first element of this bidirectional collection or `Option.none`.
     public var firstOrNone: Option<Element> {
-        return self.first.toOption()
+        self.first.toOption()
     }
     
     /// Obtains the first element of this bidirectional collection that matches a predicate.
@@ -379,12 +375,12 @@ extension BidirectionalCollection {
     /// - Parameter predicate: Filtering predicate.
     /// - Returns: First element that matches the predicate or `Option.none`.
     public func firstOrNone(_ predicate: (Element) -> Bool) -> Option<Element> {
-        return self.first(where: predicate).toOption()
+        self.first(where: predicate).toOption()
     }
     
     /// Obtains the last element of this bidirectional collection or `Option.none`.
     public var lastOrNone: Option<Element> {
-        return self.last.toOption()
+        self.last.toOption()
     }
     
     /// Obtains the last element of this bidirectional collection that matches a predicate.
@@ -392,12 +388,12 @@ extension BidirectionalCollection {
     /// - Parameter predicate: Filtering predicate.
     /// - Returns: Last element that matches the predicate or `Option.none`.
     public func lastOrNone(_ predicate: (Element) -> Bool) -> Option<Element> {
-        return self.last(where: predicate).toOption()
+        self.last(where: predicate).toOption()
     }
     
     /// Returns an element if it is the single one in this collection or `Option.none`
     public var singleOrNone: Option<Element> {
-        return self.count == 1 ? self.first.toOption() : .none()
+        self.count == 1 ? self.first.toOption() : .none()
     }
     
     /// Returns an element if it is the single one matching a predicate.
@@ -405,6 +401,6 @@ extension BidirectionalCollection {
     /// - Parameter predicate: Filtering predicate.
     /// - Returns: A value if it is the single one matching the predicate, or `Option.none`.
     public func singleOrNone(_ predicate: (Element) -> Bool) -> Option<Element> {
-        return self.filter(predicate).singleOrNone
+        self.filter(predicate).singleOrNone
     }
 }

--- a/Sources/Bow/Data/Puller.swift
+++ b/Sources/Bow/Data/Puller.swift
@@ -1,6 +1,9 @@
 /// Witness for the `Puller<A>` data type. To be used in simulated Higher Kinded Types.
 public typealias ForPuller = CoPartial<ForZipper>
 
+/// Partial application of the Puller type constructor, omitting the last type parameter.
+public typealias PullerPartial = ForPuller
+
 /// Higher Kinded Type alias to improve readability of `CoOf<ForZipper, A>`.
 public typealias PullerOf<A> = CoOf<ForZipper, A>
 

--- a/Sources/Bow/Data/SetK.swift
+++ b/Sources/Bow/Data/SetK.swift
@@ -3,6 +3,9 @@ import Foundation
 /// Witness for the `SetK<A>` data type. To be used in simulated Higher Kinded Types.
 public final class ForSetK {}
 
+/// Partial application of the SetK type constructor, omitting the last type parameter.
+public typealias SetKPartial = ForSetK
+
 /// Higher Kinded Type alias to improve readability over `Kind<ForSetK, A>`.
 public typealias SetKOf<A> = Kind<ForSetK, A>
 

--- a/Sources/Bow/Data/Try.swift
+++ b/Sources/Bow/Data/Try.swift
@@ -14,6 +14,9 @@ public enum TryError: Error {
 /// Witness for the `Try<A>` data type. To be used in simulated Higher Kinded Types.
 public final class ForTry {}
 
+/// Partial application of the Try type constructor, omitting the last type parameter.
+public typealias TryPartial = ForTry
+
 /// Higher Kinded Type alias to improve readability over `Kind<ForTry, A>`.
 public typealias TryOf<A> = Kind<ForTry, A>
 
@@ -26,7 +29,7 @@ public final class Try<A>: TryOf<A> {
     /// - Parameter value: Value to be wrapped in a successful Try.
     /// - Returns: A `Try` value wrapping the successful value.
     public static func success(_ value: A) -> Try<A> {
-        return Try(.success(value))
+        Try(.success(value))
     }
     
     /// Creates a failed Try value.
@@ -34,7 +37,7 @@ public final class Try<A>: TryOf<A> {
     /// - Parameter error: An error.
     /// - Returns: A `Try` value wrapping the error.
     public static func failure(_ error: Error) -> Try<A> {
-        return Try(.failure(error))
+        Try(.failure(error))
     }
 
     /// Creates a failed Try value.
@@ -42,7 +45,7 @@ public final class Try<A>: TryOf<A> {
     /// - Parameter error: An error.
     /// - Returns: A `Try` value wrapping the error.
     public static func raise(_ error: Error) -> Try<A> {
-        return failure(error)
+        failure(error)
     }
     
     /// Invokes a closure that may throw errors and wraps the result in a `Try` value.
@@ -67,7 +70,7 @@ public final class Try<A>: TryOf<A> {
     /// - Parameter fa: Value in the higher-kind form.
     /// - Returns: Value cast to Try.
     public static func fix(_ fa: TryOf<A>) -> Try<A> {
-        return fa as! Try<A>
+        fa as! Try<A>
     }
     
     /// Applies the provided closures based on the content of this `Try` value.
@@ -90,20 +93,20 @@ public final class Try<A>: TryOf<A> {
 
     /// Checks if this value is a failure.
     public var isFailure: Bool {
-        return fold(constant(true), constant(false))
+        fold(constant(true), constant(false))
     }
 
     /// Checks if this value is a success.
     public var isSuccess: Bool {
-        return !isFailure
+        !isFailure
     }
 
     /// Obtains the wrapped error in this `Try`.
     ///
     /// - Returns: A successful error or a failure with `TryError.unsupportedOperation` if this value was not an error.
     public func failed() -> Try<Error> {
-        return fold(Try<Error>.success,
-                    { _ in Try<Error>.failure(TryError.unsupportedOperation("Success.failed"))})
+        fold(Try<Error>.success,
+             { _ in Try<Error>.failure(TryError.unsupportedOperation("Success.failed"))})
     }
     
     /// Obtains the value wrapped in this `Try` or a default value if it contains an error.
@@ -111,7 +114,7 @@ public final class Try<A>: TryOf<A> {
     /// - Parameter defaultValue: Default value for the failure case.
     /// - Returns: Value wrapped in this `Try`, or the default value if it was an error.
     public func getOrElse(_ defaultValue: A) -> A {
-        return fold(constant(defaultValue), id)
+        fold(constant(defaultValue), id)
     }
     
     /// Attempts to recover if the contained value in this `Try` is an error.
@@ -119,7 +122,7 @@ public final class Try<A>: TryOf<A> {
     /// - Parameter f: Recovery function.
     /// - Returns: A `Try` value from the recovery, or the original value if it was not an error.
     public func recoverWith(_ f: (Error) -> Try<A>) -> Try<A> {
-        return fold(f, Try.success)
+        fold(f, Try.success)
     }
     
     /// Recovers if the contained value in this `Try` is an error.
@@ -127,7 +130,7 @@ public final class Try<A>: TryOf<A> {
     /// - Parameter f: Recovery function.
     /// - Returns: A `Try` value from the recovery, or the original value if it was not an error.
     public func recover(_ f: @escaping (Error) -> A) -> Try<A> {
-        return fold(f >>> Try.success, Try.success)
+        fold(f >>> Try.success, Try.success)
     }
 
     /// Converts this value to a failure if the transformation provides no value.
@@ -135,21 +138,21 @@ public final class Try<A>: TryOf<A> {
     /// - Parameter f: Transformation function.
     /// - Returns: A failure if the transformation of this value provides no result, or a success with the result of the transformation.
     public func mapFilter<B>(_ f: @escaping (A) -> Option<B>) -> Try<B> {
-        return self.flatMap { a in f(a).fold(constant(Try<B>.raiseError(TryError.predicateDoesNotMatch)), Try<B>.pure) }^
+        self.flatMap { a in f(a).fold(constant(Try<B>.raiseError(TryError.predicateDoesNotMatch)), Try<B>.pure) }^
     }
 
     /// Converts this value to an `Option`.
     ///
     /// - Returns: `Option.some` if this value is a success, or `Option.none` otherwise.
     public func toOption() -> Option<A> {
-        return fold(constant(Option.none()), Option.some)
+        fold(constant(Option.none()), Option.some)
     }
 
     /// Converts this value to an `Either`.
     ///
     /// - Returns: A right value if this value is a success, or a left value if it contains an error.
     public func toEither() -> Either<Error, A> {
-        return fold(Either.left, Either.right)
+        fold(Either.left, Either.right)
     }
 
     /// Obtains the value of this success or the provided default one if it is a failure.
@@ -157,14 +160,14 @@ public final class Try<A>: TryOf<A> {
     /// - Parameter defaultValue: Function providing the default value.
     /// - Returns: Wrapped value in this success, or default value otherwise.
     public func getOrDefault(_ defaultValue: @escaping @autoclosure () -> A) -> A {
-        return fold(constant(defaultValue()), id)
+        fold(constant(defaultValue()), id)
     }
 
     /// Obtains the value of this success or nil if it is a failure.
     ///
     /// - Returns: Wrapped value in this success, or nil otherwise.
     public func orNil() -> A? {
-        return fold(constant(nil), id)
+        fold(constant(nil), id)
     }
 
     /// Obtains this value or the provided default `Try` if it is a failure.
@@ -172,7 +175,7 @@ public final class Try<A>: TryOf<A> {
     /// - Parameter f: Function providing the default value.
     /// - Returns: This value if it is a success, or the default provided one otherwise.
     public func orElse(_ f: @escaping @autoclosure () -> Try<A>) -> Try<A> {
-        return fold(constant(f()), Try.success)
+        fold(constant(f()), Try.success)
     }
 }
 
@@ -181,7 +184,7 @@ public final class Try<A>: TryOf<A> {
 /// - Parameter fa: Value in higher-kind form.
 /// - Returns: Value cast to Try.
 public postfix func ^<A>(_ fa: TryOf<A>) -> Try<A> {
-    return Try.fix(fa)
+    Try.fix(fa)
 }
 
 private enum _Try<A> {
@@ -192,54 +195,54 @@ private enum _Try<A> {
 // MARK: Conformance of `Try` to `CustomStringConvertible`
 extension Try: CustomStringConvertible {
     public var description : String {
-        return fold({ error in "Failure(\(error))" },
-                    { value in "Success(\(value))" })
+        fold({ error in "Failure(\(error))" },
+             { value in "Success(\(value))" })
     }
 }
 
 // MARK: Conformance of `Try` to `CustomDebugStringConvertible`
 extension Try: CustomDebugStringConvertible where A: CustomDebugStringConvertible {
     public var debugDescription: String {
-        return fold({ error in "Failure(\(error))" },
-                    { value in "Success(\(value.debugDescription))" })
+        fold({ error in "Failure(\(error))" },
+             { value in "Success(\(value.debugDescription))" })
     }
 }
 
 // MARK: Instance of `EquatableK` for `Try`
-extension ForTry: EquatableK {
-    public static func eq<A>(_ lhs: Kind<ForTry, A>, _ rhs: Kind<ForTry, A>) -> Bool where A : Equatable {
-        let tl = Try.fix(lhs)
-        let tr = Try.fix(rhs)
-        return tl.fold({ aError in tr.fold({ bError in "\(aError)" == "\(bError)"}, constant(false))},
-                       { a in tr.fold(constant(false), { b in a == b }) })
+extension TryPartial: EquatableK {
+    public static func eq<A: Equatable>(_ lhs: TryOf<A>, _ rhs: TryOf<A>) -> Bool {
+        lhs^.fold(
+            { aError in rhs^.fold({ bError in "\(aError)" == "\(bError)"},
+                                  constant(false))},
+            { a in rhs^.fold(constant(false),
+                             { b in a == b }) })
     }
 }
 
 // MARK: Instance of `Functor` for `Try`
-extension ForTry: Functor {
-    public static func map<A, B>(_ fa: Kind<ForTry, A>, _ f: @escaping (A) -> B) -> Kind<ForTry, B> {
-        return Try.fix(fa).fold(Try.failure, Try.success <<< f)
+extension TryPartial: Functor {
+    public static func map<A, B>(_ fa: TryOf<A>, _ f: @escaping (A) -> B) -> TryOf<B> {
+        fa^.fold(Try.failure, Try.success <<< f)
     }
 }
 
 // MARK: Instance of `Applicative` for `Try`
-extension ForTry: Applicative {
-    public static func pure<A>(_ a: A) -> Kind<ForTry, A> {
-        return Try.success(a)
+extension TryPartial: Applicative {
+    public static func pure<A>(_ a: A) -> TryOf<A> {
+        Try.success(a)
     }
 }
 
 // MARK: Instance of `Selective` for `Try`
-extension ForTry: Selective {}
+extension TryPartial: Selective {}
 
 // MARK: Instance of `Monad` for `Try`
-extension ForTry: Monad {
-    public static func flatMap<A, B>(_ fa: Kind<ForTry, A>, _ f: @escaping (A) -> Kind<ForTry, B>) -> Kind<ForTry, B> {
-        let trya = Try<A>.fix(fa)
-        return trya.fold(Try<B>.raise, f)
+extension TryPartial: Monad {
+    public static func flatMap<A, B>(_ fa: TryOf<A>, _ f: @escaping (A) -> TryOf<B>) -> TryOf<B> {
+        fa^.fold(Try<B>.raise, f)
     }
 
-    public static func tailRecM<A, B>(_ a: A, _ f: @escaping (A) -> Kind<ForTry, Either<A, B>>) -> Kind<ForTry, B> {
+    public static func tailRecM<A, B>(_ a: A, _ f: @escaping (A) -> TryOf<Either<A, B>>) -> TryOf<B> {
         _tailRecM(a, f).run()
     }
     
@@ -255,46 +258,46 @@ extension ForTry: Monad {
 }
 
 // MARK: Instance of `ApplicativeError` for `Try`
-extension ForTry: ApplicativeError {
+extension TryPartial: ApplicativeError {
     public typealias E = Error
 
-    public static func raiseError<A>(_ e: Error) -> Kind<ForTry, A> {
-        return Try.failure(e)
+    public static func raiseError<A>(_ e: Error) -> TryOf<A> {
+        Try.failure(e)
     }
 
-    public static func handleErrorWith<A>(_ fa: Kind<ForTry, A>, _ f: @escaping (Error) -> Kind<ForTry, A>) -> Kind<ForTry, A> {
-        return Try.fix(fa).recoverWith({ e in Try.fix(f(e)) })
+    public static func handleErrorWith<A>(_ fa: TryOf<A>, _ f: @escaping (Error) -> TryOf<A>) -> TryOf<A> {
+        fa^.recoverWith { e in f(e)^ }
     }
 }
 
 // MARK: Instance of `MonadError` for `Try`
-extension ForTry: MonadError {}
+extension TryPartial: MonadError {}
 
 // MARK: Instance of `Foldable` for `Try`
-extension ForTry: Foldable {
-    public static func foldLeft<A, B>(_ fa: Kind<ForTry, A>, _ b: B, _ f: @escaping (B, A) -> B) -> B {
-        return Try.fix(fa).fold(constant(b),
-                                { a in f(b, a) })
+extension TryPartial: Foldable {
+    public static func foldLeft<A, B>(_ fa: TryOf<A>, _ b: B, _ f: @escaping (B, A) -> B) -> B {
+        fa^.fold(constant(b),
+                 { a in f(b, a) })
     }
 
-    public static func foldRight<A, B>(_ fa: Kind<ForTry, A>, _ b: Eval<B>, _ f: @escaping (A, Eval<B>) -> Eval<B>) -> Eval<B> {
-        return Try.fix(fa).fold(constant(b),
-                                { a in f(a, b) })
+    public static func foldRight<A, B>(_ fa: TryOf<A>, _ b: Eval<B>, _ f: @escaping (A, Eval<B>) -> Eval<B>) -> Eval<B> {
+        fa^.fold(constant(b),
+                 { a in f(a, b) })
     }
 }
 
 // MARK: Instance of `Traverse` for `Try`
-extension ForTry: Traverse {
-    public static func traverse<G: Applicative, A, B>(_ fa: Kind<ForTry, A>, _ f: @escaping (A) -> Kind<G, B>) -> Kind<G, Kind<ForTry, B>> {
-        return Try.fix(fa).fold({ _ in G.pure(Try.raise(TryError.illegalState)) },
-                                { a in G.map(f(a), { b in Try.invoke{ b } }) })
+extension TryPartial: Traverse {
+    public static func traverse<G: Applicative, A, B>(_ fa: TryOf<A>, _ f: @escaping (A) -> Kind<G, B>) -> Kind<G, TryOf<B>> {
+        fa^.fold({ _ in G.pure(Try.raise(TryError.illegalState)) },
+                 { a in G.map(f(a), { b in Try.invoke{ b } }) })
     }
 }
 
 // MARK: Instance of `FunctorFilter` for `Try`
-extension ForTry: FunctorFilter {
-    public static func mapFilter<A, B>(_ fa: Kind<ForTry, A>, _ f: @escaping (A) -> Kind<ForOption, B>) -> Kind<ForTry, B> {
-        return Try.fix(fa).flatMap { a in
+extension TryPartial: FunctorFilter {
+    public static func mapFilter<A, B>(_ fa: TryOf<A>, _ f: @escaping (A) -> OptionOf<B>) -> TryOf<B> {
+        fa^.flatMap { a in
             f(a)^.fold(constant(raiseError(TryError.predicateDoesNotMatch)), pure)
         }
     }
@@ -304,16 +307,16 @@ extension ForTry: FunctorFilter {
 // MARK: Instance of `Semigroup` for `Try`
 extension Try: Semigroup where A: Semigroup {
     public func combine(_ other: Try<A>) -> Try<A> {
-        return self.fold(constant(other),
-                         { a in other.fold(constant(Try.success(a)),
-                                           { b in Try.success(a.combine(b)) })
-                         })
+        self.fold(constant(other),
+                  { a in other.fold(constant(Try.success(a)),
+                                    { b in Try.success(a.combine(b)) })
+        })
     }
 }
 
 // MARK: Instance of `Monoid` for `Try`
 extension Try: Monoid where A: Monoid {
     public static func empty() -> Try<A> {
-        return Try.failure(TryError.illegalState)
+        Try.failure(TryError.illegalState)
     }
 }

--- a/Sources/Bow/Data/Zipper.swift
+++ b/Sources/Bow/Data/Zipper.swift
@@ -1,6 +1,9 @@
 /// Witness for the `Zipper<A>` data type. To be used in simulated Higher Kinded Types.
 public final class ForZipper {}
 
+/// Partial application of the Zipper type constructor, omitting the last type parameter.
+public typealias ZipperPartial = ForZipper
+
 /// Higher Kinded Type alias to improve readability over `Kind<ForZipper, A>`
 public typealias ZipperOf<A> = Kind<ForZipper, A>
 
@@ -137,7 +140,7 @@ extension Zipper: CustomStringConvertible where A: CustomStringConvertible {
 
 // MARK: Instance of `EquatableK` for `Zipper`
 
-extension ForZipper: EquatableK {
+extension ZipperPartial: EquatableK {
     public static func eq<A: Equatable>(_ lhs: ZipperOf<A>, _ rhs: ZipperOf<A>) -> Bool {
         lhs^.left == rhs^.left &&
             lhs^.focus == rhs^.focus &&
@@ -147,11 +150,11 @@ extension ForZipper: EquatableK {
 
 // MARK: Instance of `Invariant` for `Zipper`
 
-extension ForZipper: Invariant {}
+extension ZipperPartial: Invariant {}
 
 // MARK: Instance of `Functor` for `Zipper`
 
-extension ForZipper: Functor {
+extension ZipperPartial: Functor {
     public static func map<A, B>(_ fa: ZipperOf<A>, _ f: @escaping (A) -> B) -> ZipperOf<B> {
         Zipper(left: fa^.left.map(f), focus: f(fa^.focus), right: fa^.right.map(f))
     }
@@ -159,7 +162,7 @@ extension ForZipper: Functor {
 
 // MARK: Instance of `Comonad` for `Zipper`
 
-extension ForZipper: Comonad {
+extension ZipperPartial: Comonad {
     public static func coflatMap<A, B>(_ fa: ZipperOf<A>, _ f: @escaping (ZipperOf<A>) -> B) -> ZipperOf<B> {
         let array = fa^.asArray()
         let newLeft: [B] = fa^.left.enumerated().map { item in

--- a/Sources/BowRecursionSchemes/Data/Fix.swift
+++ b/Sources/BowRecursionSchemes/Data/Fix.swift
@@ -2,13 +2,14 @@ import Foundation
 import Bow
 
 public final class ForFix {}
+public typealias FixPartial = ForFix
 public typealias FixOf<A> = Kind<ForFix, A>
 
 public class Fix<A>: FixOf<A> {
     public let unFix: Kind<A, Eval<FixOf<A>>>
     
     public static func fix(_ value: FixOf<A>) -> Fix<A> {
-        return value as! Fix<A>
+        value as! Fix<A>
     }
     
     public init(unFix: Kind<A, Eval<FixOf<A>>>) {
@@ -21,17 +22,17 @@ public class Fix<A>: FixOf<A> {
 /// - Parameter value: Value in higher-kind form.
 /// - Returns: Value cast to Fix.
 public postfix func ^<A>(_ value: FixOf<A>) -> Fix<A> {
-    return Fix.fix(value)
+    Fix.fix(value)
 }
 
-extension ForFix: Recursive {
-    public static func projectT<F: Functor>(_ tf: Kind<ForFix, F>) -> Kind<F, Kind<ForFix, F>> {
-        return F.map(Fix.fix(tf).unFix, { x in x.value() })
+extension FixPartial: Recursive {
+    public static func projectT<F: Functor>(_ tf: FixOf<F>) -> Kind<F, FixOf<F>> {
+        F.map(tf^.unFix, { x in x.value() })
     }
 }
 
-extension ForFix: Corecursive {
-    public static func embedT<F: Functor>(_ tf: Kind<F, Eval<Kind<ForFix, F>>>) -> Eval<Kind<ForFix, F>> {
-        return Eval.later { Fix(unFix: tf) }
+extension FixPartial: Corecursive {
+    public static func embedT<F: Functor>(_ tf: Kind<F, Eval<FixOf<F>>>) -> Eval<FixOf<F>> {
+        Eval.later { Fix(unFix: tf) }
     }
 }

--- a/Sources/BowRecursionSchemes/Data/Mu.swift
+++ b/Sources/BowRecursionSchemes/Data/Mu.swift
@@ -2,11 +2,12 @@ import Foundation
 import Bow
 
 public final class ForMu {}
+public typealias MuPartial = ForMu
 public typealias MuOf<F> = Kind<ForMu, F>
 
 open class Mu<F>: MuOf<F> {
     public static func fix(_ value: MuOf<F>) -> Mu<F> {
-        return value as! Mu<F>
+        value as! Mu<F>
     }
     
     open func unMu<A>(_ fa: @escaping Algebra<F, Eval<A>>) -> Eval<A> {
@@ -19,35 +20,35 @@ open class Mu<F>: MuOf<F> {
 /// - Parameter value: Value in higher-kind form.
 /// - Returns: Value cast to Mu.
 public postfix func ^<F>(_ value: MuOf<F>) -> Mu<F> {
-    return Mu.fix(value)
+    Mu.fix(value)
 }
 
-extension ForMu: Recursive {
-    public static func projectT<F: Functor>(_ tf: Kind<ForMu, F>) -> Kind<F, Kind<ForMu, F>> {
-        return cata(tf, { ff in
-            Eval.later { F.map(ff, { f in
-                embedT(F.map(f.value(), { muf in
+extension MuPartial: Recursive {
+    public static func projectT<F: Functor>(_ tf: MuOf<F>) -> Kind<F, MuOf<F>> {
+        cata(tf, { ff in
+            Eval.later { ff.map { f in
+                embedT(f.value().map { muf in
                     Eval.now(muf)
-                })).value()
-            }) }
+                }).value()
+            } }
         })
     }
 }
 
-extension ForMu: Corecursive {
-    public static func embedT<F: Functor>(_ tf: Kind<F, Eval<Kind<ForMu, F>>>) -> Eval<Kind<ForMu, F>> {
-        return Eval.now(MuEmbed(tf))
+extension MuPartial: Corecursive {
+    public static func embedT<F: Functor>(_ tf: Kind<F, Eval<MuOf<F>>>) -> Eval<MuOf<F>> {
+        .now(MuEmbed(tf))
     }
 }
 
-private class MuEmbed<F: Functor> : Mu<F> {
-    private let tf: Kind<F, Eval<Kind<ForMu, F>>>
+private class MuEmbed<F: Functor>: Mu<F> {
+    private let tf: Kind<F, Eval<MuOf<F>>>
     
-    init(_ tf: Kind<F, Eval<Kind<ForMu, F>>>) {
+    init(_ tf: Kind<F, Eval<MuOf<F>>>) {
         self.tf = tf
     }
     
     override func unMu<A>(_ fa: @escaping Algebra<F, Eval<A>>) -> Eval<A> {
-        return fa(F.map(tf, { eval in Eval.fix(eval.flatMap { x in Mu.fix(x).unMu(fa) }) }))
+        fa(tf.map { eval in eval.flatMap { x in x^.unMu(fa) }^ })
     }
 }

--- a/Sources/BowRx/ObservableK.swift
+++ b/Sources/BowRx/ObservableK.swift
@@ -6,6 +6,9 @@ import BowEffects
 /// Witness for the `ObservableK<A>` data type. To be used in simulated Higher Kinded Types.
 public final class ForObservableK {}
 
+/// Partial application of the ObservableK type constructor, omitting the last type parameter.
+public typealias ObservableKPartial = ForObservableK
+
 /// Higher Kinded Type alias to improve readability over `Kind<ForObservableK, A>`.
 public typealias ObservableKOf<A> = Kind<ForObservableK, A>
 
@@ -14,7 +17,7 @@ public extension Observable {
     ///
     /// - Returns: An `ObservableK` wrapping this object.
     func k() -> ObservableK<Element> {
-        return ObservableK<Element>(self)
+        ObservableK<Element>(self)
     }
 }
 
@@ -49,14 +52,14 @@ public final class ObservableK<A>: ObservableKOf<A> {
     /// - Parameter value: Value in the higher-kind form.
     /// - Returns: Value cast to ObservableK.
     public static func fix(_ value: ObservableKOf<A>) -> ObservableK<A> {
-        return value as! ObservableK<A>
+        value as! ObservableK<A>
     }
     
     /// Provides an empty `ObservableK`.
     ///
     /// - Returns: An `ObservableK` that does not provide any value.
     public static func empty() -> ObservableK<A> {
-        return Observable.empty().k()
+        Observable.empty().k()
     }
 
     /// Creates an `ObservableK` from the result of evaluating a function, suspending its execution.
@@ -64,7 +67,7 @@ public final class ObservableK<A>: ObservableKOf<A> {
     /// - Parameter f: Function providing the value to be provided in the underlying `Observable`.
     /// - Returns: An `ObservableK` that provides the value obtained from the closure.
     public static func from(_ f: @escaping () throws -> A) -> ObservableK<A> {
-        return ForObservableK.defer {
+        ForObservableK.defer {
             do {
                 return pure(try f())
             } catch {
@@ -78,7 +81,7 @@ public final class ObservableK<A>: ObservableKOf<A> {
     /// - Parameter f: Function providing the value to be provided in the underlying `Observable`.
     /// - Returns: An `ObservableK` that provides the value obtained from the closure.
     public static func invoke(_ f: @escaping () throws -> ObservableKOf<A>) -> ObservableK<A> {
-        return ForObservableK.defer {
+        ForObservableK.defer {
             do {
                 return try f()
             } catch {
@@ -99,7 +102,7 @@ public final class ObservableK<A>: ObservableKOf<A> {
     /// - Parameter f: Function to be mapped.
     /// - Returns: An ObservableK resulting from the application of the function.
     public func concatMap<B>(_ f: @escaping (A) -> ObservableKOf<B>) -> ObservableK<B> {
-        return value.concatMap { a in f(a)^.value }.k()
+        value.concatMap { a in f(a)^.value }.k()
     }
 }
 
@@ -108,37 +111,45 @@ public final class ObservableK<A>: ObservableKOf<A> {
 /// - Parameter value: Value in higher-kind form.
 /// - Returns: Value cast to ObservableK.
 public postfix func ^<A>(_ value: ObservableKOf<A>) -> ObservableK<A> {
-    return ObservableK.fix(value)
+    ObservableK.fix(value)
 }
 
 // MARK: Instance of `Functor` for `ObservableK`
-extension ForObservableK: Functor {
-    public static func map<A, B>(_ fa: Kind<ForObservableK, A>, _ f: @escaping (A) -> B) -> Kind<ForObservableK, B> {
-        return ObservableK.fix(fa).value.map(f).k()
+extension ObservableKPartial: Functor {
+    public static func map<A, B>(
+        _ fa: ObservableKOf<A>,
+        _ f: @escaping (A) -> B) -> ObservableKOf<B> {
+        fa^.value.map(f).k()
     }
 }
 
 // MARK: Instance of `Applicative` for `ObservableK`
-extension ForObservableK: Applicative {
-    public static func pure<A>(_ a: A) -> Kind<ForObservableK, A> {
-        return Observable.just(a).k()
+extension ObservableKPartial: Applicative {
+    public static func pure<A>(_ a: A) -> ObservableKOf<A> {
+        Observable.just(a).k()
     }
 }
 
 // MARK: Instance of `Selective` for `ObservableK`
-extension ForObservableK: Selective {}
+extension ObservableKPartial: Selective {}
 
 // MARK: Instance of `Monad` for `ObservableK`
-extension ForObservableK: Monad {
-    public static func flatMap<A, B>(_ fa: Kind<ForObservableK, A>, _ f: @escaping (A) -> Kind<ForObservableK, B>) -> Kind<ForObservableK, B> {
-        return ObservableK.fix(fa).value.flatMap { a in ObservableK<B>.fix(f(a)).value }.k()
+extension ObservableKPartial: Monad {
+    public static func flatMap<A, B>(
+        _ fa: ObservableKOf<A>,
+        _ f: @escaping (A) -> ObservableKOf<B>) -> ObservableKOf<B> {
+        fa^.value.flatMap { a in f(a)^.value }.k()
     }
 
-    public static func tailRecM<A, B>(_ a: A, _ f: @escaping (A) -> Kind<ForObservableK, Either<A, B>>) -> Kind<ForObservableK, B> {
+    public static func tailRecM<A, B>(
+        _ a: A,
+        _ f: @escaping (A) -> ObservableKOf<Either<A, B>>) -> ObservableKOf<B> {
         _tailRecM(a, f).run()
     }
     
-    private static func _tailRecM<A, B>(_ a: A, _ f: @escaping (A) -> ObservableKOf<Either<A, B>>) -> Trampoline<ObservableKOf<B>> {
+    private static func _tailRecM<A, B>(
+        _ a: A,
+        _ f: @escaping (A) -> ObservableKOf<Either<A, B>>) -> Trampoline<ObservableKOf<B>> {
         .defer {
             let either = f(a)^.value.blockingGet()!
             return either.fold({ a in _tailRecM(a, f)},
@@ -148,28 +159,36 @@ extension ForObservableK: Monad {
 }
 
 // MARK: Instance of `ApplicativeError` for `ObservableK`
-extension ForObservableK: ApplicativeError {
+extension ObservableKPartial: ApplicativeError {
     public typealias E = Error
 
-    public static func raiseError<A>(_ e: Error) -> Kind<ForObservableK, A> {
-        return Observable.error(e).k()
+    public static func raiseError<A>(_ e: Error) -> ObservableKOf<A> {
+        Observable.error(e).k()
     }
 
-    public static func handleErrorWith<A>(_ fa: Kind<ForObservableK, A>, _ f: @escaping (Error) -> Kind<ForObservableK, A>) -> Kind<ForObservableK, A> {
-        return ObservableK.fix(fa).value.catchError { e in ObservableK.fix(f(e)).value }.k()
+    public static func handleErrorWith<A>(
+        _ fa: ObservableKOf<A>,
+        _ f: @escaping (Error) -> ObservableKOf<A>) -> ObservableKOf<A> {
+        fa^.value.catchError { e in f(e)^.value }.k()
     }
 }
 
 // MARK: Instance of `MonadError` for `ObservableK`
-extension ForObservableK: MonadError {}
+extension ObservableKPartial: MonadError {}
 
 // MARK: Instance of `Foldable` for `ObservableK`
-extension ForObservableK: Foldable {
-    public static func foldLeft<A, B>(_ fa: Kind<ForObservableK, A>, _ b: B, _ f: @escaping (B, A) -> B) -> B {
-        return ObservableK.fix(fa).value.reduce(b, accumulator: f).blockingGet()!
+extension ObservableKPartial: Foldable {
+    public static func foldLeft<A, B>(
+        _ fa: ObservableKOf<A>,
+        _ b: B,
+        _ f: @escaping (B, A) -> B) -> B {
+        fa^.value.reduce(b, accumulator: f).blockingGet()!
     }
 
-    public static func foldRight<A, B>(_ fa: Kind<ForObservableK, A>, _ b: Eval<B>, _ f: @escaping (A, Eval<B>) -> Eval<B>) -> Eval<B> {
+    public static func foldRight<A, B>(
+        _ fa: ObservableKOf<A>,
+        _ b: Eval<B>,
+        _ f: @escaping (A, Eval<B>) -> Eval<B>) -> Eval<B> {
         func loop(_ fa: ObservableK<A>) -> Eval<B> {
             if let get = fa.value.blockingGet() {
                 return f(get, Eval.defer { loop(fa.value.skip(1).k()) } )
@@ -182,27 +201,32 @@ extension ForObservableK: Foldable {
 }
 
 // MARK: Instance of `Traverse` for `ObservableK`
-extension ForObservableK: Traverse {
-    public static func traverse<G: Applicative, A, B>(_ fa: Kind<ForObservableK, A>, _ f: @escaping (A) -> Kind<G, B>) -> Kind<G, Kind<ForObservableK, B>> {
-        return fa.foldRight(Eval.always { G.pure(Observable<B>.empty().k() as ObservableKOf<B>) }, { a, eval in
+extension ObservableKPartial: Traverse {
+    public static func traverse<G: Applicative, A, B>(
+        _ fa: ObservableKOf<A>,
+        _ f: @escaping (A) -> Kind<G, B>)
+        -> Kind<G, ObservableKOf<B>> {
+        fa.foldRight(Eval.always { G.pure(Observable<B>.empty().k() as ObservableKOf<B>) }, { a, eval in
             G.map2Eval(f(a), eval, { x, y in
-                Observable.concat(Observable.just(x), ObservableK.fix(y).value).k() as ObservableKOf<B>
+                Observable.concat(Observable.just(x), y^.value).k() as ObservableKOf<B>
             })
         }).value()
     }
 }
 
 // MARK: Instance of `MonadDefer` for `ObservableK`
-extension ForObservableK: MonadDefer {
-    public static func `defer`<A>(_ fa: @escaping () -> Kind<ForObservableK, A>) -> Kind<ForObservableK, A> {
-        return Observable.deferred { ObservableK<A>.fix(fa()).value }.k()
+extension ObservableKPartial: MonadDefer {
+    public static func `defer`<A>(_ fa: @escaping () -> ObservableKOf<A>) -> ObservableKOf<A> {
+        Observable.deferred { fa()^.value }.k()
     }
 }
 
 // MARK: Instance of `Async` for `ObservableK`
-extension ForObservableK: Async {
-    public static func asyncF<A>(_ procf: @escaping (@escaping (Either<Error, A>) -> ()) -> Kind<ForObservableK, ()>) -> Kind<ForObservableK, A> {
-        return Observable.create { emitter in
+extension ObservableKPartial: Async {
+    public static func asyncF<A>(
+        _ procf: @escaping (@escaping (Either<Error, A>) -> Void)
+        -> ObservableKOf<Void>) -> ObservableKOf<A> {
+        Observable.create { emitter in
             procf { either in
                 either.fold(
                     { error in emitter.on(.error(error)) },
@@ -211,12 +235,12 @@ extension ForObservableK: Async {
         }.k()
     }
 
-    public static func continueOn<A>(_ fa: Kind<ForObservableK, A>, _ queue: DispatchQueue) -> Kind<ForObservableK, A> {
-        return fa^.value.observeOn(SerialDispatchQueueScheduler(queue: queue, internalSerialQueueName: queue.label)).k()
+    public static func continueOn<A>(_ fa: ObservableKOf<A>, _ queue: DispatchQueue) -> ObservableKOf<A> {
+        fa^.value.observeOn(SerialDispatchQueueScheduler(queue: queue, internalSerialQueueName: queue.label)).k()
     }
 
-    public static func runAsync<A>(_ fa: @escaping ((Either<ForObservableK.E, A>) -> ()) throws -> ()) -> Kind<ForObservableK, A> {
-        return Observable.create { emitter in
+    public static func runAsync<A>(_ fa: @escaping ((Either<ForObservableK.E, A>) -> Void) throws -> Void) -> ObservableKOf<A> {
+        Observable.create { emitter in
             do {
                 try fa { either in
                     either.fold({ e in emitter.onError(e) },
@@ -229,34 +253,49 @@ extension ForObservableK: Async {
 }
 
 // MARK: Instance of `Effect` for `ObservableK`
-extension ForObservableK: Effect {
-    public static func runAsync<A>(_ fa: Kind<ForObservableK, A>, _ callback: @escaping (Either<Error, A>) -> Kind<ForObservableK, ()>) -> Kind<ForObservableK, ()> {
-        return ObservableK.fix(fa).value.flatMap { a in ObservableK<()>.fix(callback(Either.right(a))).value }
-            .catchError { e in ObservableK<()>.fix(callback(Either.left(e))).value }.k()
+extension ObservableKPartial: Effect {
+    public static func runAsync<A>(
+        _ fa: ObservableKOf<A>,
+        _ callback: @escaping (Either<Error, A>) -> ObservableKOf<Void>)
+        -> ObservableKOf<Void> {
+        fa^.value.flatMap { a in callback(Either.right(a))^.value }
+            .catchError { e in callback(Either.left(e))^.value }.k()
     }
 }
 
 // MARK: Instance of `Concurrent` for `ObservableK`
-extension ForObservableK: Concurrent {
-    public static func race<A, B>(_ fa: Kind<ForObservableK, A>, _ fb: Kind<ForObservableK, B>) -> Kind<ForObservableK, Either<A, B>> {
+extension ObservableKPartial: Concurrent {
+    public static func race<A, B>(
+        _ fa: ObservableKOf<A>,
+        _ fb: ObservableKOf<B>) -> ObservableKOf<Either<A, B>> {
         let left = fa.map(Either<A, B>.left)^.value
         let right = fb.map(Either<A, B>.right)^.value
         return left.amb(right).k()
     }
     
-    public static func parMap<A, B, Z>(_ fa: Kind<ForObservableK, A>, _ fb: Kind<ForObservableK, B>, _ f: @escaping (A, B) -> Z) -> Kind<ForObservableK, Z> {
-        return Observable.zip(fa^.value, fb^.value, resultSelector: f).k()
+    public static func parMap<A, B, Z>(
+        _ fa: ObservableKOf<A>,
+        _ fb: ObservableKOf<B>,
+        _ f: @escaping (A, B) -> Z) -> ObservableKOf<Z> {
+        Observable.zip(fa^.value, fb^.value, resultSelector: f).k()
     }
     
-    public static func parMap<A, B, C, Z>(_ fa: Kind<ForObservableK, A>, _ fb: Kind<ForObservableK, B>, _ fc: Kind<ForObservableK, C>, _ f: @escaping (A, B, C) -> Z) -> Kind<ForObservableK, Z> {
-        return Observable.zip(fa^.value, fb^.value, fc^.value, resultSelector: f).k()
+    public static func parMap<A, B, C, Z>(
+        _ fa: ObservableKOf<A>,
+        _ fb: ObservableKOf<B>,
+        _ fc: ObservableKOf<C>,
+        _ f: @escaping (A, B, C) -> Z) -> ObservableKOf<Z> {
+        Observable.zip(fa^.value, fb^.value, fc^.value, resultSelector: f).k()
     }
 }
 
 // MARK: Instance of `ConcurrentEffect` for `ObservableK`
-extension ForObservableK: ConcurrentEffect {
-    public static func runAsyncCancellable<A>(_ fa: Kind<ForObservableK, A>, _ callback: @escaping (Either<ForObservableK.E, A>) -> Kind<ForObservableK, ()>) -> Kind<ForObservableK, BowEffects.Disposable> {
-        return Observable.create { _ in
+extension ObservableKPartial: ConcurrentEffect {
+    public static func runAsyncCancellable<A>(
+        _ fa: ObservableKOf<A>,
+        _ callback: @escaping (Either<ForObservableK.E, A>)
+        -> ObservableKOf<Void>) -> ObservableKOf<BowEffects.Disposable> {
+        Observable.create { _ in
             let disposable = ObservableK.fix(ObservableK.fix(fa).runAsync(callback)).value.subscribe()
             return Disposables.create {
                 disposable.dispose()
@@ -266,12 +305,12 @@ extension ForObservableK: ConcurrentEffect {
 }
 
 // MARK: Instance of `Bracket` for `ObservableK`
-extension ForObservableK: Bracket {
+extension ObservableKPartial: Bracket {
     public static func bracketCase<A, B>(
-        acquire fa: Kind<ForObservableK, A>,
-        release: @escaping (A, ExitCase<Error>) -> Kind<ForObservableK, ()>,
-        use: @escaping (A) throws -> Kind<ForObservableK, B>) -> Kind<ForObservableK, B> {
-        return Observable.create { emitter in
+        acquire fa: ObservableKOf<A>,
+        release: @escaping (A, ExitCase<Error>) -> ObservableKOf<Void>,
+        use: @escaping (A) throws -> ObservableKOf<B>) -> ObservableKOf<B> {
+        Observable.create { emitter in
             fa.handleErrorWith { e in ObservableK.from { emitter.on(.error(e)) }.value.flatMap { _ in Observable.error(e) }.k() }^
                 .concatMap { a in
                     ObservableK.invoke { try use(a)^ }

--- a/Tests/BowGenerators/Arrow/Function0+Gen.swift
+++ b/Tests/BowGenerators/Arrow/Function0+Gen.swift
@@ -5,14 +5,14 @@ import SwiftCheck
 
 extension Function0: Arbitrary where A: Arbitrary {
     public static var arbitrary: Gen<Function0<A>> {
-        return A.arbitrary.map { a in Function0 { a } }
+        A.arbitrary.map { a in Function0 { a } }
     }
 }
 
 // MARK: Instance of `ArbitraryK` for `Function0`
 
-extension ForFunction0: ArbitraryK {
-    public static func generate<A>() -> Kind<ForFunction0, A> where A : Arbitrary {
-        return Function0.arbitrary.generate
+extension Function0Partial: ArbitraryK {
+    public static func generate<A: Arbitrary>() -> Function0Of<A> {
+        Function0.arbitrary.generate
     }
 }

--- a/Tests/BowGenerators/Data/ArrayK+Gen.swift
+++ b/Tests/BowGenerators/Data/ArrayK+Gen.swift
@@ -5,14 +5,14 @@ import SwiftCheck
 
 extension ArrayK: Arbitrary where A: Arbitrary {
     public static var arbitrary: Gen<ArrayK<A>> {
-        return Array.arbitrary.map(ArrayK.init)
+        Array.arbitrary.map(ArrayK.init)
     }
 }
 
 // MARK: Instance of `ArbitraryK` for `ArrayK`
 
-extension ForArrayK: ArbitraryK {
-    public static func generate<A: Arbitrary>() -> Kind<ForArrayK, A> {
-        return ArrayK.arbitrary.generate
+extension ArrayKPartial: ArbitraryK {
+    public static func generate<A: Arbitrary>() -> ArrayKOf<A> {
+        ArrayK.arbitrary.generate
     }
 }

--- a/Tests/BowGenerators/Data/Eval+Gen.swift
+++ b/Tests/BowGenerators/Data/Eval+Gen.swift
@@ -1,8 +1,8 @@
 import Bow
 import SwiftCheck
 
-extension ForEval: ArbitraryK {
-    public static func generate<A: Arbitrary>() -> Kind<ForEval, A> {
+extension EvalPartial: ArbitraryK {
+    public static func generate<A: Arbitrary>() -> EvalOf<A> {
         let nowGen = A.arbitrary.map(Eval.now)
         let laterGen = A.arbitrary.map { x in Eval.later { x } }
         let alwaysGen = A.arbitrary.map { x in Eval.always { x } }

--- a/Tests/BowGenerators/Data/Id+Gen.swift
+++ b/Tests/BowGenerators/Data/Id+Gen.swift
@@ -5,14 +5,14 @@ import SwiftCheck
 
 extension Id: Arbitrary where A: Arbitrary {
     public static var arbitrary: Gen<Id<A>> {
-        return A.arbitrary.map(Id.init)
+        A.arbitrary.map(Id.init)
     }
 }
 
 // MARK: Instance of `ArbitraryK` for `Id`
 
-extension ForId: ArbitraryK {
-    public static func generate<A: Arbitrary>() -> Kind<ForId, A> {
-        return Id.arbitrary.generate
+extension IdPartial: ArbitraryK {
+    public static func generate<A: Arbitrary>() -> IdOf<A> {
+        Id.arbitrary.generate
     }
 }

--- a/Tests/BowGenerators/Data/NonEmptyArray+Gen.swift
+++ b/Tests/BowGenerators/Data/NonEmptyArray+Gen.swift
@@ -5,7 +5,7 @@ import SwiftCheck
 
 extension NonEmptyArray: Arbitrary where A: Arbitrary {
     public static var arbitrary: Gen<NonEmptyArray<A>> {
-        return Array.arbitrary
+        Array.arbitrary
             .suchThat { array in array.count > 0 }
             .map(NonEmptyArray.fromArrayUnsafe)
     }
@@ -13,8 +13,8 @@ extension NonEmptyArray: Arbitrary where A: Arbitrary {
 
 // MARK: Instance of `ArbitraryK` for `NonEmptyArray`
 
-extension ForNonEmptyArray: ArbitraryK {
-    public static func generate<A: Arbitrary>() -> Kind<ForNonEmptyArray, A> {
-        return NonEmptyArray.arbitrary.generate
+extension NonEmptyArrayPartial: ArbitraryK {
+    public static func generate<A: Arbitrary>() -> NonEmptyArrayOf<A> {
+        NonEmptyArray.arbitrary.generate
     }
 }

--- a/Tests/BowGenerators/Data/Option+Gen.swift
+++ b/Tests/BowGenerators/Data/Option+Gen.swift
@@ -13,8 +13,8 @@ extension Option: Arbitrary where A: Arbitrary {
 
 // MARK: Instance of `ArbitraryK` for `Option`
 
-extension ForOption: ArbitraryK {
-    public static func generate<A: Arbitrary>() -> Kind<ForOption, A> {
-        return Option.arbitrary.generate
+extension OptionPartial: ArbitraryK {
+    public static func generate<A: Arbitrary>() -> OptionOf<A> {
+        Option.arbitrary.generate
     }
 }

--- a/Tests/BowGenerators/Data/Try+Gen.swift
+++ b/Tests/BowGenerators/Data/Try+Gen.swift
@@ -13,8 +13,8 @@ extension Try: Arbitrary where A: Arbitrary {
 
 // MARK: Instance of `ArbitraryK` for `Try`
 
-extension ForTry: ArbitraryK {
-    public static func generate<A: Arbitrary>() -> Kind<ForTry, A> {
-        return Try.arbitrary.generate
+extension TryPartial: ArbitraryK {
+    public static func generate<A: Arbitrary>() -> TryOf<A> {
+        Try.arbitrary.generate
     }
 }

--- a/Tests/BowGenerators/Data/Zipper+Gen.swift
+++ b/Tests/BowGenerators/Data/Zipper+Gen.swift
@@ -12,7 +12,7 @@ extension Zipper: Arbitrary where A: Arbitrary {
 
 // MARK: Instance of `ArbitraryK` for `ArrayK`
 
-extension ForZipper: ArbitraryK {
+extension ZipperPartial: ArbitraryK {
     public static func generate<A: Arbitrary>() -> ZipperOf<A> {
         Zipper<A>.arbitrary.generate
     }

--- a/Tests/BowLaws/MonadLaws.swift
+++ b/Tests/BowLaws/MonadLaws.swift
@@ -10,7 +10,7 @@ public class MonadLaws<F: Monad & EquatableK & ArbitraryK> {
         kleisliLeftIdentity()
         kleisliRightIdentity()
         flatMapCoherence()
-        if withStackSafety { #warning("All implementations should be stack safe, this is temporary")
+        if withStackSafety { 
             stackSafety()
         }
         monadComprehensions()

--- a/Tests/BowRxGenerators/MaybeK+Gen.swift
+++ b/Tests/BowRxGenerators/MaybeK+Gen.swift
@@ -7,14 +7,14 @@ import SwiftCheck
 
 extension MaybeK: Arbitrary where A: Arbitrary {
     public static var arbitrary: Gen<MaybeK<A>> {
-        return A.arbitrary.map { x in MaybeK.pure(x)^ }
+        A.arbitrary.map { x in MaybeK.pure(x)^ }
     }
 }
 
 // MARK: Instance of `ArbitraryK` for `MaybeK`
 
-extension ForMaybeK: ArbitraryK {
-    public static func generate<A: Arbitrary>() -> Kind<ForMaybeK, A> {
-        return MaybeK.arbitrary.generate
+extension MaybeKPartial: ArbitraryK {
+    public static func generate<A: Arbitrary>() -> MaybeKOf<A> {
+        MaybeK.arbitrary.generate
     }
 }

--- a/Tests/BowRxGenerators/ObservableK+Gen.swift
+++ b/Tests/BowRxGenerators/ObservableK+Gen.swift
@@ -7,14 +7,14 @@ import SwiftCheck
 
 extension ObservableK: Arbitrary where A: Arbitrary {
     public static var arbitrary: Gen<ObservableK<A>> {
-        return A.arbitrary.map { x in ObservableK.pure(x)^ }
+        A.arbitrary.map { x in ObservableK.pure(x)^ }
     }
 }
 
 // MARK: Instance of `ArbitraryK` for `ObservableK`
 
-extension ForObservableK: ArbitraryK {
-    public static func generate<A: Arbitrary>() -> Kind<ForObservableK, A> {
-        return ObservableK.arbitrary.generate
+extension ObservableKPartial: ArbitraryK {
+    public static func generate<A: Arbitrary>() -> ObservableKOf<A> {
+        ObservableK.arbitrary.generate
     }
 }

--- a/Tests/BowRxGenerators/SingleK+Gen.swift
+++ b/Tests/BowRxGenerators/SingleK+Gen.swift
@@ -7,14 +7,14 @@ import SwiftCheck
 
 extension SingleK: Arbitrary where A: Arbitrary {
     public static var arbitrary: Gen<SingleK<A>> {
-        return A.arbitrary.map { x in SingleK.pure(x)^ }
+        A.arbitrary.map { x in SingleK.pure(x)^ }
     }
 }
 
 // MARK: Instance of `ArbitraryK` for `SingleK`
 
-extension ForSingleK: ArbitraryK {
-    public static func generate<A: Arbitrary>() -> Kind<ForSingleK, A> {
-        return SingleK.arbitrary.generate
+extension SingleKPartial: ArbitraryK {
+    public static func generate<A: Arbitrary>() -> SingleKOf<A> {
+        SingleK.arbitrary.generate
     }
 }

--- a/Tests/BowRxTests/MaybeKTest.swift
+++ b/Tests/BowRxTests/MaybeKTest.swift
@@ -5,30 +5,32 @@ import Bow
 import BowRxGenerators
 import BowEffectsLaws
 
-extension ForMaybeK: EquatableK {
-    public static func eq<A: Equatable>(_ lhs: Kind<ForMaybeK, A>, _ rhs: Kind<ForMaybeK, A>) -> Bool {
-        return MaybeK.fix(lhs).value.blockingGet() == MaybeK.fix(rhs).value.blockingGet()
+extension MaybeKPartial: EquatableK {
+    public static func eq<A: Equatable>(
+        _ lhs: MaybeKOf<A>,
+        _ rhs: MaybeKOf<A>) -> Bool {
+        lhs^.value.blockingGet() == rhs^.value.blockingGet()
     }
 }
 
 class MaybeKTest: XCTestCase {
     func testFunctorLaws() {
-        FunctorLaws<ForMaybeK>.check()
+        FunctorLaws<MaybeKPartial>.check()
     }
     
     func testApplicativeLaws() {
-        ApplicativeLaws<ForMaybeK>.check()
+        ApplicativeLaws<MaybeKPartial>.check()
     }
 
     func testSelectiveLaws() {
-        SelectiveLaws<ForMaybeK>.check()
+        SelectiveLaws<MaybeKPartial>.check()
     }
 
     func testMonadLaws() {
-        MonadLaws<ForMaybeK>.check()
+        MonadLaws<MaybeKPartial>.check()
     }
     
     func testFoldableLaws() {
-        FoldableLaws<ForMaybeK>.check()
+        FoldableLaws<MaybeKPartial>.check()
     }
 }

--- a/Tests/BowRxTests/ObservableKTest.swift
+++ b/Tests/BowRxTests/ObservableKTest.swift
@@ -5,34 +5,36 @@ import Bow
 import BowRxGenerators
 import BowEffectsLaws
 
-extension ForObservableK: EquatableK {
-    public static func eq<A: Equatable>(_ lhs: Kind<ForObservableK, A>, _ rhs: Kind<ForObservableK, A>) -> Bool {
-        return ObservableK.fix(lhs).value.blockingGet() == ObservableK.fix(rhs).value.blockingGet()
+extension ObservableKPartial: EquatableK {
+    public static func eq<A: Equatable>(
+        _ lhs: ObservableKOf<A>,
+        _ rhs: ObservableKOf<A>) -> Bool {
+        lhs^.value.blockingGet() == rhs^.value.blockingGet()
     }
 }
 
 class ObservableKTest: XCTestCase {
     func testFunctorLaws() {
-        FunctorLaws<ForObservableK>.check()
+        FunctorLaws<ObservableKPartial>.check()
     }
     
     func testApplicativeLaws() {
-        ApplicativeLaws<ForObservableK>.check()
+        ApplicativeLaws<ObservableKPartial>.check()
     }
 
     func testSelectiveLaws() {
-        SelectiveLaws<ForObservableK>.check()
+        SelectiveLaws<ObservableKPartial>.check()
     }
 
     func testMonadLaws() {
-        MonadLaws<ForObservableK>.check()
+        MonadLaws<ObservableKPartial>.check()
     }
     
     func testFoldableLaws() {
-        FoldableLaws<ForObservableK>.check()
+        FoldableLaws<ObservableKPartial>.check()
     }
     
     func testTraverseLaws() {
-        TraverseLaws<ForObservableK>.check()
+        TraverseLaws<ObservableKPartial>.check()
     }
 }

--- a/Tests/BowRxTests/SingleKTest.swift
+++ b/Tests/BowRxTests/SingleKTest.swift
@@ -5,26 +5,28 @@ import Bow
 import BowRxGenerators
 import BowEffectsLaws
 
-extension ForSingleK: EquatableK {
-    public static func eq<A: Equatable>(_ lhs: Kind<ForSingleK, A>, _ rhs: Kind<ForSingleK, A>) -> Bool {
-        return SingleK.fix(lhs).value.blockingGet() == SingleK.fix(rhs).value.blockingGet()
+extension SingleKPartial: EquatableK {
+    public static func eq<A: Equatable>(
+        _ lhs: SingleKOf<A>,
+        _ rhs: SingleKOf<A>) -> Bool {
+        lhs^.value.blockingGet() == rhs^.value.blockingGet()
     }
 }
 
 class SingleKTest: XCTestCase {
     func testFunctorLaws() {
-        FunctorLaws<ForSingleK>.check()
+        FunctorLaws<SingleKPartial>.check()
     }
     
     func testApplicativeLaws() {
-        ApplicativeLaws<ForSingleK>.check()
+        ApplicativeLaws<SingleKPartial>.check()
     }
 
     func testSelectiveLaws() {
-        SelectiveLaws<ForSingleK>.check()
+        SelectiveLaws<SingleKPartial>.check()
     }
 
     func testMonadLaws() {
-        MonadLaws<ForSingleK>.check()
+        MonadLaws<SingleKPartial>.check()
     }
 }

--- a/Tests/BowTests/Arrow/Function0Test.swift
+++ b/Tests/BowTests/Arrow/Function0Test.swift
@@ -4,31 +4,31 @@ import Bow
 
 class Function0Test: XCTestCase {
     func testEquatableLaws() {
-        EquatableKLaws<ForFunction0, Int>.check()
+        EquatableKLaws<Function0Partial, Int>.check()
     }
     
     func testFunctorLaws() {
-        FunctorLaws<ForFunction0>.check()
+        FunctorLaws<Function0Partial>.check()
     }
     
     func testApplicativeLaws() {
-        ApplicativeLaws<ForFunction0>.check()
+        ApplicativeLaws<Function0Partial>.check()
     }
 
     func testSelectiveLaws() {
-        SelectiveLaws<ForFunction0>.check()
+        SelectiveLaws<Function0Partial>.check()
     }
 
     func testMonadLaws() {
-        MonadLaws<ForFunction0>.check()
+        MonadLaws<Function0Partial>.check()
     }
     
     func testComonadLaws() {
-        ComonadLaws<ForFunction0>.check()
+        ComonadLaws<Function0Partial>.check()
     }
     
     func testBimonadLaws() {
-        BimonadLaws<ForFunction0>.check()
+        BimonadLaws<Function0Partial>.check()
     }
     
     func testSemigroupLaws() {

--- a/Tests/BowTests/Data/ArrayKTest.swift
+++ b/Tests/BowTests/Data/ArrayKTest.swift
@@ -5,23 +5,23 @@ import Bow
 
 class ArrayKTest: XCTestCase {
     func testEquatableLaws() {
-        EquatableKLaws<ForArrayK, Int>.check()
+        EquatableKLaws<ArrayKPartial, Int>.check()
     }
     
     func testFunctorLaws() {
-        FunctorLaws<ForArrayK>.check()
+        FunctorLaws<ArrayKPartial>.check()
     }
     
     func testApplicativeLaws() {
-        ApplicativeLaws<ForArrayK>.check()
+        ApplicativeLaws<ArrayKPartial>.check()
     }
 
     func testSelectiveLaws() {
-        SelectiveLaws<ForArrayK>.check()
+        SelectiveLaws<ArrayKPartial>.check()
     }
 
     func testMonadLaws() {
-        MonadLaws<ForArrayK>.check()
+        MonadLaws<ArrayKPartial>.check()
     }
     
     func testSemigroupLaws() {
@@ -29,7 +29,7 @@ class ArrayKTest: XCTestCase {
     }
     
     func testSemigroupKLaws() {
-        SemigroupKLaws<ForArrayK>.check()
+        SemigroupKLaws<ArrayKPartial>.check()
     }
     
     func testMonoidLaws() {
@@ -37,27 +37,27 @@ class ArrayKTest: XCTestCase {
     }
     
     func testMonoidKLaws() {
-        MonoidKLaws<ForArrayK>.check()
+        MonoidKLaws<ArrayKPartial>.check()
     }
     
     func testFunctorFilterLaws() {
-        FunctorFilterLaws<ForArrayK>.check()
+        FunctorFilterLaws<ArrayKPartial>.check()
     }
     
     func testMonadFilterLaws() {
-        MonadFilterLaws<ForArrayK>.check()
+        MonadFilterLaws<ArrayKPartial>.check()
     }
     
     func testFoldableLaws() {
-        FoldableLaws<ForArrayK>.check()
+        FoldableLaws<ArrayKPartial>.check()
     }
     
     func testMonadCombineLaws() {
-        MonadCombineLaws<ForArrayK>.check()
+        MonadCombineLaws<ArrayKPartial>.check()
     }
     
     func testTraverseLaws() {
-        TraverseLaws<ForArrayK>.check()
+        TraverseLaws<ArrayKPartial>.check()
     }
     
     func testMonadComprehensions() {

--- a/Tests/BowTests/Data/EndoTest.swift
+++ b/Tests/BowTests/Data/EndoTest.swift
@@ -3,14 +3,13 @@ import SwiftCheck
 import BowLaws
 import Bow
 
-extension ForEndo: EquatableK {
-    public static func eq<A>(_ a: EndoOf<A>, _ b: EndoOf<A>) -> Bool where A : Equatable {
-        return a^.run(1 as! A) == b^.run(1 as! A)
+extension EndoPartial: EquatableK {
+    public static func eq<A: Equatable>(_ a: EndoOf<A>, _ b: EndoOf<A>) -> Bool {
+        a^.run(1 as! A) == b^.run(1 as! A)
     }
 }
 
 class EndoTest: XCTestCase {
-    
     func testSemigroupLaws() {
         SemigroupLaws<Endo<Int>>.check()
     }

--- a/Tests/BowTests/Data/EvalTest.swift
+++ b/Tests/BowTests/Data/EvalTest.swift
@@ -4,30 +4,30 @@ import Bow
 
 class EvalTest: XCTestCase {
     func testFunctorLaws() {
-        FunctorLaws<ForEval>.check()
+        FunctorLaws<EvalPartial>.check()
     }
     
     func testApplicativeLaws() {
-        ApplicativeLaws<ForEval>.check()
+        ApplicativeLaws<EvalPartial>.check()
     }
     
     func testSelectiveLaws() {
-        SelectiveLaws<ForEval>.check()
+        SelectiveLaws<EvalPartial>.check()
     }
     
     func testMonadLaws() {
-        MonadLaws<ForEval>.check()
+        MonadLaws<EvalPartial>.check()
     }
     
     func testComonadLaws() {
-        ComonadLaws<ForEval>.check()
+        ComonadLaws<EvalPartial>.check()
     }
     
     func testBimonadLaws() {
-        BimonadLaws<ForEval>.check()
+        BimonadLaws<EvalPartial>.check()
     }
     
     func testEquatableKLaws() {
-        EquatableKLaws<ForEval, Int>.check()
+        EquatableKLaws<EvalPartial, Int>.check()
     }
 }

--- a/Tests/BowTests/Data/IdTest.swift
+++ b/Tests/BowTests/Data/IdTest.swift
@@ -4,27 +4,27 @@ import Bow
 
 class IdTest: XCTestCase {
     func testEquatableLaws() {
-        EquatableKLaws<ForId, Int>.check()
+        EquatableKLaws<IdPartial, Int>.check()
     }
     
     func testFunctorLaws() {
-        FunctorLaws<ForId>.check()
+        FunctorLaws<IdPartial>.check()
     }
     
     func testApplicativeLaws() {
-        ApplicativeLaws<ForId>.check()
+        ApplicativeLaws<IdPartial>.check()
     }
 
     func testSelectiveLaws() {
-        SelectiveLaws<ForId>.check()
+        SelectiveLaws<IdPartial>.check()
     }
 
     func testMonadLaws() {
-        MonadLaws<ForId>.check()
+        MonadLaws<IdPartial>.check()
     }
     
     func testComonadLaws() {
-        ComonadLaws<ForId>.check()
+        ComonadLaws<IdPartial>.check()
     }
     
     func testCustomStringConvertibleLaws() {
@@ -32,15 +32,15 @@ class IdTest: XCTestCase {
     }
     
     func testFoldableLaws() {
-        FoldableLaws<ForId>.check()
+        FoldableLaws<IdPartial>.check()
     }
     
     func testBimonadLaws() {
-        BimonadLaws<ForId>.check()
+        BimonadLaws<IdPartial>.check()
     }
     
     func testTraverseLaws() {
-        TraverseLaws<ForId>.check()
+        TraverseLaws<IdPartial>.check()
     }
     
     func testSemigroupLaws() {

--- a/Tests/BowTests/Data/NonEmptyArrayTest.swift
+++ b/Tests/BowTests/Data/NonEmptyArrayTest.swift
@@ -5,35 +5,35 @@ import Bow
 
 class NonEmptyArrayTest: XCTestCase {
     func testEquatableLaws() {
-        EquatableKLaws<ForNonEmptyArray, Int>.check()
+        EquatableKLaws<NonEmptyArrayPartial, Int>.check()
     }
     
     func testFunctorLaws() {
-        FunctorLaws<ForNonEmptyArray>.check()
+        FunctorLaws<NonEmptyArrayPartial>.check()
     }
     
     func testApplicativeLaws() {
-        ApplicativeLaws<ForNonEmptyArray>.check()
+        ApplicativeLaws<NonEmptyArrayPartial>.check()
     }
 
     func testSelectiveLaws() {
-        SelectiveLaws<ForNonEmptyArray>.check()
+        SelectiveLaws<NonEmptyArrayPartial>.check()
     }
 
     func testMonadLaws() {
-        MonadLaws<ForNonEmptyArray>.check()
+        MonadLaws<NonEmptyArrayPartial>.check()
     }
     
     func testComonadLaws() {
-        ComonadLaws<ForNonEmptyArray>.check()
+        ComonadLaws<NonEmptyArrayPartial>.check()
     }
     
     func testBimonadLaws() {
-        BimonadLaws<ForNonEmptyArray>.check()
+        BimonadLaws<NonEmptyArrayPartial>.check()
     }
     
     func testTraverseLaws() {
-        TraverseLaws<ForNonEmptyArray>.check()
+        TraverseLaws<NonEmptyArrayPartial>.check()
     }
     
     func testSemigroupLaws() {
@@ -41,7 +41,7 @@ class NonEmptyArrayTest: XCTestCase {
     }
     
     func testSemigroupKLaws() {
-        SemigroupKLaws<ForNonEmptyArray>.check()
+        SemigroupKLaws<NonEmptyArrayPartial>.check()
     }
     
     func testCustomStringConvertibleLaws() {
@@ -49,16 +49,16 @@ class NonEmptyArrayTest: XCTestCase {
     }
     
     func testFoldableLaws() {
-        FoldableLaws<ForNonEmptyArray>.check()
+        FoldableLaws<NonEmptyArrayPartial>.check()
     }
     
     func testConcatenation() {
         property("The length of the concatenation is equal to the sum of lenghts") <~ forAll { (a: NEA<Int>, b: NEA<Int>) in
-            return a.count + b.count == (a + b).count
+            a.count + b.count == (a + b).count
         }
         
         property("Adding one element increases length in one") <~ forAll { (nea: NEA<Int>, element: Int) in
-            return (nea + element).count == nea.count + 1
+            (nea + element).count == nea.count + 1
         }
         
         property("Result of concatenation contains all items from the original arrays") <~ forAll { (a: NEA<Int>, b: NEA<Int>) in

--- a/Tests/BowTests/Data/OptionTest.swift
+++ b/Tests/BowTests/Data/OptionTest.swift
@@ -5,23 +5,23 @@ import Bow
 
 class OptionTest: XCTestCase {
     func testEquatableLaws() {
-        EquatableKLaws<ForOption, Int>.check()
+        EquatableKLaws<OptionPartial, Int>.check()
     }
     
     func testFunctorLaws() {
-        FunctorLaws<ForOption>.check()
+        FunctorLaws<OptionPartial>.check()
     }
     
     func testApplicativeLaws() {
-        ApplicativeLaws<ForOption>.check()
+        ApplicativeLaws<OptionPartial>.check()
     }
 
     func testSelectiveLaws() {
-        SelectiveLaws<ForOption>.check()
+        SelectiveLaws<OptionPartial>.check()
     }
 
     func testMonadLaws() {
-        MonadLaws<ForOption>.check()
+        MonadLaws<OptionPartial>.check()
     }
     
     func testSemigroupLaws() {
@@ -33,19 +33,19 @@ class OptionTest: XCTestCase {
     }
     
     func testSemigroupKLaws() {
-        SemigroupKLaws<ForOption>.check()
+        SemigroupKLaws<OptionPartial>.check()
     }
     
     func testMonoidKLaws() {
-        MonoidKLaws<ForOption>.check()
+        MonoidKLaws<OptionPartial>.check()
     }
     
     func testFunctorFilterLaws() {
-        FunctorFilterLaws<ForOption>.check()
+        FunctorFilterLaws<OptionPartial>.check()
     }
     
     func testMonadFilterLaws() {
-        MonadFilterLaws<ForOption>.check()
+        MonadFilterLaws<OptionPartial>.check()
     }
     
     func testCustomStringConvertibleLaws() {
@@ -53,48 +53,48 @@ class OptionTest: XCTestCase {
     }
     
     func testFoldableLaws() {
-        FoldableLaws<ForOption>.check()
+        FoldableLaws<OptionPartial>.check()
     }
     
     func testTraverseLaws() {
-        TraverseLaws<ForOption>.check()
+        TraverseLaws<OptionPartial>.check()
     }
     
     func testTraverseFilterLaws() {
-        TraverseFilterLaws<ForOption>.check()
+        TraverseFilterLaws<OptionPartial>.check()
     }
     
     func testMonadCombineLaws() {
-        MonadCombineLaws<ForOption>.check()
+        MonadCombineLaws<OptionPartial>.check()
     }
 	
 	func testSemigroupalLaws() {
-        SemigroupalLaws<ForOption>.check(isEqual: isEqual(_:_:))
+        SemigroupalLaws<OptionPartial>.check(isEqual: isEqual(_:_:))
 	}
     
     func testMonoidalLaws() {
-        func isMonoidalEqual<A, B>(_ fa: Kind<ForOption, A>, _ fb: Kind<ForOption, B>) -> Bool {
+        func isMonoidalEqual<A, B>(_ fa: OptionOf<A>, _ fb: OptionOf<B>) -> Bool {
             fa.isEmpty && fb.isEmpty
         }
-        MonoidalLaws<ForOption>.check(isEqual: isMonoidalEqual)
+        MonoidalLaws<OptionPartial>.check(isEqual: isMonoidalEqual)
     }
     
     func testFromToOption() {
         property("fromOption - toOption isomorphism") <~ forAll { (x: Int?, option: Option<Int>) in
-            return Option.fromOptional(x).toOptional() == x &&
+            Option.fromOptional(x).toOptional() == x &&
                 Option.fromOptional(option.toOptional()) == option
         }
     }
     
     func testDefinedOrEmpty() {
         property("Option cannot be simultaneously empty and defined") <~ forAll { (option: Option<Int>) in
-            return xor(option.isEmpty, option.isDefined)
+            xor(option.isEmpty, option.isDefined)
         }
     }
     
     func testGetOrElse() {
         property("getOrElse consistent with orElse") <~ forAll { (option: Option<Int>, y: Int) in
-            return Option<Int>.pure(option.getOrElse(y)) == Option.fix(option).orElse(Option.some(y))
+            Option<Int>.pure(option.getOrElse(y)) == option.orElse(Option.some(y))
         }
     }
     
@@ -107,7 +107,7 @@ class OptionTest: XCTestCase {
     
     func testExistForAll() {
         property("exists and forall are equivalent") <~ forAll { (option: Option<Int>, predicate: ArrowOf<Int, Bool>) in
-            return option.exists(predicate.getArrow) == option.forall(predicate.getArrow) || option.isEmpty
+            option.exists(predicate.getArrow) == option.forall(predicate.getArrow) || option.isEmpty
         }
     }
 }

--- a/Tests/BowTests/Data/TryTest.swift
+++ b/Tests/BowTests/Data/TryTest.swift
@@ -4,23 +4,23 @@ import Bow
 
 class TryTest: XCTestCase {
     func testEquatableLaws() {
-        EquatableKLaws<ForTry, Int>.check()
+        EquatableKLaws<TryPartial, Int>.check()
     }
     
     func testFunctorLaws() {
-        FunctorLaws<ForTry>.check()
+        FunctorLaws<TryPartial>.check()
     }
     
     func testApplicativeLaws() {
-        ApplicativeLaws<ForTry>.check()
+        ApplicativeLaws<TryPartial>.check()
     }
 
     func testSelectiveLaws() {
-        SelectiveLaws<ForTry>.check()
+        SelectiveLaws<TryPartial>.check()
     }
 
     func testMonadLaws() {
-        MonadLaws<ForTry>.check()
+        MonadLaws<TryPartial>.check()
     }
     
     func testCustomStringConvertibleLaws() {
@@ -28,15 +28,15 @@ class TryTest: XCTestCase {
     }
     
     func testFoldableLaws() {
-        FoldableLaws<ForTry>.check()
+        FoldableLaws<TryPartial>.check()
     }
     
     func testTraverseLaws() {
-        TraverseLaws<ForTry>.check()
+        TraverseLaws<TryPartial>.check()
     }
 
     func testFunctorFilterLaws() {
-        FunctorFilterLaws<ForTry>.check()
+        FunctorFilterLaws<TryPartial>.check()
     }
 
     func testSemigroupLaws() {

--- a/Tests/BowTests/Data/ZipperTest.swift
+++ b/Tests/BowTests/Data/ZipperTest.swift
@@ -5,15 +5,15 @@ import Bow
 
 class ZipperTest: XCTestCase {
     func testEquatableLaws() {
-        EquatableKLaws<ForZipper, Int>.check()
+        EquatableKLaws<ZipperPartial, Int>.check()
     }
     
     func testFunctorLaws() {
-        FunctorLaws<ForZipper>.check()
+        FunctorLaws<ZipperPartial>.check()
     }
     
     func testComonadLaws() {
-        ComonadLaws<ForZipper>.check()
+        ComonadLaws<ZipperPartial>.check()
     }
     
     let nonEmptyArrayGen = [Int].arbitrary.suchThat { x in x.count > 0 }


### PR DESCRIPTION
## Goal

Currently, there is some dissonance between HKTs with one type argument and others with 2 or more arguments. Whereas the latter have their `Partial` versions, the former do not have this alias. This results in the following when instances for type classes need to be provided:

```swift
extension ForOption: Functor { ... }
extension EitherPartial: Functor { ... }
```

It seems weird not to have a single convention when implementing instances of type classes on the kind level, and having to remember that, for types with one type argument you need to use the `For` form, and for others the `Partial` form.

This PR unifies the convention by providing a `Partial` alias for types with a single type argument, so that the previous code still works, but the preferred way of doing it is:

```swift
extension OptionPartial: Functor { ... }
extension EitherPartial: Functor { ... }
```

This way, every time one needs to provide an instance for a type class in the kind level, only needs to remember that it is done in the `Partial` type.

Besides this, the PR updates the code of the modified files to make aesthetic changes:

- Remove returns when possible.
- Use `TOf<A>` instead of `Kind<T, A>` when possible.
- Use `^` instead of `fix` when possible.
- Break down lines and simplify some code for better readability.

Documentation has been updated accordingly.