### PR TITLE
Cleanup Transformers folder in Core module

### DIFF
--- a/Sources/Bow/Transformers/EitherT.swift
+++ b/Sources/Bow/Transformers/EitherT.swift
@@ -37,7 +37,7 @@ public postfix func ^<F, A, B>(_ fa: EitherTOf<F, A, B>) -> EitherT<F, A, B> {
     EitherT.fix(fa)
 }
 
-// MARK: Functions for `EitherT` when the effect has an instance of `Functor`.
+// MARK: Functions for EitherT when the effect has an instance of Functor
 extension EitherT where F: Functor {
     /// Applies the provided closures based on the content of the nested `Either` value.
     ///
@@ -107,7 +107,7 @@ extension EitherT where F: Functor {
     }
 }
 
-// MARK: Functions for `EitherT` when the effect has an instance of `Applicative`.
+// MARK: Functions for EitherT when the effect has an instance of Applicative
 extension EitherT where F: Applicative {
     /// Creates an `EitherT` with a nested left value.
     ///
@@ -134,7 +134,7 @@ extension EitherT where F: Applicative {
     }
 }
 
-// MARK: Functions for `EitherT` when the effect has an instance of `Monad`.
+// MARK: Functions for EitherT when the effect has an instance of Monad
 extension EitherT where F: Monad {
     /// Flatmaps a function that produces an effect and lifts it back to `EitherT`
     ///
@@ -145,7 +145,7 @@ extension EitherT where F: Monad {
     }
 }
 
