### PR TITLE
Cleanup Data folder in Core module

### DIFF
--- a/Bow.xcodeproj/project.pbxproj
+++ b/Bow.xcodeproj/project.pbxproj
@@ -188,6 +188,7 @@
 		11E4190B22B90FE2009BDFB3 /* AutoGetter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11E4190A22B90FE2009BDFB3 /* AutoGetter.swift */; };
 		11E4190F22B91169009BDFB3 /* AutoSetter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11E4190E22B91169009BDFB3 /* AutoSetter.swift */; };
 		11E4191222B935AE009BDFB3 /* Kind+Optics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11E4191022B93596009BDFB3 /* Kind+Optics.swift */; };
+		11E5F3D3242BB16C005CF07A /* Ior.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BA0F477217E2E9200969984 /* Ior.swift */; };
 		11E71715219D722900B94845 /* BoundSetter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BA0F4B2217E2E9200969984 /* BoundSetter.swift */; };
 		11E71716219D722900B94845 /* Fold.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BA0F4BE217E2E9200969984 /* Fold.swift */; };
 		11E71717219D722900B94845 /* Getter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BA0F4B3217E2E9200969984 /* Getter.swift */; };
@@ -312,7 +313,6 @@
 		8BA0F57F217E2E9200969984 /* Either.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BA0F474217E2E9200969984 /* Either.swift */; };
 		8BA0F583217E2E9200969984 /* Id.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BA0F475217E2E9200969984 /* Id.swift */; };
 		8BA0F587217E2E9200969984 /* DictionaryK.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BA0F476217E2E9200969984 /* DictionaryK.swift */; };
-		8BA0F58B217E2E9200969984 /* Ior.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BA0F477217E2E9200969984 /* Ior.swift */; };
 		8BA0F58F217E2E9200969984 /* Option.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BA0F478217E2E9200969984 /* Option.swift */; };
 		8BA0F593217E2E9200969984 /* NonEmptyArray.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BA0F479217E2E9200969984 /* NonEmptyArray.swift */; };
 		8BA0F597217E2E9200969984 /* EitherK.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BA0F47A217E2E9200969984 /* EitherK.swift */; };
@@ -3151,7 +3151,6 @@
 				11D36A19223261EC00CBD85F /* Selective.swift in Sources */,
 				8BA0F657217E2E9200969984 /* MonadCombine.swift in Sources */,
 				11ED7A2A226E094C00C27994 /* Result.swift in Sources */,
-				8BA0F58B217E2E9200969984 /* Ior.swift in Sources */,
 				8BA0F5BF217E2E9200969984 /* Coreader.swift in Sources */,
 				1171ED4B23C48985005362E0 /* StoreT.swift in Sources */,
 				118C35DD240E5C2200113C66 /* CoSum.swift in Sources */,
@@ -3177,6 +3176,7 @@
 				609CC14D2365410500096D5D /* Decidable.swift in Sources */,
 				8BA0F5EB217E2E9200969984 /* MonadState.swift in Sources */,
 				8BA0F607217E2E9200969984 /* MonadError.swift in Sources */,
+				11E5F3D3242BB16C005CF07A /* Ior.swift in Sources */,
 				11A5FDD022E5C79F00FF7821 /* BindingOperator.swift in Sources */,
 				8BA0F597217E2E9200969984 /* EitherK.swift in Sources */,
 				1171ED4D23C4CB7C005362E0 /* TracedT.swift in Sources */,

