### PR TITLE
Cleanup Arrow folder in Bow Core

### DIFF
--- a/Sources/Bow/Arrow/Cokleisli.swift
+++ b/Sources/Bow/Arrow/Cokleisli.swift
@@ -48,7 +48,7 @@ public postfix func ^<F, A, B>(_ value: CokleisliOf<F, A, B>) -> Cokleisli<F, A,
     Cokleisli.fix(value)
 }
 
-// MARK: Functions for `Cokleisli` when the effect has a `Comonad` instance.
+// MARK: Functions for Cokleisli when the effect has a Comonad instance.
 extension Cokleisli where F: Comonad {
     /// Creates a Cokleisli that extracts the value of a `Comonad`.
     ///

--- a/Sources/Bow/Arrow/Function0.swift
+++ b/Sources/Bow/Arrow/Function0.swift
@@ -44,33 +44,35 @@ public postfix func ^<A>(_ fa: Function0Of<A>) -> Function0<A> {
     Function0.fix(fa)
 }
 
-// MARK: Protocol conformances
-
-// MARK: Instance of `EquatableK` for `Function0`
+// MARK: Instance of EquatableK for Function0
 extension Function0Partial: EquatableK {
-    public static func eq<A: Equatable>(_ lhs: Function0Of<A>, _ rhs: Function0Of<A>) -> Bool {
-        Function0.fix(lhs).extract() == Function0.fix(rhs).extract()
+    public static func eq<A: Equatable>(
+        _ lhs: Function0Of<A>,
+        _ rhs: Function0Of<A>) -> Bool {
+        lhs^.extract() == rhs^.extract()
     }
 }
 
-// MARK: Instance of `Functor` for `Function0`
+// MARK: Instance of Functor for Function0
 extension Function0Partial: Functor {
-    public static func map<A, B>(_ fa: Function0Of<A>, _ f: @escaping (A) -> B) -> Function0Of<B> {
-        Function0(Function0.fix(fa).f >>> f)
+    public static func map<A, B>(
+        _ fa: Function0Of<A>,
+        _ f: @escaping (A) -> B) -> Function0Of<B> {
+        Function0(fa^.f >>> f)
     }
 }
 
-// MARK: Instance of `Applicative` for `Function0`
+// MARK: Instance of Applicative for Function0
 extension Function0Partial: Applicative {
     public static func pure<A>(_ a: A) -> Function0Of<A> {
         Function0(constant(a))
     }
 }
 
-// MARK: Instance of `Selective` for `Function0`
+// MARK: Instance of Selective for Function0
 extension Function0Partial: Selective {}
 
-// MARK: Instance of `Monad` for `Function0`
+// MARK: Instance of Monad for Function0
 extension Function0Partial: Monad {
     public static func flatMap<A, B>(_ fa: Function0Of<A>, _ f: @escaping (A) -> Function0Of<B>) -> Function0Of<B> {
         f(fa^.f())
@@ -88,7 +90,7 @@ extension Function0Partial: Monad {
     }
 }
 
-// MARK: Instance of `Comonad` for `Function0`
+// MARK: Instance of Comonad for Function0
 extension Function0Partial: Comonad {
     public static func coflatMap<A, B>(_ fa: Function0Of<A>, _ f: @escaping (Function0Of<A>) -> B) -> Function0Of<B> {
         Function0<B> { f(fa^) }
@@ -99,17 +101,17 @@ extension Function0Partial: Comonad {
     }
 }
 
-// MARK: Instance of `Bimonad` for `Function0`
+// MARK: Instance of Bimonad for Function0
 extension Function0Partial: Bimonad {}
 
-// MARK: Instance of `Semigroup` for `Function0`
+// MARK: Instance of Semigroup for Function0
 extension Function0: Semigroup where A: Semigroup {
     public func combine(_ other: Function0<A>) -> Function0<A> {
         Function0 { self.invoke().combine(other.invoke()) }
     }
 }
 
-// MARK: Instance of `Monoid` for `Function0`
+// MARK: Instance of Monoid for Function0
 extension Function0: Monoid where A: Monoid {
     public static func empty() -> Function0<A> {
         Function0(constant(A.empty()))

--- a/Sources/Bow/Arrow/Function1.swift
+++ b/Sources/Bow/Arrow/Function1.swift
@@ -18,7 +18,7 @@ public final class Function1<I, O>: Function1Of<I, O> {
     /// - Parameter fa: Value in the higher-kind form.
     /// - Returns: Value cast to `Function1`.
     public static func fix(_ fa: Function1Of<I, O>) -> Function1<I, O> {
-        return fa as! Function1<I, O>
+        fa as! Function1<I, O>
     }
     
     /// Constructs a value of `Function1`.
@@ -33,7 +33,7 @@ public final class Function1<I, O>: Function1Of<I, O> {
     /// - Parameter value: Input to the function.
     /// - Returns: Result of invoking the function.
     public func invoke(_ value: I) -> O {
-        return f(value)
+        f(value)
     }
 
     /// Composes with another function.
@@ -41,7 +41,7 @@ public final class Function1<I, O>: Function1Of<I, O> {
     /// - Parameter f: Function to compose.
     /// - Returns: Composition of the two functions.
     public func compose<A>(_ f: Function1<A, I>) -> Function1<A, O> {
-        return Function1<A, O>(self.f <<< f.f)
+        Function1<A, O>(self.f <<< f.f)
     }
 
     /// Concatenates another function.
@@ -49,7 +49,7 @@ public final class Function1<I, O>: Function1Of<I, O> {
     /// - Parameter f: Function to concatenate.
     /// - Returns: Concatenation of the two functions.
     public func andThen<A>(_ f: Function1<O, A>) -> Function1<I, A> {
-        return f.compose(self)
+        f.compose(self)
     }
 
     /// Composes with another function.
@@ -57,7 +57,7 @@ public final class Function1<I, O>: Function1Of<I, O> {
     /// - Parameter f: Function to compose.
     /// - Returns: Composition of the two functions.
     public func contramap<A>(_ f: @escaping (A) -> I) -> Function1<A, O> {
-        return Function1<A, O>(self.f <<< f)
+        Function1<A, O>(self.f <<< f)
     }
 }
 
@@ -66,62 +66,71 @@ public final class Function1<I, O>: Function1Of<I, O> {
 /// - Parameter fa: Value in the higher-kind form.
 /// - Returns: Value cast to `Function1`.
 public postfix func ^<I, O>(_ fa: Function1Of<I, O>) -> Function1<I, O> {
-    return Function1.fix(fa)
+    Function1.fix(fa)
 }
 
-// MARK: Protocol conformances
-
-// MARK: Instance of `Functor` for `Function1`
+// MARK: Instance of Functor for Function1
 extension Function1Partial: Functor {
-    public static func map<A, B>(_ fa: Kind<Function1Partial<I>, A>, _ f: @escaping (A) -> B) -> Kind<Function1Partial<I>, B> {
-        return Function1(Function1.fix(fa).f >>> f)
+    public static func map<A, B>(
+        _ fa: Function1Of<I, A>,
+        _ f: @escaping (A) -> B) -> Function1Of<I, B> {
+        Function1(fa^.f >>> f)
     }
 }
 
-// MARK: Instance of `Applicative` for `Function1`
+// MARK: Instance of Applicative for Function1
 extension Function1Partial: Applicative {
-    public static func pure<A>(_ a: A) -> Kind<Function1Partial<I>, A> {
-        return Function1(constant(a))
+    public static func pure<A>(_ a: A) -> Function1Of<I, A> {
+        Function1(constant(a))
     }
 }
 
-// MARK: Instance of `Selective` for `Function1`
+// MARK: Instance of Selective for Function1
 extension Function1Partial: Selective {}
 
-// MARK: Instance of `Monad` for `Function1`
+// MARK: Instance of Monad for Function1
 extension Function1Partial: Monad {
-    public static func flatMap<A, B>(_ fa: Kind<Function1Partial<I>, A>, _ f: @escaping (A) -> Kind<Function1Partial<I>, B>) -> Kind<Function1Partial<I>, B> {
-        return Function1<I, B>({ i in Function1.fix(f(Function1.fix(fa).f(i))).f(i) })
+    public static func flatMap<A, B>(
+        _ fa: Function1Of<I, A>,
+        _ f: @escaping (A) -> Function1Of<I, B>) -> Function1Of<I, B> {
+        Function1<I, B> { i in f(fa^.f(i))^.f(i) }
     }
 
-    private static func step<A, B>(_ a: A, _ t: I, _ f: @escaping (A) -> Function1Of<I, Either<A, B>>) -> Trampoline<B> {
+    private static func step<A, B>(
+        _ a: A,
+        _ t: I,
+        _ f: @escaping (A) -> Function1Of<I, Either<A, B>>) -> Trampoline<B> {
         .defer {
             f(a)^.f(t).fold({ a in step(a, t, f) },
                            { b in .done(b) })
         }
     }
 
-    public static func tailRecM<A, B>(_ a: A, _ f: @escaping (A) -> Kind<Function1Partial<I>, Either<A, B>>) -> Kind<Function1Partial<I>, B> {
-        return Function1<I, B>({ t in step(a, t, f).run() })
+    public static func tailRecM<A, B>(
+        _ a: A,
+        _ f: @escaping (A) -> Function1Of<I, Either<A, B>>) -> Function1Of<I, B> {
+        Function1<I, B>({ t in step(a, t, f).run() })
     }
 }
 
-// MARK: Instance of `MonadReader` for `Function1`
+// MARK: Instance of MonadReader for Function1
 extension Function1Partial: MonadReader {
     public typealias D = I
 
-    public static func ask() -> Kind<Function1Partial<I>, I> {
-        return Function1(id)
+    public static func ask() -> Function1Of<I, I> {
+        Function1(id)
     }
 
-    public static func local<A>(_ fa: Kind<Function1Partial<I>, A>, _ f: @escaping (I) -> I) -> Kind<Function1Partial<I>, A> {
-        return Function1(f >>> Function1.fix(fa).f)
+    public static func local<A>(
+        _ fa: Function1Of<I, A>,
+        _ f: @escaping (I) -> I) -> Function1Of<I, A> {
+        Function1(f >>> fa^.f)
     }
 }
 
-// MARK: Instance of `Semigroup` for Function1
+// MARK: Instance of Semigroup for Function1
 extension Function1: Semigroup where O: Semigroup {
     public func combine(_ other: Function1<I, O>) -> Function1<I, O> {
-        return Function1 { i in self.invoke(i).combine(other.invoke(i)) }
+        Function1 { i in self.invoke(i).combine(other.invoke(i)) }
     }
 }

--- a/Sources/Bow/Arrow/FunctionK.swift
+++ b/Sources/Bow/Arrow/FunctionK.swift
@@ -20,7 +20,7 @@ open class FunctionK<F, G> {
     /// - Parameter g: Function to compose with this one.
     /// - Returns: A function that transform the input with this function and the received one afterwards.
     public func andThen<H>(_ g: FunctionK<G, H>) -> FunctionK<F, H> {
-        return ComposedFunctionK<F, G, H>(self, g)
+        ComposedFunctionK<F, G, H>(self, g)
     }
 
     /// Composes this function with another one.
@@ -28,7 +28,7 @@ open class FunctionK<F, G> {
     /// - Parameter g: Function to compose with this one.
     /// - Returns: A function that transform the input with the received function and this one afterwards.
     public func compose<H>(_ g: FunctionK<H, F>) -> FunctionK<H, G> {
-        return ComposedFunctionK<H, F, G>(g, self)
+        ComposedFunctionK<H, F, G>(g, self)
     }
 }
 
@@ -47,7 +47,7 @@ public extension FunctionK where F == G {
 
 private class IdFunctionK<F>: FunctionK<F, F> {
     override func invoke<A>(_ fa: Kind<F, A>) -> Kind<F, A> {
-        return fa
+        fa
     }
 }
 
@@ -61,6 +61,6 @@ private class ComposedFunctionK<F, G, H>: FunctionK<F, H> {
     }
 
     override func invoke<A>(_ fa: Kind<F, A>) -> Kind<H, A> {
-        return g.invoke(f.invoke(fa))
+        g.invoke(f.invoke(fa))
     }
 }


### PR DESCRIPTION
## Goal

Cleanup code in the Arrow folder in the Core module by:

- Using `FOf<A>` instead of `Kind<F, A>`.
- Removing backticks in `MARK` sections as they do not render properly in Jazzy.
- Removing returns.
- Replacing `fix` by `^`.