### PR TITLE
Cleanup Syntax folder in Core module

### DIFF
--- a/Sources/Bow/Syntax/BooleanFunctions.swift
+++ b/Sources/Bow/Syntax/BooleanFunctions.swift
@@ -4,8 +4,8 @@ import Foundation
 ///
 /// - Parameter a: Value to be negated.
 /// - Returns: `true` if the input was `false`; `false`, otherwise.
-public func not(_ a : Bool) -> Bool {
-    return !a
+public func not(_ a: Bool) -> Bool {
+    !a
 }
 
 /// Conjunction of two boolean values.
@@ -14,8 +14,8 @@ public func not(_ a : Bool) -> Bool {
 ///   - a: Left-hand side value.
 ///   - b: Right-hand side value.
 /// - Returns: `true` if both inputs are `true`, or `false` otherwise.
-public func and(_ a : Bool, _ b : Bool) -> Bool {
-    return a && b
+public func and(_ a: Bool, _ b: Bool) -> Bool {
+    a && b
 }
 
 /// Disjunction of two boolean values.
@@ -24,8 +24,8 @@ public func and(_ a : Bool, _ b : Bool) -> Bool {
 ///   - a: Left-hand side value.
 ///   - b: Right-hand side value.
 /// - Returns: `false` if both inputs are `false`, or `true` otherwise.
-public func or(_ a : Bool, _ b : Bool) -> Bool {
-    return a || b
+public func or(_ a: Bool, _ b: Bool) -> Bool {
+    a || b
 }
 
 /// Exclusive or of two boolean values.
@@ -34,16 +34,16 @@ public func or(_ a : Bool, _ b : Bool) -> Bool {
 ///   - a: Left-hand side value.
 ///   - b: Right-hand side value.
 /// - Returns: `true` if both inputs have different truth value, or `false` if they are equal.
-public func xor(_ a : Bool, _ b : Bool) -> Bool {
-    return a != b
+public func xor(_ a: Bool, _ b: Bool) -> Bool {
+    a != b
 }
 
 /// Given a 0-ary function, provides a 0-ary function that returns the complement boolean value.
 ///
 /// - Parameter ff: Function to be complemented.
 /// - Returns: Function that returns the negated result of `ff`.
-public func complement(_ ff : @escaping () -> Bool) -> () -> Bool {
-    return ff >>> not
+public func complement(_ ff: @escaping () -> Bool) -> () -> Bool {
+    ff >>> not
 }
 
 /// Given a 1-ary function, provides a 1-ary function that returns the complement boolean value.
@@ -52,8 +52,8 @@ public func complement(_ ff : @escaping () -> Bool) -> () -> Bool {
 ///   - ff: Function to be complemented.
 ///   - a: 1st argument of `ff`.
 /// - Returns: Function that returns the negated result of `ff`.
-public func complement<A>(_ ff : @escaping (_ a: A) -> Bool) -> (A) -> Bool {
-    return ff >>> not
+public func complement<A>(_ ff: @escaping (_ a: A) -> Bool) -> (A) -> Bool {
+    ff >>> not
 }
 
 /// Given a 2-ary function, provides a 2-ary function that returns the complement boolean value.
@@ -63,8 +63,8 @@ public func complement<A>(_ ff : @escaping (_ a: A) -> Bool) -> (A) -> Bool {
 ///   - a: 1st argument of `ff`.
 ///   - b: 2nd argument of `ff`.
 /// - Returns: Function that returns the negated result of `ff`.
-public func complement<A, B>(_ ff : @escaping (_ a: A, _ b: B) -> Bool) -> (A, B) -> Bool {
-    return { a, b in !ff(a, b) }
+public func complement<A, B>(_ ff: @escaping (_ a: A, _ b: B) -> Bool) -> (A, B) -> Bool {
+    { a, b in !ff(a, b) }
 }
 
 /// Given a 3-ary function, provides a 3-ary function that returns the complement boolean value.
@@ -75,8 +75,8 @@ public func complement<A, B>(_ ff : @escaping (_ a: A, _ b: B) -> Bool) -> (A, B
 ///   - b: 2nd argument of `ff`.
 ///   - c: 3rd argument of `ff`.
 /// - Returns: Function that returns the negated result of `ff`.
-public func complement<A, B, C>(_ ff : @escaping (_ a: A, _ b: B, _ c: C) -> Bool) -> (A, B, C) -> Bool {
-    return { a, b, c in !ff(a, b, c) }
+public func complement<A, B, C>(_ ff: @escaping (_ a: A, _ b: B, _ c: C) -> Bool) -> (A, B, C) -> Bool {
+    { a, b, c in !ff(a, b, c) }
 }
 
 /// Given a 4-ary function, provides a 4-ary function that returns the complement boolean value.
@@ -88,8 +88,8 @@ public func complement<A, B, C>(_ ff : @escaping (_ a: A, _ b: B, _ c: C) -> Boo
 ///   - c: 3rd argument of `ff`.
 ///   - d: 4th argument of `ff`.
 /// - Returns: Function that returns the negated result of `ff`.
-public func complement<A, B, C, D>(_ ff : @escaping (_ a: A, _ b: B, _ c: C, _ d: D) -> Bool) -> (A, B, C, D) -> Bool {
-    return { a, b, c, d in !ff(a, b, c, d) }
+public func complement<A, B, C, D>(_ ff: @escaping (_ a: A, _ b: B, _ c: C, _ d: D) -> Bool) -> (A, B, C, D) -> Bool {
+    { a, b, c, d in !ff(a, b, c, d) }
 }
 
 /// Given a 5-ary function, provides a 5-ary function that returns the complement boolean value.
@@ -102,8 +102,8 @@ public func complement<A, B, C, D>(_ ff : @escaping (_ a: A, _ b: B, _ c: C, _ d
 ///   - d: 4th argument of `ff`.
 ///   - e: 5th argument of `ff`.
 /// - Returns: Function that returns the negated result of `ff`.
-public func complement<A, B, C, D, E>(_ ff : @escaping (_ a: A, _ b: B, _ c: C, _ d: D, _ e: E) -> Bool) -> (A, B, C, D, E) -> Bool {
-    return { a, b, c, d, e in !ff(a, b, c, d, e) }
+public func complement<A, B, C, D, E>(_ ff: @escaping (_ a: A, _ b: B, _ c: C, _ d: D, _ e: E) -> Bool) -> (A, B, C, D, E) -> Bool {
+    { a, b, c, d, e in !ff(a, b, c, d, e) }
 }
 
 /// Given a 6-ary function, provides a 6-ary function that returns the complement boolean value.
@@ -117,8 +117,8 @@ public func complement<A, B, C, D, E>(_ ff : @escaping (_ a: A, _ b: B, _ c: C, 
 ///   - e: 5th argument of `ff`.
 ///   - f: 6th argument of `ff`.
 /// - Returns: Function that returns the negated result of `ff`.
-public func complement<A, B, C, D, E, F>(_ ff : @escaping (_ a: A, _ b: B, _ c: C, _ d: D, _ e: E, _ f: F) -> Bool) -> (A, B, C, D, E, F) -> Bool {
-    return { a, b, c, d, e, f in !ff(a, b, c, d, e, f) }
+public func complement<A, B, C, D, E, F>(_ ff: @escaping (_ a: A, _ b: B, _ c: C, _ d: D, _ e: E, _ f: F) -> Bool) -> (A, B, C, D, E, F) -> Bool {
+    { a, b, c, d, e, f in !ff(a, b, c, d, e, f) }
 }
 
 /// Given a 7-ary function, provides a 7-ary function that returns the complement boolean value.
@@ -133,8 +133,8 @@ public func complement<A, B, C, D, E, F>(_ ff : @escaping (_ a: A, _ b: B, _ c: 
 ///   - f: 6th argument of `ff`.
 ///   - g: 7th argument of `ff`.
 /// - Returns: Function that returns the negated result of `ff`.
-public func complement<A, B, C, D, E, F, G>(_ ff : @escaping (_ a: A, _ b: B, _ c: C, _ d: D, _ e: E, _ f: F, _ g: G) -> Bool) -> (A, B, C, D, E, F, G) -> Bool {
-    return { a, b, c, d, e, f, g in !ff(a, b, c, d, e, f, g) }
+public func complement<A, B, C, D, E, F, G>(_ ff: @escaping (_ a: A, _ b: B, _ c: C, _ d: D, _ e: E, _ f: F, _ g: G) -> Bool) -> (A, B, C, D, E, F, G) -> Bool {
+    { a, b, c, d, e, f, g in !ff(a, b, c, d, e, f, g) }
 }
 
 /// Given a 8-ary function, provides a 8-ary function that returns the complement boolean value.
@@ -150,8 +150,8 @@ public func complement<A, B, C, D, E, F, G>(_ ff : @escaping (_ a: A, _ b: B, _ 
 ///   - g: 7th argument of `ff`.
 ///   - h: 8th argument of `ff`.
 /// - Returns: Function that returns the negated result of `ff`.
-public func complement<A, B, C, D, E, F, G, H>(_ ff : @escaping (_ a: A, _ b: B, _ c: C, _ d: D, _ e: E, _ f: F, _ g: G, _ h: H) -> Bool) -> (A, B, C, D, E, F, G, H) -> Bool {
-    return { a, b, c, d, e, f, g, h in !ff(a, b, c, d, e, f, g, h) }
+public func complement<A, B, C, D, E, F, G, H>(_ ff: @escaping (_ a: A, _ b: B, _ c: C, _ d: D, _ e: E, _ f: F, _ g: G, _ h: H) -> Bool) -> (A, B, C, D, E, F, G, H) -> Bool {
+    { a, b, c, d, e, f, g, h in !ff(a, b, c, d, e, f, g, h) }
 }
 
 /// Given a 9-ary function, provides a 9-ary function that returns the complement boolean value.
@@ -168,8 +168,8 @@ public func complement<A, B, C, D, E, F, G, H>(_ ff : @escaping (_ a: A, _ b: B,
 ///   - h: 8th argument of `ff`.
 ///   - i: 9th argument of `ff`.
 /// - Returns: Function that returns the negated result of `ff`.
-public func complement<A, B, C, D, E, F, G, H, I>(_ ff : @escaping (_ a: A, _ b: B, _ c: C, _ d: D, _ e: E, _ f: F, _ g: G, _ h: H, _ i: I) -> Bool) -> (A, B, C, D, E, F, G, H, I) -> Bool {
-    return { a, b, c, d, e, f, g, h, i in !ff(a, b, c, d, e, f, g, h, i) }
+public func complement<A, B, C, D, E, F, G, H, I>(_ ff: @escaping (_ a: A, _ b: B, _ c: C, _ d: D, _ e: E, _ f: F, _ g: G, _ h: H, _ i: I) -> Bool) -> (A, B, C, D, E, F, G, H, I) -> Bool {
+    { a, b, c, d, e, f, g, h, i in !ff(a, b, c, d, e, f, g, h, i) }
 }
 
 /// Given a 10-ary function, provides a 10-ary function that returns the complement boolean value.
@@ -187,6 +187,6 @@ public func complement<A, B, C, D, E, F, G, H, I>(_ ff : @escaping (_ a: A, _ b:
 ///   - i: 9th argument of `ff`.
 ///   - j: 10th argument of `ff`.
 /// - Returns: Function that returns the negated result of `ff`.
-public func complement<A, B, C, D, E, F, G, H, I, J>(_ ff : @escaping (_ a: A, _ b: B, _ c: C, _ d: D, _ e: E, _ f: F, _ g: G, _ h: H, _ i: I, _ j: J) -> Bool) -> (A, B, C, D, E, F, G, H, I, J) -> Bool {
-    return { a, b, c, d, e, f, g, h, i, j in !ff(a, b, c, d, e, f, g, h, i, j) }
+public func complement<A, B, C, D, E, F, G, H, I, J>(_ ff: @escaping (_ a: A, _ b: B, _ c: C, _ d: D, _ e: E, _ f: F, _ g: G, _ h: H, _ i: I, _ j: J) -> Bool) -> (A, B, C, D, E, F, G, H, I, J) -> Bool {
+    { a, b, c, d, e, f, g, h, i, j in !ff(a, b, c, d, e, f, g, h, i, j) }
 }

--- a/Sources/Bow/Syntax/Curry.swift
+++ b/Sources/Bow/Syntax/Curry.swift
@@ -4,94 +4,94 @@ import Foundation
 ///
 /// - Parameter fun: Function to be curried.
 /// - Returns: `fun` in curried form.
-public func curry<A, B, C>(_ fun : @escaping (A, B) -> C) -> (A) -> (B) -> C {
-    return { a in { b in fun(a, b) }}
+public func curry<A, B, C>(_ fun: @escaping (A, B) -> C) -> (A) -> (B) -> C {
+    { a in { b in fun(a, b) }}
 }
 
 /// Uncurries a 2-ary function.
 ///
 /// - Parameter fun: Function to be uncurried.
 /// - Returns: `fun` in uncurried form.
-public func uncurry<A, B, C>(_ fun : @escaping (A) -> (B) -> C) -> (A, B) -> C {
-    return { a, b in fun(a)(b) }
+public func uncurry<A, B, C>(_ fun: @escaping (A) -> (B) -> C) -> (A, B) -> C {
+    { a, b in fun(a)(b) }
 }
 
 /// Curries a 3-ary function.
 ///
 /// - Parameter fun: Function to be curried.
 /// - Returns: `fun` in curried form.
-public func curry<A, B, C, D>(_ fun : @escaping (A, B, C) -> D) -> (A) -> (B) -> (C) -> D {
-    return { a in { b in { c in fun(a,b,c) } } }
+public func curry<A, B, C, D>(_ fun: @escaping (A, B, C) -> D) -> (A) -> (B) -> (C) -> D {
+    { a in { b in { c in fun(a,b,c) } } }
 }
 
 /// Uncurries a 3-ary function.
 ///
 /// - Parameter fun: Function to be uncurried.
 /// - Returns: `fun` in uncurried form.
-public func uncurry<A, B, C, D>(_ fun : @escaping (A) -> (B) -> (C) -> D) -> (A, B, C) -> D {
-    return { a, b, c in fun(a)(b)(c) }
+public func uncurry<A, B, C, D>(_ fun: @escaping (A) -> (B) -> (C) -> D) -> (A, B, C) -> D {
+    { a, b, c in fun(a)(b)(c) }
 }
 
 /// Curries a 4-ary function.
 ///
 /// - Parameter fun: Function to be curried.
 /// - Returns: `fun` in curried form.
-public func curry<A, B, C, D, E>(_ fun : @escaping (A, B, C, D) -> E) -> (A) -> (B) -> (C) -> (D) -> E {
-    return { a in { b in { c in { d in fun(a,b,c,d) } } } }
+public func curry<A, B, C, D, E>(_ fun: @escaping (A, B, C, D) -> E) -> (A) -> (B) -> (C) -> (D) -> E {
+    { a in { b in { c in { d in fun(a,b,c,d) } } } }
 }
 
 /// Uncurries a 4-ary function.
 ///
 /// - Parameter fun: Function to be uncurried.
 /// - Returns: `fun` in uncurried form.
-public func uncurry<A, B, C, D, E>(_ fun : @escaping (A) -> (B) -> (C) -> (D) -> E) -> (A, B, C, D) -> E {
-    return { a, b, c, d in fun(a)(b)(c)(d) }
+public func uncurry<A, B, C, D, E>(_ fun: @escaping (A) -> (B) -> (C) -> (D) -> E) -> (A, B, C, D) -> E {
+    { a, b, c, d in fun(a)(b)(c)(d) }
 }
 
 /// Curries a 5-ary function.
 ///
 /// - Parameter fun: Function to be curried.
 /// - Returns: `fun` in curried form.
-public func curry<A, B, C, D, E, F>(_ fun : @escaping (A, B, C, D, E) -> F) -> (A) -> (B) -> (C) -> (D) -> (E) -> F {
-    return { a in { b in { c in { d in { e in fun(a,b,c,d,e) } } } } }
+public func curry<A, B, C, D, E, F>(_ fun: @escaping (A, B, C, D, E) -> F) -> (A) -> (B) -> (C) -> (D) -> (E) -> F {
+    { a in { b in { c in { d in { e in fun(a,b,c,d,e) } } } } }
 }
 
 /// Uncurries a 5-ary function.
 ///
 /// - Parameter fun: Function to be uncurried.
 /// - Returns: `fun` in uncurried form.
-public func uncurry<A, B, C, D, E, F>(_ fun : @escaping (A) -> (B) -> (C) -> (D) -> (E) -> F) -> (A, B, C, D, E) -> F {
-    return { a, b, c, d, e in fun(a)(b)(c)(d)(e) }
+public func uncurry<A, B, C, D, E, F>(_ fun: @escaping (A) -> (B) -> (C) -> (D) -> (E) -> F) -> (A, B, C, D, E) -> F {
+    { a, b, c, d, e in fun(a)(b)(c)(d)(e) }
 }
 
 /// Curries a 6-ary function.
 ///
 /// - Parameter fun: Function to be curried.
 /// - Returns: `fun` in curried form.
-public func curry<A, B, C, D, E, F, G>(_ fun : @escaping (A, B, C, D, E, F) -> G) -> (A) -> (B) -> (C) -> (D) -> (E) -> (F) -> G {
-    return { a in { b in { c in { d in { e in { f in fun(a,b,c,d,e,f) } } } } } }
+public func curry<A, B, C, D, E, F, G>(_ fun: @escaping (A, B, C, D, E, F) -> G) -> (A) -> (B) -> (C) -> (D) -> (E) -> (F) -> G {
+    { a in { b in { c in { d in { e in { f in fun(a,b,c,d,e,f) } } } } } }
 }
 
 /// Uncurries a 6-ary function.
 ///
 /// - Parameter fun: Function to be uncurried.
 /// - Returns: `fun` in uncurried form.
-public func uncurry<A, B, C, D, E, F, G>(_ fun : @escaping (A) -> (B) -> (C) -> (D) -> (E) -> (F) -> G) -> (A, B, C, D, E, F) -> G {
-    return { a, b, c, d, e, f in fun(a)(b)(c)(d)(e)(f) }
+public func uncurry<A, B, C, D, E, F, G>(_ fun: @escaping (A) -> (B) -> (C) -> (D) -> (E) -> (F) -> G) -> (A, B, C, D, E, F) -> G {
+    { a, b, c, d, e, f in fun(a)(b)(c)(d)(e)(f) }
 }
 
 /// Curries a 7-ary function.
 ///
 /// - Parameter fun: Function to be curried.
 /// - Returns: `fun` in curried form.
-public func curry<A, B, C, D, E, F, G, H>(_ fun : @escaping (A, B, C, D, E, F, G) -> H) -> (A) -> (B) -> (C) -> (D) -> (E) -> (F) -> (G) -> H {
-    return { a in { b in { c in { d in { e in { f in { g in fun(a,b,c,d,e,f,g) } } } } } } }
+public func curry<A, B, C, D, E, F, G, H>(_ fun: @escaping (A, B, C, D, E, F, G) -> H) -> (A) -> (B) -> (C) -> (D) -> (E) -> (F) -> (G) -> H {
+    { a in { b in { c in { d in { e in { f in { g in fun(a,b,c,d,e,f,g) } } } } } } }
 }
 
 /// Uncurries a 7-ary function.
 ///
 /// - Parameter fun: Function to be uncurried.
 /// - Returns: `fun` in uncurried form.
-public func uncurry<A, B, C, D, E, F, G, H>(_ fun : @escaping (A) -> (B) -> (C) -> (D) -> (E) -> (F) -> (G) -> H) -> (A, B, C, D, E, F, G) -> H {
-    return { a, b, c, d, e, f, g in fun(a)(b)(c)(d)(e)(f)(g) }
+public func uncurry<A, B, C, D, E, F, G, H>(_ fun: @escaping (A) -> (B) -> (C) -> (D) -> (E) -> (F) -> (G) -> H) -> (A, B, C, D, E, F, G) -> H {
+    { a, b, c, d, e, f, g in fun(a)(b)(c)(d)(e)(f)(g) }
 }

--- a/Sources/Bow/Syntax/Memoization.swift
+++ b/Sources/Bow/Syntax/Memoization.swift
@@ -9,7 +9,7 @@ import Foundation
 ///   - f: Function to be memoized. This function must be pure and deterministic in order to have consistent results.
 ///   - a: Function input.
 /// - Returns: A function that behaves like `f` but saves already computed results.
-public func memoize<A, B>(_ f : @escaping (_ a: A) -> B) -> (A) -> B where A : Hashable {
+public func memoize<A, B>(_ f: @escaping (_ a: A) -> B) -> (A) -> B where A: Hashable {
     var cached = Dictionary<A, B>()
     
     return { a in
@@ -37,10 +37,10 @@ public func memoize<A, B>(_ f : @escaping (_ a: A) -> B) -> (A) -> B where A : H
 ///   - a: Input to the recursive step.
 ///   - input: Current value for the recursion.
 /// - Returns: A function that behaves like `f` but saves already computed results.
-public func memoize<A, B>(_ f : @escaping (_ step: (_ a: A) -> B, _ input: A) -> B) -> (A) -> B where A : Hashable {
+public func memoize<A, B>(_ f: @escaping (_ step: (_ a: A) -> B, _ input: A) -> B) -> (A) -> B where A: Hashable {
     var cached = Dictionary<A, B>()
     
-    func wrap(_ a : A) -> B {
+    func wrap(_ a: A) -> B {
         if let cachedResult = cached[a] {
             return cachedResult
         }

--- a/Sources/Bow/Syntax/PartialApplication.swift
+++ b/Sources/Bow/Syntax/PartialApplication.swift
@@ -8,8 +8,8 @@ infix operator |> : AdditionPrecedence
 ///   - a: Argument to apply.
 ///   - fun: Function receiving the argument.
 /// - Returns: Result of running the function with the argument as input.
-public func |><A, B>(_ a : A, _ fun : (A) -> B) -> B {
-    return fun(a)
+public func |><A, B>(_ a: A, _ fun: (A) -> B) -> B {
+    fun(a)
 }
 
 /// Applies the first argument to a 2-ary function, returning a 1-ary function with the rest of the arguments of the original function.
@@ -18,8 +18,8 @@ public func |><A, B>(_ a : A, _ fun : (A) -> B) -> B {
 ///   - a: Input to the first argument of the function
 ///   - fun: Function to be applied.
 /// - Returns: A function with the same behavior of the input function where the first argument is fixed to the value of the provided argument.
-public func |><A, B, C>(_ a : A, _ fun : @escaping (A, B) -> C) -> (B) -> C {
-    return { b in fun(a,b) }
+public func |><A, B, C>(_ a: A, _ fun: @escaping (A, B) -> C) -> (B) -> C {
+    { b in fun(a,b) }
 }
 
 /// Applies the first argument to a 3-ary function, returning a 2-ary function with the rest of the arguments of the original function.
@@ -28,8 +28,8 @@ public func |><A, B, C>(_ a : A, _ fun : @escaping (A, B) -> C) -> (B) -> C {
 ///   - a: Input to the first argument of the function
 ///   - fun: Function to be applied.
 /// - Returns: A function with the same behavior of the input function where the first argument is fixed to the value of the provided argument.
-public func |><A, B, C, D>(_ a : A, _ fun : @escaping (A, B, C) -> D) -> (B, C) -> D {
-    return { b, c in fun(a, b, c) }
+public func |><A, B, C, D>(_ a: A, _ fun: @escaping (A, B, C) -> D) -> (B, C) -> D {
+    { b, c in fun(a, b, c) }
 }
 
 /// Applies the first argument to a 4-ary function, returning a 3-ary function with the rest of the arguments of the original function.
@@ -38,8 +38,8 @@ public func |><A, B, C, D>(_ a : A, _ fun : @escaping (A, B, C) -> D) -> (B, C) 
 ///   - a: Input to the first argument of the function
 ///   - fun: Function to be applied.
 /// - Returns: A function with the same behavior of the input function where the first argument is fixed to the value of the provided argument.
-public func |><A, B, C, D, E>(_ a : A, _ fun : @escaping (A, B, C, D) -> E) -> (B, C, D) -> E {
-    return { b, c, d in fun(a, b, c, d) }
+public func |><A, B, C, D, E>(_ a: A, _ fun: @escaping (A, B, C, D) -> E) -> (B, C, D) -> E {
+    { b, c, d in fun(a, b, c, d) }
 }
 
 /// Applies the first argument to a 5-ary function, returning a 4-ary function with the rest of the arguments of the original function.
@@ -48,8 +48,8 @@ public func |><A, B, C, D, E>(_ a : A, _ fun : @escaping (A, B, C, D) -> E) -> (
 ///   - a: Input to the first argument of the function
 ///   - fun: Function to be applied.
 /// - Returns: A function with the same behavior of the input function where the first argument is fixed to the value of the provided argument.
-public func |><A, B, C, D, E, F>(_ a : A, _ fun : @escaping (A, B, C, D, E) -> F) -> (B, C, D, E) -> F {
-    return { b, c, d, e in fun(a, b, c, d, e) }
+public func |><A, B, C, D, E, F>(_ a: A, _ fun: @escaping (A, B, C, D, E) -> F) -> (B, C, D, E) -> F {
+    { b, c, d, e in fun(a, b, c, d, e) }
 }
 
 /// Applies the first argument to a 6-ary function, returning a 5-ary function with the rest of the arguments of the original function.
@@ -58,8 +58,8 @@ public func |><A, B, C, D, E, F>(_ a : A, _ fun : @escaping (A, B, C, D, E) -> F
 ///   - a: Input to the first argument of the function
 ///   - fun: Function to be applied.
 /// - Returns: A function with the same behavior of the input function where the first argument is fixed to the value of the provided argument.
-public func |><A, B, C, D, E, F, G>(_ a : A, _ fun : @escaping (A, B, C, D, E, F) -> G) -> (B, C, D, E, F) -> G {
-    return { b, c, d, e, f in fun(a, b, c, d, e, f) }
+public func |><A, B, C, D, E, F, G>(_ a: A, _ fun: @escaping (A, B, C, D, E, F) -> G) -> (B, C, D, E, F) -> G {
+    { b, c, d, e, f in fun(a, b, c, d, e, f) }
 }
 
 /// Applies the first argument to a 7-ary function, returning a 6-ary function with the rest of the arguments of the original function.
@@ -68,8 +68,8 @@ public func |><A, B, C, D, E, F, G>(_ a : A, _ fun : @escaping (A, B, C, D, E, F
 ///   - a: Input to the first argument of the function
 ///   - fun: Function to be applied.
 /// - Returns: A function with the same behavior of the input function where the first argument is fixed to the value of the provided argument.
-public func |><A, B, C, D, E, F, G, H>(_ a : A, _ fun : @escaping (A, B, C, D, E, F, G) -> H) -> (B, C, D, E, F, G) -> H {
-    return { b, c, d, e, f, g in fun(a, b, c, d, e, f, g) }
+public func |><A, B, C, D, E, F, G, H>(_ a: A, _ fun: @escaping (A, B, C, D, E, F, G) -> H) -> (B, C, D, E, F, G) -> H {
+    { b, c, d, e, f, g in fun(a, b, c, d, e, f, g) }
 }
 
 /// Applies the first argument to a 8-ary function, returning a 7-ary function with the rest of the arguments of the original function.
@@ -78,7 +78,7 @@ public func |><A, B, C, D, E, F, G, H>(_ a : A, _ fun : @escaping (A, B, C, D, E
 ///   - a: Input to the first argument of the function
 ///   - fun: Function to be applied.
 /// - Returns: A function with the same behavior of the input function where the first argument is fixed to the value of the provided argument.
-public func |><A, B, C, D, E, F, G, H, I>(_ a : A, _ fun : @escaping (A, B, C, D, E, F, G, H) -> I) -> (B, C, D, E, F, G, H) -> I {
-    return { b, c, d, e, f, g, h in fun(a, b, c, d, e, f, g, h) }
+public func |><A, B, C, D, E, F, G, H, I>(_ a: A, _ fun: @escaping (A, B, C, D, E, F, G, H) -> I) -> (B, C, D, E, F, G, H) -> I {
+    { b, c, d, e, f, g, h in fun(a, b, c, d, e, f, g, h) }
 }
 

--- a/Sources/Bow/Syntax/Predef.swift
+++ b/Sources/Bow/Syntax/Predef.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 public typealias Unit = ()
-public let unit : Unit = ()
+public let unit: Unit = ()
 
 /// Identity function.
 ///
@@ -9,8 +9,8 @@ public let unit : Unit = ()
 ///
 /// - Parameter a: A value.
 /// - Returns: The value received as input, with no modifications.
-public func id<A>(_ a : A) -> A {
-    return a
+public func id<A>(_ a: A) -> A {
+    a
 }
 
 /// Provides a constant function.
@@ -18,7 +18,7 @@ public func id<A>(_ a : A) -> A {
 /// - Parameter a: Constant value to return.
 /// - Returns: A 0-ary function that constantly return the value provided as argument.
 public func constant<A>(_ a: @autoclosure @escaping () -> A) -> () -> A {
-    return a
+    a
 }
 
 /// Provides a constant function.
@@ -26,7 +26,7 @@ public func constant<A>(_ a: @autoclosure @escaping () -> A) -> () -> A {
 /// - Parameter a: Constant value to return.
 /// - Returns: A 1-ary function that constantly return the value provided as argument, regardless of its input parameter.
 public func constant<A, B>(_ a: @autoclosure @escaping () -> A) -> (B) -> A {
-    return { _ in a() }
+    { _ in a() }
 }
 
 /// Provides a constant function.
@@ -34,7 +34,7 @@ public func constant<A, B>(_ a: @autoclosure @escaping () -> A) -> (B) -> A {
 /// - Parameter a: Constant value to return.
 /// - Returns: A 2-ary function that constantly return the value provided as argument, regardless of its input parameters.
 public func constant<A, B, C>(_ a: @autoclosure @escaping () -> A) -> (B, C) -> A {
-    return { _, _ in a() }
+    { _, _ in a() }
 }
 
 /// Provides a constant function.
@@ -42,7 +42,7 @@ public func constant<A, B, C>(_ a: @autoclosure @escaping () -> A) -> (B, C) -> 
 /// - Parameter a: Constant value to return.
 /// - Returns: A 3-ary function that constantly return the value provided as argument, regardless of its input parameters.
 public func constant<A, B, C, D>(_ a: @autoclosure @escaping () -> A) -> (B, C, D) -> A {
-    return { _, _, _ in a() }
+    { _, _, _ in a() }
 }
 
 /// Provides a constant function.
@@ -50,7 +50,7 @@ public func constant<A, B, C, D>(_ a: @autoclosure @escaping () -> A) -> (B, C, 
 /// - Parameter a: Constant value to return.
 /// - Returns: A 4-ary function that constantly return the value provided as argument, regardless of its input parameters.
 public func constant<A, B, C, D, E>(_ a: @autoclosure @escaping () -> A) -> (B, C, D, E) -> A {
-    return { _, _, _, _ in a() }
+    { _, _, _, _ in a() }
 }
 
 /**
@@ -67,8 +67,8 @@ public func constant<A, B, C, D, E>(_ a: @autoclosure @escaping () -> A) -> (B, 
 ///   - g: Left-hand side of the function composition.
 ///   - f: Right-hand side of the function composition.
 /// - Returns: A function that applies `g` to the output of `f`.
-public func compose<A, B>(_ g : @escaping (A) -> B, _ f : @escaping () -> A) -> () -> B {
-    return andThen(f, g)
+public func compose<A, B>(_ g: @escaping (A) -> B, _ f: @escaping () -> A) -> () -> B {
+    andThen(f, g)
 }
 
 /// Composes a 0-ary function with a 1-ary function.
@@ -79,8 +79,8 @@ public func compose<A, B>(_ g : @escaping (A) -> B, _ f : @escaping () -> A) -> 
 ///   - g: Left-hand side of the function composition.
 ///   - f: Right-hand side of the function composition.
 /// - Returns: A function that applies `g` to the output of `f`.
-public func compose<A, B>(_ g : @escaping (A) throws -> B, _ f : @escaping () -> A) -> () throws -> B {
-    return andThen(f, g)
+public func compose<A, B>(_ g: @escaping (A) throws -> B, _ f: @escaping () -> A) -> () throws -> B {
+    andThen(f, g)
 }
 
 /// Composes a 0-ary function with a 1-ary function.
@@ -91,8 +91,8 @@ public func compose<A, B>(_ g : @escaping (A) throws -> B, _ f : @escaping () ->
 ///   - g: Left-hand side of the function composition.
 ///   - f: Right-hand side of the function composition.
 /// - Returns: A function that applies `g` to the output of `f`.
-public func compose<A, B>(_ g : @escaping (A) -> B, _ f : @escaping () throws -> A) -> () throws -> B {
-    return andThen(f, g)
+public func compose<A, B>(_ g: @escaping (A) -> B, _ f: @escaping () throws -> A) -> () throws -> B {
+    andThen(f, g)
 }
 
 /// Composes a 0-ary function with a 1-ary function.
@@ -103,8 +103,8 @@ public func compose<A, B>(_ g : @escaping (A) -> B, _ f : @escaping () throws ->
 ///   - g: Left-hand side of the function composition.
 ///   - f: Right-hand side of the function composition.
 /// - Returns: A function that applies `g` to the output of `f`.
-public func compose<A, B>(_ g : @escaping (A) throws -> B, _ f : @escaping () throws -> A) -> () throws -> B {
-    return andThen(f, g)
+public func compose<A, B>(_ g: @escaping (A) throws -> B, _ f: @escaping () throws -> A) -> () throws -> B {
+    andThen(f, g)
 }
 
 /// Composes a 1-ary function with a 1-ary function.
@@ -115,8 +115,8 @@ public func compose<A, B>(_ g : @escaping (A) throws -> B, _ f : @escaping () th
 ///   - g: Left-hand side of the function composition.
 ///   - f: Right-hand side of the function composition.
 /// - Returns: A function that applies `g` to the output of `f`.
-public func compose<A, B, C>(_ g : @escaping (B) -> C, _ f : @escaping (A) -> B) -> (A) -> C {
-    return andThen(f, g)
+public func compose<A, B, C>(_ g: @escaping (B) -> C, _ f: @escaping (A) -> B) -> (A) -> C {
+    andThen(f, g)
 }
 
 /// Composes a 1-ary function with a 1-ary function.
@@ -127,8 +127,8 @@ public func compose<A, B, C>(_ g : @escaping (B) -> C, _ f : @escaping (A) -> B)
 ///   - g: Left-hand side of the function composition.
 ///   - f: Right-hand side of the function composition.
 /// - Returns: A function that applies `g` to the output of `f`.
-public func compose<A, B, C>(_ g : @escaping (B) throws -> C, _ f : @escaping (A) -> B) -> (A) throws -> C {
-    return andThen(f, g)
+public func compose<A, B, C>(_ g: @escaping (B) throws -> C, _ f: @escaping (A) -> B) -> (A) throws -> C {
+    andThen(f, g)
 }
 
 /// Composes a 1-ary function with a 1-ary function.
@@ -139,8 +139,8 @@ public func compose<A, B, C>(_ g : @escaping (B) throws -> C, _ f : @escaping (A
 ///   - g: Left-hand side of the function composition.
 ///   - f: Right-hand side of the function composition.
 /// - Returns: A function that applies `g` to the output of `f`.
-public func compose<A, B, C>(_ g : @escaping (B) -> C, _ f : @escaping (A) throws -> B) -> (A) throws -> C {
-    return andThen(f, g)
+public func compose<A, B, C>(_ g: @escaping (B) -> C, _ f: @escaping (A) throws -> B) -> (A) throws -> C {
+    andThen(f, g)
 }
 
 /// Composes a 1-ary function with a 1-ary function.
@@ -151,8 +151,8 @@ public func compose<A, B, C>(_ g : @escaping (B) -> C, _ f : @escaping (A) throw
 ///   - g: Left-hand side of the function composition.
 ///   - f: Right-hand side of the function composition.
 /// - Returns: A function that applies `g` to the output of `f`.
-public func compose<A, B, C>(_ g : @escaping (B) throws -> C, _ f : @escaping (A) throws -> B) -> (A) throws -> C {
-    return andThen(f, g)
+public func compose<A, B, C>(_ g: @escaping (B) throws -> C, _ f: @escaping (A) throws -> B) -> (A) throws -> C {
+    andThen(f, g)
 }
 
 /// Composes a 0-ary function with a 1-ary function.
@@ -163,8 +163,8 @@ public func compose<A, B, C>(_ g : @escaping (B) throws -> C, _ f : @escaping (A
 ///   - g: Left-hand side of the function composition.
 ///   - f: Right-hand side of the function composition.
 /// - Returns: A function that applies `g` to the output of `f`.
-public func andThen<A, B>(_ f : @escaping () -> A, _ g : @escaping (A) -> B) -> () -> B {
-    return { g(f()) }
+public func andThen<A, B>(_ f: @escaping () -> A, _ g: @escaping (A) -> B) -> () -> B {
+    { g(f()) }
 }
 
 /// Composes a 0-ary function with a 1-ary function.
@@ -175,8 +175,8 @@ public func andThen<A, B>(_ f : @escaping () -> A, _ g : @escaping (A) -> B) -> 
 ///   - g: Left-hand side of the function composition.
 ///   - f: Right-hand side of the function composition.
 /// - Returns: A function that applies `g` to the output of `f`.
-public func andThen<A, B>(_ f : @escaping () throws -> A, _ g : @escaping (A) -> B) -> () throws -> B {
-    return { g(try f()) }
+public func andThen<A, B>(_ f: @escaping () throws -> A, _ g: @escaping (A) -> B) -> () throws -> B {
+    { g(try f()) }
 }
 
 /// Composes a 0-ary function with a 1-ary function.
@@ -187,8 +187,8 @@ public func andThen<A, B>(_ f : @escaping () throws -> A, _ g : @escaping (A) ->
 ///   - g: Left-hand side of the function composition.
 ///   - f: Right-hand side of the function composition.
 /// - Returns: A function that applies `g` to the output of `f`.
-public func andThen<A, B>(_ f : @escaping () -> A, _ g : @escaping (A) throws -> B) -> () throws -> B {
-    return { try g(f()) }
+public func andThen<A, B>(_ f: @escaping () -> A, _ g: @escaping (A) throws -> B) -> () throws -> B {
+    { try g(f()) }
 }
 
 /// Composes a 0-ary function with a 1-ary function.
@@ -199,8 +199,8 @@ public func andThen<A, B>(_ f : @escaping () -> A, _ g : @escaping (A) throws ->
 ///   - g: Left-hand side of the function composition.
 ///   - f: Right-hand side of the function composition.
 /// - Returns: A function that applies `g` to the output of `f`.
-public func andThen<A, B>(_ f : @escaping () throws -> A, _ g : @escaping (A) throws -> B) -> () throws -> B {
-    return { try g(try f()) }
+public func andThen<A, B>(_ f: @escaping () throws -> A, _ g: @escaping (A) throws -> B) -> () throws -> B {
+    { try g(try f()) }
 }
 
 /// Composes a 1-ary function with a 1-ary function.
@@ -211,8 +211,8 @@ public func andThen<A, B>(_ f : @escaping () throws -> A, _ g : @escaping (A) th
 ///   - g: Left-hand side of the function composition.
 ///   - f: Right-hand side of the function composition.
 /// - Returns: A function that applies `g` to the output of `f`.
-public func andThen<A, B, C>(_ f : @escaping (A) -> B, _ g : @escaping (B) -> C) -> (A) -> C {
-    return { x in g(f(x)) }
+public func andThen<A, B, C>(_ f: @escaping (A) -> B, _ g: @escaping (B) -> C) -> (A) -> C {
+    { x in g(f(x)) }
 }
 
 /// Composes a 1-ary function with a 1-ary function.
@@ -223,8 +223,8 @@ public func andThen<A, B, C>(_ f : @escaping (A) -> B, _ g : @escaping (B) -> C)
 ///   - g: Left-hand side of the function composition.
 ///   - f: Right-hand side of the function composition.
 /// - Returns: A function that applies `g` to the output of `f`.
-public func andThen<A, B, C>(_ f : @escaping (A) throws -> B, _ g : @escaping (B) -> C) -> (A) throws -> C {
-    return { x in g(try f(x)) }
+public func andThen<A, B, C>(_ f: @escaping (A) throws -> B, _ g: @escaping (B) -> C) -> (A) throws -> C {
+    { x in g(try f(x)) }
 }
 
 /// Composes a 1-ary function with a 1-ary function.
@@ -235,8 +235,8 @@ public func andThen<A, B, C>(_ f : @escaping (A) throws -> B, _ g : @escaping (B
 ///   - g: Left-hand side of the function composition.
 ///   - f: Right-hand side of the function composition.
 /// - Returns: A function that applies `g` to the output of `f`.
-public func andThen<A, B, C>(_ f : @escaping (A) -> B, _ g : @escaping (B) throws -> C) -> (A) throws -> C {
-    return { x in try g(f(x)) }
+public func andThen<A, B, C>(_ f: @escaping (A) -> B, _ g: @escaping (B) throws -> C) -> (A) throws -> C {
+    { x in try g(f(x)) }
 }
 
 /// Composes a 1-ary function with a 1-ary function.
@@ -247,12 +247,12 @@ public func andThen<A, B, C>(_ f : @escaping (A) -> B, _ g : @escaping (B) throw
 ///   - g: Left-hand side of the function composition.
 ///   - f: Right-hand side of the function composition.
 /// - Returns: A function that applies `g` to the output of `f`.
-public func andThen<A, B, C>(_ f : @escaping (A) throws -> B, _ g : @escaping (B) throws -> C) -> (A) throws -> C {
-    return { x in try g(try f(x)) }
+public func andThen<A, B, C>(_ f: @escaping (A) throws -> B, _ g: @escaping (B) throws -> C) -> (A) throws -> C {
+    { x in try g(try f(x)) }
 }
 
-infix operator >>> : AdditionPrecedence
-infix operator <<< : AdditionPrecedence
+infix operator >>>: AdditionPrecedence
+infix operator <<<: AdditionPrecedence
 
 /// Composes a 0-ary function with a 1-ary function.
 ///
@@ -262,20 +262,8 @@ infix operator <<< : AdditionPrecedence
 ///   - g: Left-hand side of the function composition.
 ///   - f: Right-hand side of the function composition.
 /// - Returns: A function that applies `g` to the output of `f`.
-public func >>><A, B>(_ f : @escaping () -> A, _ g : @escaping (A) -> B) -> () -> B {
-    return andThen(f, g)
-}
-
-/// Composes a 0-ary function with a 1-ary function.
-///
-/// Returns a function that is the result of applying `g` to the output of `f`.
-///
-/// - Parameters:
-///   - g: Left-hand side of the function composition.
-///   - f: Right-hand side of the function composition.
-/// - Returns: A function that applies `g` to the output of `f`.
-public func >>><A, B>(_ f : @escaping () throws -> A, _ g : @escaping (A) -> B) -> () throws -> B {
-    return andThen(f, g)
+public func >>><A, B>(_ f: @escaping () -> A, _ g: @escaping (A) -> B) -> () -> B {
+    andThen(f, g)
 }
 
 /// Composes a 0-ary function with a 1-ary function.
@@ -286,8 +274,8 @@ public func >>><A, B>(_ f : @escaping () throws -> A, _ g : @escaping (A) -> B) 
 ///   - g: Left-hand side of the function composition.
 ///   - f: Right-hand side of the function composition.
 /// - Returns: A function that applies `g` to the output of `f`.
-public func >>><A, B>(_ f : @escaping () -> A, _ g : @escaping (A) throws -> B) -> () throws -> B {
-    return andThen(f, g)
+public func >>><A, B>(_ f: @escaping () throws -> A, _ g: @escaping (A) -> B) -> () throws -> B {
+    andThen(f, g)
 }
 
 /// Composes a 0-ary function with a 1-ary function.
@@ -298,56 +286,8 @@ public func >>><A, B>(_ f : @escaping () -> A, _ g : @escaping (A) throws -> B) 
 ///   - g: Left-hand side of the function composition.
 ///   - f: Right-hand side of the function composition.
 /// - Returns: A function that applies `g` to the output of `f`.
-public func >>><A, B>(_ f : @escaping () throws -> A, _ g : @escaping (A) throws -> B) -> () throws -> B {
-    return andThen(f, g)
-}
-
-/// Composes a 1-ary function with a 1-ary function.
-///
-/// Returns a function that is the result of applying `g` to the output of `f`.
-///
-/// - Parameters:
-///   - g: Left-hand side of the function composition.
-///   - f: Right-hand side of the function composition.
-/// - Returns: A function that applies `g` to the output of `f`.
-public func >>><A, B, C>(_ f : @escaping (A) -> B, _ g : @escaping (B) -> C) -> (A) -> C {
-    return andThen(f, g)
-}
-
-/// Composes a 1-ary function with a 1-ary function.
-///
-/// Returns a function that is the result of applying `g` to the output of `f`.
-///
-/// - Parameters:
-///   - g: Left-hand side of the function composition.
-///   - f: Right-hand side of the function composition.
-/// - Returns: A function that applies `g` to the output of `f`.
-public func >>><A, B, C>(_ f : @escaping (A) throws -> B, _ g : @escaping (B) -> C) -> (A) throws -> C {
-    return andThen(f, g)
-}
-
-/// Composes a 1-ary function with a 1-ary function.
-///
-/// Returns a function that is the result of applying `g` to the output of `f`.
-///
-/// - Parameters:
-///   - g: Left-hand side of the function composition.
-///   - f: Right-hand side of the function composition.
-/// - Returns: A function that applies `g` to the output of `f`.
-public func >>><A, B, C>(_ f : @escaping (A) -> B, _ g : @escaping (B) throws -> C) -> (A) throws -> C {
-    return andThen(f, g)
-}
-
-/// Composes a 1-ary function with a 1-ary function.
-///
-/// Returns a function that is the result of applying `g` to the output of `f`.
-///
-/// - Parameters:
-///   - g: Left-hand side of the function composition.
-///   - f: Right-hand side of the function composition.
-/// - Returns: A function that applies `g` to the output of `f`.
-public func >>><A, B, C>(_ f : @escaping (A) throws -> B, _ g : @escaping (B) throws -> C) -> (A) throws -> C {
-    return andThen(f, g)
+public func >>><A, B>(_ f: @escaping () -> A, _ g: @escaping (A) throws -> B) -> () throws -> B {
+    andThen(f, g)
 }
 
 /// Composes a 0-ary function with a 1-ary function.
@@ -358,8 +298,56 @@ public func >>><A, B, C>(_ f : @escaping (A) throws -> B, _ g : @escaping (B) th
 ///   - g: Left-hand side of the function composition.
 ///   - f: Right-hand side of the function composition.
 /// - Returns: A function that applies `g` to the output of `f`.
-public func <<<<A, B>(_ g : @escaping (A) -> B, _ f : @escaping () -> A) -> () -> B {
-    return f >>> g
+public func >>><A, B>(_ f: @escaping () throws -> A, _ g: @escaping (A) throws -> B) -> () throws -> B {
+    andThen(f, g)
+}
+
+/// Composes a 1-ary function with a 1-ary function.
+///
+/// Returns a function that is the result of applying `g` to the output of `f`.
+///
+/// - Parameters:
+///   - g: Left-hand side of the function composition.
+///   - f: Right-hand side of the function composition.
+/// - Returns: A function that applies `g` to the output of `f`.
+public func >>><A, B, C>(_ f: @escaping (A) -> B, _ g: @escaping (B) -> C) -> (A) -> C {
+    andThen(f, g)
+}
+
+/// Composes a 1-ary function with a 1-ary function.
+///
+/// Returns a function that is the result of applying `g` to the output of `f`.
+///
+/// - Parameters:
+///   - g: Left-hand side of the function composition.
+///   - f: Right-hand side of the function composition.
+/// - Returns: A function that applies `g` to the output of `f`.
+public func >>><A, B, C>(_ f: @escaping (A) throws -> B, _ g: @escaping (B) -> C) -> (A) throws -> C {
+    andThen(f, g)
+}
+
+/// Composes a 1-ary function with a 1-ary function.
+///
+/// Returns a function that is the result of applying `g` to the output of `f`.
+///
+/// - Parameters:
+///   - g: Left-hand side of the function composition.
+///   - f: Right-hand side of the function composition.
+/// - Returns: A function that applies `g` to the output of `f`.
+public func >>><A, B, C>(_ f: @escaping (A) -> B, _ g: @escaping (B) throws -> C) -> (A) throws -> C {
+    andThen(f, g)
+}
+
+/// Composes a 1-ary function with a 1-ary function.
+///
+/// Returns a function that is the result of applying `g` to the output of `f`.
+///
+/// - Parameters:
+///   - g: Left-hand side of the function composition.
+///   - f: Right-hand side of the function composition.
+/// - Returns: A function that applies `g` to the output of `f`.
+public func >>><A, B, C>(_ f: @escaping (A) throws -> B, _ g: @escaping (B) throws -> C) -> (A) throws -> C {
+    andThen(f, g)
 }
 
 /// Composes a 0-ary function with a 1-ary function.
@@ -370,8 +358,8 @@ public func <<<<A, B>(_ g : @escaping (A) -> B, _ f : @escaping () -> A) -> () -
 ///   - g: Left-hand side of the function composition.
 ///   - f: Right-hand side of the function composition.
 /// - Returns: A function that applies `g` to the output of `f`.
-public func <<<<A, B>(_ g : @escaping (A) throws -> B, _ f : @escaping () -> A) -> () throws -> B {
-    return f >>> g
+public func <<<<A, B>(_ g: @escaping (A) -> B, _ f: @escaping () -> A) -> () -> B {
+    f >>> g
 }
 
 /// Composes a 0-ary function with a 1-ary function.
@@ -382,8 +370,8 @@ public func <<<<A, B>(_ g : @escaping (A) throws -> B, _ f : @escaping () -> A) 
 ///   - g: Left-hand side of the function composition.
 ///   - f: Right-hand side of the function composition.
 /// - Returns: A function that applies `g` to the output of `f`.
-public func <<<<A, B>(_ g : @escaping (A) -> B, _ f : @escaping () throws -> A) -> () throws -> B {
-    return f >>> g
+public func <<<<A, B>(_ g: @escaping (A) throws -> B, _ f: @escaping () -> A) -> () throws -> B {
+    f >>> g
 }
 
 /// Composes a 0-ary function with a 1-ary function.
@@ -394,8 +382,20 @@ public func <<<<A, B>(_ g : @escaping (A) -> B, _ f : @escaping () throws -> A) 
 ///   - g: Left-hand side of the function composition.
 ///   - f: Right-hand side of the function composition.
 /// - Returns: A function that applies `g` to the output of `f`.
-public func <<<<A, B>(_ g : @escaping (A) throws -> B, _ f : @escaping () throws -> A) -> () throws -> B {
-    return f >>> g
+public func <<<<A, B>(_ g: @escaping (A) -> B, _ f: @escaping () throws -> A) -> () throws -> B {
+    f >>> g
+}
+
+/// Composes a 0-ary function with a 1-ary function.
+///
+/// Returns a function that is the result of applying `g` to the output of `f`.
+///
+/// - Parameters:
+///   - g: Left-hand side of the function composition.
+///   - f: Right-hand side of the function composition.
+/// - Returns: A function that applies `g` to the output of `f`.
+public func <<<<A, B>(_ g: @escaping (A) throws -> B, _ f: @escaping () throws -> A) -> () throws -> B {
+    f >>> g
 }
 
 /// Composes a 1-ary function with a 1-ary function.
@@ -406,8 +406,8 @@ public func <<<<A, B>(_ g : @escaping (A) throws -> B, _ f : @escaping () throws
 ///   - g: Left-hand side of the function composition.
 ///   - f: Right-hand side of the function composition.
 /// - Returns: A function that applies `g` to the output of `f`.
-public func <<<<A, B, C>(_ g : @escaping (B) -> C, _ f : @escaping (A) -> B) -> (A) -> C {
-    return f >>> g
+public func <<<<A, B, C>(_ g: @escaping (B) -> C, _ f: @escaping (A) -> B) -> (A) -> C {
+    f >>> g
 }
 
 /// Composes a 1-ary function with a 1-ary function.
@@ -418,8 +418,8 @@ public func <<<<A, B, C>(_ g : @escaping (B) -> C, _ f : @escaping (A) -> B) -> 
 ///   - g: Left-hand side of the function composition.
 ///   - f: Right-hand side of the function composition.
 /// - Returns: A function that applies `g` to the output of `f`.
-public func <<<<A, B, C>(_ g : @escaping (B) throws -> C, _ f : @escaping (A) -> B) -> (A) throws -> C {
-    return f >>> g
+public func <<<<A, B, C>(_ g: @escaping (B) throws -> C, _ f: @escaping (A) -> B) -> (A) throws -> C {
+    f >>> g
 }
 
 /// Composes a 1-ary function with a 1-ary function.
@@ -430,8 +430,8 @@ public func <<<<A, B, C>(_ g : @escaping (B) throws -> C, _ f : @escaping (A) ->
 ///   - g: Left-hand side of the function composition.
 ///   - f: Right-hand side of the function composition.
 /// - Returns: A function that applies `g` to the output of `f`.
-public func <<<<A, B, C>(_ g : @escaping (B) -> C, _ f : @escaping (A) throws -> B) -> (A) throws -> C {
-    return f >>> g
+public func <<<<A, B, C>(_ g: @escaping (B) -> C, _ f: @escaping (A) throws -> B) -> (A) throws -> C {
+    f >>> g
 }
 
 /// Composes a 1-ary function with a 1-ary function.
@@ -442,8 +442,8 @@ public func <<<<A, B, C>(_ g : @escaping (B) -> C, _ f : @escaping (A) throws ->
 ///   - g: Left-hand side of the function composition.
 ///   - f: Right-hand side of the function composition.
 /// - Returns: A function that applies `g` to the output of `f`.
-public func <<<<A, B, C>(_ g : @escaping (B) throws -> C, _ f : @escaping (A) throws -> B) -> (A) throws -> C {
-    return f >>> g
+public func <<<<A, B, C>(_ g: @escaping (B) throws -> C, _ f: @escaping (A) throws -> B) -> (A) throws -> C {
+    f >>> g
 }
 
 /// Flips the arguments of a binary function.

--- a/Sources/Bow/Syntax/Reverse.swift
+++ b/Sources/Bow/Syntax/Reverse.swift
@@ -4,70 +4,70 @@ import Foundation
 ///
 /// - Parameter f: Function whose inputs should be reversed.
 /// - Returns: A function with the same behaviour as `f` but with reversed input parameters.
-public func reverse<P1, P2, R>(_ f : @escaping (P1, P2) -> R) -> (P2, P1) -> R {
-    return { p2, p1 in f(p1, p2) }
+public func reverse<P1, P2, R>(_ f: @escaping (P1, P2) -> R) -> (P2, P1) -> R {
+    { p2, p1 in f(p1, p2) }
 }
 
 /// Reverses the inputs of a 3-ary function.
 ///
 /// - Parameter f: Function whose inputs should be reversed.
 /// - Returns: A function with the same behaviour as `f` but with reversed input parameters.
-public func reverse<P1, P2, P3, R>(_ f : @escaping (P1, P2, P3) -> R) -> (P3, P2, P1) -> R {
-    return { p3, p2, p1 in f(p1, p2, p3) }
+public func reverse<P1, P2, P3, R>(_ f: @escaping (P1, P2, P3) -> R) -> (P3, P2, P1) -> R {
+    { p3, p2, p1 in f(p1, p2, p3) }
 }
 
 /// Reverses the inputs of a 4-ary function.
 ///
 /// - Parameter f: Function whose inputs should be reversed.
 /// - Returns: A function with the same behaviour as `f` but with reversed input parameters.
-public func reverse<P1, P2, P3, P4, R>(_ f : @escaping (P1, P2, P3, P4) -> R) -> (P4, P3, P2, P1) -> R {
-    return { p4, p3, p2, p1 in f(p1, p2, p3, p4) }
+public func reverse<P1, P2, P3, P4, R>(_ f: @escaping (P1, P2, P3, P4) -> R) -> (P4, P3, P2, P1) -> R {
+    { p4, p3, p2, p1 in f(p1, p2, p3, p4) }
 }
 
 /// Reverses the inputs of a 5-ary function.
 ///
 /// - Parameter f: Function whose inputs should be reversed.
 /// - Returns: A function with the same behaviour as `f` but with reversed input parameters.
-public func reverse<P1, P2, P3, P4, P5, R>(_ f : @escaping (P1, P2, P3, P4, P5) -> R) -> (P5, P4, P3, P2, P1) -> R {
-    return { p5, p4, p3, p2, p1 in f(p1, p2, p3, p4, p5) }
+public func reverse<P1, P2, P3, P4, P5, R>(_ f: @escaping (P1, P2, P3, P4, P5) -> R) -> (P5, P4, P3, P2, P1) -> R {
+    { p5, p4, p3, p2, p1 in f(p1, p2, p3, p4, p5) }
 }
 
 /// Reverses the inputs of a 6-ary function.
 ///
 /// - Parameter f: Function whose inputs should be reversed.
 /// - Returns: A function with the same behaviour as `f` but with reversed input parameters.
-public func reverse<P1, P2, P3, P4, P5, P6, R>(_ f : @escaping (P1, P2, P3, P4, P5, P6) -> R) -> (P6, P5, P4, P3, P2, P1) -> R {
-    return { p6, p5, p4, p3, p2, p1 in f(p1, p2, p3, p4, p5, p6) }
+public func reverse<P1, P2, P3, P4, P5, P6, R>(_ f: @escaping (P1, P2, P3, P4, P5, P6) -> R) -> (P6, P5, P4, P3, P2, P1) -> R {
+    { p6, p5, p4, p3, p2, p1 in f(p1, p2, p3, p4, p5, p6) }
 }
 
 /// Reverses the inputs of a 7-ary function.
 ///
 /// - Parameter f: Function whose inputs should be reversed.
 /// - Returns: A function with the same behaviour as `f` but with reversed input parameters.
-public func reverse<P1, P2, P3, P4, P5, P6, P7, R>(_ f : @escaping (P1, P2, P3, P4, P5, P6, P7) -> R) -> (P7, P6, P5, P4, P3, P2, P1) -> R {
-    return { p7, p6, p5, p4, p3, p2, p1 in f(p1, p2, p3, p4, p5, p6, p7) }
+public func reverse<P1, P2, P3, P4, P5, P6, P7, R>(_ f: @escaping (P1, P2, P3, P4, P5, P6, P7) -> R) -> (P7, P6, P5, P4, P3, P2, P1) -> R {
+    { p7, p6, p5, p4, p3, p2, p1 in f(p1, p2, p3, p4, p5, p6, p7) }
 }
 
 /// Reverses the inputs of a 8-ary function.
 ///
 /// - Parameter f: Function whose inputs should be reversed.
 /// - Returns: A function with the same behaviour as `f` but with reversed input parameters.
-public func reverse<P1, P2, P3, P4, P5, P6, P7, P8, R>(_ f : @escaping (P1, P2, P3, P4, P5, P6, P7, P8) -> R) -> (P8, P7, P6, P5, P4, P3, P2, P1) -> R {
-    return { p8, p7, p6, p5, p4, p3, p2, p1 in f(p1, p2, p3, p4, p5, p6, p7, p8) }
+public func reverse<P1, P2, P3, P4, P5, P6, P7, P8, R>(_ f: @escaping (P1, P2, P3, P4, P5, P6, P7, P8) -> R) -> (P8, P7, P6, P5, P4, P3, P2, P1) -> R {
+    { p8, p7, p6, p5, p4, p3, p2, p1 in f(p1, p2, p3, p4, p5, p6, p7, p8) }
 }
 
 /// Reverses the inputs of a 9-ary function.
 ///
 /// - Parameter f: Function whose inputs should be reversed.
 /// - Returns: A function with the same behaviour as `f` but with reversed input parameters.
-public func reverse<P1, P2, P3, P4, P5, P6, P7, P8, P9, R>(_ f : @escaping (P1, P2, P3, P4, P5, P6, P7, P8, P9) -> R) -> (P9, P8, P7, P6, P5, P4, P3, P2, P1) -> R {
-    return { p9, p8, p7, p6, p5, p4, p3, p2, p1 in f(p1, p2, p3, p4, p5, p6, p7, p8, p9) }
+public func reverse<P1, P2, P3, P4, P5, P6, P7, P8, P9, R>(_ f: @escaping (P1, P2, P3, P4, P5, P6, P7, P8, P9) -> R) -> (P9, P8, P7, P6, P5, P4, P3, P2, P1) -> R {
+    { p9, p8, p7, p6, p5, p4, p3, p2, p1 in f(p1, p2, p3, p4, p5, p6, p7, p8, p9) }
 }
 
 /// Reverses the inputs of a 10-ary function.
 ///
 /// - Parameter f: Function whose inputs should be reversed.
 /// - Returns: A function with the same behaviour as `f` but with reversed input parameters.
-public func reverse<P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, R>(_ f : @escaping (P1, P2, P3, P4, P5, P6, P7, P8, P9, P10) -> R) -> (P10, P9, P8, P7, P6, P5, P4, P3, P2, P1) -> R {
-    return { p10, p9, p8, p7, p6, p5, p4, p3, p2, p1 in f(p1, p2, p3, p4, p5, p6, p7, p8, p9, p10) }
+public func reverse<P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, R>(_ f: @escaping (P1, P2, P3, P4, P5, P6, P7, P8, P9, P10) -> R) -> (P10, P9, P8, P7, P6, P5, P4, P3, P2, P1) -> R {
+    { p10, p9, p8, p7, p6, p5, p4, p3, p2, p1 in f(p1, p2, p3, p4, p5, p6, p7, p8, p9, p10) }
 }


### PR DESCRIPTION
## Goal

Cleanup code in the Syntax folder in the Core module by:

- Using `FOf<A>` instead of `Kind<F, A>`.
- Removing backticks in `MARK` sections as they do not render properly in Jazzy.
- Removing returns.
- Replacing `fix` by `^`.