--- a/Sources/Bow/Data/Co.swift
+++ b/Sources/Bow/Data/Co.swift
@@ -108,7 +108,9 @@ public extension CoT where M == ForId {
     ///   - co: Monadic actions to explore the Comonad.
     ///   - wa: Comonadic space to explore.
     /// - Returns: A new Comonadic space resulting from the exploration.
-    static func select<A, B>(_ co: Co<W, (A) -> B>, _ wa: Kind<W, A>) -> Kind<W, B> {
+    static func select<A, B>(
+        _ co: Co<W, (A) -> B>,
+        _ wa: Kind<W, A>) -> Kind<W, B> {
         co.run(wa.coflatMap { wa in
             { f in wa.map(f) }
         })
@@ -166,20 +168,24 @@ public postfix func ^<W, M, A>(_ value: CoTOf<W, M, A>) -> CoT<W, M, A> {
     CoT.fix(value)
 }
 
-// MARK: Instance of `Functor` for `CoT`
+// MARK: Instance of Functor for CoT
 
 extension CoTPartial: Functor {
-    public static func map<A, B>(_ fa: CoTOf<W, M, A>, _ f: @escaping (A) -> B) -> CoTOf<W, M, B> {
+    public static func map<A, B>(
+        _ fa: CoTOf<W, M, A>,
+        _ f: @escaping (A) -> B) -> CoTOf<W, M, B> {
         CoT<W, M, B> { b in
             fa^.runT(b.map { bb in bb <<< f })
         }
     }
 }
 
-// MARK: Instance of `Applicative` for `CoT`
+// MARK: Instance of Applicative for CoT
 
 extension CoTPartial: Applicative {
-    public static func ap<A, B>(_ ff: CoTOf<W, M, (A) -> B>, _ fa: CoTOf<W, M, A>) -> CoTOf<W, M, B> {
+    public static func ap<A, B>(
+        _ ff: CoTOf<W, M, (A) -> B>,
+        _ fa: CoTOf<W, M, A>) -> CoTOf<W, M, B> {
         CoT<W, M, B> { w in
             ff^.cow(w.coflatMap { wf in
                 { g in
@@ -194,10 +200,12 @@ extension CoTPartial: Applicative {
     }
 }
 
-// MARK: Instance of `Monad` for `CoT`
+// MARK: Instance of Monad for CoT
 
 extension CoTPartial: Monad {
-    public static func flatMap<A, B>(_ fa: CoTOf<W, M, A>, _ f: @escaping (A) -> CoTOf<W, M, B>) -> CoTOf<W, M, B> {
+    public static func flatMap<A, B>(
+        _ fa: CoTOf<W, M, A>,
+        _ f: @escaping (A) -> CoTOf<W, M, B>) -> CoTOf<W, M, B> {
         CoT { w in
             fa^.cow(w.coflatMap { wa in
                 { a in
@@ -207,7 +215,9 @@ extension CoTPartial: Monad {
         }
     }
     
-    public static func tailRecM<A, B>(_ a: A, _ f: @escaping (A) -> CoTOf<W, M, Either<A, B>>) -> CoTOf<W, M, B> {
+    public static func tailRecM<A, B>(
+        _ a: A,
+        _ f: @escaping (A) -> CoTOf<W, M, Either<A, B>>) -> CoTOf<W, M, B> {
         f(a).flatMap { either in
             either.fold(
                 { aa in tailRecM(aa, f) },
@@ -216,7 +226,7 @@ extension CoTPartial: Monad {
     }
 }
 
-// MARK: Instance of `MonadReader` for `CoT`
+// MARK: Instance of MonadReader for CoT
 
 extension CoTPartial: MonadReader where W: ComonadEnv {
     public typealias D = W.E
@@ -225,12 +235,14 @@ extension CoTPartial: MonadReader where W: ComonadEnv {
         CoT.liftT(W.ask)
     }
     
-    public static func local<A>(_ fa: CoTOf<W, M, A>, _ f: @escaping (W.E) -> W.E) -> CoTOf<W, M, A> {
+    public static func local<A>(
+        _ fa: CoTOf<W, M, A>,
+        _ f: @escaping (W.E) -> W.E) -> CoTOf<W, M, A> {
         CoT(fa^.cow <<< { wa in wa.local(f) })
     }
 }
 
-// MARK: Instance of `MonadState` for `CoT`
+// MARK: Instance of MonadState for CoT
 
 extension CoTPartial: MonadState where W: ComonadStore {
     public typealias S = W.S
@@ -244,7 +256,7 @@ extension CoTPartial: MonadState where W: ComonadStore {
     }
 }
 
-// MARK: Instance of `MonadWriter` for `CoT`
+// MARK: Instance of MonadWriter for CoT
 
 extension CoTPartial: MonadWriter where W: ComonadTraced {
     public typealias W = W.M

--- a/Sources/Bow/Data/Const.swift
+++ b/Sources/Bow/Data/Const.swift
@@ -19,7 +19,7 @@ public final class Const<A, T>: ConstOf<A, T> {
     /// - Parameter fa: Value in the higher-kind form.
     /// - Returns: Value cast to Const.
     public static func fix(_ fa: ConstOf<A, T>) -> Const<A, T> {
-        return fa as! Const<A, T>
+        fa as! Const<A, T>
     }
     
     /// Initializes a constant value.
@@ -33,7 +33,7 @@ public final class Const<A, T>: ConstOf<A, T> {
     ///
     /// - Returns: The same wrapped value, changing the right type argument.
     public func retag<U>() -> Const<A, U> {
-        return Const<A, U>(value)
+        Const<A, U>(value)
     }
 }
 
@@ -42,92 +42,108 @@ public final class Const<A, T>: ConstOf<A, T> {
 /// - Parameter fa: Value in higher-kind form.
 /// - Returns: Value cast to Const.
 public postfix func ^<A, T>(_ fa: ConstOf<A, T>) -> Const<A, T> {
-    return Const.fix(fa)
+    Const.fix(fa)
 }
 
-// MARK: Conformance to `CustomStringConvertible`
+// MARK: Conformance to CustomStringConvertible
 extension Const: CustomStringConvertible {
     public var description : String {
-        return "Const(\(value))"
+        "Const(\(value))"
     }
 }
 
-// MARK: Conformance to `CustomDebugStringConvertible`
+// MARK: Conformance to CustomDebugStringConvertible
 extension Const: CustomDebugStringConvertible where A: CustomDebugStringConvertible{
     public var debugDescription: String {
-        return "Const(\(value.debugDescription))"
+        "Const(\(value.debugDescription))"
     }
 }
 
-// MARK: Instance of `EquatableK` for `Const`
+// MARK: Instance of EquatableK for Const
 extension ConstPartial: EquatableK where A: Equatable {
-    public static func eq<T>(_ lhs: Kind<ConstPartial<A>, T>, _ rhs: Kind<ConstPartial<A>, T>) -> Bool where T: Equatable {
-        return Const.fix(lhs).value == Const.fix(rhs).value
+    public static func eq<T: Equatable>(
+        _ lhs: ConstOf<A, T>,
+        _ rhs: ConstOf<A, T>) -> Bool {
+        lhs^.value == rhs^.value
     }
 }
 
-// MARK: Instance of `Functor` for `Const`
+// MARK: Instance of Functor for Const
 extension ConstPartial: Functor {
-    public static func map<C, B>(_ fa: Kind<ConstPartial<A>, C>, _ f: @escaping (C) -> B) -> Kind<ConstPartial<A>, B> {
-        return Const.fix(fa).retag()
+    public static func map<C, B>(
+        _ fa: ConstOf<A, C>,
+        _ f: @escaping (C) -> B) -> ConstOf<A, B> {
+        fa^.retag()
     }
 }
 
-// MARK: Instance of `Applicative` for `Const`
+// MARK: Instance of Applicative for Const
 extension ConstPartial: Applicative where A: Monoid {
-    public static func pure<C>(_ a: C) -> Kind<ConstPartial<A>, C> {
-        return Const<A, C>(A.empty())
+    public static func pure<C>(_ a: C) -> ConstOf<A, C> {
+        Const<A, C>(.empty())
     }
 
-    public static func ap<C, B>(_ ff: Kind<ConstPartial<A>, (C) -> B>, _ fa: Kind<ConstPartial<A>, C>) -> Kind<ConstPartial<A>, B> {
-        let cf: Const<A, B> = Const.fix(ff).retag()
-        let ca: Const<A, B> = Const.fix(fa).retag()
-        return cf.combine(ca)
+    public static func ap<C, B>(
+        _ ff: ConstOf<A, (C) -> B>,
+        _ fa: ConstOf<A, C>) -> ConstOf<A, B> {
+        ff^.retag().combine(fa^.retag())
     }
 }
 
-// MARK: Instance of `Foldable` for `Const`
+// MARK: Instance of Foldable for Const
 extension ConstPartial: Foldable {
-    public static func foldLeft<C, B>(_ fa: Kind<ConstPartial<A>, C>, _ b: B, _ f: @escaping (B, C) -> B) -> B {
+    public static func foldLeft<C, B>(
+        _ fa: ConstOf<A, C>,
+        _ b: B,
+        _ f: @escaping (B, C) -> B) -> B {
         return b
     }
 
-    public static func foldRight<C, B>(_ fa: Kind<ConstPartial<A>, C>, _ b: Eval<B>, _ f: @escaping (C, Eval<B>) -> Eval<B>) -> Eval<B> {
+    public static func foldRight<C, B>(
+        _ fa: ConstOf<A, C>,
+        _ b: Eval<B>,
+        _ f: @escaping (C, Eval<B>) -> Eval<B>) -> Eval<B> {
         return b
     }
 }
 
-// MARK: Instance of `Traverse` for `Const`
+// MARK: Instance of Traverse for Const
 extension ConstPartial: Traverse {
-    public static func traverse<G: Applicative, C, B>(_ fa: Kind<ConstPartial<A>, C>, _ f: @escaping (C) -> Kind<G, B>) -> Kind<G, Kind<ConstPartial<A>, B>> {
-        return G.pure(Const.fix(fa).retag())
+    public static func traverse<G: Applicative, C, B>(
+        _ fa: ConstOf<A, C>,
+        _ f: @escaping (C) -> Kind<G, B>) -> Kind<G, ConstOf<A, B>> {
+        G.pure(fa^.retag())
     }
 }
 
-// MARK: Instance of `FunctorFilter` for `Const`
+// MARK: Instance of FunctorFilter for Const
 extension ConstPartial: FunctorFilter {}
 
-// MARK: Instance of `TraverseFilter` for `Const`
+// MARK: Instance of TraverseFilter for Const
 extension ConstPartial: TraverseFilter {
-    public static func traverseFilter<C, B, G: Applicative>(_ fa: Kind<ConstPartial<A>, C>, _ f: @escaping (C) -> Kind<G, Kind<ForOption, B>>) -> Kind<G, Kind<ConstPartial<A>, B>> {
-        return G.pure(Const.fix(fa).retag())
+    public static func traverseFilter<C, B, G: Applicative>(
+        _ fa: ConstOf<A, C>,
+        _ f: @escaping (C) -> Kind<G, OptionOf<B>>) -> Kind<G, ConstOf<A, B>> {
+        G.pure(fa^.retag())
     }
 
-    public static func mapFilter<C, B>(_ fa: Kind<ConstPartial<A>, C>, _ f: @escaping (C) -> Kind<ForOption, B>) -> Kind<ConstPartial<A>, B> {
-        return traverseFilter(fa, { a in Id<OptionOf<B>>.pure(f(a)) }).extract()
+    public static func mapFilter<C, B>(
+        _ fa: ConstOf<A, C>,
+        _ f: @escaping (C) -> OptionOf<B>) -> ConstOf<A, B> {
+        traverseFilter(fa, { a in Id<OptionOf<B>>.pure(f(a)) })^.value
     }
 }
 
-// MARK: Instance of `Semigroup` for `Const`
+// MARK: Instance of Semigroup for Const
 extension Const: Semigroup where A: Semigroup {
-    public func combine(_ other : Const<A, T>) -> Const<A, T> {
-        return Const<A, T>(self.value.combine(other.value))
+    public func combine(_ other: Const<A, T>) -> Const<A, T> {
+        Const<A, T>(self.value.combine(other.value))
     }
 }
 
-// MARK: Instance of `Monoid` for `Const`
+// MARK: Instance of Monoid for Const
 extension Const: Monoid where A: Monoid {
     public static func empty() -> Const<A, T> {
-        return Const(A.empty())
+        Const(A.empty())
     }
 }

--- a/Sources/Bow/Data/Coreader.swift
+++ b/Sources/Bow/Data/Coreader.swift
@@ -6,7 +6,7 @@ public class Coreader<A, B>: CoreaderT<ForId, A, B> {
     ///
     /// - Parameter run: Function to be enclosed in this Coreader.
     public init(_ run: @escaping (A) -> B) {
-        super.init({ idA in run((idA as! Id<A>).extract()) })
+        super.init { idA in run(idA^.value) }
     }
     
     /// Runs this Coreader function with the given input.
@@ -14,7 +14,7 @@ public class Coreader<A, B>: CoreaderT<ForId, A, B> {
     /// - Parameter a: Input value for the function.
     /// - Returns: Output of the function.
     public func runId(_ a: A) -> B {
-        return self.run(Id<A>.pure(a))
+        self.run(Id(a))
     }
 }
 

--- a/Sources/Bow/Data/Day.swift
+++ b/Sources/Bow/Data/Day.swift
@@ -53,7 +53,8 @@ public final class Day<F: Comonad, G: Comonad, A>: DayOf<F, G, A> {
     /// It goes from `Day f (Day g h) a` to `Day (Day f g) h a`.
     ///
     /// - Returns: Left associated Day convolution.
-    public func assoc<FF: Comonad, GG: Comonad>() -> Day<DayPartial<F, FF>, GG, A> where G == DayPartial<FF, GG> {
+    public func assoc<FF: Comonad, GG: Comonad>() -> Day<DayPartial<F, FF>, GG, A>
+        where G == DayPartial<FF, GG> {
         let newLeft = Day<F, FF, Any>(
             left: self.left,
             right: self.right^.left) { a, b in (a, b) }
@@ -71,7 +72,8 @@ public final class Day<F: Comonad, G: Comonad, A>: DayOf<F, G, A> {
     /// It goes from `Day (Day f g) h a` to `Day f (Day g h) a`.
     ///
     /// - Returns: Right associated Day convolution.
-    public func disassoc<FF: Comonad, GG: Comonad>() -> Day<FF, DayPartial<GG, G>, A> where F == DayPartial<FF, GG> {
+    public func disassoc<FF: Comonad, GG: Comonad>() -> Day<FF, DayPartial<GG, G>, A>
+        where F == DayPartial<FF, GG> {
         let newRight = Day<GG, G, Any>(
             left: self.left^.right,
             right: self.right) { a, b in (a, b) }
@@ -162,7 +164,9 @@ public postfix func ^<F, G, A>(_ value: DayOf<F, G, A>) -> Day<F, G, A> {
 // MARK: Instance of Functor for Day
 
 extension DayPartial: Functor {
-    public static func map<A, B>(_ fa: DayOf<F, G, A>, _ f: @escaping (A) -> B) -> DayOf<F, G, B> {
+    public static func map<A, B>(
+        _ fa: DayOf<F, G, A>,
+        _ f: @escaping (A) -> B) -> DayOf<F, G, B> {
         fa^.step { left, right, get in
             Day(left: left, right: right) { b, c in f(get(b, c)) }
         }
@@ -176,7 +180,9 @@ extension DayPartial: Applicative where F: Applicative, G: Applicative {
         Day(left: F.pure(()), right: G.pure(())) { _, _ in a }
     }
     
-    public static func ap<A, B>(_ ff: DayOf<F, G, (A) -> B>, _ fa: DayOf<F, G, A>) -> DayOf<F, G, B> {
+    public static func ap<A, B>(
+        _ ff: DayOf<F, G, (A) -> B>,
+        _ fa: DayOf<F, G, A>) -> DayOf<F, G, B> {
         fa^.step { left, right, get in
             ff^.step { lf, rf, getf in
                 let l = F.map(left, lf) { x, y in (x, y) as Any }
@@ -194,7 +200,9 @@ extension DayPartial: Applicative where F: Applicative, G: Applicative {
 // MARK: Instance of Comonad for Day
 
 extension DayPartial: Comonad {
-    public static func coflatMap<A, B>(_ fa: DayOf<F, G, A>, _ f: @escaping (DayOf<F, G, A>) -> B) -> DayOf<F, G, B> {
+    public static func coflatMap<A, B>(
+        _ fa: DayOf<F, G, A>,
+        _ f: @escaping (DayOf<F, G, A>) -> B) -> DayOf<F, G, B> {
         fa^.step { left, right, get in
             let l = left.duplicate().map { x in x as Any }
             let r = right.duplicate().map { x in x as Any }

--- a/Sources/Bow/Data/Dictionary.swift
+++ b/Sources/Bow/Data/Dictionary.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-// MARK: Instance of `Semigroup` for `Dictionary`
+// MARK: Instance of Semigroup for Dictionary
 
 extension Dictionary: Semigroup {
     public func combine(_ other: Dictionary<Key, Value>) -> Dictionary<Key, Value> {
@@ -8,7 +8,7 @@ extension Dictionary: Semigroup {
     }
 }
 
-// MARK: Instances of `Monoid` for `Dictionary`
+// MARK: Instances of Monoid for Dictionary
 
 extension Dictionary: Monoid {
     public static func empty() -> Dictionary<Key, Value> {

--- a/Sources/Bow/Data/DictionaryK.swift
+++ b/Sources/Bow/Data/DictionaryK.swift
@@ -18,7 +18,7 @@ public final class DictionaryK<K: Hashable, A>: DictionaryKOf<K, A> {
     /// - Parameter fa: Value in the higher-kind form.
     /// - Returns: Value cast to DictionaryK.
     public static func fix(_ fa: DictionaryKOf<K, A>) -> DictionaryK<K, A> {
-        return fa as! DictionaryK<K, A>
+        fa as! DictionaryK<K, A>
     }
 
     /// Initializes a `DictionaryK`.
@@ -32,7 +32,7 @@ public final class DictionaryK<K: Hashable, A>: DictionaryKOf<K, A> {
     ///
     /// - Returns: A Swift dictionary wrapped in this value.
     public func asDictionary() -> [K: A] {
-        return self.dictionary
+        dictionary
     }
 
     /// Zips this dictionary with another one and combines their values with the provided function.
@@ -58,7 +58,7 @@ public final class DictionaryK<K: Hashable, A>: DictionaryKOf<K, A> {
     ///   - f: Combining function.
     /// - Returns: Result of zipping the values of both dictionaries and combining their values.
     public func map2Eval<B, Z>(_ fb: Eval<DictionaryK<K, B>>, _ f: @escaping (A, B) -> Z) -> Eval<DictionaryK<K, Z>> {
-        return Eval.fix(fb.map { b in self.map2(b, f) })
+        fb.map { b in self.map2(b, f) }^
     }
 
     /// Sequential application.
@@ -66,7 +66,7 @@ public final class DictionaryK<K: Hashable, A>: DictionaryKOf<K, A> {
     /// - Parameter fa: A dictionary.
     /// - Returns: A dictionary with the result of applying the functions in this dictionary to the values in the argument.
     public func ap<AA, B>(_ fa: DictionaryK<K, AA>) -> DictionaryK<K, B> where A == (AA) -> B {
-        return flatMap { f in fa.map { a in f(a) }^ }
+        flatMap { f in fa.map { a in f(a) }^ }
     }
 
     /// Applies the provided function to all values in this dictionary, flattening the final result.
@@ -74,7 +74,7 @@ public final class DictionaryK<K: Hashable, A>: DictionaryKOf<K, A> {
     /// - Parameter f: Transforming function.
     /// - Returns: A dictionary with the outputs of applying the function to all values in this dictionary.
     public func flatMap<B>(_ f: (A) -> DictionaryK<K, B>) -> DictionaryK<K, B> {
-        return Dictionary<K, B>(uniqueKeysWithValues: self.dictionary.compactMap { k, a in
+        Dictionary<K, B>(uniqueKeysWithValues: self.dictionary.compactMap { k, a in
             f(a).dictionary[k].map { v in (k, v) }
         }).k()
     }
@@ -85,7 +85,7 @@ public final class DictionaryK<K: Hashable, A>: DictionaryKOf<K, A> {
 /// - Parameter fa: Value in higher-kind form.
 /// - Returns: Value cast to DictionaryK.
 public postfix func ^<K, A>(_ fa: DictionaryKOf<K, A>) -> DictionaryK<K, A> {
-    return DictionaryK.fix(fa)
+    DictionaryK.fix(fa)
 }
 
 // MARK: Convenience functions to convert to DictionaryK
@@ -94,19 +94,19 @@ public extension Dictionary {
     ///
     /// - Returns: A `DictionaryK` wrapping this Swift dictionary.
     func k() -> DictionaryK<Key, Value> {
-        return DictionaryK<Key, Value>(self)
+        DictionaryK<Key, Value>(self)
     }
 }
 
-// MARK: Instance of `Semigroup` for `DictionaryK`
+// MARK: Instance of Semigroup for DictionaryK
 
 extension DictionaryK: Semigroup {
     public func combine(_ other: DictionaryK<K, A>) -> DictionaryK<K, A> {
-        (self.dictionary.combine(other.dictionary)).k()
+        self.dictionary.combine(other.dictionary).k()
     }
 }
 
-// MARK: Instance of `Monoid` for `DictionaryK`
+// MARK: Instance of Monoid for DictionaryK
 
 extension DictionaryK: Monoid {
     public static func empty() -> DictionaryK<K, A> {
@@ -114,46 +114,60 @@ extension DictionaryK: Monoid {
     }
 }
 
-// MARK: Instance of `EquatableK` for `DictionaryK`
+// MARK: Instance of EquatableK for DictionaryK
 
 extension DictionaryKPartial: EquatableK {
-    public static func eq<A: Equatable>(_ lhs: Kind<DictionaryKPartial<K>, A>, _ rhs: Kind<DictionaryKPartial<K>, A>) -> Bool {
+    public static func eq<A: Equatable>(
+        _ lhs: DictionaryKOf<K, A>,
+        _ rhs: DictionaryKOf<K, A>) -> Bool {
         lhs^.asDictionary() == rhs^.asDictionary()
     }
 }
 
-// MARK: Instance of `Functor` for `DictionaryK`
+// MARK: Instance of Functor for DictionaryK
 
 extension DictionaryKPartial: Functor {
-    public static func map<A, B>(_ fa: Kind<DictionaryKPartial<K>, A>, _ f: @escaping (A) -> B) -> Kind<DictionaryKPartial<K>, B> {
+    public static func map<A, B>(
+        _ fa: DictionaryKOf<K, A>,
+        _ f: @escaping (A) -> B) -> DictionaryKOf<K, B> {
         fa^.asDictionary().mapValues(f).k()
     }
 }
 
-// MARK: Instance of `FunctorFilter` for `DictionaryK`
+// MARK: Instance of FunctorFilter for DictionaryK
 
 extension DictionaryKPartial: FunctorFilter {
-    public static func mapFilter<A, B>(_ fa: Kind<DictionaryKPartial<K>, A>, _ f: @escaping (A) -> Kind<ForOption, B>) -> Kind<DictionaryKPartial<K>, B> {
+    public static func mapFilter<A, B>(
+        _ fa: DictionaryKOf<K, A>,
+        _ f: @escaping (A) -> OptionOf<B>) -> DictionaryKOf<K, B> {
         fa.map(f).sequence()^.fold({ DictionaryK.empty() }, id)
     }
 }
 
-// MARK: Instance of `Foldable` for `DictionaryK`
+// MARK: Instance of Foldable for DictionaryK
 
 extension DictionaryKPartial: Foldable {
-    public static func foldLeft<A, B>(_ fa: Kind<DictionaryKPartial<K>, A>, _ b: B, _ f: @escaping (B, A) -> B) -> B {
+    public static func foldLeft<A, B>(
+        _ fa: DictionaryKOf<K, A>,
+        _ b: B,
+        _ f: @escaping (B, A) -> B) -> B {
         fa^.asDictionary().values.lazy.reduce(b, f)
     }
     
-    public static func foldRight<A, B>(_ fa: Kind<DictionaryKPartial<K>, A>, _ b: Eval<B>, _ f: @escaping (A, Eval<B>) -> Eval<B>) -> Eval<B> {
+    public static func foldRight<A, B>(
+        _ fa: DictionaryKOf<K, A>,
+        _ b: Eval<B>,
+        _ f: @escaping (A, Eval<B>) -> Eval<B>) -> Eval<B> {
         fa^.asDictionary().values.reversed().lazy.reduce(b) { b, a in f(a, b) }
     }
 }
 
-// MARK: Instance of `Traverse` for `DictionaryK`
+// MARK: Instance of Traverse for DictionaryK
 
 extension DictionaryKPartial: Traverse {
-    public static func traverse<G: Applicative, A, B>(_ fa: Kind<DictionaryKPartial<K>, A>, _ f: @escaping (A) -> Kind<G, B>) -> Kind<G, Kind<DictionaryKPartial<K>, B>> {
+    public static func traverse<G: Applicative, A, B>(
+        _ fa: DictionaryKOf<K, A>,
+        _ f: @escaping (A) -> Kind<G, B>) -> Kind<G, DictionaryKOf<K, B>> {
         var result = G.pure([K: B]())
         fa^.asDictionary().forEach { item in
             result = G.map(f(item.value), result) { x, y in

--- a/Sources/Bow/Data/Either.swift
+++ b/Sources/Bow/Data/Either.swift
@@ -22,7 +22,7 @@ public final class Either<A, B>: EitherOf<A, B> {
     /// - Parameter a: Value to be wrapped in a left of this Either type.
     /// - Returns: A left value of Either.
     public static func left(_ a: A) -> Either<A, B> {
-        return Either(.left(a))
+        Either(.left(a))
     }
 
     /// Constructs a right value
@@ -30,7 +30,7 @@ public final class Either<A, B>: EitherOf<A, B> {
     /// - Parameter b: Value to be wrapped in a right of this Either type.
     /// - Returns: A right value of Either.
     public static func right(_ b: B) -> Either<A, B> {
-        return Either(.right(b))
+        Either(.right(b))
     }
 
     /// Safe downcast.
@@ -38,7 +38,7 @@ public final class Either<A, B>: EitherOf<A, B> {
     /// - Parameter fa: Value in the higher-kind form.
     /// - Returns: Value cast to Either.
     public static func fix(_ fa: EitherOf<A, B>) -> Either<A, B> {
-        return fa as! Either<A, B>
+        fa as! Either<A, B>
     }
 
     /// Applies the provided closures based on the content of this `Either` value.
@@ -56,38 +56,38 @@ public final class Either<A, B>: EitherOf<A, B> {
 
     /// Checks if this value belongs to the left type.
     public var isLeft: Bool {
-        return fold(constant(true), constant(false))
+        fold(constant(true), constant(false))
     }
 
     /// Checks if this value belongs to the right type.
     public var isRight: Bool {
-        return !isLeft
+        !isLeft
     }
 
     /// Attempts to obtain a value of the left type.
     ///
     /// This propery is unsafe and can cause fatal errors if it is invoked on a right value.
     public var leftValue: A {
-        return fold(id, { _ in fatalError("Attempted to obtain leftValue on a right instance") })
+        fold(id, { _ in fatalError("Attempted to obtain leftValue on a right instance") })
     }
     
     /// Attempts to obtain a value of the right type.
     ///
     /// This property is unsafe and can cause fatal errors if it is invoked on a left value.
     public var rightValue: B {
-        return fold({ _ in fatalError("Attempted to obtain rightValue on a left instance") }, id)
+        fold({ _ in fatalError("Attempted to obtain rightValue on a left instance") }, id)
     }
 
     /// Returns the value of the right type, or `nil` if it is a left value.
     public var orNil: B? {
-        return fold(constant(nil), id)
+        fold(constant(nil), id)
     }
 
     /// Reverses the types of this either. Left values become right values and vice versa.
     ///
     /// - Returns: An either value with its types reversed respect to this one.
     public func swap() -> Either<B, A> {
-        return fold(Either<B, A>.right, Either<B, A>.left)
+        fold(Either<B, A>.right, Either<B, A>.left)
     }
 
     /// Transforms both type parameters, preserving the structure of this value.
@@ -97,8 +97,8 @@ public final class Either<A, B>: EitherOf<A, B> {
     ///   - fb: Closure to be applied when there is a right value.
     /// - Returns: Result of applying the corresponding closure to this value.
     public func bimap<C, D>(_ fa: (A) -> C, _ fb: (B) -> D) -> Either<C, D> {
-        return fold({ a in Either<C, D>.left(fa(a)) },
-                    { b in Either<C, D>.right(fb(b)) })
+        fold({ a in Either<C, D>.left(fa(a)) },
+             { b in Either<C, D>.right(fb(b)) })
     }
 
     /// Transforms the left type parameter, preserving the structure of this value.
@@ -106,7 +106,7 @@ public final class Either<A, B>: EitherOf<A, B> {
     /// - Parameter f: Transforming closure.
     /// - Returns: Result of appliying the transformation to any left value in this value.
     public func mapLeft<C>(_ f: (A) -> C) -> Either<C, B> {
-        return bimap(f, id)
+        bimap(f, id)
     }
 
     /// Returns the value from this `Either.right` value or allows callers to transform the `Either.left` to `Either.right`.
@@ -114,7 +114,7 @@ public final class Either<A, B>: EitherOf<A, B> {
     /// - Parameter f: Left transforming function.
     /// - Returns: Value of this `Either.right` or transformation of this `Either.left`.
     public func getOrHandle(_ f: (A) -> B) -> B {
-        return fold(f, id)
+        fold(f, id)
     }
 
     /// Converts this `Either` to an `Option`.
@@ -123,7 +123,7 @@ public final class Either<A, B>: EitherOf<A, B> {
     ///
     /// - Returns: An option containing a right value, or none if there is a left value.
     public func toOption() -> Option<B> {
-        return fold(constant(Option<B>.none()), Option<B>.some)
+        fold(constant(Option<B>.none()), Option<B>.some)
     }
 
     /// Obtains the value wrapped if it is a right value, or the default value provided as an argument.
@@ -131,7 +131,7 @@ public final class Either<A, B>: EitherOf<A, B> {
     /// - Parameter defaultValue: Value to be returned if this value is left.
     /// - Returns: The wrapped value if it is right; otherwise, the default value.
     public func getOrElse(_ defaultValue: B) -> B {
-        return fold(constant(defaultValue), id)
+        fold(constant(defaultValue), id)
     }
 
     /// Filters the right values, providing a default left value if the do not match the provided predicate.
@@ -141,10 +141,10 @@ public final class Either<A, B>: EitherOf<A, B> {
     ///   - defaultValue: Value to be returned if the right value does not satisfies the predicate.
     /// - Returns: This value, if it matches the predicate or is left; otherwise, a left value wrapping the default value.
     public func filterOrElse(_ predicate : @escaping (B) -> Bool, _ defaultValue : A) -> Either<A, B> {
-        return fold(Either<A, B>.left,
-                    { b in predicate(b) ?
-                        Either<A, B>.right(b) :
-                        Either<A, B>.left(defaultValue) })
+        fold(Either<A, B>.left,
+             { b in predicate(b) ?
+                Either<A, B>.right(b) :
+                Either<A, B>.left(defaultValue) })
     }
 
     /// Filters the right values, providing a function to transform those that do not match the predicate into a left-type value.
@@ -154,7 +154,7 @@ public final class Either<A, B>: EitherOf<A, B> {
     ///   - f: Transforming function.
     /// - Returns: This value, if it matches the predicate or is left; otherwise, a left value wrapping the transformation of the right value.
     public func filterOrOther(_ predicate: @escaping (B) -> Bool, _ f: @escaping (B) -> A) -> Either<A, B> {
-        return flatMap { b in predicate(b) ? Either.right(b) : Either.left(f(b)) }^
+        flatMap { b in predicate(b) ? Either.right(b) : Either.left(f(b)) }^
     }
 
     /// Flattens the right side of this value, providing a default value in case the wrapped value is not present.
@@ -162,7 +162,7 @@ public final class Either<A, B>: EitherOf<A, B> {
     /// - Parameter f: Function providing a default value.
     /// - Returns: An Either value where the right side is not optional.
     public func leftIfNull<BB>(_ f: @escaping @autoclosure () -> A) -> Either<A, BB> where B == Optional<BB> {
-        return flatMap { b in
+        flatMap { b in
             if let some = b {
                 return Either<A, BB>.right(some)
             } else {
@@ -179,7 +179,7 @@ public extension Either where B: Equatable {
     /// - Parameter element: Element to check.
     /// - Returns: Boolean value indicating if the element was found or not.
     func contains(_ element: B) -> Bool {
-        return fold(constant(false), { b in b == element })
+        fold(constant(false), { b in b == element })
     }
 }
 
@@ -210,7 +210,7 @@ public extension Optional {
 /// - Parameter fa: Value in the higher-kind form.
 /// - Returns: Value cast to Either.
 public postfix func ^<A, B>(_ fa: EitherOf<A, B>) -> Either<A, B> {
-    return Either.fix(fa)
+    Either.fix(fa)
 }
 
 private enum _Either<A, B> {
@@ -218,60 +218,75 @@ private enum _Either<A, B> {
     case right(B)
 }
 
-// MARK: Conformance of `Either` to `CustomStringConvertible`
+// MARK: Conformance of Either to CustomStringConvertible
 extension Either: CustomStringConvertible {
     public var description: String {
-        return fold({ a in "Left(\(a))"},
-                    { b in "Right(\(b))"})
+        fold({ a in "Left(\(a))"},
+             { b in "Right(\(b))"})
     }
 }
 
-// MARK: Conformance of `Either` to `CustomDebugStringConvertible`, provided that both of its type arguments conform to `CustomDebugStringConvertible`.
+// MARK: Conformance of Either to CustomDebugStringConvertible
 extension Either: CustomDebugStringConvertible where A: CustomDebugStringConvertible, B: CustomDebugStringConvertible {
     public var debugDescription: String {
-        return fold({ a in "Left(\(a.debugDescription)"},
-                    { b in "Right(\(b.debugDescription))"})
+        fold({ a in "Left(\(a.debugDescription)"},
+             { b in "Right(\(b.debugDescription))"})
     }
 }
 
-// MARK: Instance of `EquatableK` for `Either`.
+// MARK: Instance of EquatableK for Either
 extension EitherPartial: EquatableK where L: Equatable {
-    public static func eq<A>(_ lhs: Kind<EitherPartial<L>, A>, _ rhs: Kind<EitherPartial<L>, A>) -> Bool where A : Equatable {
-        let el = Either.fix(lhs)
-        let er = Either.fix(rhs)
-        return el.fold({ la in er.fold({ lb in la == lb }, constant(false)) },
-                       { ra in er.fold(constant(false), { rb in ra == rb })})
+    public static func eq<A: Equatable>(
+        _ lhs: EitherOf<L, A>,
+        _ rhs: EitherOf<L, A>) -> Bool {
+        lhs^.fold(
+            { la in rhs^.fold(
+                { lb in la == lb },
+                constant(false))
+            },
+            { ra in rhs^.fold(
+                constant(false),
+                { rb in ra == rb })
+        })
     }
 }
 
-// MARK: Instance of `Functor` for `Either`.
+// MARK: Instance of Functor for Either
 extension EitherPartial: Functor {
-    public static func map<A, B>(_ fa: Kind<EitherPartial<L>, A>, _ f: @escaping (A) -> B) -> Kind<EitherPartial<L>, B> {
-        return Either.fix(fa).fold(Either.left, Either.right <<< f)
+    public static func map<A, B>(
+        _ fa: EitherOf<L, A>,
+        _ f: @escaping (A) -> B) -> EitherOf<L, B> {
+        fa^.fold(Either.left, Either.right <<< f)
     }
 }
 
-// MARK: Instance of `Applicative` for `Either`.
+// MARK: Instance of Applicative for Either
 extension EitherPartial: Applicative {
-    public static func pure<A>(_ a: A) -> Kind<EitherPartial<L>, A> {
-        return Either.right(a)
+    public static func pure<A>(_ a: A) -> EitherOf<L, A> {
+        Either.right(a)
     }
 }
 
-// MARK: Instance of `Selective` for `Either`
+// MARK: Instance of Selective for Either
 extension EitherPartial: Selective {}
 
-// MARK: Instance of `Monad` for `Either`.
+// MARK: Instance of Monad for Either
 extension EitherPartial: Monad {
-    public static func flatMap<A, B>(_ fa: Kind<EitherPartial<L>, A>, _ f: @escaping (A) -> Kind<EitherPartial<L>, B>) -> Kind<EitherPartial<L>, B> {
-        return Either.fix(fa).fold(Either.left, f)
+    public static func flatMap<A, B>(
+        _ fa: EitherOf<L, A>,
+        _ f: @escaping (A) -> EitherOf<L, B>) -> EitherOf<L, B> {
+        fa^.fold(Either.left, f)
     }
 
-    public static func tailRecM<A, B>(_ a: A, _ f: @escaping (A) -> Kind<EitherPartial<L>, Either<A, B>>) -> Kind<EitherPartial<L>, B> {
+    public static func tailRecM<A, B>(
+        _ a: A,
+        _ f: @escaping (A) -> EitherOf<L, Either<A, B>>) -> EitherOf<L, B> {
         _tailRecM(a, f).run()
     }
     
-    private static func _tailRecM<A, B>(_ a: A, _ f: @escaping (A) -> EitherOf<L, Either<A, B>>) -> Trampoline<EitherOf<L, B>> {
+    private static func _tailRecM<A, B>(
+        _ a: A,
+        _ f: @escaping (A) -> EitherOf<L, Either<A, B>>) -> Trampoline<EitherOf<L, B>> {
         .defer {
             f(a)^.fold({ l in .done(Either.left(l)) },
                       { either in
@@ -282,59 +297,81 @@ extension EitherPartial: Monad {
     }
 }
 
-// MARK: Instance of `ApplicativeError` for `Either`.
+// MARK: Instance of ApplicativeError for Either
 extension EitherPartial: ApplicativeError {
     public typealias E = L
 
-    public static func raiseError<A>(_ e: L) -> Kind<EitherPartial<L>, A> {
-        return Either.left(e)
+    public static func raiseError<A>(_ e: L) -> EitherOf<L, A> {
+        Either.left(e)
     }
 
-    public static func handleErrorWith<A>(_ fa: Kind<EitherPartial<L>, A>, _ f: @escaping (L) -> Kind<EitherPartial<L>, A>) -> Kind<EitherPartial<L>, A> {
-        return Either.fix(fa).fold(f, constant(Either.fix(fa)))
+    public static func handleErrorWith<A>(
+        _ fa: EitherOf<L, A>,
+        _ f: @escaping (L) -> EitherOf<L, A>) -> EitherOf<L, A> {
+        fa^.fold(f, constant(fa^))
     }
 }
 
-// MARK: Instance of `MonadError` for `Either`.
+// MARK: Instance of MonadError for Either
 extension EitherPartial: MonadError {}
 
-// MARK: Instance of `Foldable` for `Either`.
+// MARK: Instance of Foldable for Either
 extension EitherPartial: Foldable {
-    public static func foldLeft<A, B>(_ fa: Kind<EitherPartial<L>, A>, _ c: B, _ f: @escaping (B, A) -> B) -> B {
-        return Either.fix(fa).fold(constant(c), { b in f(c, b) })
+    public static func foldLeft<A, B>(
+        _ fa: EitherOf<L, A>,
+        _ c: B,
+        _ f: @escaping (B, A) -> B) -> B {
+        fa^.fold(constant(c),
+                 { b in f(c, b) })
     }
 
-    public static func foldRight<A, B>(_ fa: Kind<EitherPartial<L>, A>, _ c: Eval<B>, _ f: @escaping (A, Eval<B>) -> Eval<B>) -> Eval<B> {
-        return Either.fix(fa).fold(constant(c), { b in f(b, c) })
+    public static func foldRight<A, B>(
+        _ fa: EitherOf<L, A>,
+        _ c: Eval<B>,
+        _ f: @escaping (A, Eval<B>) -> Eval<B>) -> Eval<B> {
+        fa^.fold(constant(c),
+                 { b in f(b, c) })
     }
 }
 
-// MARK: Instance of `Traverse` for `Either`.
+// MARK: Instance of Traverse for Either
 extension EitherPartial: Traverse {
-    public static func traverse<G: Applicative, A, B>(_ fa: Kind<EitherPartial<L>, A>, _ f: @escaping (A) -> Kind<G, B>) -> Kind<G, Kind<EitherPartial<L>, B>> {
-        return Either.fix(fa).fold({ a in G.pure(Either.left(a)) },
-                                   { b in G.map(f(b), { c in Either.right(c) }) })
+    public static func traverse<G: Applicative, A, B>(
+        _ fa: EitherOf<L, A>,
+        _ f: @escaping (A) -> Kind<G, B>) -> Kind<G, EitherOf<L, B>> {
+        fa^.fold(
+            { a in G.pure(Either.left(a)) },
+            { b in f(b).map { c in Either.right(c) } })
     }
 }
 
-// MARK: Instance of `SemigroupK` for `Either`.
+// MARK: Instance of SemigroupK for Either
 extension EitherPartial: SemigroupK {
-    public static func combineK<A>(_ x: Kind<EitherPartial<L>, A>, _ y: Kind<EitherPartial<L>, A>) -> Kind<EitherPartial<L>, A> {
-        return Either.fix(x).fold(constant(Either.fix(y)), Either.right)
+    public static func combineK<A>(
+        _ x: EitherOf<L, A>,
+        _ y: EitherOf<L, A>) -> EitherOf<L, A> {
+        x^.fold(constant(y^),
+                Either.right)
     }
 }
 
-// MARK: Instance of `Semigroup` for `Either`.
+// MARK: Instance of Semigroup for Either
 extension Either: Semigroup where A: Semigroup, B: Semigroup {
     public func combine(_ other: Either<A, B>) -> Either<A, B> {
-        return self.fold({ l1 in other.fold({ l2 in .left(l1.combine(l2)) }, { r2 in .left(l1) }) },
-                         { r1 in other.fold({ l2 in .left(l2) }, { r2 in .right(r1.combine(r2)) }) })
+        self.fold(
+            { l1 in
+                other.fold({ l2 in .left(l1.combine(l2)) },
+                           { r2 in .left(l1) }) },
+            { r1 in
+                other.fold({ l2 in .left(l2) },
+                           { r2 in .right(r1.combine(r2)) }) }
+        )
     }
 }
 
-// MARK: Instance of `Monoid` for `Either`.
+// MARK: Instance of Monoid for Either
 extension Either: Monoid where A: Monoid, B: Monoid {
     public static func empty() -> Either<A, B> {
-        return .right(B.empty())
+        .right(B.empty())
     }
 }

--- a/Sources/Bow/Data/EitherK.swift
+++ b/Sources/Bow/Data/EitherK.swift
@@ -18,7 +18,7 @@ public final class EitherK<F, G, A>: EitherKOf<F, G, A> {
     /// - Parameter fa: Value in the higher-kind form.
     /// - Returns: Value cast to EitherK.
     public static func fix(_ fa: EitherKOf<F, G, A>) -> EitherK<F, G, A> {
-        return fa as! EitherK<F, G, A>
+        fa as! EitherK<F, G, A>
     }
     
     /// Initializes a EitherK from an Either.
@@ -49,7 +49,7 @@ public final class EitherK<F, G, A>: EitherKOf<F, G, A> {
     ///   - g: Function to apply if the contained value in this `EitherK` is a member of the right type.
     /// - Returns: Result of applying the corresponding function to this value.
     public func fold<H>(_ f: FunctionK<F, H>, _ g: FunctionK<G, H>) -> Kind<H, A> {
-        return run.fold({ fa in f.invoke(fa) }, { ga in g.invoke(ga) })
+        run.fold({ fa in f.invoke(fa) }, { ga in g.invoke(ga) })
     }
 }
 
@@ -58,78 +58,113 @@ public final class EitherK<F, G, A>: EitherKOf<F, G, A> {
 /// - Parameter fa: Value in higher-kind form.
 /// - Returns: Value cast to EitherK.
 public postfix func ^<F, G, A>(_ fa: EitherKOf<F, G, A>) -> EitherK<F, G, A> {
-    return EitherK.fix(fa)
+    EitherK.fix(fa)
 }
 
-// MARK: Instance of `EquatableK` for `EitherK`.
+extension EitherK where F: Applicative {
+    /// Creates a left value with the provided value.
+    ///
+    /// - Parameter a: Value to be wrapped in the left side.
+    /// - Returns: An EitherK with the provided value on the left side.
+    public static func left(_ a: A) -> EitherK<F, G, A> {
+        EitherK(F.pure(a))
+    }
+}
+
+extension EitherK where G: Applicative {
+    /// Creates a right value with the provided value.
+    ///
+    /// - Parameter a: Value to be wrapped in the right side.
+    /// - Returns: An EitherK with the provided value on the right side.
+    public static func right(_ a: A) -> EitherK<F, G, A> {
+        EitherK(G.pure(a))
+    }
+}
+
+// MARK: Instance of EquatableK for EitherK.
 extension EitherKPartial: EquatableK where F: EquatableK, G: EquatableK {
-    public static func eq<A>(_ lhs: Kind<EitherKPartial<F, G>, A>, _ rhs: Kind<EitherKPartial<F, G>, A>) -> Bool where A : Equatable {
-        return EitherK.fix(lhs).run == EitherK.fix(rhs).run
+    public static func eq<A: Equatable>(
+        _ lhs: EitherKOf<F, G, A>,
+        _ rhs: EitherKOf<F, G, A>) -> Bool {
+        lhs^.run == rhs^.run
     }
 }
 
-// MARK: Instance of `Invariant` for `EitherK`.
+// MARK: Instance of Invariant for EitherK.
 extension EitherKPartial: Invariant where F: Invariant, G: Invariant {
-    public static func imap<A, B>(_ fa: Kind<EitherKPartial<F, G>, A>, _ f: @escaping (A) -> B, _ g: @escaping (B) -> A) -> Kind<EitherKPartial<F, G>, B> {
-        return EitherK(fa^.run.bimap({ a in a.imap(f, g) }, { b in b.imap(f, g) }))
+    public static func imap<A, B>(
+        _ fa: EitherKOf<F, G, A>,
+        _ f: @escaping (A) -> B,
+        _ g: @escaping (B) -> A) -> EitherKOf<F, G, B> {
+        EitherK(fa^.run.bimap({ a in a.imap(f, g) },
+                              { b in b.imap(f, g) }))
     }
 }
 
-// MARK: Instance of `Functor` for `EitherK`.
+// MARK: Instance of Functor for EitherK.
 extension EitherKPartial: Functor where F: Functor, G: Functor {
-    public static func map<A, B>(_ fa: Kind<EitherKPartial<F, G>, A>, _ f: @escaping (A) -> B) -> Kind<EitherKPartial<F, G>, B> {
-        let cop = EitherK<F, G, A>.fix(fa)
-        return EitherK(cop.run.bimap({ fa in fa.map(f) },
-                                       { ga in ga.map(f) }))
+    public static func map<A, B>(
+        _ fa: EitherKOf<F, G, A>,
+        _ f: @escaping (A) -> B) -> EitherKOf<F, G, B> {
+        EitherK(fa^.run.bimap({ fa in fa.map(f) },
+                              { ga in ga.map(f) }))
     }
 }
 
-// MARK: Instance of `Comonad` for `EitherK`.
+// MARK: Instance of Comonad for EitherK.
 extension EitherKPartial: Comonad where F: Comonad, G: Comonad {
-    public static func coflatMap<A, B>(_ fa: Kind<EitherKPartial<F, G>, A>, _ f: @escaping (Kind<EitherKPartial<F, G>, A>) -> B) -> Kind<EitherKPartial<F, G>, B> {
-        let cop = EitherK<F, G, A>.fix(fa)
-        return EitherK(cop.run.bimap(
+    public static func coflatMap<A, B>(
+        _ fa: EitherKOf<F, G, A>,
+        _ f: @escaping (EitherKOf<F, G, A>) -> B) -> EitherKOf<F, G, B> {
+        EitherK(fa^.run.bimap(
             { fa in fa.coflatMap { a in f(EitherK(Either.left(a))) } },
             { ga in ga.coflatMap { a in f(EitherK(Either.right(a))) } }))
     }
 
-    public static func extract<A>(_ fa: Kind<EitherKPartial<F, G>, A>) -> A {
-        let cop = EitherK<F, G, A>.fix(fa)
-        return cop.run.fold({ fa in fa.extract() },
-                            { ga in ga.extract() })
+    public static func extract<A>(_ fa: EitherKOf<F, G, A>) -> A {
+        fa^.run.fold({ fa in fa.extract() },
+                     { ga in ga.extract() })
     }
 }
 
-// MARK: Instance of `Foldable` for `EitherK`.
+// MARK: Instance of Foldable for EitherK.
 extension EitherKPartial: Foldable where F: Foldable, G: Foldable {
-    public static func foldLeft<A, B>(_ fa: Kind<EitherKPartial<F, G>, A>, _ b: B, _ f: @escaping (B, A) -> B) -> B {
-        let cop = EitherK<F, G, A>.fix(fa)
-        return cop.run.fold(
+    public static func foldLeft<A, B>(
+        _ fa: EitherKOf<F, G, A>,
+        _ b: B,
+        _ f: @escaping (B, A) -> B) -> B {
+        fa^.run.fold(
             { fa in fa.foldLeft(b, f) },
             { ga in ga.foldLeft(b, f) })
     }
 
-    public static func foldRight<A, B>(_ fa: Kind<EitherKPartial<F, G>, A>, _ b: Eval<B>, _ f: @escaping (A, Eval<B>) -> Eval<B>) -> Eval<B> {
-        let cop = EitherK<F, G, A>.fix(fa)
-        return cop.run.fold(
+    public static func foldRight<A, B>(
+        _ fa: EitherKOf<F, G, A>,
+        _ b: Eval<B>,
+        _ f: @escaping (A, Eval<B>) -> Eval<B>) -> Eval<B> {
+        fa^.run.fold(
             { fa in fa.foldRight(b, f) },
             { ga in ga.foldRight(b, f) })
     }
 }
 
-// MARK: Instance of `Traverse` for `EitherK`.
+// MARK: Instance of Traverse for EitherK.
 extension EitherKPartial: Traverse where F: Traverse, G: Traverse {
-    public static func traverse<H: Applicative, A, B>(_ fa: Kind<EitherKPartial<F, G>, A>, _ f: @escaping (A) -> Kind<H, B>) -> Kind<H, Kind<EitherKPartial<F, G>, B>> {
-        let cop = EitherK<F, G, A>.fix(fa)
-        return cop.run.fold(
-            { fa in H.map(fa.traverse(f), { fb in EitherK(Either.left(fb)) })},
-            { ga in H.map(ga.traverse(f), { gb in EitherK(Either.right(gb)) })})
+    public static func traverse<H: Applicative, A, B>(
+        _ fa: EitherKOf<F, G, A>,
+        _ f: @escaping (A) -> Kind<H, B>) -> Kind<H, EitherKOf<F, G, B>> {
+        fa^.run.fold(
+            { fa in fa.traverse(f).map { fb in EitherK(Either.left(fb)) } },
+            { ga in ga.traverse(f).map { gb in EitherK(Either.right(gb)) } })
     }
 }
 
-// MARK: Instance of `Contravariant` for `EitherK`
+// MARK: Instance of Contravariant for EitherK
 extension EitherKPartial: Contravariant where F: Contravariant, G: Contravariant {
-    public static func contramap<A, B>(_ fa: Kind<EitherKPartial<F, G>, A>, _ f: @escaping (B) -> A) -> Kind<EitherKPartial<F, G>, B> {
-        return EitherK(fa^.run.bimap({ a in a.contramap(f) }, { b in b.contramap(f) }))
+    public static func contramap<A, B>(
+        _ fa: EitherKOf<F, G, A>,
+        _ f: @escaping (B) -> A) -> EitherKOf<F, G, B> {
+        EitherK(fa^.run.bimap({ a in a.contramap(f) },
+                              { b in b.contramap(f) }))
     }
 }

--- a/Sources/Bow/Data/Eval.swift
+++ b/Sources/Bow/Data/Eval.swift
@@ -79,8 +79,8 @@ public class Eval<A>: EvalOf<A> {
 
 public extension Eval where A == () {
     /// Provides a unit in an Eval.
-    static var unit: Eval<()> {
-        Now<()>(())
+    static var unit: Eval<Void> {
+        Now<Void>(())
     }
 }
 
@@ -217,34 +217,42 @@ private class Bind<A, B>: Eval<B> {
     }
 }
 
-// MARK: Instance of `Functor` for `Eval`
+// MARK: Instance of Functor for Eval
 extension EvalPartial: Functor {
-    public static func map<A, B>(_ fa: EvalOf<A>, _ f: @escaping (A) -> B) -> EvalOf<B> {
+    public static func map<A, B>(
+        _ fa: EvalOf<A>,
+        _ f: @escaping (A) -> B) -> EvalOf<B> {
         FMap(fa^, f)
     }
 }
 
-// MARK: Instance of `Applicative` for `Eval`
+// MARK: Instance of Applicative for Eval
 extension EvalPartial: Applicative {
     public static func pure<A>(_ a: A) -> EvalOf<A> {
         Eval.now(a)
     }
 }
 
-// MARK: Instance of `Selective` for `Eval`
+// MARK: Instance of Selective for Eval
 extension EvalPartial: Selective {}
 
-// MARK: Instance of `Monad` for `Eval`
+// MARK: Instance of Monad for Eval
 extension EvalPartial: Monad {
-    public static func flatMap<A, B>(_ fa: EvalOf<A>, _ f: @escaping (A) -> EvalOf<B>) -> EvalOf<B> {
+    public static func flatMap<A, B>(
+        _ fa: EvalOf<A>,
+        _ f: @escaping (A) -> EvalOf<B>) -> EvalOf<B> {
         Bind(fa^, f)
     }
 
-    public static func tailRecM<A, B>(_ a: A, _ f: @escaping (A) -> EvalOf<Either<A, B>>) -> EvalOf<B> {
+    public static func tailRecM<A, B>(
+        _ a: A,
+        _ f: @escaping (A) -> EvalOf<Either<A, B>>) -> EvalOf<B> {
         _tailRecM(a, f).run()
     }
     
-    private static func _tailRecM<A, B>(_ a: A, _ f: @escaping (A) -> EvalOf<Either<A, B>>) -> Trampoline<EvalOf<B>> {
+    private static func _tailRecM<A, B>(
+        _ a: A,
+        _ f: @escaping (A) -> EvalOf<Either<A, B>>) -> Trampoline<EvalOf<B>> {
         .defer {
             f(a)^.value().fold({ a in _tailRecM(a, f) },
                                { b in .done(Eval<B>.pure(b)) })
@@ -252,9 +260,11 @@ extension EvalPartial: Monad {
     }
 }
 
-// MARK: Instance of `Comonad` for `Eval`
+// MARK: Instance of Comonad for Eval
 extension EvalPartial: Comonad {
-    public static func coflatMap<A, B>(_ fa: EvalOf<A>, _ f: @escaping (EvalOf<A>) -> B) -> EvalOf<B> {
+    public static func coflatMap<A, B>(
+        _ fa: EvalOf<A>,
+        _ f: @escaping (EvalOf<A>) -> B) -> EvalOf<B> {
         Eval.later { f(fa) }
     }
     
@@ -263,12 +273,14 @@ extension EvalPartial: Comonad {
     }
 }
 
-// MARK: Instance of `Bimonad` for `Eval`
+// MARK: Instance of Bimonad for Eval
 extension EvalPartial: Bimonad {}
 
-// MARK: Instance of `EquatableK` for `Eval`
+// MARK: Instance of EquatableK for Eval
 extension EvalPartial: EquatableK {
-    public static func eq<A: Equatable>(_ lhs: EvalOf<A>, _ rhs: EvalOf<A>) -> Bool {
+    public static func eq<A: Equatable>(
+        _ lhs: EvalOf<A>,
+        _ rhs: EvalOf<A>) -> Bool {
         lhs^.value() == rhs^.value()
     }
 }

--- a/Sources/Bow/Data/Id.swift
+++ b/Sources/Bow/Data/Id.swift
@@ -38,55 +38,65 @@ public postfix func ^<A>(_ fa: IdOf<A>) -> Id<A> {
     Id.fix(fa)
 }
 
-// MARK: Conformance of `Id` to `CustomStringConvertible`.
+// MARK: Conformance of Id to CustomStringConvertible.
 extension Id: CustomStringConvertible {
     public var description: String {
         "Id(\(value))"
     }
 }
 
-// MARK: Conformance of `Id` to `CustomDebugStringConvertible`, given that type parameter also conforms to `CustomDebugStringConvertible`.
+// MARK: Conformance of Id to CustomDebugStringConvertible
 extension Id: CustomDebugStringConvertible where A : CustomDebugStringConvertible {
     public var debugDescription: String {
         "Id(\(value.debugDescription))"
     }
 }
 
-// MARK: Instance of `EquatableK` for `Id`
+// MARK: Instance of EquatableK for Id
 extension IdPartial: EquatableK {
-    public static func eq<A: Equatable>(_ lhs: IdOf<A>, _ rhs: IdOf<A>) -> Bool {
+    public static func eq<A: Equatable>(
+        _ lhs: IdOf<A>,
+        _ rhs: IdOf<A>) -> Bool {
         lhs^.value == rhs^.value
     }
 }
 
-// MARK: Instance of `Functor` for `Id`
+// MARK: Instance of Functor for Id
 extension IdPartial: Functor {
-    public static func map<A, B>(_ fa: IdOf<A>, _ f: @escaping (A) -> B) -> IdOf<B> {
+    public static func map<A, B>(
+        _ fa: IdOf<A>,
+        _ f: @escaping (A) -> B) -> IdOf<B> {
         Id(f(fa^.value))
     }
 }
 
-// MARK: Instance of `Applicative` for `Id`
+// MARK: Instance of Applicative for Id
 extension IdPartial: Applicative {
     public static func pure<A>(_ a: A) -> IdOf<A> {
         Id(a)
     }
 }
 
-// MARK: Instance of `Selective` for `Id`
+// MARK: Instance of Selective for Id
 extension IdPartial: Selective {}
 
-// MARK: Instance of `Monad` for `Id`
+// MARK: Instance of Monad for Id
 extension IdPartial: Monad {
-    public static func flatMap<A, B>(_ fa: IdOf<A>, _ f: @escaping (A) -> IdOf<B>) -> IdOf<B> {
+    public static func flatMap<A, B>(
+        _ fa: IdOf<A>,
+        _ f: @escaping (A) -> IdOf<B>) -> IdOf<B> {
         f(fa^.value)
     }
 
-    public static func tailRecM<A, B>(_ a: A, _ f: @escaping (A) -> IdOf<Either<A, B>>) -> IdOf<B> {
+    public static func tailRecM<A, B>(
+        _ a: A,
+        _ f: @escaping (A) -> IdOf<Either<A, B>>) -> IdOf<B> {
         _tailRecM(a, f).run()
     }
     
-    private static func _tailRecM<A, B>(_ a: A, _ f: @escaping (A) -> IdOf<Either<A, B>>) -> Trampoline<IdOf<B>> {
+    private static func _tailRecM<A, B>(
+        _ a: A,
+        _ f: @escaping (A) -> IdOf<Either<A, B>>) -> Trampoline<IdOf<B>> {
         .defer {
             f(a)^.value.fold(
                 { left in _tailRecM(left, f) },
@@ -95,9 +105,11 @@ extension IdPartial: Monad {
     }
 }
 
-// MARK: Instance of `Comonad` for `Id`
+// MARK: Instance of Comonad for Id
 extension IdPartial: Comonad {
-    public static func coflatMap<A, B>(_ fa: IdOf<A>, _ f: @escaping (IdOf<A>) -> B) -> IdOf<B> {
+    public static func coflatMap<A, B>(
+        _ fa: IdOf<A>,
+        _ f: @escaping (IdOf<A>) -> B) -> IdOf<B> {
         fa.map { a in f(Id(a)) }
     }
 
@@ -106,35 +118,43 @@ extension IdPartial: Comonad {
     }
 }
 
-// MARK: Instance of `Bimonad` for `Id`
+// MARK: Instance of Bimonad for Id
 extension IdPartial: Bimonad {}
 
-// MARK: Instance of `Foldable` for `Id`
+// MARK: Instance of Foldable for Id
 extension IdPartial: Foldable {
-    public static func foldLeft<A, B>(_ fa: IdOf<A>, _ b: B, _ f: @escaping (B, A) -> B) -> B {
+    public static func foldLeft<A, B>(
+        _ fa: IdOf<A>,
+        _ b: B,
+        _ f: @escaping (B, A) -> B) -> B {
         f(b, fa^.value)
     }
 
-    public static func foldRight<A, B>(_ fa: IdOf<A>, _ b: Eval<B>, _ f: @escaping (A, Eval<B>) -> Eval<B>) -> Eval<B> {
+    public static func foldRight<A, B>(
+        _ fa: IdOf<A>,
+        _ b: Eval<B>,
+        _ f: @escaping (A, Eval<B>) -> Eval<B>) -> Eval<B> {
         f(fa^.value, b)
     }
 }
 
-// MARK: Instance of `Traverse` for `Id`
+// MARK: Instance of Traverse for Id
 extension IdPartial: Traverse {
-    public static func traverse<G: Applicative, A, B>(_ fa: IdOf<A>, _ f: @escaping (A) -> Kind<G, B>) -> Kind<G, IdOf<B>> {
+    public static func traverse<G: Applicative, A, B>(
+        _ fa: IdOf<A>,
+        _ f: @escaping (A) -> Kind<G, B>) -> Kind<G, IdOf<B>> {
         G.map(f(fa^.value), Id<B>.init)
     }
 }
 
-// MARK: Instance of `Semigroup` for `Id`
+// MARK: Instance of Semigroup for Id
 extension Id: Semigroup where A: Semigroup {
     public func combine(_ other: Id<A>) -> Id<A> {
         Id(self.value.combine(other.value))
     }
 }
 
-// MARK: Instance of `Monoid` for `Id`
+// MARK: Instance of Monoid for Id
 extension Id: Monoid where A: Monoid {
     public static func empty() -> Id<A> {
         Id(A.empty())

--- a/Sources/Bow/Data/Ior.swift
+++ b/Sources/Bow/Data/Ior.swift
@@ -22,7 +22,7 @@ public final class Ior<A, B>: IorOf<A, B> {
     /// - Parameter a: A value of the left type.
     /// - Returns: An `Ior` of the left type.
     public static func left(_ a: A) -> Ior<A, B> {
-        return Ior<A, B>(.left(a))
+        Ior<A, B>(.left(a))
     }
     
     /// Creates an Ior value of the right type.
@@ -30,7 +30,7 @@ public final class Ior<A, B>: IorOf<A, B> {
     /// - Parameter b: A value of the right type.
     /// - Returns: An `Ior` of the right type.
     public static func right(_ b: B) -> Ior<A, B> {
-        return Ior<A, B>(.right(b))
+        Ior<A, B>(.right(b))
     }
     
     /// Creates an Ior value with both types.
@@ -40,7 +40,7 @@ public final class Ior<A, B>: IorOf<A, B> {
     ///   - b: A value of the right type.
     /// - Returns: An `Ior` of both types.
     public static func both(_ a: A, _ b: B) -> Ior<A, B> {
-        return Ior<A, B>(.both(a, b))
+        Ior<A, B>(.both(a, b))
     }
     
     /// Creates an Ior value from two optional values.
@@ -50,10 +50,10 @@ public final class Ior<A, B>: IorOf<A, B> {
     ///   - mb: An optional value of the right type.
     /// - Returns: An optional `Ior` that is empty if both options are empty, or has a present `Ior` with the present values of the options.
     public static func fromOptions(_ ma: Option<A>, _ mb: Option<B>) -> Option<Ior<A, B>> {
-        return ma.fold({ mb.fold({ Option.none() },
-                                 { b in Option.some(Ior.right(b))}) },
-                       { a in mb.fold({ Option.some(Ior.left(a)) },
-                                      { b in Option.some(Ior.both(a, b))})})
+        ma.fold({ mb.fold({ Option.none() },
+                          { b in Option.some(Ior.right(b))}) },
+                { a in mb.fold({ Option.some(Ior.left(a)) },
+                               { b in Option.some(Ior.both(a, b))})})
     }
 
     /// Safe downcast.
@@ -61,7 +61,7 @@ public final class Ior<A, B>: IorOf<A, B> {
     /// - Parameter fa: Value in the higher-kind form.
     /// - Returns: Value cast to Ior.
     public static func fix(_ fa: IorOf<A, B>) -> Ior<A, B> {
-        return fa as! Ior<A, B>
+        fa as! Ior<A, B>
     }
     
     /// Applies the provided closures based on the content of this `Ior` value.
@@ -81,17 +81,17 @@ public final class Ior<A, B>: IorOf<A, B> {
     
     /// Checks if this value contains only a value of the left type.
     public var isLeft: Bool {
-        return fold(constant(true), constant(false), constant(false))
+        fold(constant(true), constant(false), constant(false))
     }
     
     /// Checks if this value contains only a value of the right type.
     public var isRight: Bool {
-        return fold(constant(false), constant(true), constant(false))
+        fold(constant(false), constant(true), constant(false))
     }
     
     /// Checks if this value contains values of both left and right types.
     public var isBoth: Bool {
-        return fold(constant(false), constant(false), constant(true))
+        fold(constant(false), constant(false), constant(true))
     }
 
     /// Transforms both type parameters with the provided closures.
@@ -101,9 +101,9 @@ public final class Ior<A, B>: IorOf<A, B> {
     ///   - fb: Closure to transform the right type.
     /// - Returns: An `Ior` value with its type parameters transformed using the provided functions.
     public func bimap<C, D>(_ fa: (A) -> C, _ fb: (B) -> D) -> Ior<C, D> {
-        return fold({ a in Ior<C, D>.left(fa(a)) },
-                    { b in Ior<C, D>.right(fb(b)) },
-                    { a, b in Ior<C, D>.both(fa(a), fb(b)) })
+        fold({ a in Ior<C, D>.left(fa(a)) },
+             { b in Ior<C, D>.right(fb(b)) },
+             { a, b in Ior<C, D>.both(fa(a), fb(b)) })
     }
     
     /// Transforms the left type parameter with the provided closure.
@@ -111,18 +111,18 @@ public final class Ior<A, B>: IorOf<A, B> {
     /// - Parameter f: Transforming function.
     /// - Returns: An `Ior` value with its left type parameter transformed using the provided function.
     public func mapLeft<C>(_ f: (A) -> C) -> Ior<C, B> {
-        return fold({ a in Ior<C, B>.left(f(a)) },
-                    Ior<C, B>.right,
-                    { a, b in Ior<C, B>.both(f(a), b) })
+        fold({ a in Ior<C, B>.left(f(a)) },
+             Ior<C, B>.right,
+             { a, b in Ior<C, B>.both(f(a), b) })
     }
     
     /// Swaps the type parameters.
     ///
     /// - Returns: An `Ior` where the left values are right and vice versa, and both values are swapped.
     public func swap() -> Ior<B, A> {
-        return fold(Ior<B, A>.right,
-                    Ior<B, A>.left,
-                    { a, b in Ior<B, A>.both(b, a) })
+        fold(Ior<B, A>.right,
+             Ior<B, A>.left,
+             { a, b in Ior<B, A>.both(b, a) })
     }
     
     /// Transforms this `Ior` to nested `Either` values representing the possible values wrapped.
@@ -132,36 +132,36 @@ public final class Ior<A, B>: IorOf<A, B> {
     ///     - `Ior.right` is mapped to `Either.left(Either.right)`.
     ///     - `Ior.both` is mapped to `Either.right` containing a tuple of the two values.
     public func unwrap() -> Either<Either<A, B>, (A, B)> {
-        return fold({ a in Either.left(Either.left(a)) },
-                    { b in Either.left(Either.right(b)) },
-                    { a, b in Either.right((a, b)) })
+        fold({ a in Either.left(Either.left(a)) },
+             { b in Either.left(Either.right(b)) },
+             { a, b in Either.right((a, b)) })
     }
     
     /// Obtains a tuple of optional values with the values wrapped in this `Ior`.
     ///
     /// - Returns: A tuple of optional values that are present or absent based on the contents of this `Ior`.
     public func pad() -> (Option<A>, Option<B>) {
-        return fold({ a in (Option.some(a), Option.none()) },
-                    { b in (Option.none(), Option.some(b)) },
-                    { a, b in (Option.some(a), Option.some(b)) })
+        fold({ a in (Option.some(a), Option.none()) },
+             { b in (Option.none(), Option.some(b)) },
+             { a, b in (Option.some(a), Option.some(b)) })
     }
     
     /// Converts this `Ior` to an `Either`.
     ///
     /// - Returns: An `Either` value with a direct mapping of the left and right cases, and mapping the both case to a right value (losing the left value).
     public func toEither() -> Either<A, B> {
-        return fold(Either.left,
-                    Either.right,
-                    { _, b in Either.right(b) })
+        fold(Either.left,
+             Either.right,
+             { _, b in Either.right(b) })
     }
     
     /// Converts this `Ior` to an `Option`.
     ///
     /// - Returns: An `Option` of the right type, discarding any left value in this `Ior`.
     public func toOption() -> Option<B> {
-        return fold({ _ in Option<B>.none() },
-                    { b in Option<B>.some(b) },
-                    { _, b in Option<B>.some(b) })
+        fold({ _ in Option<B>.none() },
+             { b in Option<B>.some(b) },
+             { _, b in Option<B>.some(b) })
     }
     
     /// Obtains a value of the right type, or a default if there is none.
@@ -169,9 +169,9 @@ public final class Ior<A, B>: IorOf<A, B> {
     /// - Parameter defaultValue: Default value for the left case.
     /// - Returns: Right value wrapped in the right and both cases, or the default value if this `Ior` contains a left value.
     public func getOrElse(_ defaultValue: B) -> B {
-        return fold(constant(defaultValue),
-                    id,
-                    { _, b in b })
+        fold(constant(defaultValue),
+             id,
+             { _, b in b })
     }
 }
 
@@ -180,7 +180,7 @@ public final class Ior<A, B>: IorOf<A, B> {
 /// - Parameter fa: Value in higher-kind form.
 /// - Returns: Value cast to Ior.
 public postfix func ^<A, B>(_ fa: IorOf<A, B>) -> Ior<A, B> {
-    return Ior.fix(fa)
+    Ior.fix(fa)
 }
 
 private enum _Ior<A, B> {
@@ -189,114 +189,132 @@ private enum _Ior<A, B> {
     case both(A, B)
 }
 
-// MARK: Conformance to `CustomStringConvertible`
+// MARK: Conformance to CustomStringConvertible
 extension Ior: CustomStringConvertible {
     public var description: String {
-        return fold({ a in "Left(\(a))" },
-                    { b in "Right(\(b))" },
-                    { a, b in "Both(\(a),\(b))" })
+        fold({ a in "Left(\(a))" },
+             { b in "Right(\(b))" },
+             { a, b in "Both(\(a),\(b))" })
     }
 }
 
-// MARK: Conformance to `CustomDebugStringConvertible`
+// MARK: Conformance to CustomDebugStringConvertible
 extension Ior: CustomDebugStringConvertible where A: CustomDebugStringConvertible, B: CustomDebugStringConvertible {
     public var debugDescription : String {
-        return fold({ a in "Left(\(a.debugDescription))" },
-                    { b in "Right(\(b.debugDescription))" },
-                    { a, b in "Both(\(a.debugDescription), \(b.debugDescription))" })
+        fold({ a in "Left(\(a.debugDescription))" },
+             { b in "Right(\(b.debugDescription))" },
+             { a, b in "Both(\(a.debugDescription), \(b.debugDescription))" })
     }
 }
 
-// MARK: Instance of `EquatableK` for `Ior`
+// MARK: Instance of EquatableK for Ior
 extension IorPartial: EquatableK where L: Equatable {
-    public static func eq<A>(_ lhs: Kind<IorPartial<L>, A>, _ rhs: Kind<IorPartial<L>, A>) -> Bool where A : Equatable {
-        let il = Ior.fix(lhs)
-        let ir = Ior.fix(rhs)
-        return il.fold({ la in ir.fold({ ra in la == ra }, constant(false), constant(false)) },
-                       { lb in ir.fold(constant(false), { rb in lb == rb }, constant(false)) },
-                       { la, lb in ir.fold(constant(false), constant(false), { ra, rb in la == ra && lb == rb })})
+    public static func eq<A: Equatable>(
+        _ lhs: IorOf<L, A>,
+        _ rhs: IorOf<L, A>) -> Bool {
+        lhs^.fold({ la in rhs^.fold({ ra in la == ra },
+                                    constant(false),
+                                    constant(false)) },
+                  { lb in rhs^.fold(constant(false),
+                                    { rb in lb == rb },
+                                    constant(false)) },
+                  { la, lb in rhs^.fold(constant(false),
+                                        constant(false),
+                                        { ra, rb in la == ra && lb == rb }) }
+        )
     }
 }
 
-// MARK: Instance of `Functor` for `Ior`
+// MARK: Instance of Functor for Ior
 extension IorPartial: Functor {
-    public static func map<A, B>(_ fa: Kind<IorPartial<L>, A>, _ f: @escaping (A) -> B) -> Kind<IorPartial<L>, B> {
-        let ior = Ior.fix(fa)
-        return ior.fold({ a    in Ior.left(a) },
-                        { b    in Ior.right(f(b)) },
-                        { a, b in Ior.both(a, f(b)) })
+    public static func map<A, B>(
+        _ fa: IorOf<L, A>,
+        _ f: @escaping (A) -> B) -> IorOf<L, B> {
+        fa^.fold({ a    in Ior.left(a) },
+                 { b    in Ior.right(f(b)) },
+                 { a, b in Ior.both(a, f(b)) })
     }
 }
 
-// MARK: Instance of `Applicative` for `Ior`
+// MARK: Instance of Applicative for Ior
 extension IorPartial: Applicative where L: Semigroup {
-    public static func pure<A>(_ a: A) -> Kind<IorPartial<L>, A> {
-        return Ior.right(a)
+    public static func pure<A>(_ a: A) -> IorOf<L, A> {
+        Ior.right(a)
     }
 }
 
-// MARK: Instance of `Selective` for `Ior`
+// MARK: Instance of Selective for Ior
 extension IorPartial: Selective where L: Semigroup {}
 
-// MARK: Instance of `Monad` for `Ior`
+// MARK: Instance of Monad for Ior
 extension IorPartial: Monad where L: Semigroup {
-    public static func flatMap<A, B>(_ fa: Kind<IorPartial<L>, A>, _ f: @escaping (A) -> Kind<IorPartial<L>, B>) -> Kind<IorPartial<L>, B> {
-        return Ior.fix(fa).fold(
+    public static func flatMap<A, B>(
+        _ fa: IorOf<L, A>,
+        _ f: @escaping (A) -> IorOf<L, B>) -> IorOf<L, B> {
+        fa^.fold(
             Ior.left,
             f,
-            { a, b in Ior.fix(f(b)).fold({ lft in Ior.left(a.combine(lft)) },
-                                         { rgt in Ior.right(rgt) },
-                                         { lft, rgt in Ior.both(a.combine(lft), rgt) })
+            { a, b in f(b)^.fold({ lft in Ior.left(a.combine(lft)) },
+                                 { rgt in Ior.right(rgt) },
+                                 { lft, rgt in Ior.both(a.combine(lft), rgt) })
         })
     }
 
-    private static func loop<A, B>(_ v: Ior<L, Either<A, B>>,
-                                   _ f: @escaping (A) -> Ior<L, Either<A, B>>) -> Trampoline<Ior<L, B>> {
+    private static func loop<A, B>(
+        _ v: Ior<L, Either<A, B>>,
+        _ f: @escaping (A) -> Ior<L, Either<A, B>>) -> Trampoline<Ior<L, B>> {
         .defer {
-            return v.fold({ left in .done(.left(left)) },
-                          { right in
-                            right.fold({ a in loop(f(a), f) },
-                                       { b in .done(.right(b)) })
-            },
-                          { left, right in
-                            right.fold({ a in
-                                f(a).fold({ aLeft in .done(.left(aLeft.combine(left))) },
-                                          { aRight in loop(.both(left, aRight), f) },
-                                          { aLeft, aRight in loop(.both(left.combine(aLeft), aRight), f) })
-                                        },
-                                       { b in .done(.both(left, b)) })
+             v.fold({ left in .done(.left(left)) },
+                    { right in
+                        right.fold({ a in loop(f(a), f) },
+                                   { b in .done(.right(b)) })
+             },
+                    { left, right in
+                        right.fold({ a in
+                            f(a).fold({ aLeft in .done(.left(aLeft.combine(left))) },
+                                      { aRight in loop(.both(left, aRight), f) },
+                                      { aLeft, aRight in loop(.both(left.combine(aLeft), aRight), f) })
+                        },
+                                   { b in .done(.both(left, b)) })
             })
         }
     }
 
-    public static func tailRecM<A, B>(_ a: A, _ f: @escaping (A) -> Kind<IorPartial<L>, Either<A, B>>) -> Kind<IorPartial<L>, B> {
+    public static func tailRecM<A, B>(
+        _ a: A,
+        _ f: @escaping (A) -> IorOf<L, Either<A, B>>) -> IorOf<L, B> {
         loop(f(a)^, { a in f(a)^ }).run()
     }
 }
 
-// MARK: Instance of `Foldable` for `Ior`
+// MARK: Instance of Foldable for Ior
 extension IorPartial: Foldable {
-    public static func foldLeft<A, B>(_ fa: Kind<IorPartial<L>, A>, _ c: B, _ f: @escaping (B, A) -> B) -> B {
-        let ior = Ior.fix(fa)
-        return ior.fold(constant(c),
-                        { b    in f(c, b) },
-                        { _, b in f(c, b) })
+    public static func foldLeft<A, B>(
+        _ fa: IorOf<L, A>,
+        _ c: B,
+        _ f: @escaping (B, A) -> B) -> B {
+        fa^.fold(constant(c),
+                 { b    in f(c, b) },
+                 { _, b in f(c, b) })
     }
 
-    public static func foldRight<A, B>(_ fa: Kind<IorPartial<L>, A>, _ c: Eval<B>, _ f: @escaping (A, Eval<B>) -> Eval<B>) -> Eval<B> {
-        let ior = Ior.fix(fa)
-        return ior.fold(constant(c),
-                        { b    in f(b, c) },
-                        { _, b in f(b, c) })
+    public static func foldRight<A, B>(
+        _ fa: IorOf<L, A>,
+        _ c: Eval<B>,
+        _ f: @escaping (A, Eval<B>) -> Eval<B>) -> Eval<B> {
+        fa^.fold(constant(c),
+                 { b    in f(b, c) },
+                 { _, b in f(b, c) })
     }
 }
 
-// MARK: Instance of `Traverse` for `Ior`
+// MARK: Instance of Traverse for Ior
 extension IorPartial: Traverse {
-    public static func traverse<G: Applicative, A, B>(_ fa: Kind<IorPartial<L>, A>, _ f: @escaping (A) -> Kind<G, B>) -> Kind<G, Kind<IorPartial<L>, B>> {
-        let ior = Ior.fix(fa)
-        return ior.fold({ a    in G.pure(Ior.left(a)) },
-                        { b    in f(b).map(Ior.right) },
-                        { _, b in f(b).map(Ior.right) })
+    public static func traverse<G: Applicative, A, B>(
+        _ fa: IorOf<L, A>,
+        _ f: @escaping (A) -> Kind<G, B>) -> Kind<G, IorOf<L, B>> {
+        fa^.fold({ a    in G.pure(Ior.left(a)) },
+                 { b    in f(b).map(Ior.right) },
+                 { _, b in f(b).map(Ior.right) })
     }
 }

--- a/Sources/Bow/Data/Ior.swift
+++ b/Sources/Bow/Data/Ior.swift
@@ -212,15 +212,19 @@ extension IorPartial: EquatableK where L: Equatable {
     public static func eq<A: Equatable>(
         _ lhs: IorOf<L, A>,
         _ rhs: IorOf<L, A>) -> Bool {
-        lhs^.fold({ la in rhs^.fold({ ra in la == ra },
-                                    constant(false),
-                                    constant(false)) },
-                  { lb in rhs^.fold(constant(false),
-                                    { rb in lb == rb },
-                                    constant(false)) },
-                  { la, lb in rhs^.fold(constant(false),
-                                        constant(false),
-                                        { ra, rb in la == ra && lb == rb }) }
+        lhs^.fold(
+            { (la: L) -> Bool in
+                rhs^.fold({ ra in la == ra },
+                          constant(false),
+                          constant(false)) },
+            { (lb: A) -> Bool in
+                rhs^.fold(constant(false),
+                          { rb in lb == rb },
+                          constant(false)) },
+            { (la: L, lb: A) -> Bool in
+                rhs^.fold(constant(false),
+                          constant(false),
+                          { ra, rb in la == ra && lb == rb }) }
         )
     }
 }

--- a/Sources/Bow/Data/Moore.swift
+++ b/Sources/Bow/Data/Moore.swift
@@ -22,7 +22,7 @@ public final class Moore<E, V>: MooreOf<E, V> {
     /// - Parameter value: Value in the higher-kind form.
     /// - Returns: Value cast to Moore.
     public static func fix(_ value: MooreOf<E, V>) -> Moore<E, V> {
-        return value as! Moore<E, V>
+        value as! Moore<E, V>
     }
     
     /// Creates a Moore machine from a hidden initial state and a function that provides the next value and handling function.
@@ -31,7 +31,9 @@ public final class Moore<E, V>: MooreOf<E, V> {
     ///   - state: Initial state.
     ///   - next: Function to determine the next value and handling function.
     /// - Returns: A Moore machine described from the input values.
-    public static func unfold<S>(_ state: S, _ next: @escaping (S) -> (V, (E) -> S)) -> Moore<E, V> {
+    public static func unfold<S>(
+        _ state: S,
+        _ next: @escaping (S) -> (V, (E) -> S)) -> Moore<E, V> {
         let (a, transition) = next(state)
         return Moore(view: a) { input in
             unfold(transition(input), next)
@@ -45,7 +47,10 @@ public final class Moore<E, V>: MooreOf<E, V> {
     ///   - render: Rendering function.
     ///   - update: Update function.
     /// - Returns: A Moore machine described from the input functions.
-    public static func from<S>(initialState: S, render: @escaping (S) -> V, update: @escaping (S, E) -> S) -> Moore<E, V> {
+    public static func from<S>(
+        initialState: S,
+        render: @escaping (S) -> V,
+        update: @escaping (S, E) -> S) -> Moore<E, V> {
         unfold(initialState) { state in
             (render(state), { input in update(state, input) })
         }
@@ -58,7 +63,10 @@ public final class Moore<E, V>: MooreOf<E, V> {
     ///   - render: Rendering function.
     ///   - update: Update function.
     /// - Returns: A Moore machine described from the input functions.
-    public static func from<S>(initialState: S, render: @escaping (S) -> V, update: @escaping (E) -> State<S, S>) -> Moore<E, V> {
+    public static func from<S>(
+        initialState: S,
+        render: @escaping (S) -> V,
+        update: @escaping (E) -> State<S, S>) -> Moore<E, V> {
         from(initialState: initialState, render: render, update: { s, e in update(e).run(s).0 })
     }
     
@@ -102,7 +110,9 @@ public postfix func ^<E, V>(_ value: MooreOf<E, V>) -> Moore<E, V> {
 // MARK: Instance of Functor for Moore
 
 extension MoorePartial: Functor {
-    public static func map<A, B>(_ fa: MooreOf<E, A>, _ f: @escaping (A) -> B) -> MooreOf<E, B> {
+    public static func map<A, B>(
+        _ fa: MooreOf<E, A>,
+        _ f: @escaping (A) -> B) -> MooreOf<E, B> {
         Moore<E, B>(view: f(fa^.view),
                     handle: { update in fa^.handle(update).map(f)^ })
     }
@@ -111,7 +121,9 @@ extension MoorePartial: Functor {
 // MARK: Instance of Comonad for Moore
 
 extension MoorePartial: Comonad {
-    public static func coflatMap<A, B>(_ fa: MooreOf<E, A>, _ f: @escaping (MooreOf<E, A>) -> B) -> MooreOf<E, B> {
+    public static func coflatMap<A, B>(
+        _ fa: MooreOf<E, A>,
+        _ f: @escaping (MooreOf<E, A>) -> B) -> MooreOf<E, B> {
         Moore<E, B>(view: f(fa^),
                     handle: { update in fa^.handle(update).coflatMap(f)^ })
     }

--- a/Sources/Bow/Data/NonEmptyArray.swift
+++ b/Sources/Bow/Data/NonEmptyArray.swift
@@ -29,7 +29,7 @@ public final class NonEmptyArray<A>: NonEmptyArrayOf<A> {
     ///   - rhs: Right hand side of the concatenation.
     /// - Returns: A non-empty array that contains the elements of the two arguments in the same order.
     public static func +(lhs: NonEmptyArray<A>, rhs: NonEmptyArray<A>) -> NonEmptyArray<A> {
-        NonEmptyArray(head: lhs.head, tail: lhs.tail + [rhs.head] + rhs.tail)
+        NEA(head: lhs.head, tail: lhs.tail + [rhs.head] + rhs.tail)
     }
 
     /// Concatenates a non-empty array with a Swift array.
@@ -39,7 +39,7 @@ public final class NonEmptyArray<A>: NonEmptyArrayOf<A> {
     ///   - rhs: A Swift array.
     /// - Returns: A non-empty array that contains the elements of the two arguments in the same order.
     public static func +(lhs: NonEmptyArray<A>, rhs: [A]) -> NonEmptyArray<A> {
-        NonEmptyArray(head: lhs.head, tail: lhs.tail + rhs)
+        NEA(head: lhs.head, tail: lhs.tail + rhs)
     }
 
     /// Appends an element to a non-empty array.
@@ -49,7 +49,7 @@ public final class NonEmptyArray<A>: NonEmptyArrayOf<A> {
     ///   - rhs: An element.
     /// - Returns: A non-empty array that has the new element at the end.
     public static func +(lhs: NonEmptyArray<A>, rhs: A) -> NonEmptyArray<A> {
-        NonEmptyArray(head: lhs.head, tail: lhs.tail + [rhs])
+        NEA(head: lhs.head, tail: lhs.tail + [rhs])
     }
 
     /// Creates a non-empty array from several values.
@@ -59,7 +59,7 @@ public final class NonEmptyArray<A>: NonEmptyArrayOf<A> {
     ///   - tail: Variable number of values for the rest of the non-empty array.
     /// - Returns: A non-empty array that contains all elements in the specified order.
     public static func of(_ head: A, _ tail: A...) -> NonEmptyArray<A> {
-        NonEmptyArray(head: head, tail: tail)
+        NEA(head: head, tail: tail)
     }
 
     /// Creates a non-empty array from a Swift array.
@@ -67,7 +67,7 @@ public final class NonEmptyArray<A>: NonEmptyArrayOf<A> {
     /// - Parameter array: A Swift array.
     /// - Returns: An optional non-empty array with the contents of the argument, or `Option.none` if it was empty.
     public static func fromArray(_ array: [A]) -> Option<NonEmptyArray<A>> {
-        array.isEmpty ? Option<NonEmptyArray<A>>.none() : Option<NonEmptyArray<A>>.some(NonEmptyArray(all: array))
+        array.isEmpty ? Option.none() : Option.some(NEA(all: array))
     }
 
     /// Unsafely creates a non-empty array from a Swift array.
@@ -77,7 +77,7 @@ public final class NonEmptyArray<A>: NonEmptyArrayOf<A> {
     /// - Parameter array: A Swift array.
     /// - Returns: A non-empty array with the contents of the argument.
     public static func fromArrayUnsafe(_ array: [A]) -> NonEmptyArray<A> {
-        NonEmptyArray(all: array)
+        NEA(all: array)
     }
 
     /// Safe downcast.
@@ -85,7 +85,7 @@ public final class NonEmptyArray<A>: NonEmptyArrayOf<A> {
     /// - Parameter fa: Value in higher-kind form.
     /// - Returns: Value cast to NonEmptyArray.
     public static func fix(_ fa: NonEmptyArrayOf<A>) -> NonEmptyArray<A> {
-        fa as! NonEmptyArray<A>
+        fa as! NEA<A>
     }
 
     /// Initializes a non-empty array.
@@ -117,9 +117,9 @@ public final class NonEmptyArray<A>: NonEmptyArrayOf<A> {
     public func getOrNone(_ i: Int) -> Option<A> {
         let a = all()
         if i >= 0 && i < a.count {
-            return Option<A>.some(a[i])
+            return .some(a[i])
         } else {
-            return Option<A>.none()
+            return .none()
         }
     }
 
@@ -139,7 +139,6 @@ public postfix func ^<A>(_ fa: NonEmptyArrayOf<A>) -> NonEmptyArray<A> {
     NonEmptyArray.fix(fa)
 }
 
-// MARK: Functions for `NonEmptyArray` when the type conforms to `Equatable`
 public extension NonEmptyArray where A: Equatable {
     /// Checks if an element appears in this array.
     ///
@@ -158,14 +157,14 @@ public extension NonEmptyArray where A: Equatable {
     }
 }
 
-// Conformance of `NonEmptyArray` to `CustomStringConvertible`
+// MARK: Conformance of NonEmptyArray to CustomStringConvertible
 extension NonEmptyArray: CustomStringConvertible {
     public var description: String {
         "NonEmptyArray(\(self.all()))"
     }
 }
 
-// Conformance of `NonEmptyArray` to `CustomDebugStringConvertible`
+// MARK: Conformance of NonEmptyArray to CustomDebugStringConvertible
 extension NonEmptyArray: CustomDebugStringConvertible where A: CustomDebugStringConvertible {
     public var debugDescription: String {
         let contentsString = self.all().map { x in x.debugDescription }.joined(separator: ", ")
@@ -173,57 +172,66 @@ extension NonEmptyArray: CustomDebugStringConvertible where A: CustomDebugString
     }
 }
 
-// MARK: Instance of `EquatableK` for `NonEmptyArray`
+// MARK: Instance of EquatableK for NonEmptyArray
 extension NonEmptyArrayPartial: EquatableK {
-    public static func eq<A: Equatable>(_ lhs: NonEmptyArrayOf<A>, _ rhs: NonEmptyArrayOf<A>) -> Bool {
+    public static func eq<A: Equatable>(
+        _ lhs: NonEmptyArrayOf<A>,
+        _ rhs: NonEmptyArrayOf<A>) -> Bool {
         lhs^.all() == rhs^.all()
     }
 }
 
-// MARK: Instance of `Functor` for `NonEmptyArray`
+// MARK: Instance of Functor for NonEmptyArray
 extension NonEmptyArrayPartial: Functor {
-    public static func map<A, B>(_ fa: NonEmptyArrayOf<A>, _ f: @escaping (A) -> B) -> NonEmptyArrayOf<B> {
-        NonEmptyArray.fromArrayUnsafe(fa^.all().map(f))
+    public static func map<A, B>(
+        _ fa: NonEmptyArrayOf<A>,
+        _ f: @escaping (A) -> B) -> NonEmptyArrayOf<B> {
+        NEA.fromArrayUnsafe(fa^.all().map(f))
     }
 }
 
-// MARK: Instance of `Applicative` for `NonEmptyArray`
+// MARK: Instance of Applicative for NonEmptyArray
 extension NonEmptyArrayPartial: Applicative {
     public static func pure<A>(_ a: A) -> NonEmptyArrayOf<A> {
-        NonEmptyArray(head: a, tail: [])
+        NEA(head: a, tail: [])
     }
 }
 
-// MARK: Instance of `Selective` for `NonEmptyArray`
+// MARK: Instance of Selective for NonEmptyArray
 extension NonEmptyArrayPartial: Selective {}
 
-// MARK: Instance of `Monad` for `NonEmptyArray`
+// MARK: Instance of Monad for NonEmptyArray
 extension NonEmptyArrayPartial: Monad {
-    public static func flatMap<A, B>(_ fa: NonEmptyArrayOf<A>, _ f: @escaping (A) -> NonEmptyArrayOf<B>) -> NonEmptyArrayOf<B> {
+    public static func flatMap<A, B>(
+        _ fa: NonEmptyArrayOf<A>,
+        _ f: @escaping (A) -> NonEmptyArrayOf<B>) -> NonEmptyArrayOf<B> {
         f(fa^.head)^ + fa^.tail.flatMap{ a in f(a)^.all() }
     }
 
-    private static func go<A, B>(_ buf: [B],
-                                 _ f: @escaping (A) -> NonEmptyArrayOf<Either<A, B>>,
-                                 _ v: NonEmptyArray<Either<A, B>>) -> Trampoline<[B]> {
+    private static func go<A, B>(
+        _ buf: [B],
+        _ f: @escaping (A) -> NonEmptyArrayOf<Either<A, B>>,
+        _ v: NonEmptyArray<Either<A, B>>) -> Trampoline<[B]> {
         .defer {
             let head = v.head
             return head.fold({ a in go(buf, f, NonEmptyArray.fix(f(a)) + v.tail) },
                              { b in
                                 let newBuf = buf + [b]
-                                let x = NonEmptyArray<Either<A, B>>.fromArray(v.tail)
+                                let x = NEA<Either<A, B>>.fromArray(v.tail)
                                 return x.fold({ .done(newBuf) },
                                               { value in go(newBuf, f, value) })
             })
         }
     }
 
-    public static func tailRecM<A, B>(_ a: A, _ f: @escaping (A) -> NonEmptyArrayOf<Either<A, B>>) -> NonEmptyArrayOf<B> {
-        NonEmptyArray.fromArrayUnsafe(go([], f, f(a)^).run())
+    public static func tailRecM<A, B>(
+        _ a: A,
+        _ f: @escaping (A) -> NonEmptyArrayOf<Either<A, B>>) -> NonEmptyArrayOf<B> {
+        NEA.fromArrayUnsafe(go([], f, f(a)^).run())
     }
 }
 
-// MARK: Instance of `Comonad` for `NonEmptyArray`
+// MARK: Instance of Comonad for NonEmptyArray
 extension NonEmptyArrayPartial: Comonad {
     public static func coflatMap<A, B>(_ fa: NonEmptyArrayOf<A>, _ f: @escaping (NonEmptyArrayOf<A>) -> B) -> NonEmptyArrayOf<B> {
         func consume(_ array: [A], _ buf: [B] = []) -> [B] {
@@ -235,7 +243,7 @@ extension NonEmptyArrayPartial: Comonad {
                 return consume(tail, newBuf)
             }
         }
-        return NonEmptyArray(head: f(fa^), tail: consume(fa^.tail))
+        return NEA(head: f(fa^), tail: consume(fa^.tail))
     }
 
     public static func extract<A>(_ fa: NonEmptyArrayOf<A>) -> A {
@@ -243,25 +251,33 @@ extension NonEmptyArrayPartial: Comonad {
     }
 }
 
-// MARK: Instance of `Bimonad` for `NonEmptyArray`
+// MARK: Instance of Bimonad for NonEmptyArray
 extension NonEmptyArrayPartial: Bimonad {}
 
-// MARK: Instance of `Foldable` for `NonEmptyArray`
+// MARK: Instance of Foldable for NonEmptyArray
 extension NonEmptyArrayPartial: Foldable {
-    public static func foldLeft<A, B>(_ fa: NonEmptyArrayOf<A>, _ b: B, _ f: @escaping (B, A) -> B) -> B {
+    public static func foldLeft<A, B>(
+        _ fa: NonEmptyArrayOf<A>,
+        _ b: B,
+        _ f: @escaping (B, A) -> B) -> B {
         fa^.tail.reduce(f(b, fa^.head), f)
     }
 
-    public static func foldRight<A, B>(_ fa: NonEmptyArrayOf<A>, _ b: Eval<B>, _ f: @escaping (A, Eval<B>) -> Eval<B>) -> Eval<B> {
+    public static func foldRight<A, B>(
+        _ fa: NonEmptyArrayOf<A>,
+        _ b: Eval<B>,
+        _ f: @escaping (A, Eval<B>) -> Eval<B>) -> Eval<B> {
         fa^.all().k().foldRight(b, f)
     }
 }
 
-// MARK: Instance of `Traverse` for `NonEmptyArray`
+// MARK: Instance of Traverse for NonEmptyArray
 extension NonEmptyArrayPartial: Traverse {
-    public static func traverse<G: Applicative, A, B>(_ fa: NonEmptyArrayOf<A>, _ f: @escaping (A) -> Kind<G, B>) -> Kind<G, NonEmptyArrayOf<B>> {
+    public static func traverse<G: Applicative, A, B>(
+        _ fa: NonEmptyArrayOf<A>,
+        _ f: @escaping (A) -> Kind<G, B>) -> Kind<G, NonEmptyArrayOf<B>> {
         let arrayTraverse = fa^.all().k().traverse(f)
-        return G.map(arrayTraverse, { x in NonEmptyArray.fromArrayUnsafe(x^.asArray) })
+        return G.map(arrayTraverse, { x in NEA.fromArrayUnsafe(x^.asArray) })
     }
 }
 
@@ -271,14 +287,16 @@ public extension NEA {
     }
 }
 
-// MARK: Instance of `SemigroupK` for `NonEmptyArray`
+// MARK: Instance of SemigroupK for NonEmptyArray
 extension NonEmptyArrayPartial: SemigroupK {
-    public static func combineK<A>(_ x: NonEmptyArrayOf<A>, _ y: NonEmptyArrayOf<A>) -> NonEmptyArrayOf<A> {
+    public static func combineK<A>(
+        _ x: NonEmptyArrayOf<A>,
+        _ y: NonEmptyArrayOf<A>) -> NonEmptyArrayOf<A> {
         x^ + y^
     }
 }
 
-// MARK: Instance of `Semigroup` for `NonEmptyArray`
+// MARK: Instance of Semigroup for NonEmptyArray
 extension NonEmptyArray: Semigroup {
     public func combine(_ other: NonEmptyArray<A>) -> NonEmptyArray<A> {
         self + other

--- a/Sources/Bow/Data/Option.swift
+++ b/Sources/Bow/Data/Option.swift
@@ -135,7 +135,7 @@ public postfix func ^<A>(_ fa: OptionOf<A>) -> Option<A> {
     Option.fix(fa)
 }
 
-// MARK: Conformance of `Option` to `CustomStringConvertible`.
+// MARK: Conformance of Option to CustomStringConvertible
 extension Option: CustomStringConvertible {
     public var description: String {
         fold({ "None" },
@@ -143,7 +143,7 @@ extension Option: CustomStringConvertible {
     }
 }
 
-// MARK: Conformance of `Option` to `CustomDebugStringConvertible`.
+// MARK: Conformance of Option to CustomDebugStringConvertible
 extension Option: CustomDebugStringConvertible where A: CustomDebugStringConvertible {
     public var debugDescription : String {
         fold(constant("None"),
@@ -151,42 +151,52 @@ extension Option: CustomDebugStringConvertible where A: CustomDebugStringConvert
     }
 }
 
-// MARK: Instance of `EquatableK` for `Option`.
+// MARK: Instance of EquatableK for Option
 extension OptionPartial: EquatableK {
-    public static func eq<A: Equatable>(_ lhs: OptionOf<A>, _ rhs: OptionOf<A>) -> Bool {
+    public static func eq<A: Equatable>(
+        _ lhs: OptionOf<A>,
+        _ rhs: OptionOf<A>) -> Bool {
         lhs^.fold({ rhs^.fold(constant(true), constant(false)) },
                   { a in rhs^.fold(constant(false), { b in a == b })})
     }
 }
 
-// MARK: Instance of `Functor` for `Option`.
+// MARK: Instance of Functor for Option
 extension OptionPartial: Functor {
-    public static func map<A, B>(_ fa: OptionOf<A>, _ f: @escaping (A) -> B) -> OptionOf<B> {
+    public static func map<A, B>(
+        _ fa: OptionOf<A>,
+        _ f: @escaping (A) -> B) -> OptionOf<B> {
         fa^.fold(Option.none, Option.some <<< f)
     }
 }
 
-// MARK: Instance of `Applicative` for `Option`.
+// MARK: Instance of Applicative for Option
 extension OptionPartial: Applicative {
     public static func pure<A>(_ a: A) -> OptionOf<A> {
         Option.some(a)
     }
 }
 
-// MARK: Instance of `Selective` for `Option`
+// MARK: Instance of Selective for Option
 extension OptionPartial: Selective {}
 
-// MARK: Instance of `Monad` for `Option`.
+// MARK: Instance of Monad for Option
 extension OptionPartial: Monad {
-    public static func flatMap<A, B>(_ fa: OptionOf<A>, _ f: @escaping (A) -> OptionOf<B>) -> OptionOf<B> {
+    public static func flatMap<A, B>(
+        _ fa: OptionOf<A>,
+        _ f: @escaping (A) -> OptionOf<B>) -> OptionOf<B> {
         fa^.fold(Option<B>.none, f)
     }
 
-    public static func tailRecM<A, B>(_ a: A, _ f: @escaping (A) -> OptionOf<Either<A, B>>) -> OptionOf<B> {
+    public static func tailRecM<A, B>(
+        _ a: A,
+        _ f: @escaping (A) -> OptionOf<Either<A, B>>) -> OptionOf<B> {
         _tailRecM(a, f).run()
     }
     
-    private static func _tailRecM<A, B>(_ a: A, _ f: @escaping (A) -> OptionOf<Either<A, B>>) -> Trampoline<OptionOf<B>> {
+    private static func _tailRecM<A, B>(
+        _ a: A,
+        _ f: @escaping (A) -> OptionOf<Either<A, B>>) -> Trampoline<OptionOf<B>> {
         .defer {
             f(a)^.fold({ .done(Option.none()) },
                        { either in
@@ -197,7 +207,7 @@ extension OptionPartial: Monad {
     }
 }
 
-// MARK: Instance of `ApplicativeError` for `Option`.
+// MARK: Instance of ApplicativeError for Option
 extension OptionPartial: ApplicativeError {
     public typealias E = Unit
 
@@ -205,70 +215,84 @@ extension OptionPartial: ApplicativeError {
         Option.none()
     }
 
-    public static func handleErrorWith<A>(_ fa: OptionOf<A>, _ f: @escaping (Unit) -> OptionOf<A>) -> OptionOf<A> {
+    public static func handleErrorWith<A>(
+        _ fa: OptionOf<A>,
+        _ f: @escaping (Unit) -> OptionOf<A>) -> OptionOf<A> {
         fa^.orElse(f(unit)^)
     }
 }
 
-// MARK: Instance of `MonadError` for `Option`.
+// MARK: Instance of MonadError for Option
 extension OptionPartial: MonadError {}
 
-// MARK: Instance of `FunctorFilter` for `Option`.
+// MARK: Instance of FunctorFilter for Option
 extension OptionPartial: FunctorFilter {}
 
-// MARK: Instance of `MonadFilter` for `Option`.
+// MARK: Instance of MonadFilter for Option
 extension OptionPartial: MonadFilter {
     public static func empty<A>() -> OptionOf<A> {
         Option.none()
     }
 }
 
-// MARK: Instance of `Foldable` for `Option`.
+// MARK: Instance of Foldable for Option
 extension OptionPartial: Foldable {
-    public static func foldLeft<A, B>(_ fa: OptionOf<A>, _ b: B, _ f: @escaping (B, A) -> B) -> B {
+    public static func foldLeft<A, B>(
+        _ fa: OptionOf<A>,
+        _ b: B,
+        _ f: @escaping (B, A) -> B) -> B {
         fa^.fold({ b },
                  { a in f(b, a) })
     }
 
-    public static func foldRight<A, B>(_ fa: OptionOf<A>, _ b: Eval<B>, _ f: @escaping (A, Eval<B>) -> Eval<B>) -> Eval<B> {
+    public static func foldRight<A, B>(
+        _ fa: OptionOf<A>,
+        _ b: Eval<B>,
+        _ f: @escaping (A, Eval<B>) -> Eval<B>) -> Eval<B> {
         fa^.fold(constant(b),
                  { a in f(a, b) })
     }
 }
 
-// MARK: Instance of `Traverse` for `Option`.
+// MARK: Instance of Traverse for Option
 extension OptionPartial: Traverse {
-    public static func traverse<G: Applicative, A, B>(_ fa: OptionOf<A>, _ f: @escaping (A) -> Kind<G, B>) -> Kind<G, OptionOf<B>> {
+    public static func traverse<G: Applicative, A, B>(
+        _ fa: OptionOf<A>,
+        _ f: @escaping (A) -> Kind<G, B>) -> Kind<G, OptionOf<B>> {
         fa^.fold({ G.pure(Option<B>.none()) },
                  { a in G.map(f(a), Option<B>.some)})
     }
 }
 
-// MARK: Instance of `TraverseFilter` for `Option`.
+// MARK: Instance of TraverseFilter for Option
 extension OptionPartial: TraverseFilter {
-    public static func traverseFilter<A, B, G: Applicative>(_ fa: OptionOf<A>, _ f: @escaping (A) -> Kind<G, OptionOf<B>>) -> Kind<G, OptionOf<B>> {
+    public static func traverseFilter<A, B, G: Applicative>(
+        _ fa: OptionOf<A>,
+        _ f: @escaping (A) -> Kind<G, OptionOf<B>>) -> Kind<G, OptionOf<B>> {
         fa^.fold({ G.pure(Option<B>.none()) }, f)
     }
 }
 
-// MARK: Instance of `SemigroupK` for `Option`
+// MARK: Instance of SemigroupK for Option
 extension OptionPartial: SemigroupK {
-    public static func combineK<A>(_ x: OptionOf<A>, _ y: OptionOf<A>) -> OptionOf<A> {
+    public static func combineK<A>(
+        _ x: OptionOf<A>,
+        _ y: OptionOf<A>) -> OptionOf<A> {
         x^.fold(constant(y), Option.some)
     }
 }
 
-// MARK: Instance of `MonoidK` for `Option`
+// MARK: Instance of MonoidK for Option
 extension OptionPartial: MonoidK {
     public static func emptyK<A>() -> OptionOf<A> {
         Option.none()
     }
 }
 
-// MARK: Instance of `MonadCombine` for `Option`
+// MARK: Instance of MonadCombine for Option
 extension OptionPartial: MonadCombine {}
 
-// MARK: Instance of `Semigroup` for `Option`, provided that `A` has an instance of `Semigroup`.
+// MARK: Instance of Semigroup for Option
 extension Option: Semigroup where A: Semigroup {
     public func combine(_ other: Option<A>) -> Option<A> {
         self.fold(constant(other),
@@ -278,21 +302,23 @@ extension Option: Semigroup where A: Semigroup {
     }
 }
 
-// MARK: Instance of `Semigroupal` for `Option`,
+// MARK: Instance of Semigroupal for Option
 extension OptionPartial: Semigroupal {
-    public static func product<A, B>(_ a: OptionOf<A>, _ b: OptionOf<B>) -> OptionOf<(A, B)> {
+    public static func product<A, B>(
+        _ a: OptionOf<A>,
+        _ b: OptionOf<B>) -> OptionOf<(A, B)> {
         ForOption.zip(a, b)
     }
 }
 
-// MARK: Instance of `Monoidal` for `Option`,
+// MARK: Instance of Monoidal for Option
 extension OptionPartial: Monoidal {
     public static func identity<A>() -> OptionOf<A> {
         Option.none()
     }
 }
 
-// MARK: Instance of `Monoid` for `Option`, provided that `A` has an instance of `Monoid`.
+// MARK: Instance of Monoid for Option
 extension Option: Monoid where A: Monoid {
     public static func empty() -> Option<A> {
         .none()

--- a/Sources/Bow/Data/Result.swift
+++ b/Sources/Bow/Data/Result.swift
@@ -4,35 +4,35 @@ public extension Result {
     ///
     /// - Returns: An Either.left if this is a Result.failure, or an Either.right if this is a Result.success
     func toEither() -> Either<Failure, Success> {
-        return fold(Either.left, Either.right)
+        fold(Either.left, Either.right)
     }
 
     /// Converts this Result into a Try value.
     ///
     /// - Returns: A Try.failure if this is a Result.failure, or a Try.success if this is a Result.success
     func toTry() -> Try<Success> {
-        return fold(Try.failure, Try.success)
+        fold(Try.failure, Try.success)
     }
     
     /// Converts this Result into a Validated value.
     ///
     /// - Returns: A Validated.invalid if this is a Result.failure, or a Validated.valid if this is a Result.success.
     func toValidated() -> Validated<Failure, Success> {
-        return fold(Validated.invalid, Validated.valid)
+        fold(Validated.invalid, Validated.valid)
     }
     
     /// Converts this Result into a ValidatedNEA value.
     ///
     /// - Returns: A Validated.invalid with a NonEmptyArray of the Failure type if this is a Result.failure, or a Validated.valid if this is a Result.success.
     func toValidatedNEA() -> ValidatedNEA<Failure, Success> {
-        return toValidated().toValidatedNEA()
+        toValidated().toValidatedNEA()
     }
 
     /// Converts this Result into an Option value.
     ///
     /// - Returns: Option.none if this is a Result.failure, or Option.some if this is a Result.success.
     func toOption() -> Option<Success> {
-        return fold(constant(Option.none()), Option.some)
+        fold(constant(Option.none()), Option.some)
     }
 
     /// Applies the corresponding closure based on the value contained in this result.
@@ -57,7 +57,7 @@ public extension Either where A: Error {
     ///
     /// - Returns: A Result.success if this is an Either.right, or a Result.failure if this is an Either.left.
     func toResult() -> Result<B, A> {
-        return self.fold(Result.failure, Result.success)
+        self.fold(Result.failure, Result.success)
     }
 }
 
@@ -68,6 +68,17 @@ public extension Validated where E: Error {
     ///
     /// - Returns: A Result.success if this is a Validated.valid, or a Result.failure if this is a Validated.invalid.
     func toResult() -> Result<A, E> {
-        return self.fold(Result.failure, Result.success)
+        self.fold(Result.failure, Result.success)
+    }
+}
+
+// MARK: Conversion to Result
+
+public extension Try {
+    /// Converts this Try into a Result value.
+    ///
+    /// - Returns: A Result.success if this is a Try.success, or a Result.failure if this is a Try.failure.
+    func toResult() -> Result<A, Error> {
+        self.fold(Result.failure, Result.success)
     }
 }

--- a/Sources/Bow/Data/Set.swift
+++ b/Sources/Bow/Data/Set.swift
@@ -1,13 +1,13 @@
 import Foundation
 
-// MARK: Instance of `Semigroup` for `Set`
+// MARK: Instance of Semigroup for Set
 extension Set: Semigroup {
     public func combine(_ other: Set<Element>) -> Set<Element> {
         self.union(other)
     }
 }
 
-// MARK: Instance of `Monoid` for `Set`
+// MARK: Instance of Monoid for Set
 extension Set: Monoid {
     public static func empty() -> Set<Element> {
         Set()

--- a/Sources/Bow/Data/SetK.swift
+++ b/Sources/Bow/Data/SetK.swift
@@ -20,7 +20,7 @@ public final class SetK<A: Hashable>: SetKOf<A> {
     ///   - rhs: Right hand side of the union.
     /// - Returns: A new set that includes all elements present in both sets.
     public static func +(lhs: SetK<A>, rhs: SetK<A>) -> SetK<A> {
-        return SetK(lhs.set.union(rhs.set))
+        SetK(lhs.set.union(rhs.set))
     }
 
     /// Safe downcast.
@@ -28,7 +28,7 @@ public final class SetK<A: Hashable>: SetKOf<A> {
     /// - Parameter fa: Value in the higher-kind form.
     /// - Returns: Value cast to SetK.
     public static func fix(_ fa: SetKOf<A>) -> SetK<A> {
-        return fa as! SetK<A>
+        fa as! SetK<A>
     }
 
     /// Initializes a `SetK` with the elements of a `Swift.Set`.
@@ -47,7 +47,7 @@ public final class SetK<A: Hashable>: SetKOf<A> {
 
     /// Extracts a `Swift.Set` from this wrapper.
     public var asSet: Set<A> {
-        return set
+        self.set
     }
 
     /// Combines this set with another using the union of the underlying `Swift.Set`s.
@@ -55,7 +55,7 @@ public final class SetK<A: Hashable>: SetKOf<A> {
     /// - Parameter y: A set
     /// - Returns: A set containing the elements of the two sets.
     public func combineK(_ y: SetK<A>) -> SetK<A> {
-        return self + y
+        self + y
     }
 }
 
@@ -64,20 +64,20 @@ public final class SetK<A: Hashable>: SetKOf<A> {
 /// - Parameter fa: Value in higher-kind form.
 /// - Returns: Value cast to SetK.
 public postfix func ^<A>(_ fa: SetKOf<A>) -> SetK<A> {
-    return SetK.fix(fa)
+    SetK.fix(fa)
 }
 
-// MARK: Instance of `Semigroup` for `SetK`
+// MARK: Instance of Semigroup for SetK
 extension SetK: Semigroup {
     public func combine(_ other: SetK<A>) -> SetK<A> {
-        return self + other
+        self + other
     }
 }
 
-// MARK: Instance of `Monoid` for `SetK`
+// MARK: Instance of Monoid for SetK
 extension SetK: Monoid {
     public static func empty() -> SetK<A> {
-        return SetK(Set([]))
+        SetK(Set([]))
     }
 }
 
@@ -87,6 +87,6 @@ public extension Set {
     ///
     /// - Returns: A `SetK` that contains the elements of this set.
     func k() -> SetK<Element> {
-        return SetK(self)
+        SetK(self)
     }
 }

--- a/Sources/Bow/Data/Sum.swift
+++ b/Sources/Bow/Data/Sum.swift
@@ -131,24 +131,34 @@ public postfix func ^<F, G, V>(_ value: SumOf<F, G, V>) -> Sum<F, G, V> {
     Sum.fix(value)
 }
 
+// MARK: Instance of Invariant for Sum
+
 extension SumPartial: Invariant where F: Functor, G: Functor {}
 
+// MARK: Instance of Functor for Sum
+
 extension SumPartial: Functor where F: Functor, G: Functor {
-    public static func map<A, B>(_ fa: Kind<SumPartial<F, G>, A>, _ f: @escaping (A) -> B) -> Kind<SumPartial<F, G>, B> {
+    public static func map<A, B>(
+        _ fa: SumOf<F, G, A>,
+        _ f: @escaping (A) -> B) -> SumOf<F, G, B> {
         Sum(left: fa^.left.map(f),
             right: fa^.right.map(f),
             side: fa^.side)
     }
 }
 
+// MARK: Instance of Comonad for Sum
+
 extension SumPartial: Comonad where F: Comonad, G: Comonad {
-    public static func coflatMap<A, B>(_ fa: Kind<SumPartial<F, G>, A>, _ f: @escaping (Kind<SumPartial<F, G>, A>) -> B) -> Kind<SumPartial<F, G>, B> {
+    public static func coflatMap<A, B>(
+        _ fa: SumOf<F, G, A>,
+        _ f: @escaping (SumOf<F, G, A>) -> B) -> SumOf<F, G, B> {
         Sum(left: fa^.left.coflatMap { l in f(Sum(left: l, right: fa^.right, side: .left)) },
             right: fa^.right.coflatMap { r in f(Sum(left: fa^.left, right: r, side: .right)) },
             side: fa^.side)
     }
 
-    public static func extract<A>(_ fa: Kind<SumPartial<F, G>, A>) -> A {
+    public static func extract<A>(_ fa: SumOf<F, G, A>) -> A {
         switch fa^.side {
         case .left: return fa^.left.extract()
         case .right: return fa^.right.extract()

--- a/Sources/Bow/Data/Validated.swift
+++ b/Sources/Bow/Data/Validated.swift
@@ -25,7 +25,7 @@ public final class Validated<E, A>: ValidatedOf<E, A> {
     /// - Parameter value: Valid value to be wrapped in this validated.
     /// - Returns: A `Validated` value wrapping the parameter.
     public static func valid(_ value: A) -> Validated<E, A> {
-        return Validated<E, A>(.valid(value))
+        Validated<E, A>(.valid(value))
     }
     
     /// Constructs an invalid value.
@@ -33,7 +33,7 @@ public final class Validated<E, A>: ValidatedOf<E, A> {
     /// - Parameter value: Invalid value to be wrapped in this validated.
     /// - Returns: A `Validated` value wrapping the parameter.
     public static func invalid(_ value: E) -> Validated<E, A> {
-        return Validated<E, A>(.invalid(value))
+        Validated<E, A>(.invalid(value))
     }
     
     /// Constructs a `Validated` from a `Try` value.
@@ -41,7 +41,7 @@ public final class Validated<E, A>: ValidatedOf<E, A> {
     /// - Parameter t: A `Try` value.
     /// - Returns: A `Validated` that contains an invalid error or a valid value, obtained from the `Try` value.
     public static func fromTry(_ t: Try<A>) -> Validated<Error, A> {
-        return t.fold(Validated<Error, A>.invalid, Validated<Error, A>.valid)
+        t.fold(Validated<Error, A>.invalid, Validated<Error, A>.valid)
     }
     
     /// Constructs a `Validated` from an `Option` value.
@@ -50,8 +50,10 @@ public final class Validated<E, A>: ValidatedOf<E, A> {
     ///   - m: An `Option` value.
     ///   - ifNone: A closure providing a value for the invalid case if the option is not present.
     /// - Returns: A `Validated` containing a valid value from the option, or an invalid wrapping the default value from the closure.
-    public static func fromOption(_ m: Option<A>, ifNone: @escaping () -> E) -> Validated<E, A> {
-        return m.fold(ifNone >>> Validated<E, A>.invalid, Validated<E, A>.valid)
+    public static func fromOption(
+        _ m: Option<A>,
+        ifNone: @escaping () -> E) -> Validated<E, A> {
+        m.fold(ifNone >>> Validated<E, A>.invalid, Validated<E, A>.valid)
     }
     
     /// Safe downcast.
@@ -59,7 +61,7 @@ public final class Validated<E, A>: ValidatedOf<E, A> {
     /// - Parameter fa: Value in the higher-kind form.
     /// - Returns: Value cast to Validated.
     public static func fix(_ fa: ValidatedOf<E, A>) -> Validated<E, A> {
-        return fa as! Validated<E, A>
+        fa as! Validated<E, A>
     }
     
     /// Applies the provided closures based on the content of this `Validated` value.
@@ -77,12 +79,12 @@ public final class Validated<E, A>: ValidatedOf<E, A> {
     
     /// Checks if this value is valid.
     public var isValid: Bool {
-        return fold(constant(false), constant(true))
+        fold(constant(false), constant(true))
     }
     
     /// Checks if this value is invalid.
     public var isInvalid: Bool {
-        return !isValid
+        !isValid
     }
     
     /// Checks if the valid value in this `Validated` matches a predicate.
@@ -90,35 +92,36 @@ public final class Validated<E, A>: ValidatedOf<E, A> {
     /// - Parameter predicate: Predicate to match the valid values.
     /// - Returns: `false` if the contained value is invalid or does not match the predicate; `true` otherwise.
     public func exists(_ predicate: (A) -> Bool) -> Bool {
-        return fold(constant(false), predicate)
+        fold(constant(false), predicate)
     }
     
     /// Converts this value to an `Either` value.
     ///
     /// - Returns: An `Either.left` if this value is invalid, or an `Either.right` if this value is valid.
     public func toEither() -> Either<E, A> {
-        return fold(Either.left, Either.right)
+        fold(Either.left, Either.right)
     }
     
     /// Converts this value to an `Option` value.
     ///
     /// - Returns: An `Option.none` if this value is invalid, or an `Option.some` if this value is valid.
     public func toOption() -> Option<A> {
-        return fold(constant(Option.none()), Option.some)
+        fold(constant(Option.none()), Option.some)
     }
     
     /// Converts this value to an `Array` value.
     ///
     /// - Returns: An empty array if this value is invalid, or a singleton array if this value is valid.
     public func toArray() -> [A] {
-        return fold(constant([]), { a in [a] })
+        fold(constant([]), { a in [a] })
     }
 
     /// Wraps the invalid values of this type into a `NonEmptyArray`.
     ///
     /// - Returns: A value that is equivalent to the original one but wraps the invalid value in a `NonEmptyArray`.
     public func toValidatedNEA() -> Validated<NEA<E>, A> {
-        return fold({ e in Validated<NEA<E>, A>.invalid(NEA.fix(NEA.pure(e))) }, Validated<NEA<E>, A>.valid)
+        fold({ e in Validated<NEA<E>, A>.invalid(NEA.of(e)) },
+             Validated<NEA<E>, A>.valid)
     }
     
     /// Applies a function in the `Either` context to this value.
@@ -128,14 +131,14 @@ public final class Validated<E, A>: ValidatedOf<E, A> {
     /// - Parameter f: A closure in the `Either` context.
     /// - Returns: Transformation of this validated value with the provided closure.
     public func withEither<EE, B>(_ f: (Either<E, A>) -> Either<EE, B>) -> Validated<EE, B> where EE: Semigroup {
-        return Validated<EE, B>.fix(Validated<EE, B>.fromEither(f(self.toEither())))
+        Validated<EE, B>.fromEither(f(self.toEither()))^
     }
     
     /// Swaps the valid and invalid types.
     ///
     /// - Returns: A valid value if it was invalid, and vice versa.
     public func swap() -> Validated<A, E> {
-        return fold(Validated<A, E>.valid, Validated<A, E>.invalid)
+        fold(Validated<A, E>.valid, Validated<A, E>.invalid)
     }
     
     /// Obtains the valid value or a default value for the invalid case.
@@ -143,7 +146,7 @@ public final class Validated<E, A>: ValidatedOf<E, A> {
     /// - Parameter defaultValue: Default value for the invalid case.
     /// - Returns: Valid value or default value otherwise.
     public func getOrElse(_ defaultValue: A) -> A {
-        return fold(constant(defaultValue), id)
+        fold(constant(defaultValue), id)
     }
     
     /// Obtains the valid value or maps the invalid value.
@@ -151,7 +154,7 @@ public final class Validated<E, A>: ValidatedOf<E, A> {
     /// - Parameter f: Mapping function for invalid values.
     /// - Returns: The valid value or the mapped invalid value.
     public func valueOr(_ f: (E) -> A) -> A {
-        return fold(f, id)
+        fold(f, id)
     }
 
     /// Obtains this validated if is valid, or a default value if not.
@@ -159,17 +162,17 @@ public final class Validated<E, A>: ValidatedOf<E, A> {
     /// - Parameter defaultValue: Value to return if this value is invalid.
     /// - Returns: This value if it is valid, or the default one otherwise.
     public func orElse(_ defaultValue: Validated<E, A>) -> Validated<E, A> {
-        return fold(constant(defaultValue), Validated.valid)
+        fold(constant(defaultValue), Validated.valid)
     }
     
     /// Obtains the valid value or nil if it is not present
     public var orNil: A? {
-        return fold(constant(nil), id)
+        fold(constant(nil), id)
     }
     
     /// Obtains the valid value or none if it is not present
     public var orNone: Option<A> {
-        return fold(constant(.none()), Option.some)
+        fold(constant(.none()), Option.some)
     }
 }
 
@@ -178,7 +181,7 @@ public final class Validated<E, A>: ValidatedOf<E, A> {
 /// - Parameter fa: Value in higher-kind form.
 /// - Returns: Value cast to Validated.
 public postfix func ^<E, A>(_ fa: ValidatedOf<E, A>) -> Validated<E, A> {
-    return Validated.fix(fa)
+    Validated.fix(fa)
 }
 
 private enum _Validated<A, B> {
@@ -186,59 +189,64 @@ private enum _Validated<A, B> {
     case valid(B)
 }
 
-// MARK: Conformance of `Validated` to `CustomStringConvertible`
-extension Validated: CustomStringConvertible {
+// MARK: Conformance of Validated to CustomStringConvertible
+extension Validated: CustomStringConvertible where E: CustomStringConvertible, A: CustomStringConvertible {
     public var description: String {
-        return fold({ e in "Invalid(\(e))" },
-                    { a in "Valid(\(a))" })
+        fold({ e in "Invalid(\(e.description))" },
+             { a in "Valid(\(a.description))" })
     }
 }
 
-// MARK: Conformance of `Validated` to `CustomDebugStringConvertible`
-extension Validated: CustomDebugStringConvertible where E : CustomDebugStringConvertible, A : CustomDebugStringConvertible {
+// MARK: Conformance of Validated to CustomDebugStringConvertible
+extension Validated: CustomDebugStringConvertible where E: CustomDebugStringConvertible, A: CustomDebugStringConvertible {
     public var debugDescription: String {
-        return fold({ error in "Invalid(\(error.debugDescription))" },
-                    { value in "Valid(\(value.debugDescription))" })
+        fold({ error in "Invalid(\(error.debugDescription))" },
+             { value in "Valid(\(value.debugDescription))" })
     }
 }
 
-// MARK: Instance of `EquatableK` for `Validated`
+// MARK: Instance of EquatableK for Validated
 extension ValidatedPartial: EquatableK where I: Equatable {
-    public static func eq<A>(_ lhs: Kind<ValidatedPartial<I>, A>, _ rhs: Kind<ValidatedPartial<I>, A>) -> Bool where A : Equatable {
-        let vl = Validated.fix(lhs)
-        let vr = Validated.fix(rhs)
-        return vl.fold({ le in vr.fold({ re in le == re }, constant(false)) },
-                       { la in vr.fold(constant(false), { ra in la == ra }) })
+    public static func eq<A: Equatable>(
+        _ lhs: ValidatedOf<I, A>,
+        _ rhs: ValidatedOf<I, A>) -> Bool {
+        lhs^.fold({ le in rhs^.fold({ re in le == re }, constant(false)) },
+                  { la in rhs^.fold(constant(false), { ra in la == ra }) })
     }
 }
 
-// MARK: Instance of `Functor` for `Validated`
+// MARK: Instance of Functor for Validated
 extension ValidatedPartial: Functor {
-    public static func map<A, B>(_ fa: Kind<ValidatedPartial<I>, A>, _ f: @escaping (A) -> B) -> Kind<ValidatedPartial<I>, B> {
-        return Validated.fix(fa).fold(Validated.invalid, f >>> Validated.valid)
+    public static func map<A, B>(
+        _ fa: ValidatedOf<I, A>,
+        _ f: @escaping (A) -> B) -> ValidatedOf<I, B> {
+        fa^.fold(Validated.invalid,
+                 f >>> Validated.valid)
     }
 }
 
-// MARK: Instance of `Applicative` for `Validated`
+// MARK: Instance of Applicative for Validated
 extension ValidatedPartial: Applicative where I: Semigroup {
-    public static func pure<A>(_ a: A) -> Kind<ValidatedPartial<I>, A> {
-        return Validated.valid(a)
+    public static func pure<A>(_ a: A) -> ValidatedOf<I, A> {
+        Validated.valid(a)
     }
 
-    public static func ap<A, B>(_ ff: Kind<ValidatedPartial<I>, (A) -> B>, _ fa: Kind<ValidatedPartial<I>, A>) -> Kind<ValidatedPartial<I>, B> {
-        let valA = Validated.fix(fa)
-        let valF = Validated.fix(ff)
-        return valA.fold({ e in valF.fold({ ee in Validated.invalid(e.combine(ee)) },
-                                          { _ in Validated.invalid(e) }) },
-                         { a in valF.fold({ ee in Validated.invalid(ee) },
-                                          { f in Validated.valid(f(a)) }) })
+    public static func ap<A, B>(
+        _ ff: ValidatedOf<I, (A) -> B>,
+        _ fa: ValidatedOf<I, A>) -> ValidatedOf<I, B> {
+        fa^.fold({ e in ff^.fold({ ee in Validated.invalid(e.combine(ee)) },
+                                 { _ in Validated.invalid(e) }) },
+                 { a in ff^.fold({ ee in Validated.invalid(ee) },
+                                 { f in Validated.valid(f(a)) }) })
     }
 }
 
-// MARK: Instance of `Selective` for `Validated`
+// MARK: Instance of Selective for Validated
 extension ValidatedPartial: Selective where I: Semigroup {
-    public static func select<A, B>(_ fab: Kind<ValidatedPartial<I>, Either<A, B>>, _ f: Kind<ValidatedPartial<I>, (A) -> B>) -> Kind<ValidatedPartial<I>, B> {
-        return Validated.fix(fab).fold(
+    public static func select<A, B>(
+        _ fab: ValidatedOf<I, Either<A, B>>,
+        _ f: ValidatedOf<I, (A) -> B>) -> ValidatedOf<I, B> {
+        fab^.fold(
             { e in Validated.invalid(e) },
             { eab in eab.fold({ a in map(f, { ff in ff(a) }) },
                               { b in Validated.valid(b) })
@@ -246,51 +254,68 @@ extension ValidatedPartial: Selective where I: Semigroup {
     }
 }
 
-// MARK: Instance of `ApplicativeError` for `Validated`
+// MARK: Instance of ApplicativeError for Validated
 extension ValidatedPartial: ApplicativeError where I: Semigroup {
     public typealias E = I
 
-    public static func raiseError<A>(_ e: I) -> Kind<ValidatedPartial<I>, A> {
-        return Validated.invalid(e)
+    public static func raiseError<A>(_ e: I) -> ValidatedOf<I, A> {
+        Validated.invalid(e)
     }
 
-    public static func handleErrorWith<A>(_ fa: Kind<ValidatedPartial<I>, A>, _ f: @escaping (I) -> Kind<ValidatedPartial<I>, A>) -> Kind<ValidatedPartial<I>, A> {
-        return Validated.fix(fa).fold(f, Validated.valid)
+    public static func handleErrorWith<A>(
+        _ fa: ValidatedOf<I, A>,
+        _ f: @escaping (I) -> ValidatedOf<I, A>) -> ValidatedOf<I, A> {
+        fa^.fold(f, Validated.valid)
     }
 }
 
-// MARK: Instance of `Foldable` for `Validated`
+// MARK: Instance of Foldable for Validated
 extension ValidatedPartial: Foldable {
-    public static func foldLeft<A, B>(_ fa: Kind<ValidatedPartial<I>, A>, _ b: B, _ f: @escaping (B, A) -> B) -> B {
-        return Validated.fix(fa).fold(constant(b), { a in f(b, a) })
+    public static func foldLeft<A, B>(
+        _ fa: ValidatedOf<I, A>,
+        _ b: B,
+        _ f: @escaping (B, A) -> B) -> B {
+        fa^.fold(constant(b), { a in f(b, a) })
     }
 
-    public static func foldRight<A, B>(_ fa: Kind<ValidatedPartial<I>, A>, _ b: Eval<B>, _ f: @escaping (A, Eval<B>) -> Eval<B>) -> Eval<B> {
-        return Validated.fix(fa).fold(constant(b), { a in f(a, b) })
+    public static func foldRight<A, B>(
+        _ fa: ValidatedOf<I, A>,
+        _ b: Eval<B>,
+        _ f: @escaping (A, Eval<B>) -> Eval<B>) -> Eval<B> {
+        fa^.fold(constant(b), { a in f(a, b) })
     }
 }
 
-// MARK: Instance of `Traverse` for `Validated`
+// MARK: Instance of Traverse for Validated
 extension ValidatedPartial: Traverse {
-    public static func traverse<G: Applicative, A, B>(_ fa: Kind<ValidatedPartial<I>, A>, _ f: @escaping (A) -> Kind<G, B>) -> Kind<G, Kind<ValidatedPartial<I>, B>> {
-        return Validated.fix(fa).fold(Validated.invalid >>> G.pure,
-                                      { a in G.map(f(a), Validated.valid) })
+    public static func traverse<G: Applicative, A, B>(
+        _ fa: ValidatedOf<I, A>,
+        _ f: @escaping (A) -> Kind<G, B>) -> Kind<G, ValidatedOf<I, B>> {
+        fa^.fold(Validated.invalid >>> G.pure,
+                 { a in G.map(f(a), Validated.valid) })
     }
 }
 
-// MARK: Instance of `SemigroupK` for `Validated`
+// MARK: Instance of SemigroupK for Validated
 extension ValidatedPartial: SemigroupK where I: Semigroup {
-    public static func combineK<A>(_ x: Kind<ValidatedPartial<I>, A>, _ y: Kind<ValidatedPartial<I>, A>) -> Kind<ValidatedPartial<I>, A> {
-        return Validated.fix(x).fold({ e in
-            Validated.fix(y).fold({ ee in Validated.invalid(e.combine(ee)) },
-                   Validated.valid) }, Validated.valid)
+    public static func combineK<A>(
+        _ x: ValidatedOf<I, A>,
+        _ y: ValidatedOf<I, A>) -> ValidatedOf<I, A> {
+        x^.fold({ e in
+            y^.fold(
+                { ee in Validated.invalid(e.combine(ee)) },
+                Validated.valid) },
+            Validated.valid)
     }
 }
 
-// MARK: Instance of `Semigroup` for `Validated`
+// MARK: Instance of Semigroup for Validated
 extension Validated: Semigroup where E: Semigroup, A: Semigroup {
     public func combine(_ other: Validated<E, A>) -> Validated<E, A> {
-        return self.fold({ e1 in other.fold({ e2 in .invalid(e1.combine(e2)) }, { a2 in .invalid(e1) }) },
-                         { a1 in other.fold({ e2 in .invalid(e2)}, { a2 in .valid(a1.combine(a2)) }) })
+        self.fold(
+            { e1 in other.fold({ e2 in .invalid(e1.combine(e2)) },
+                               { a2 in .invalid(e1) }) },
+            { a1 in other.fold({ e2 in .invalid(e2)},
+                               { a2 in .valid(a1.combine(a2)) }) })
     }
 }

--- a/Sources/Bow/Data/Zipper.swift
+++ b/Sources/Bow/Data/Zipper.swift
@@ -49,7 +49,9 @@ public final class Zipper<A>: ZipperOf<A> {
         guard !array.isEmpty else {
             return nil
         }
-        self.init(left: [], focus: array[0], right: Array(array[1...]))
+        self.init(left: [],
+                  focus: array[0],
+                  right: Array(array[1...]))
     }
     
     /// Moves the focus one step to the left. If it is already in the leftmost position, it does nothing.
@@ -138,38 +140,49 @@ extension Zipper: CustomStringConvertible where A: CustomStringConvertible {
     }
 }
 
-// MARK: Instance of `EquatableK` for `Zipper`
+// MARK: Instance of EquatableK for Zipper
 
 extension ZipperPartial: EquatableK {
-    public static func eq<A: Equatable>(_ lhs: ZipperOf<A>, _ rhs: ZipperOf<A>) -> Bool {
+    public static func eq<A: Equatable>(
+        _ lhs: ZipperOf<A>,
+        _ rhs: ZipperOf<A>) -> Bool {
         lhs^.left == rhs^.left &&
             lhs^.focus == rhs^.focus &&
             lhs^.right == rhs^.right
     }
 }
 
-// MARK: Instance of `Invariant` for `Zipper`
+// MARK: Instance of Invariant for Zipper
 
 extension ZipperPartial: Invariant {}
 
-// MARK: Instance of `Functor` for `Zipper`
+// MARK: Instance of Functor for Zipper
 
 extension ZipperPartial: Functor {
-    public static func map<A, B>(_ fa: ZipperOf<A>, _ f: @escaping (A) -> B) -> ZipperOf<B> {
-        Zipper(left: fa^.left.map(f), focus: f(fa^.focus), right: fa^.right.map(f))
+    public static func map<A, B>(
+        _ fa: ZipperOf<A>,
+        _ f: @escaping (A) -> B) -> ZipperOf<B> {
+        Zipper(left: fa^.left.map(f),
+               focus: f(fa^.focus),
+               right: fa^.right.map(f))
     }
 }
 
-// MARK: Instance of `Comonad` for `Zipper`
+// MARK: Instance of Comonad for Zipper
 
 extension ZipperPartial: Comonad {
-    public static func coflatMap<A, B>(_ fa: ZipperOf<A>, _ f: @escaping (ZipperOf<A>) -> B) -> ZipperOf<B> {
+    public static func coflatMap<A, B>(
+        _ fa: ZipperOf<A>,
+        _ f: @escaping (ZipperOf<A>) -> B) -> ZipperOf<B> {
         let array = fa^.asArray()
         let newLeft: [B] = fa^.left.enumerated().map { item in
             let l = Array(array[0 ..< item.offset])
             let focus = array[item.offset]
             let r = Array(array[(item.offset + 1)...])
-            return f(Zipper(left: l, focus: focus, right: r))
+            
+            return f(Zipper(left: l,
+                            focus: focus,
+                            right: r))
         }
         let newFocus: B = f(fa)
         let leftCount = fa^.left.count + 1
@@ -177,9 +190,14 @@ extension ZipperPartial: Comonad {
             let l = Array(array[0 ..< item.offset + leftCount])
             let focus = array[item.offset + leftCount]
             let r = Array(array[(item.offset + 1 + leftCount)...])
-            return f(Zipper(left: l, focus: focus, right: r))
+            
+            return f(Zipper(left: l,
+                            focus: focus,
+                            right: r))
         }
-        return Zipper(left: newLeft, focus: newFocus, right: newRight)
+        return Zipper(left: newLeft,
+                      focus: newFocus,
+                      right: newRight)
     }
     
     public static func extract<A>(_ fa: ZipperOf<A>) -> A {


### PR DESCRIPTION
## Goal

Cleanup code in the Data folder in the Core module by:

- Using `FOf<A>` instead of `Kind<F, A>`.
- Removing backticks in `MARK` sections as they do not render properly in Jazzy.
- Removing returns.
- Replacing `fix` by `^`.