-// MARK: Instance of `EquatableK` for `EitherT`
+// MARK: Instance of EquatableK for EitherT
 extension EitherTPartial: EquatableK where F: EquatableK, L: Equatable {
     public static func eq<A: Equatable>(
         _ lhs: EitherTOf<F, L, A>,
@@ -154,10 +154,10 @@ extension EitherTPartial: EquatableK where F: EquatableK, L: Equatable {
     }
 }
 
-// MARK: Instance of `Invariant` for `EitherT`
+// MARK: Instance of Invariant for EitherT
 extension EitherTPartial: Invariant where F: Functor {}
 
-// MARK: Instance of `Functor` for `EitherT`
+// MARK: Instance of Functor for EitherT
 extension EitherTPartial: Functor where F: Functor {
     public static func map<A, B>(
         _ fa: EitherTOf<F, L, A>,
@@ -166,7 +166,7 @@ extension EitherTPartial: Functor where F: Functor {
     }
 }
 
-// MARK: Instance of `Applicative` for `EitherT`
+// MARK: Instance of Applicative for EitherT
 extension EitherTPartial: Applicative where F: Applicative {
     public static func pure<A>(_ a: A) -> EitherTOf<F, L, A> {
         EitherT(F.pure(.right(a)))
@@ -181,10 +181,10 @@ extension EitherTPartial: Applicative where F: Applicative {
     }
 }
 
-// MARK: Instance of `Selective` for `EitherT`
+// MARK: Instance of Selective for EitherT
 extension EitherTPartial: Selective where F: Monad {}
 
-// MARK: Instance of `Monad` for `EitherT`
+// MARK: Instance of Monad for EitherT
 extension EitherTPartial: Monad where F: Monad {
     public static func flatMap<A, B>(
         _ fa: EitherTOf<F, L, A>,
@@ -192,13 +192,17 @@ extension EitherTPartial: Monad where F: Monad {
         flatMapF(fa^.value) { b in f(b)^.value }
     }
 
-    private static func flatMapF<A, B>(_ fa: Kind<F, Either<L, A>>, _ f: @escaping (A) -> Kind<F, Either<L, B>>) -> EitherT<F, L, B> {
+    private static func flatMapF<A, B>(
+        _ fa: Kind<F, Either<L, A>>,
+        _ f: @escaping (A) -> Kind<F, Either<L, B>>) -> EitherT<F, L, B> {
         EitherT(fa.flatMap { either in
             either.fold({ a in F.pure(Either<L, B>.left(a)) }, f)
         })
     }
 
-    public static func tailRecM<A, B>(_ a: A, _ f: @escaping (A) -> EitherTOf<F, L, Either<A, B>>) -> EitherTOf<F, L, B> {
+    public static func tailRecM<A, B>(
+        _ a: A,
+        _ f: @escaping (A) -> EitherTOf<F, L, Either<A, B>>) -> EitherTOf<F, L, B> {
         EitherT(F.tailRecM(a, { a in
             F.map(f(a)^.value, { recursionControl in
                 recursionControl.fold({ left in .right(.left(left)) },
@@ -211,7 +215,7 @@ extension EitherTPartial: Monad where F: Monad {
     }
 }
 
-// MARK: Instance of `ApplicativeError` for `EitherT`
+// MARK: Instance of ApplicativeError for EitherT
 extension EitherTPartial: ApplicativeError where F: Monad {
     public typealias E = L
 
@@ -229,32 +233,42 @@ extension EitherTPartial: ApplicativeError where F: Monad {
     }
 }
 
-// MARK: Instance of `MonadError` for `EitherT`
+// MARK: Instance of MonadError for EitherT
 extension EitherTPartial: MonadError where F: Monad {}
 
-// MARK: Instance of `SemigroupK` for `EitherT`
+// MARK: Instance of SemigroupK for EitherT
 extension EitherTPartial: SemigroupK where F: Monad {
-    public static func combineK<A>(_ x: EitherTOf<F, L, A>, _ y: EitherTOf<F, L, A>) -> EitherTOf<F, L, A> {
+    public static func combineK<A>(
+        _ x: EitherTOf<F, L, A>,
+        _ y: EitherTOf<F, L, A>) -> EitherTOf<F, L, A> {
         EitherT(x^.value.flatMap { either in
             either.fold(constant(y^.value), { b in F.pure(Either.right(b)) })
         })
     }
 }
 
-// MARK: Instance of `Foldable` for `EitherT`
+// MARK: Instance of Foldable for EitherT
 extension EitherTPartial: Foldable where F: Foldable {
-    public static func foldLeft<A, B>(_ fa: EitherTOf<F, L, A>, _ b: B, _ f: @escaping (B, A) -> B) -> B {
+    public static func foldLeft<A, B>(
+        _ fa: EitherTOf<F, L, A>,
+        _ b: B,
+        _ f: @escaping (B, A) -> B) -> B {
         fa^.value.foldLeft(b, { bb, either in either.foldLeft(bb, f) })
     }
     
-    public static func foldRight<A, B>(_ fa: EitherTOf<F, L, A>, _ b: Eval<B>, _ f: @escaping (A, Eval<B>) -> Eval<B>) -> Eval<B> {
+    public static func foldRight<A, B>(
+        _ fa: EitherTOf<F, L, A>,
+        _ b: Eval<B>,
+        _ f: @escaping (A, Eval<B>) -> Eval<B>) -> Eval<B> {
         fa^.value.foldRight(b, { either, bb in either.foldRight(bb, f) })
     }
 }
 
-// MARK: Instance of `Traverse` for `EitherT`
+// MARK: Instance of Traverse for EitherT
 extension EitherTPartial: Traverse where F: Traverse {
-    public static func traverse<G: Applicative, A, B>(_ fa: EitherTOf<F, L, A>, _ f: @escaping (A) -> Kind<G, B>) -> Kind<G, EitherTOf<F, L, B>> {
+    public static func traverse<G: Applicative, A, B>(
+        _ fa: EitherTOf<F, L, A>,
+        _ f: @escaping (A) -> Kind<G, B>) -> Kind<G, EitherTOf<F, L, B>> {
         fa^.value.traverse { either in either.traverse(f) }
             .map { x in EitherT(x.map{ b in b^ }) }
     }

--- a/Sources/Bow/Transformers/EnvT.swift
+++ b/Sources/Bow/Transformers/EnvT.swift
@@ -191,7 +191,9 @@ extension EnvTPartial: ComonadStore where W: ComonadStore {
         wa^.lower().position
     }
     
-    public static func peek<A>(_ wa: EnvTOf<E, W, A>, _ s: W.S) -> A {
+    public static func peek<A>(
+        _ wa: EnvTOf<E, W, A>,
+        _ s: W.S) -> A {
         wa^.lower().peek(s)
     }
 }
@@ -201,11 +203,15 @@ extension EnvTPartial: ComonadStore where W: ComonadStore {
 extension EnvTPartial: ComonadTraced where W: ComonadTraced {
     public typealias M = W.M
     
-    public static func trace<A>(_ wa: EnvTOf<E, W, A>, _ m: W.M) -> A {
+    public static func trace<A>(
+        _ wa: EnvTOf<E, W, A>,
+        _ m: W.M) -> A {
         wa^.lower().trace(m)
     }
     
-    public static func listens<A, B>(_ wa: EnvTOf<E, W, A>, _ f: @escaping (W.M) -> B) -> EnvTOf<E, W, (B, A)> {
+    public static func listens<A, B>(
+        _ wa: EnvTOf<E, W, A>,
+        _ f: @escaping (W.M) -> B) -> EnvTOf<E, W, (B, A)> {
         EnvT(wa^.e, wa^.lower().listens(f))
     }
     

--- a/Sources/Bow/Transformers/StateT.swift
+++ b/Sources/Bow/Transformers/StateT.swift
@@ -193,7 +193,9 @@ extension StateTPartial: Invariant where F: Functor {}
 
 // MARK: Instance of Functor for StateT
 extension StateTPartial: Functor where F: Functor {
-    public static func map<A, B>(_ fa: StateTOf<F, S, A>, _ f: @escaping (A) -> B) -> StateTOf<F, S, B> {
+    public static func map<A, B>(
+        _ fa: StateTOf<F, S, A>,
+        _ f: @escaping (A) -> B) -> StateTOf<F, S, B> {
         fa^.transform({ (s, a) in (s, f(a)) })
     }
 }
@@ -210,7 +212,9 @@ extension StateTPartial: Selective where F: Monad {}
 
 // MARK: Instance of Monad for StateT
 extension StateTPartial: Monad where F: Monad {
-    public static func flatMap<A, B>(_ fa: StateTOf<F, S, A>, _ f: @escaping (A) -> StateTOf<F, S, B>) -> StateTOf<F, S, B> {
+    public static func flatMap<A, B>(
+        _ fa: StateTOf<F, S, A>,
+        _ f: @escaping (A) -> StateTOf<F, S, B>) -> StateTOf<F, S, B> {
         StateT<F, S, B>(
             fa^.runF >>> { fsa in
                 fsa.flatMap { (s, a) in
@@ -219,7 +223,9 @@ extension StateTPartial: Monad where F: Monad {
             })
     }
 
-    public static func tailRecM<A, B>(_ a: A, _ f: @escaping (A) -> StateTOf<F, S, Either<A, B>>) -> StateTOf<F, S, B> {
+    public static func tailRecM<A, B>(
+        _ a: A,
+        _ f: @escaping (A) -> StateTOf<F, S, Either<A, B>>) -> StateTOf<F, S, B> {
         StateT<F, S, B> { s in
             F.tailRecM((s, a), { pair in
                 F.map(f(pair.1)^.runM(pair.0), { sss, ab in
@@ -243,7 +249,9 @@ extension StateTPartial: MonadState where F: Monad {
 
 // MARK: Instance of SemigroupK for StateT
 extension StateTPartial: SemigroupK where F: Monad & SemigroupK {
-    public static func combineK<A>(_ x: StateTOf<F, S, A>, _ y: StateTOf<F, S, A>) -> StateTOf<F, S, A> {
+    public static func combineK<A>(
+        _ x: StateTOf<F, S, A>,
+        _ y: StateTOf<F, S, A>) -> StateTOf<F, S, A> {
         StateT { s in x^.runM(s).combineK(y^.runM(s)) }
     }
 }
@@ -301,7 +309,9 @@ extension StateTPartial: MonadReader where F: MonadReader {
         StateT.liftF(F.ask())
     }
     
-    public static func local<A>(_ fa: StateTOf<F, S, A>, _ f: @escaping (F.D) -> F.D) -> StateTOf<F, S, A> {
+    public static func local<A>(
+        _ fa: StateTOf<F, S, A>,
+        _ f: @escaping (F.D) -> F.D) -> StateTOf<F, S, A> {
         fa^.transformT { a in F.local(a, f) }
     }
 }

--- a/Sources/Bow/Transformers/StoreT.swift
+++ b/Sources/Bow/Transformers/StoreT.swift
@@ -93,7 +93,9 @@ extension StoreTPartial: Invariant where W: Functor {}
 // MARK: Instance of Functor for StoreT
 
 extension StoreTPartial: Functor where W: Functor {
-    public static func map<A, B>(_ fa: StoreTOf<S, W, A>, _ f: @escaping (A) -> B) -> StoreTOf<S, W, B> {
+    public static func map<A, B>(
+        _ fa: StoreTOf<S, W, A>,
+        _ f: @escaping (A) -> B) -> StoreTOf<S, W, B> {
         StoreT(fa^.state, fa^.render.map { ff in ff >>> f })
     }
 }
@@ -105,7 +107,9 @@ extension StoreTPartial: Applicative where W: Applicative, S: Monoid {
         StoreT(S.empty(), W.pure(constant(a)))
     }
     
-    public static func ap<A, B>(_ ff: StoreTOf<S, W, (A) -> B>, _ fa: StoreTOf<S, W, A>) -> StoreTOf<S, W, B> {
+    public static func ap<A, B>(
+        _ ff: StoreTOf<S, W, (A) -> B>,
+        _ fa: StoreTOf<S, W, A>) -> StoreTOf<S, W, B> {
         StoreT(ff^.state.combine(fa^.state),
                W.map(ff^.render, fa^.render) { rf, ra in { s in rf(s)(ra(s)) } })
     }
@@ -114,7 +118,9 @@ extension StoreTPartial: Applicative where W: Applicative, S: Monoid {
 // MARK: Instance of Comonad for StoreT
 
 extension StoreTPartial: Comonad where W: Comonad {
-    public static func coflatMap<A, B>(_ fa: StoreTOf<S, W, A>, _ f: @escaping (StoreTOf<S, W, A>) -> B) -> StoreTOf<S, W, B> {
+    public static func coflatMap<A, B>(
+        _ fa: StoreTOf<S, W, A>,
+        _ f: @escaping (StoreTOf<S, W, A>) -> B) -> StoreTOf<S, W, B> {
         StoreT(fa^.state,
                fa^.render.coflatMap { wa in { s in f(StoreT(s, wa)) } })
     }
@@ -131,7 +137,9 @@ extension StoreTPartial: ComonadStore where W: Comonad {
         wa^.state
     }
     
-    public static func peek<A>(_ wa: StoreTOf<S, W, A>, _ s: S) -> A {
+    public static func peek<A>(
+        _ wa: StoreTOf<S, W, A>,
+        _ s: S) -> A {
         wa^.render.extract()(s)
     }
 }
@@ -141,11 +149,15 @@ extension StoreTPartial: ComonadStore where W: Comonad {
 extension StoreTPartial: ComonadTraced where W: ComonadTraced {
     public typealias M = W.M
     
-    public static func trace<A>(_ wa: StoreTOf<S, W, A>, _ m: W.M) -> A {
+    public static func trace<A>(
+        _ wa: StoreTOf<S, W, A>,
+        _ m: W.M) -> A {
         wa^.lower().trace(m)
     }
     
-    public static func listens<A, B>(_ wa: StoreTOf<S, W, A>, _ f: @escaping (W.M) -> B) -> StoreTOf<S, W, (B, A)> {
+    public static func listens<A, B>(
+        _ wa: StoreTOf<S, W, A>,
+        _ f: @escaping (W.M) -> B) -> StoreTOf<S, W, (B, A)> {
         StoreT(wa^.state, wa^.render.listens(f).map { result in
             let (b, f) = result
             return f >>> { a in (b, a) }
@@ -172,7 +184,9 @@ extension StoreTPartial: ComonadEnv where W: ComonadEnv {
         wa^.lower().ask()
     }
     
-    public static func local<A>(_ wa: StoreTOf<S, W, A>, _ f: @escaping (W.E) -> W.E) -> StoreTOf<S, W, A> {
+    public static func local<A>(
+        _ wa: StoreTOf<S, W, A>,
+        _ f: @escaping (W.E) -> W.E) -> StoreTOf<S, W, A> {
         StoreT(wa^.state, wa^.render.local(f))
     }
 }

--- a/Sources/Bow/Transformers/TracedT.swift
+++ b/Sources/Bow/Transformers/TracedT.swift
@@ -75,7 +75,9 @@ extension TracedTPartial: Invariant where W: Functor {}
 // MARK: Instance of Functor for TracedT
 
 extension TracedTPartial: Functor where W: Functor {
-    public static func map<A, B>(_ fa: TracedTOf<M, W, A>, _ f: @escaping (A) -> B) -> TracedTOf<M, W, B> {
+    public static func map<A, B>(
+        _ fa: TracedTOf<M, W, A>,
+        _ f: @escaping (A) -> B) -> TracedTOf<M, W, B> {
         TracedT(fa^.value.map { ff in ff >>> f })
     }
 }
@@ -87,7 +89,9 @@ extension TracedTPartial: Applicative where W: Applicative {
         TracedT(W.pure(constant(a)))
     }
     
-    public static func ap<A, B>(_ ff: TracedTOf<M, W, (A) -> B>, _ fa: TracedTOf<M, W, A>) -> TracedTOf<M, W, B> {
+    public static func ap<A, B>(
+        _ ff: TracedTOf<M, W, (A) -> B>,
+        _ fa: TracedTOf<M, W, A>) -> TracedTOf<M, W, B> {
         TracedT(W.map(ff^.value, fa^.value) { vf, va in
             { m in vf(m)(va(m))}
         })
@@ -97,7 +101,9 @@ extension TracedTPartial: Applicative where W: Applicative {
 // MARK: Instance of Comonad for TracedT
 
 extension TracedTPartial: Comonad where W: Comonad, M: Monoid {
-    public static func coflatMap<A, B>(_ fa: TracedTOf<M, W, A>, _ f: @escaping (TracedTOf<M, W, A>) -> B) -> TracedTOf<M, W, B> {
+    public static func coflatMap<A, B>(
+        _ fa: TracedTOf<M, W, A>,
+        _ f: @escaping (TracedTOf<M, W, A>) -> B) -> TracedTOf<M, W, B> {
         TracedT(fa^.value.coflatMap { wma in
             { m in
                 f(TracedT(wma.map { ma in
@@ -115,11 +121,15 @@ extension TracedTPartial: Comonad where W: Comonad, M: Monoid {
 // MARK: Instance of ComonadTraced for TracedT
 
 extension TracedTPartial: ComonadTraced where W: Comonad, M: Monoid {
-    public static func trace<A>(_ wa: TracedTOf<M, W, A>, _ m: M) -> A {
+    public static func trace<A>(
+        _ wa: TracedTOf<M, W, A>,
+        _ m: M) -> A {
         wa^.value.extract()(m)
     }
 
-    public static func listens<A, B>(_ wa: TracedTOf<M, W, A>, _ f: @escaping (M) -> B) -> TracedTOf<M, W, (B, A)> {
+    public static func listens<A, B>(
+        _ wa: TracedTOf<M, W, A>,
+        _ f: @escaping (M) -> B) -> TracedTOf<M, W, (B, A)> {
         TracedT(wa^.value.map { g in
             { m in (f(m), g(m)) }
         })
@@ -145,7 +155,9 @@ extension TracedTPartial: ComonadStore where W: ComonadStore, M: Monoid {
         wa^.lower().position
     }
     
-    public static func peek<A>(_ wa: TracedTOf<M, W, A>, _ s: W.S) -> A {
+    public static func peek<A>(
+        _ wa: TracedTOf<M, W, A>,
+        _ s: W.S) -> A {
         wa^.lower().peek(s)
     }
 }
@@ -159,7 +171,9 @@ extension TracedTPartial: ComonadEnv where W: ComonadEnv, M: Monoid {
         wa^.lower().ask()
     }
     
-    public static func local<A>(_ wa: TracedTOf<M, W, A>, _ f: @escaping (W.E) -> W.E) -> TracedTOf<M, W, A> {
+    public static func local<A>(
+        _ wa: TracedTOf<M, W, A>,
+        _ f: @escaping (W.E) -> W.E) -> TracedTOf<M, W, A> {
         TracedT(wa^.value.local(f))
     }
 }

--- a/Sources/Bow/Transformers/WriterT.swift
+++ b/Sources/Bow/Transformers/WriterT.swift
@@ -86,7 +86,7 @@ extension WriterT where F: Functor {
     }
 }
 
-// MARK: Functions for WriterT when the effect has an instance of Functor and the accumulator type has an instance of `Monoid`
+// MARK: Functions for WriterT when the effect has an instance of Functor and the accumulator type has an instance of Monoid
 extension WriterT where F: Functor, W: Monoid {
     /// Lifts an effect to a `WriterT` using the empty value of the `Monoid` as the accumulator.
     ///
@@ -238,7 +238,9 @@ extension WriterT where F: Monad, W: Monoid {
 
 // MARK: Instance of EquatableK for WriterT
 extension WriterTPartial: EquatableK where F: EquatableK & Functor, W: Equatable {
-    public static func eq<A: Equatable>(_ lhs: WriterTOf<F, W, A>, _ rhs: WriterTOf<F, W, A>) -> Bool {
+    public static func eq<A: Equatable>(
+        _ lhs: WriterTOf<F, W, A>,
+        _ rhs: WriterTOf<F, W, A>) -> Bool {
         let wl0 = lhs^.value.map { t in t.0 }
         let wl1 = lhs^.value.map { t in t.1 }
         let wr0 = rhs^.value.map { t in t.0 }
@@ -252,7 +254,9 @@ extension WriterTPartial: Invariant where F: Functor {}
 
 // MARK: Instance of Functor for WriterT
 extension WriterTPartial: Functor where F: Functor {
-    public static func map<A, B>(_ fa: WriterTOf<F, W, A>, _ f: @escaping (A) -> B) -> WriterTOf<F, W, B> {
+    public static func map<A, B>(
+        _ fa: WriterTOf<F, W, A>,
+        _ f: @escaping (A) -> B) -> WriterTOf<F, W, B> {
         WriterT(fa^.value.map { pair in (pair.0, f(pair.1)) })
     }
 }
@@ -269,7 +273,9 @@ extension WriterTPartial: Selective where F: Monad, W: Monoid {}
 
 // MARK: Instance of Monad for WriterT
 extension WriterTPartial: Monad where F: Monad, W: Monoid {
-    public static func flatMap<A, B>(_ fa: WriterTOf<F, W, A>, _ f: @escaping (A) -> WriterTOf<F, W, B>) -> WriterTOf<F, W, B> {
+    public static func flatMap<A, B>(
+        _ fa: WriterTOf<F, W, A>,
+        _ f: @escaping (A) -> WriterTOf<F, W, B>) -> WriterTOf<F, W, B> {
         WriterT(fa^.value.flatMap { pair in
             f(pair.1)^.value.map { pair2 in
                 (pair.0.combine(pair2.0), pair2.1)
@@ -277,7 +283,9 @@ extension WriterTPartial: Monad where F: Monad, W: Monoid {
         })
     }
 
-    public static func tailRecM<A, B>(_ a: A, _ f: @escaping (A) -> WriterTOf<F, W, Either<A, B>>) -> WriterTOf<F, W, B> {
+    public static func tailRecM<A, B>(
+        _ a: A,
+        _ f: @escaping (A) -> WriterTOf<F, W, Either<A, B>>) -> WriterTOf<F, W, B> {
         WriterT(F.tailRecM(a, { inA in
             f(inA)^.value.map { pair in
                 pair.1.fold(Either.left,
@@ -299,7 +307,9 @@ extension WriterTPartial: MonadFilter where F: MonadFilter, W: Monoid {
 
 // MARK: Instance of SemigroupK for WriterT
 extension WriterTPartial: SemigroupK where F: SemigroupK {
-    public static func combineK<A>(_ x: WriterTOf<F, W, A>, _ y: WriterTOf<F, W, A>) -> WriterTOf<F, W, A> {
+    public static func combineK<A>(
+        _ x: WriterTOf<F, W, A>,
+        _ y: WriterTOf<F, W, A>) -> WriterTOf<F, W, A> {
         WriterT(x^.value.combineK(y^.value))
     }
 }
@@ -360,7 +370,9 @@ extension WriterTPartial: MonadReader where F: MonadReader, W: Monoid {
         WriterT.liftF(F.ask())
     }
     
-    public static func local<A>(_ fa: WriterTOf<F, W, A>, _ f: @escaping (F.D) -> F.D) -> WriterTOf<F, W, A> {
+    public static func local<A>(
+        _ fa: WriterTOf<F, W, A>,
+        _ f: @escaping (F.D) -> F.D) -> WriterTOf<F, W, A> {
         fa^.transformT { a in F.local(a, f) }
     }
 }


### PR DESCRIPTION
## Goal

Cleanup code in the Transformers folder in the Core module by:

- Using `FOf<A>` instead of `Kind<F, A>`.
- Removing backticks in `MARK` sections as they do not render properly in Jazzy.
- Removing returns.
- Replacing `fix` by `^`.