### PR TITLE
Cleanup Typeclasses folder in Core module

### DIFF
--- a/Sources/Bow/Typeclasses/Applicative.swift
+++ b/Sources/Bow/Typeclasses/Applicative.swift
@@ -43,8 +43,10 @@ public extension Applicative {
     ///   - fa: 1st computation.
     ///   - fb: 2nd computation.
     /// - Returns: Result of running the second computation after the first one.
-    static func sequenceRight<A, B>(_ fa: Kind<Self, A>, _ fb: Kind<Self, B>) -> Kind<Self, B> {
-        return map(fa, fb) { _, b in b }
+    static func zipRight<A, B>(
+        _ fa: Kind<Self, A>,
+        _ fb: Kind<Self, B>) -> Kind<Self, B> {
+        map(fa, fb) { _, b in b }
     }
 
     /// Sequentially compose two computations, discarding the value produced by the second.
@@ -53,8 +55,10 @@ public extension Applicative {
     ///   - fa: 1st computation.
     ///   - fb: 2nd computation.
     /// - Returns: Result produced from the first computation after both are computed.
-    static func sequenceLeft<A, B>(_ fa: Kind<Self, A>, _ fb: Kind<Self, B>) -> Kind<Self, A> {
-        return map(fa, fb) { a, _ in a }
+    static func zipLeft<A, B>(
+        _ fa: Kind<Self, A>,
+        _ fb: Kind<Self, B>) -> Kind<Self, A> {
+        map(fa, fb) { a, _ in a }
     }
 
     /// Creates a tuple in the context implementing this instance from two values in the same context.
@@ -63,8 +67,10 @@ public extension Applicative {
     ///   - fa: 1st value for the tuple.
     ///   - fb: 2nd value for the tuple.
     /// - Returns: A tuple of the provided values in the context implementing this instance.
-    static func product<A, B>(_ fa: Kind<Self, A>, _ fb: Kind<Self, B>) -> Kind<Self, (A, B)> {
-        return ap(map(fa, { (a: A) in { (b: B) in (a, b) }}), fb)
+    static func product<A, B>(
+        _ fa: Kind<Self, A>,
+        _ fb: Kind<Self, B>) -> Kind<Self, (A, B)> {
+        ap(map(fa, { (a: A) in { (b: B) in (a, b) }}), fb)
     }
 
     /// Adds an element to the right of a tuple in the context implementing this instance.
@@ -73,8 +79,10 @@ public extension Applicative {
     ///   - fa: A tuple of two elements in the context implementing this instance.
     ///   - fz: A value in the context implementing this instance.
     /// - Returns: A tuple with the value of the second argument added to the right of the tuple, in the context implementing this instance.
-    static func product<A, B, Z>(_ fa: Kind<Self, (A, B)>, _ fz: Kind<Self, Z>) -> Kind<Self, (A, B, Z)> {
-        return map(product(fa, fz), { a, b in (a.0, a.1, b) })
+    static func product<A, B, Z>(
+        _ fa: Kind<Self, (A, B)>,
+        _ fz: Kind<Self, Z>) -> Kind<Self, (A, B, Z)> {
+        map(product(fa, fz), { a, b in (a.0, a.1, b) })
     }
 
     /// Adds an element to the right of a tuple in the context implementing this instance.
@@ -83,8 +91,10 @@ public extension Applicative {
     ///   - fa: A tuple of three elements in the context implementing this instance.
     ///   - fz: A value in the context implementing this instance.
     /// - Returns: A tuple with the value of the second argument added to the right of the tuple, in the context implementing this instance.
-    static func product<A, B, C, Z>(_ fa: Kind<Self, (A, B, C)>, _ fz: Kind<Self, Z>) -> Kind<Self, (A, B, C, Z)> {
-        return map(product(fa, fz), { a, b in (a.0, a.1, a.2, b) })
+    static func product<A, B, C, Z>(
+        _ fa: Kind<Self, (A, B, C)>,
+        _ fz: Kind<Self, Z>) -> Kind<Self, (A, B, C, Z)> {
+        map(product(fa, fz), { a, b in (a.0, a.1, a.2, b) })
     }
 
     /// Adds an element to the right of a tuple in the context implementing this instance.
@@ -93,8 +103,10 @@ public extension Applicative {
     ///   - fa: A tuple of four elements in the context implementing this instance.
     ///   - fz: A value in the context implementing this instance.
     /// - Returns: A tuple with the value of the second argument added to the right of the tuple, in the context implementing this instance.
-    static func product<A, B, C, D, Z>(_ fa: Kind<Self, (A, B, C, D)>, _ fz: Kind<Self, Z>) -> Kind<Self, (A, B, C, D, Z)> {
-        return map(product(fa, fz), { a, b in (a.0, a.1, a.2, a.3, b) })
+    static func product<A, B, C, D, Z>(
+        _ fa: Kind<Self, (A, B, C, D)>,
+        _ fz: Kind<Self, Z>) -> Kind<Self, (A, B, C, D, Z)> {
+        map(product(fa, fz), { a, b in (a.0, a.1, a.2, a.3, b) })
     }
 
     /// Adds an element to the right of a tuple in the context implementing this instance.
@@ -103,8 +115,10 @@ public extension Applicative {
     ///   - fa: A tuple of five elements in the context implementing this instance.
     ///   - fz: A value in the context implementing this instance.
     /// - Returns: A tuple with the value of the second argument added to the right of the tuple, in the context implementing this instance.
-    static func product<A, B, C, D, E, Z>(_ fa: Kind<Self, (A, B, C, D, E)>, _ fz: Kind<Self, Z>) -> Kind<Self, (A, B, C, D, E, Z)> {
-        return map(product(fa, fz), { a, b in (a.0, a.1, a.2, a.3, a.4, b) })
+    static func product<A, B, C, D, E, Z>(
+        _ fa: Kind<Self, (A, B, C, D, E)>,
+        _ fz: Kind<Self, Z>) -> Kind<Self, (A, B, C, D, E, Z)> {
+        map(product(fa, fz), { a, b in (a.0, a.1, a.2, a.3, a.4, b) })
     }
 
     /// Adds an element to the right of a tuple in the context implementing this instance.
@@ -113,8 +127,10 @@ public extension Applicative {
     ///   - fa: A tuple of six elements in the context implementing this instance.
     ///   - fz: A value in the context implementing this instance.
     /// - Returns: A tuple with the value of the second argument added to the right of the tuple, in the context implementing this instance.
-    static func product<A, B, C, D, E, G, Z>(_ fa: Kind<Self, (A, B, C, D, E, G)>, _ fz: Kind<Self, Z>) -> Kind<Self, (A, B, C, D, E, G, Z)> {
-        return map(product(fa, fz), { a, b in (a.0, a.1, a.2, a.3, a.4, a.5, b) })
+    static func product<A, B, C, D, E, G, Z>(
+        _ fa: Kind<Self, (A, B, C, D, E, G)>,
+        _ fz: Kind<Self, Z>) -> Kind<Self, (A, B, C, D, E, G, Z)> {
+        map(product(fa, fz), { a, b in (a.0, a.1, a.2, a.3, a.4, a.5, b) })
     }
 
     /// Adds an element to the right of a tuple in the context implementing this instance.
@@ -123,8 +139,10 @@ public extension Applicative {
     ///   - fa: A tuple of seven elements in the context implementing this instance.
     ///   - fz: A value in the context implementing this instance.
     /// - Returns: A tuple with the value of the second argument added to the right of the tuple, in the context implementing this instance.
-    static func product<A, B, C, D, E, G, H, Z>(_ fa: Kind<Self, (A, B, C, D, E, G, H)>, _ fz: Kind<Self, Z>) -> Kind<Self, (A, B, C, D, E, G, H, Z)> {
-        return map(product(fa, fz), { a, b in (a.0, a.1, a.2, a.3, a.4, a.5, a.6, b) })
+    static func product<A, B, C, D, E, G, H, Z>(
+        _ fa: Kind<Self, (A, B, C, D, E, G, H)>,
+        _ fz: Kind<Self, Z>) -> Kind<Self, (A, B, C, D, E, G, H, Z)> {
+        map(product(fa, fz), { a, b in (a.0, a.1, a.2, a.3, a.4, a.5, a.6, b) })
     }
 
     /// Adds an element to the right of a tuple in the context implementing this instance.
@@ -133,8 +151,10 @@ public extension Applicative {
     ///   - fa: A tuple of eight elements in the context implementing this instance.
     ///   - fz: A value in the context implementing this instance.
     /// - Returns: A tuple with the value of the second argument added to the right of the tuple, in the context implementing this instance.
-    static func product<A, B, C, D, E, G, H, I, Z>(_ fa: Kind<Self, (A, B, C, D, E, G, H, I)>, _ fz: Kind<Self, Z>) -> Kind<Self, (A, B, C, D, E, G, H, I, Z)> {
-        return map(product(fa, fz), { a, b in (a.0, a.1, a.2, a.3, a.4, a.5, a.6, a.7, b) })
+    static func product<A, B, C, D, E, G, H, I, Z>(
+        _ fa: Kind<Self, (A, B, C, D, E, G, H, I)>,
+        _ fz: Kind<Self, Z>) -> Kind<Self, (A, B, C, D, E, G, H, I, Z)> {
+        map(product(fa, fz), { a, b in (a.0, a.1, a.2, a.3, a.4, a.5, a.6, a.7, b) })
     }
 
     /// Performs two computations in the context implementing this instance and combines their result using the provided function.
@@ -144,8 +164,11 @@ public extension Applicative {
     ///   - fb: A lazy value in the context implementing this instance.
     ///   - f: A function to combine the result of the computations.
     /// - Returns: A lazy value with the result of combining the results of each computation.
-    static func map2Eval<A, B, Z>(_ fa: Kind<Self, A>, _ fb: Eval<Kind<Self, B>>, _ f: @escaping (A, B) -> Z) -> Eval<Kind<Self, Z>> {
-        return Eval.fix(fb.map{ fc in map(fa, fc, f) })
+    static func map2Eval<A, B, Z>(
+        _ fa: Kind<Self, A>,
+        _ fb: Eval<Kind<Self, B>>,
+        _ f: @escaping (A, B) -> Z) -> Eval<Kind<Self, Z>> {
+        fb.map { fc in map(fa, fc, f) }^
     }
 
     /// Creates a tuple out of two values in the context implementing this instance.
@@ -154,9 +177,10 @@ public extension Applicative {
     ///   - a: 1st value of the tuple.
     ///   - b: 2nd value of the tuple.
     /// - Returns: A tuple in the context implementing this instance.
-    static func zip<A, B>(_ a: Kind<Self, A>,
-                             _ b : Kind<Self, B>) -> Kind<Self, (A, B)> {
-        return product(a, b)
+    static func zip<A, B>(
+        _ a: Kind<Self, A>,
+        _ b : Kind<Self, B>) -> Kind<Self, (A, B)> {
+        product(a, b)
     }
 
     /// Creates a tuple out of three values in the context implementing this instance.
@@ -166,10 +190,11 @@ public extension Applicative {
     ///   - b: 2nd value of the tuple.
     ///   - c: 3rd value of the tuple.
     /// - Returns: A tuple in the context implementing this instance.
-    static func zip<A, B, C>(_ a: Kind<Self, A>,
-                                _ b: Kind<Self, B>,
-                                _ c: Kind<Self, C>) -> Kind<Self, (A, B, C)> {
-        return product(product(a, b), c)
+    static func zip<A, B, C>(
+        _ a: Kind<Self, A>,
+        _ b: Kind<Self, B>,
+        _ c: Kind<Self, C>) -> Kind<Self, (A, B, C)> {
+        product(product(a, b), c)
     }
 
     /// Creates a tuple out of four values in the context implementing this instance.
@@ -180,11 +205,12 @@ public extension Applicative {
     ///   - c: 3rd value of the tuple.
     ///   - d: 4th value of the tuple.
     /// - Returns: A tuple in the context implementing this instance.
-    static func zip<A, B, C, D>(_ a: Kind<Self, A>,
-                                   _ b: Kind<Self, B>,
-                                   _ c: Kind<Self, C>,
-                                   _ d: Kind<Self, D>) -> Kind<Self, (A, B, C, D)> {
-        return product(product(product(a, b), c), d)
+    static func zip<A, B, C, D>(
+        _ a: Kind<Self, A>,
+        _ b: Kind<Self, B>,
+        _ c: Kind<Self, C>,
+        _ d: Kind<Self, D>) -> Kind<Self, (A, B, C, D)> {
+        product(product(product(a, b), c), d)
     }
 
     /// Creates a tuple out of five values in the context implementing this instance.
@@ -196,12 +222,13 @@ public extension Applicative {
     ///   - d: 4th value of the tuple.
     ///   - e: 5th value of the tuple.
     /// - Returns: A tuple in the context implementing this instance.
-    static func zip<A, B, C, D, E>(_ a: Kind<Self, A>,
-                                      _ b: Kind<Self, B>,
-                                      _ c: Kind<Self, C>,
-                                      _ d: Kind<Self, D>,
-                                      _ e: Kind<Self, E>) -> Kind<Self, (A, B, C, D, E)> {
-        return product(product(product(product(a, b), c), d), e)
+    static func zip<A, B, C, D, E>(
+        _ a: Kind<Self, A>,
+        _ b: Kind<Self, B>,
+        _ c: Kind<Self, C>,
+        _ d: Kind<Self, D>,
+        _ e: Kind<Self, E>) -> Kind<Self, (A, B, C, D, E)> {
+        product(product(product(product(a, b), c), d), e)
     }
 
     /// Creates a tuple out of six values in the context implementing this instance.
@@ -214,13 +241,14 @@ public extension Applicative {
     ///   - e: 5th value of the tuple.
     ///   - g: 6th value of the tuple.
     /// - Returns: A tuple in the context implementing this instance.
-    static func zip<A, B, C, D, E, G>(_ a: Kind<Self, A>,
-                                         _ b: Kind<Self, B>,
-                                         _ c: Kind<Self, C>,
-                                         _ d: Kind<Self, D>,
-                                         _ e: Kind<Self, E>,
-                                         _ g: Kind<Self, G>) -> Kind<Self, (A, B, C, D, E, G)> {
-        return product(product(product(product(product(a, b), c), d), e), g)
+    static func zip<A, B, C, D, E, G>(
+        _ a: Kind<Self, A>,
+        _ b: Kind<Self, B>,
+        _ c: Kind<Self, C>,
+        _ d: Kind<Self, D>,
+        _ e: Kind<Self, E>,
+        _ g: Kind<Self, G>) -> Kind<Self, (A, B, C, D, E, G)> {
+        product(product(product(product(product(a, b), c), d), e), g)
     }
 
     /// Creates a tuple out of seven values in the context implementing this instance.
@@ -234,14 +262,15 @@ public extension Applicative {
     ///   - g: 6th value of the tuple.
     ///   - h: 7th value of the tuple.
     /// - Returns: A tuple in the context implementing this instance.
-    static func zip<A, B, C, D, E, G, H>(_ a: Kind<Self, A>,
-                                            _ b: Kind<Self, B>,
-                                            _ c: Kind<Self, C>,
-                                            _ d: Kind<Self, D>,
-                                            _ e: Kind<Self, E>,
-                                            _ g: Kind<Self, G>,
-                                            _ h: Kind<Self, H>) -> Kind<Self, (A, B, C, D, E, G, H)> {
-        return product(product(product(product(product(product(a, b), c), d), e), g), h)
+    static func zip<A, B, C, D, E, G, H>(
+        _ a: Kind<Self, A>,
+        _ b: Kind<Self, B>,
+        _ c: Kind<Self, C>,
+        _ d: Kind<Self, D>,
+        _ e: Kind<Self, E>,
+        _ g: Kind<Self, G>,
+        _ h: Kind<Self, H>) -> Kind<Self, (A, B, C, D, E, G, H)> {
+        product(product(product(product(product(product(a, b), c), d), e), g), h)
     }
 
     /// Creates a tuple out of eight values in the context implementing this instance.
@@ -256,15 +285,16 @@ public extension Applicative {
     ///   - h: 7th value of the tuple.
     ///   - i: 8th value of the tuple.
     /// - Returns: A tuple in the context implementing this instance.
-    static func zip<A, B, C, D, E, G, H, I>(_ a: Kind<Self, A>,
-                                               _ b: Kind<Self, B>,
-                                               _ c: Kind<Self, C>,
-                                               _ d: Kind<Self, D>,
-                                               _ e: Kind<Self, E>,
-                                               _ g: Kind<Self, G>,
-                                               _ h: Kind<Self, H>,
-                                               _ i: Kind<Self, I>) -> Kind<Self, (A, B, C, D, E, G, H, I)> {
-        return product(product(product(product(product(product(product(a, b), c), d), e), g), h), i)
+    static func zip<A, B, C, D, E, G, H, I>(
+        _ a: Kind<Self, A>,
+        _ b: Kind<Self, B>,
+        _ c: Kind<Self, C>,
+        _ d: Kind<Self, D>,
+        _ e: Kind<Self, E>,
+        _ g: Kind<Self, G>,
+        _ h: Kind<Self, H>,
+        _ i: Kind<Self, I>) -> Kind<Self, (A, B, C, D, E, G, H, I)> {
+        product(product(product(product(product(product(product(a, b), c), d), e), g), h), i)
     }
 
     /// Creates a tuple out of nine values in the context implementing this instance.
@@ -280,16 +310,17 @@ public extension Applicative {
     ///   - i: 8th value of the tuple.
     ///   - j: 9th value of the tuple.
     /// - Returns: A tuple in the context implementing this instance.
-    static func zip<A, B, C, D, E, G, H, I, J>(_ a: Kind<Self, A>,
-                                                  _ b: Kind<Self, B>,
-                                                  _ c: Kind<Self, C>,
-                                                  _ d: Kind<Self, D>,
-                                                  _ e: Kind<Self, E>,
-                                                  _ g: Kind<Self, G>,
-                                                  _ h: Kind<Self, H>,
-                                                  _ i: Kind<Self, I>,
-                                                  _ j: Kind<Self, J>) -> Kind<Self, (A, B, C, D, E, G, H, I, J)> {
-        return product(product(product(product(product(product(product(product(a, b), c), d), e), g), h), i), j)
+    static func zip<A, B, C, D, E, G, H, I, J>(
+        _ a: Kind<Self, A>,
+        _ b: Kind<Self, B>,
+        _ c: Kind<Self, C>,
+        _ d: Kind<Self, D>,
+        _ e: Kind<Self, E>,
+        _ g: Kind<Self, G>,
+        _ h: Kind<Self, H>,
+        _ i: Kind<Self, I>,
+        _ j: Kind<Self, J>) -> Kind<Self, (A, B, C, D, E, G, H, I, J)> {
+        product(product(product(product(product(product(product(product(a, b), c), d), e), g), h), i), j)
     }
 
     /// Combines the result of two computations in the context implementing this instance, using the provided function.
@@ -299,10 +330,11 @@ public extension Applicative {
     ///   - b: 2nd computation.
     ///   - f: Combination function.
     /// - Returns: Result of combining the provided computations, in the context implementing this instance.
-    static func map<A, B, Z>(_ a: Kind<Self, A>,
-                             _ b: Kind<Self, B>,
-                             _ f: @escaping (A, B) -> Z) -> Kind<Self, Z> {
-        return map(zip(a, b), f)
+    static func map<A, B, Z>(
+        _ a: Kind<Self, A>,
+        _ b: Kind<Self, B>,
+        _ f: @escaping (A, B) -> Z) -> Kind<Self, Z> {
+        map(zip(a, b), f)
     }
 
     /// Combines the result of three computations in the context implementing this instance, using the provided function.
@@ -313,11 +345,12 @@ public extension Applicative {
     ///   - c: 3rd computation.
     ///   - f: Combination function.
     /// - Returns: Result of combining the provided computations, in the context implementing this instance.
-    static func map<A, B, C, Z>(_ a: Kind<Self, A>,
-                                _ b: Kind<Self, B>,
-                                _ c: Kind<Self, C>,
-                                _ f: @escaping (A, B, C) -> Z) -> Kind<Self, Z> {
-        return map(zip(a, b, c), f)
+    static func map<A, B, C, Z>(
+        _ a: Kind<Self, A>,
+        _ b: Kind<Self, B>,
+        _ c: Kind<Self, C>,
+        _ f: @escaping (A, B, C) -> Z) -> Kind<Self, Z> {
+        map(zip(a, b, c), f)
     }
 
     /// Combines the result of four computations in the context implementing this instance, using the provided function.
@@ -329,12 +362,13 @@ public extension Applicative {
     ///   - d: 4th computation.
     ///   - f: Combination function.
     /// - Returns: Result of combining the provided computations, in the context implementing this instance.
-    static func map<A, B, C, D, Z>(_ a: Kind<Self, A>,
-                                   _ b: Kind<Self, B>,
-                                   _ c: Kind<Self, C>,
-                                   _ d: Kind<Self, D>,
-                                   _ f: @escaping (A, B, C, D) -> Z) -> Kind<Self, Z> {
-        return map(zip(a, b, c, d), f)
+    static func map<A, B, C, D, Z>(
+        _ a: Kind<Self, A>,
+        _ b: Kind<Self, B>,
+        _ c: Kind<Self, C>,
+        _ d: Kind<Self, D>,
+        _ f: @escaping (A, B, C, D) -> Z) -> Kind<Self, Z> {
+        map(zip(a, b, c, d), f)
     }
 
     /// Combines the result of five computations in the context implementing this instance, using the provided function.
@@ -347,13 +381,14 @@ public extension Applicative {
     ///   - e: 5th computation.
     ///   - f: Combination function.
     /// - Returns: Result of combining the provided computations, in the context implementing this instance.
-    static func map<A, B, C, D, E, Z>(_ a: Kind<Self, A>,
-                                      _ b: Kind<Self, B>,
-                                      _ c: Kind<Self, C>,
-                                      _ d: Kind<Self, D>,
-                                      _ e: Kind<Self, E>,
-                                      _ f: @escaping (A, B, C, D, E) -> Z) -> Kind<Self, Z> {
-        return map(zip(a, b, c, d, e), f)
+    static func map<A, B, C, D, E, Z>(
+        _ a: Kind<Self, A>,
+        _ b: Kind<Self, B>,
+        _ c: Kind<Self, C>,
+        _ d: Kind<Self, D>,
+        _ e: Kind<Self, E>,
+        _ f: @escaping (A, B, C, D, E) -> Z) -> Kind<Self, Z> {
+        map(zip(a, b, c, d, e), f)
     }
 
     /// Combines the result of six computations in the context implementing this instance, using the provided function.
@@ -367,14 +402,15 @@ public extension Applicative {
     ///   - g: 6th computation.
     ///   - f: Combination function.
     /// - Returns: Result of combining the provided computations, in the context implementing this instance.
-    static func map<A, B, C, D, E, G, Z>(_ a: Kind<Self, A>,
-                                         _ b: Kind<Self, B>,
-                                         _ c: Kind<Self, C>,
-                                         _ d: Kind<Self, D>,
-                                         _ e: Kind<Self, E>,
-                                         _ g: Kind<Self, G>,
-                                         _ f: @escaping (A, B, C, D, E, G) -> Z) -> Kind<Self, Z> {
-        return map(zip(a, b, c, d, e, g), f)
+    static func map<A, B, C, D, E, G, Z>(
+        _ a: Kind<Self, A>,
+        _ b: Kind<Self, B>,
+        _ c: Kind<Self, C>,
+        _ d: Kind<Self, D>,
+        _ e: Kind<Self, E>,
+        _ g: Kind<Self, G>,
+        _ f: @escaping (A, B, C, D, E, G) -> Z) -> Kind<Self, Z> {
+        map(zip(a, b, c, d, e, g), f)
     }
 
     /// Combines the result of seven computations in the context implementing this instance, using the provided function.
@@ -389,15 +425,16 @@ public extension Applicative {
     ///   - h: 7th computation.
     ///   - f: Combination function.
     /// - Returns: Result of combining the provided computations, in the context implementing this instance.
-    static func map<A, B, C, D, E, G, H, Z>(_ a: Kind<Self, A>,
-                                            _ b: Kind<Self, B>,
-                                            _ c: Kind<Self, C>,
-                                            _ d: Kind<Self, D>,
-                                            _ e: Kind<Self, E>,
-                                            _ g: Kind<Self, G>,
-                                            _ h: Kind<Self, H>,
-                                            _ f: @escaping (A, B, C, D, E, G, H) -> Z) -> Kind<Self, Z> {
-        return map(zip(a, b, c, d, e, g, h), f)
+    static func map<A, B, C, D, E, G, H, Z>(
+        _ a: Kind<Self, A>,
+        _ b: Kind<Self, B>,
+        _ c: Kind<Self, C>,
+        _ d: Kind<Self, D>,
+        _ e: Kind<Self, E>,
+        _ g: Kind<Self, G>,
+        _ h: Kind<Self, H>,
+        _ f: @escaping (A, B, C, D, E, G, H) -> Z) -> Kind<Self, Z> {
+        map(zip(a, b, c, d, e, g, h), f)
     }
 
     /// Combines the result of eight computations in the context implementing this instance, using the provided function.
@@ -413,16 +450,17 @@ public extension Applicative {
     ///   - i: 8th computation.
     ///   - f: Combination function.
     /// - Returns: Result of combining the provided computations, in the context implementing this instance.
-    static func map<A, B, C, D, E, G, H, I, Z>(_ a: Kind<Self, A>,
-                                               _ b: Kind<Self, B>,
-                                               _ c: Kind<Self, C>,
-                                               _ d: Kind<Self, D>,
-                                               _ e: Kind<Self, E>,
-                                               _ g: Kind<Self, G>,
-                                               _ h: Kind<Self, H>,
-                                               _ i: Kind<Self, I>,
-                                               _ f: @escaping (A, B, C, D, E, G, H, I) -> Z) -> Kind<Self, Z> {
-        return map(zip(a, b, c, d, e, g, h, i), f)
+    static func map<A, B, C, D, E, G, H, I, Z>(
+        _ a: Kind<Self, A>,
+        _ b: Kind<Self, B>,
+        _ c: Kind<Self, C>,
+        _ d: Kind<Self, D>,
+        _ e: Kind<Self, E>,
+        _ g: Kind<Self, G>,
+        _ h: Kind<Self, H>,
+        _ i: Kind<Self, I>,
+        _ f: @escaping (A, B, C, D, E, G, H, I) -> Z) -> Kind<Self, Z> {
+        map(zip(a, b, c, d, e, g, h, i), f)
     }
 
     /// Combines the result of nine computations in the context implementing this instance, using the provided function.
@@ -439,17 +477,18 @@ public extension Applicative {
     ///   - j: 9th computation.
     ///   - f: Combination function.
     /// - Returns: Result of combining the provided computations, in the context implementing this instance.
-    static func map<A, B, C, D, E, G, H, I, J, Z>(_ a: Kind<Self, A>,
-                                                  _ b: Kind<Self, B>,
-                                                  _ c: Kind<Self, C>,
-                                                  _ d: Kind<Self, D>,
-                                                  _ e: Kind<Self, E>,
-                                                  _ g: Kind<Self, G>,
-                                                  _ h: Kind<Self, H>,
-                                                  _ i: Kind<Self, I>,
-                                                  _ j: Kind<Self, J>,
-                                                  _ f: @escaping (A, B, C, D, E, G, H, I, J) -> Z) -> Kind<Self, Z> {
-        return map(zip(a, b, c, d, e, g, h, i, j), f)
+    static func map<A, B, C, D, E, G, H, I, J, Z>(
+        _ a: Kind<Self, A>,
+        _ b: Kind<Self, B>,
+        _ c: Kind<Self, C>,
+        _ d: Kind<Self, D>,
+        _ e: Kind<Self, E>,
+        _ g: Kind<Self, G>,
+        _ h: Kind<Self, H>,
+        _ i: Kind<Self, I>,
+        _ j: Kind<Self, J>,
+        _ f: @escaping (A, B, C, D, E, G, H, I, J) -> Z) -> Kind<Self, Z> {
+        map(zip(a, b, c, d, e, g, h, i, j), f)
     }
 }
 
@@ -462,7 +501,7 @@ public extension Kind where F: Applicative {
     /// - Parameter a: Value to be lifted.
     /// - Returns: Provided value in the context type implementing this instance.
     static func pure(_ a: A) -> Kind<F, A> {
-        return F.pure(a)
+        F.pure(a)
     }
 
     /// Sequential application.
@@ -473,7 +512,25 @@ public extension Kind where F: Applicative {
     ///   - fa: A value in the context implementing this instance.
     /// - Returns: A value in the context implementing this instance, resulting of the transformation of the contained original value with the contained function.
     func ap<AA, B>(_ fa: Kind<F, AA>) -> Kind<F, B> where A == (AA) -> B {
-        return F.ap(self, fa)
+        F.ap(self, fa)
+    }
+    
+    /// Sequentially compose with another computation, discarding the value produced by this computation.
+    ///
+    /// - Parameters:
+    ///   - fb: Another computation.
+    /// - Returns: Result of running the second computation after the first one.
+    func zipRight<B>(_ fb: Kind<F, B>) -> Kind<F, B> {
+        F.zipRight(self, fb)
+    }
+
+    /// Sequentially compose with another computation, discarding the value produced by the provided computation.
+    ///
+    /// - Parameters:
+    ///   - fb: 2nd computation.
+    /// - Returns: Result produced from this computation after both are computed.
+    func zipLeft<B>(_ fb: Kind<F, B>) -> Kind<F, A> {
+        F.zipLeft(self, fb)
     }
 
     /// Creates a tuple in the context implementing this instance from two values in the same context.
@@ -484,8 +541,11 @@ public extension Kind where F: Applicative {
     ///   - fa: 1st value for the tuple.
     ///   - fb: 2nd value for the tuple.
     /// - Returns: A tuple of the provided values in the context implementing this instance.
-    static func product<AA, B>(_ fa: Kind<F, AA>, _ fb: Kind<F, B>) -> Kind<F, (AA, B)> where A == (AA, B) {
-        return F.product(fa, fb)
+    static func product<AA, B>(
+        _ fa: Kind<F, AA>,
+        _ fb: Kind<F, B>) -> Kind<F, (AA, B)>
+        where A == (AA, B) {
+        F.product(fa, fb)
     }
 
     /// Adds an element to the right of a tuple in the context implementing this instance.
@@ -496,8 +556,11 @@ public extension Kind where F: Applicative {
     ///   - fa: A tuple of two elements in the context implementing this instance.
     ///   - fz: A value in the context implementing this instance.
     /// - Returns: A tuple with the value of the second argument added to the right of the tuple, in the context implementing this instance.
-    static func product<AA, B, Z>(_ fa: Kind<F, (AA, B)>, _ fz: Kind<F, Z>) -> Kind<F, (AA, B, Z)> where A == (AA, B, Z) {
-        return F.product(fa, fz)
+    static func product<AA, B, Z>(
+        _ fa: Kind<F, (AA, B)>,
+        _ fz: Kind<F, Z>) -> Kind<F, (AA, B, Z)>
+        where A == (AA, B, Z) {
+        F.product(fa, fz)
     }
 
     /// Adds an element to the right of a tuple in the context implementing this instance.
@@ -508,8 +571,11 @@ public extension Kind where F: Applicative {
     ///   - fa: A tuple of three elements in the context implementing this instance.
     ///   - fz: A value in the context implementing this instance.
     /// - Returns: A tuple with the value of the second argument added to the right of the tuple, in the context implementing this instance.
-    static func product<AA, B, C, Z>(_ fa: Kind<F, (AA, B, C)>, _ fz: Kind<F, Z>) -> Kind<F, (AA, B, C, Z)> where A == (AA, B, C, Z) {
-        return F.product(fa, fz)
+    static func product<AA, B, C, Z>(
+        _ fa: Kind<F, (AA, B, C)>,
+        _ fz: Kind<F, Z>) -> Kind<F, (AA, B, C, Z)>
+        where A == (AA, B, C, Z) {
+        F.product(fa, fz)
     }
 
     /// Adds an element to the right of a tuple in the context implementing this instance.
@@ -520,8 +586,11 @@ public extension Kind where F: Applicative {
     ///   - fa: A tuple of four elements in the context implementing this instance.
     ///   - fz: A value in the context implementing this instance.
     /// - Returns: A tuple with the value of the second argument added to the right of the tuple, in the context implementing this instance.
-    static func product<AA, B, C, D, Z>(_ fa: Kind<F, (AA, B, C, D)>, _ fz: Kind<F, Z>) -> Kind<F, (AA, B, C, D, Z)> where A == (AA, B, C, D, Z) {
-        return F.product(fa, fz)
+    static func product<AA, B, C, D, Z>(
+        _ fa: Kind<F, (AA, B, C, D)>,
+        _ fz: Kind<F, Z>) -> Kind<F, (AA, B, C, D, Z)>
+        where A == (AA, B, C, D, Z) {
+        F.product(fa, fz)
     }
 
     /// Adds an element to the right of a tuple in the context implementing this instance.
@@ -532,8 +601,11 @@ public extension Kind where F: Applicative {
     ///   - fa: A tuple of five elements in the context implementing this instance.
     ///   - fz: A value in the context implementing this instance.
     /// - Returns: A tuple with the value of the second argument added to the right of the tuple, in the context implementing this instance.
-    static func product<AA, B, C, D, E, Z>(_ fa: Kind<F, (AA, B, C, D, E)>, _ fz: Kind<F, Z>) -> Kind<F, (AA, B, C, D, E, Z)> where A == (AA, B, C, D, E, Z) {
-        return F.product(fa, fz)
+    static func product<AA, B, C, D, E, Z>(
+        _ fa: Kind<F, (AA, B, C, D, E)>,
+        _ fz: Kind<F, Z>) -> Kind<F, (AA, B, C, D, E, Z)>
+        where A == (AA, B, C, D, E, Z) {
+        F.product(fa, fz)
     }
 
     /// Adds an element to the right of a tuple in the context implementing this instance.
@@ -544,8 +616,11 @@ public extension Kind where F: Applicative {
     ///   - fa: A tuple of six elements in the context implementing this instance.
     ///   - fz: A value in the context implementing this instance.
     /// - Returns: A tuple with the value of the second argument added to the right of the tuple, in the context implementing this instance.
-    static func product<AA, B, C, D, E, G, Z>(_ fa: Kind<F, (AA, B, C, D, E, G)>, _ fz: Kind<F, Z>) -> Kind<F, (AA, B, C, D, E, G, Z)> where A == (AA, B, C, D, E, G, Z) {
-        return F.product(fa, fz)
+    static func product<AA, B, C, D, E, G, Z>(
+        _ fa: Kind<F, (AA, B, C, D, E, G)>,
+        _ fz: Kind<F, Z>) -> Kind<F, (AA, B, C, D, E, G, Z)>
+        where A == (AA, B, C, D, E, G, Z) {
+        F.product(fa, fz)
     }
 
     /// Adds an element to the right of a tuple in the context implementing this instance.
@@ -556,8 +631,11 @@ public extension Kind where F: Applicative {
     ///   - fa: A tuple of seven elements in the context implementing this instance.
     ///   - fz: A value in the context implementing this instance.
     /// - Returns: A tuple with the value of the second argument added to the right of the tuple, in the context implementing this instance.
-    static func product<AA, B, C, D, E, G, H, Z>(_ fa: Kind<F, (AA, B, C, D, E, G, H)>, _ fz: Kind<F, Z>) -> Kind<F, (AA, B, C, D, E, G, H, Z)> where A == (AA, B, C, D, E, G, H, Z) {
-        return F.product(fa, fz)
+    static func product<AA, B, C, D, E, G, H, Z>(
+        _ fa: Kind<F, (AA, B, C, D, E, G, H)>,
+        _ fz: Kind<F, Z>) -> Kind<F, (AA, B, C, D, E, G, H, Z)>
+        where A == (AA, B, C, D, E, G, H, Z) {
+        F.product(fa, fz)
     }
 
     /// Adds an element to the right of a tuple in the context implementing this instance.
@@ -568,8 +646,11 @@ public extension Kind where F: Applicative {
     ///   - fa: A tuple of eight elements in the context implementing this instance.
     ///   - fz: A value in the context implementing this instance.
     /// - Returns: A tuple with the value of the second argument added to the right of the tuple, in the context implementing this instance.
-    static func product<AA, B, C, D, E, G, H, I, Z>(_ fa: Kind<F, (AA, B, C, D, E, G, H, I)>, _ fz : Kind<F, Z>) -> Kind<F, (AA, B, C, D, E, G, H, I, Z)> where A == (AA, B, C, D, E, G, H, I, Z) {
-        return F.product(fa, fz)
+    static func product<AA, B, C, D, E, G, H, I, Z>(
+        _ fa: Kind<F, (AA, B, C, D, E, G, H, I)>,
+        _ fz: Kind<F, Z>) -> Kind<F, (AA, B, C, D, E, G, H, I, Z)>
+        where A == (AA, B, C, D, E, G, H, I, Z) {
+        F.product(fa, fz)
     }
 
     /// Creates a tuple out of two values in the context implementing this instance.
@@ -580,9 +661,11 @@ public extension Kind where F: Applicative {
     ///   - a: 1st value of the tuple.
     ///   - b: 2nd value of the tuple.
     /// - Returns: A tuple in the context implementing this instance.
-    static func zip<AA, B>(_ a: Kind<F, AA>,
-                           _ b : Kind<F, B>) -> Kind<F, (AA, B)> where A == (AA, B){
-        return F.zip(a, b)
+    static func zip<AA, B>(
+        _ a: Kind<F, AA>,
+        _ b: Kind<F, B>) -> Kind<F, (AA, B)>
+        where A == (AA, B){
+        F.zip(a, b)
     }
 
     /// Creates a tuple out of three values in the context implementing this instance.
@@ -594,10 +677,12 @@ public extension Kind where F: Applicative {
     ///   - b: 2nd value of the tuple.
     ///   - c: 3rd value of the tuple.
     /// - Returns: A tuple in the context implementing this instance.
-    static func zip<AA, B, C>(_ a: Kind<F, AA>,
-                              _ b: Kind<F, B>,
-                              _ c: Kind<F, C>) -> Kind<F, (AA, B, C)> where A == (AA, B, C) {
-        return F.zip(a, b, c)
+    static func zip<AA, B, C>(
+        _ a: Kind<F, AA>,
+        _ b: Kind<F, B>,
+        _ c: Kind<F, C>) -> Kind<F, (AA, B, C)>
+        where A == (AA, B, C) {
+        F.zip(a, b, c)
     }
 
     /// Creates a tuple out of four values in the context implementing this instance.
@@ -610,11 +695,13 @@ public extension Kind where F: Applicative {
     ///   - c: 3rd value of the tuple.
     ///   - d: 4th value of the tuple.
     /// - Returns: A tuple in the context implementing this instance.
-    static func zip<AA, B, C, D>(_ a: Kind<F, AA>,
-                                 _ b: Kind<F, B>,
-                                 _ c: Kind<F, C>,
-                                 _ d: Kind<F, D>) -> Kind<F, (AA, B, C, D)> where A == (AA, B, C, D) {
-        return F.zip(a, b, c, d)
+    static func zip<AA, B, C, D>(
+        _ a: Kind<F, AA>,
+        _ b: Kind<F, B>,
+        _ c: Kind<F, C>,
+        _ d: Kind<F, D>) -> Kind<F, (AA, B, C, D)>
+        where A == (AA, B, C, D) {
+        F.zip(a, b, c, d)
     }
 
     /// Creates a tuple out of five values in the context implementing this instance.
@@ -628,12 +715,14 @@ public extension Kind where F: Applicative {
     ///   - d: 4th value of the tuple.
     ///   - e: 5th value of the tuple.
     /// - Returns: A tuple in the context implementing this instance.
-    static func zip<AA, B, C, D, E>(_ a: Kind<F, AA>,
-                                    _ b: Kind<F, B>,
-                                    _ c: Kind<F, C>,
-                                    _ d: Kind<F, D>,
-                                    _ e: Kind<F, E>) -> Kind<F, (AA, B, C, D, E)> where A == (AA, B, C, D, E) {
-        return F.zip(a, b, c, d, e)
+    static func zip<AA, B, C, D, E>(
+        _ a: Kind<F, AA>,
+        _ b: Kind<F, B>,
+        _ c: Kind<F, C>,
+        _ d: Kind<F, D>,
+        _ e: Kind<F, E>) -> Kind<F, (AA, B, C, D, E)>
+        where A == (AA, B, C, D, E) {
+        F.zip(a, b, c, d, e)
     }
 
     /// Creates a tuple out of six values in the context implementing this instance.
@@ -648,13 +737,15 @@ public extension Kind where F: Applicative {
     ///   - e: 5th value of the tuple.
     ///   - g: 6th value of the tuple.
     /// - Returns: A tuple in the context implementing this instance.
-    static func zip<AA, B, C, D, E, G>(_ a: Kind<F, AA>,
-                                       _ b: Kind<F, B>,
-                                       _ c: Kind<F, C>,
-                                       _ d: Kind<F, D>,
-                                       _ e: Kind<F, E>,
-                                       _ g: Kind<F, G>) -> Kind<F, (AA, B, C, D, E, G)> where A == (AA, B, C, D, E, G) {
-        return F.zip(a, b, c, d, e, g)
+    static func zip<AA, B, C, D, E, G>(
+        _ a: Kind<F, AA>,
+        _ b: Kind<F, B>,
+        _ c: Kind<F, C>,
+        _ d: Kind<F, D>,
+        _ e: Kind<F, E>,
+        _ g: Kind<F, G>) -> Kind<F, (AA, B, C, D, E, G)>
+        where A == (AA, B, C, D, E, G) {
+        F.zip(a, b, c, d, e, g)
     }
 
     /// Creates a tuple out of seven values in the context implementing this instance.
@@ -670,14 +761,16 @@ public extension Kind where F: Applicative {
     ///   - g: 6th value of the tuple.
     ///   - h: 7th value of the tuple.
     /// - Returns: A tuple in the context implementing this instance.
-    static func zip<AA, B, C, D, E, G, H>(_ a: Kind<F, AA>,
-                                          _ b: Kind<F, B>,
-                                          _ c: Kind<F, C>,
-                                          _ d: Kind<F, D>,
-                                          _ e: Kind<F, E>,
-                                          _ g: Kind<F, G>,
-                                          _ h: Kind<F, H>) -> Kind<F, (AA, B, C, D, E, G, H)> where A == (AA, B, C, D, E, G, H) {
-        return F.zip(a, b, c, d, e, g, h)
+    static func zip<AA, B, C, D, E, G, H>(
+        _ a: Kind<F, AA>,
+        _ b: Kind<F, B>,
+        _ c: Kind<F, C>,
+        _ d: Kind<F, D>,
+        _ e: Kind<F, E>,
+        _ g: Kind<F, G>,
+        _ h: Kind<F, H>) -> Kind<F, (AA, B, C, D, E, G, H)>
+        where A == (AA, B, C, D, E, G, H) {
+        F.zip(a, b, c, d, e, g, h)
     }
 
     /// Creates a tuple out of eight values in the context implementing this instance.
@@ -694,15 +787,17 @@ public extension Kind where F: Applicative {
     ///   - h: 7th value of the tuple.
     ///   - i: 8th value of the tuple.
     /// - Returns: A tuple in the context implementing this instance.
-    static func zip<AA, B, C, D, E, G, H, I>(_ a: Kind<F, AA>,
-                                             _ b: Kind<F, B>,
-                                             _ c: Kind<F, C>,
-                                             _ d: Kind<F, D>,
-                                             _ e: Kind<F, E>,
-                                             _ g: Kind<F, G>,
-                                             _ h: Kind<F, H>,
-                                             _ i: Kind<F, I>) -> Kind<F, (AA, B, C, D, E, G, H, I)> where A == (AA, B, C, D, E, G, H, I) {
-        return F.zip(a, b, c, d, e, g, h, i)
+    static func zip<AA, B, C, D, E, G, H, I>(
+        _ a: Kind<F, AA>,
+        _ b: Kind<F, B>,
+        _ c: Kind<F, C>,
+        _ d: Kind<F, D>,
+        _ e: Kind<F, E>,
+        _ g: Kind<F, G>,
+        _ h: Kind<F, H>,
+        _ i: Kind<F, I>) -> Kind<F, (AA, B, C, D, E, G, H, I)>
+        where A == (AA, B, C, D, E, G, H, I) {
+        F.zip(a, b, c, d, e, g, h, i)
     }
 
     /// Creates a tuple out of nine values in the context implementing this instance.
@@ -720,16 +815,18 @@ public extension Kind where F: Applicative {
     ///   - i: 8th value of the tuple.
     ///   - j: 9th value of the tuple.
     /// - Returns: A tuple in the context implementing this instance.
-    static func zip<AA, B, C, D, E, G, H, I, J>(_ a: Kind<F, AA>,
-                                                _ b: Kind<F, B>,
-                                                _ c: Kind<F, C>,
-                                                _ d: Kind<F, D>,
-                                                _ e: Kind<F, E>,
-                                                _ g: Kind<F, G>,
-                                                _ h: Kind<F, H>,
-                                                _ i: Kind<F, I>,
-                                                _ j: Kind<F, J>) -> Kind<F, (AA, B, C, D, E, G, H, I, J)> where A == (AA, B, C, D, E, G, H, I, J) {
-        return F.zip(a, b, c, d, e, g, h, i, j)
+    static func zip<AA, B, C, D, E, G, H, I, J>(
+        _ a: Kind<F, AA>,
+        _ b: Kind<F, B>,
+        _ c: Kind<F, C>,
+        _ d: Kind<F, D>,
+        _ e: Kind<F, E>,
+        _ g: Kind<F, G>,
+        _ h: Kind<F, H>,
+        _ i: Kind<F, I>,
+        _ j: Kind<F, J>) -> Kind<F, (AA, B, C, D, E, G, H, I, J)>
+        where A == (AA, B, C, D, E, G, H, I, J) {
+        F.zip(a, b, c, d, e, g, h, i, j)
     }
 
     /// Combines the result of two computations in the context implementing this instance, using the provided function.
@@ -741,10 +838,11 @@ public extension Kind where F: Applicative {
     ///   - b: 2nd computation.
     ///   - f: Combination function.
     /// - Returns: Result of combining the provided computations, in the context implementing this instance.
-    static func map<B, Z>(_ a: Kind<F, Z>,
-                          _ b: Kind<F, B>,
-                          _ f: @escaping (Z, B) -> A) -> Kind<F, A> {
-        return F.map(a, b, f)
+    static func map<B, Z>(
+        _ a: Kind<F, Z>,
+        _ b: Kind<F, B>,
+        _ f: @escaping (Z, B) -> A) -> Kind<F, A> {
+        F.map(a, b, f)
     }
 
     /// Combines the result of three computations in the context implementing this instance, using the provided function.
@@ -757,11 +855,12 @@ public extension Kind where F: Applicative {
     ///   - c: 3rd computation.
     ///   - f: Combination function.
     /// - Returns: Result of combining the provided computations, in the context implementing this instance.
-    static func map<B, C, Z>(_ a: Kind<F, Z>,
-                             _ b: Kind<F, B>,
-                             _ c: Kind<F, C>,
-                             _ f: @escaping (Z, B, C) -> A) -> Kind<F, A> {
-        return F.map(a, b, c, f)
+    static func map<B, C, Z>(
+        _ a: Kind<F, Z>,
+        _ b: Kind<F, B>,
+        _ c: Kind<F, C>,
+        _ f: @escaping (Z, B, C) -> A) -> Kind<F, A> {
+        F.map(a, b, c, f)
     }
 
     /// Combines the result of four computations in the context implementing this instance, using the provided function.
@@ -775,12 +874,13 @@ public extension Kind where F: Applicative {
     ///   - d: 4th computation.
     ///   - f: Combination function.
     /// - Returns: Result of combining the provided computations, in the context implementing this instance.
-    static func map<B, C, D, Z>(_ a: Kind<F, Z>,
-                                _ b: Kind<F, B>,
-                                _ c: Kind<F, C>,
-                                _ d: Kind<F, D>,
-                                _ f: @escaping (Z, B, C, D) -> A) -> Kind<F, A> {
-        return F.map(a, b, c, d, f)
+    static func map<B, C, D, Z>(
+        _ a: Kind<F, Z>,
+        _ b: Kind<F, B>,
+        _ c: Kind<F, C>,
+        _ d: Kind<F, D>,
+        _ f: @escaping (Z, B, C, D) -> A) -> Kind<F, A> {
+        F.map(a, b, c, d, f)
     }
 
     /// Combines the result of five computations in the context implementing this instance, using the provided function.
@@ -795,13 +895,14 @@ public extension Kind where F: Applicative {
     ///   - e: 5th computation.
     ///   - f: Combination function.
     /// - Returns: Result of combining the provided computations, in the context implementing this instance.
-    static func map<B, C, D, E, Z>(_ a: Kind<F, Z>,
-                                   _ b: Kind<F, B>,
-                                   _ c: Kind<F, C>,
-                                   _ d: Kind<F, D>,
-                                   _ e: Kind<F, E>,
-                                   _ f: @escaping (Z, B, C, D, E) -> A) -> Kind<F, A> {
-        return F.map(a, b, c, d, e, f)
+    static func map<B, C, D, E, Z>(
+        _ a: Kind<F, Z>,
+        _ b: Kind<F, B>,
+        _ c: Kind<F, C>,
+        _ d: Kind<F, D>,
+        _ e: Kind<F, E>,
+        _ f: @escaping (Z, B, C, D, E) -> A) -> Kind<F, A> {
+        F.map(a, b, c, d, e, f)
     }
 
     /// Combines the result of six computations in the context implementing this instance, using the provided function.
@@ -817,14 +918,15 @@ public extension Kind where F: Applicative {
     ///   - g: 6th computation.
     ///   - f: Combination function.
     /// - Returns: Result of combining the provided computations, in the context implementing this instance.
-    static func map<B, C, D, E, G, Z>(_ a: Kind<F, Z>,
-                                      _ b: Kind<F, B>,
-                                      _ c: Kind<F, C>,
-                                      _ d: Kind<F, D>,
-                                      _ e: Kind<F, E>,
-                                      _ g: Kind<F, G>,
-                                      _ f: @escaping (Z, B, C, D, E, G) -> A) -> Kind<F, A> {
-        return F.map(a, b, c, d, e, g, f)
+    static func map<B, C, D, E, G, Z>(
+        _ a: Kind<F, Z>,
+        _ b: Kind<F, B>,
+        _ c: Kind<F, C>,
+        _ d: Kind<F, D>,
+        _ e: Kind<F, E>,
+        _ g: Kind<F, G>,
+        _ f: @escaping (Z, B, C, D, E, G) -> A) -> Kind<F, A> {
+        F.map(a, b, c, d, e, g, f)
     }
 
     /// Combines the result of seven computations in the context implementing this instance, using the provided function.
@@ -841,15 +943,16 @@ public extension Kind where F: Applicative {
     ///   - h: 7th computation.
     ///   - f: Combination function.
     /// - Returns: Result of combining the provided computations, in the context implementing this instance.
-    static func map<B, C, D, E, G, H, Z>(_ a: Kind<F, Z>,
-                                         _ b: Kind<F, B>,
-                                         _ c: Kind<F, C>,
-                                         _ d: Kind<F, D>,
-                                         _ e: Kind<F, E>,
-                                         _ g: Kind<F, G>,
-                                         _ h: Kind<F, H>,
-                                         _ f: @escaping (Z, B, C, D, E, G, H) -> A) -> Kind<F, A> {
-        return F.map(a, b, c, d, e, g, h, f)
+    static func map<B, C, D, E, G, H, Z>(
+        _ a: Kind<F, Z>,
+        _ b: Kind<F, B>,
+        _ c: Kind<F, C>,
+        _ d: Kind<F, D>,
+        _ e: Kind<F, E>,
+        _ g: Kind<F, G>,
+        _ h: Kind<F, H>,
+        _ f: @escaping (Z, B, C, D, E, G, H) -> A) -> Kind<F, A> {
+        F.map(a, b, c, d, e, g, h, f)
     }
 
     /// Combines the result of eight computations in the context implementing this instance, using the provided function.
@@ -867,16 +970,17 @@ public extension Kind where F: Applicative {
     ///   - i: 8th computation.
     ///   - f: Combination function.
     /// - Returns: Result of combining the provided computations, in the context implementing this instance.
-    static func map<B, C, D, E, G, H, I, Z>(_ a: Kind<F, Z>,
-                                            _ b: Kind<F, B>,
-                                            _ c: Kind<F, C>,
-                                            _ d: Kind<F, D>,
-                                            _ e: Kind<F, E>,
-                                            _ g: Kind<F, G>,
-                                            _ h: Kind<F, H>,
-                                            _ i: Kind<F, I>,
-                                            _ f: @escaping (Z, B, C, D, E, G, H, I) -> A) -> Kind<F, A> {
-        return F.map(a, b, c, d, e, g, h, i, f)
+    static func map<B, C, D, E, G, H, I, Z>(
+        _ a: Kind<F, Z>,
+        _ b: Kind<F, B>,
+        _ c: Kind<F, C>,
+        _ d: Kind<F, D>,
+        _ e: Kind<F, E>,
+        _ g: Kind<F, G>,
+        _ h: Kind<F, H>,
+        _ i: Kind<F, I>,
+        _ f: @escaping (Z, B, C, D, E, G, H, I) -> A) -> Kind<F, A> {
+        F.map(a, b, c, d, e, g, h, i, f)
     }
 
     /// Combines the result of nine computations in the context implementing this instance, using the provided function.
@@ -895,16 +999,17 @@ public extension Kind where F: Applicative {
     ///   - j: 9th computation.
     ///   - f: Combination function.
     /// - Returns: Result of combining the provided computations, in the context implementing this instance.
-    static func map<B, C, D, E, G, H, I, J, Z>(_ a: Kind<F, Z>,
-                                               _ b: Kind<F, B>,
-                                               _ c: Kind<F, C>,
-                                               _ d: Kind<F, D>,
-                                               _ e: Kind<F, E>,
-                                               _ g: Kind<F, G>,
-                                               _ h: Kind<F, H>,
-                                               _ i: Kind<F, I>,
-                                               _ j: Kind<F, J>,
-                                               _ f: @escaping (Z, B, C, D, E, G, H, I, J) -> A) -> Kind<F, A> {
-        return F.map(a, b, c, d, e, g, h, i, j, f)
+    static func map<B, C, D, E, G, H, I, J, Z>(
+        _ a: Kind<F, Z>,
+        _ b: Kind<F, B>,
+        _ c: Kind<F, C>,
+        _ d: Kind<F, D>,
+        _ e: Kind<F, E>,
+        _ g: Kind<F, G>,
+        _ h: Kind<F, H>,
+        _ i: Kind<F, I>,
+        _ j: Kind<F, J>,
+        _ f: @escaping (Z, B, C, D, E, G, H, I, J) -> A) -> Kind<F, A> {
+        F.map(a, b, c, d, e, g, h, i, j, f)
     }
 }

--- a/Sources/Bow/Typeclasses/ApplicativeError.swift
+++ b/Sources/Bow/Typeclasses/ApplicativeError.swift
@@ -32,7 +32,7 @@ public extension ApplicativeError {
     ///   - f: A recovery function.
     /// - Returns: A value where the possible errors have been recovered using the provided function.
     static func handleError<A>(_ fa: Kind<Self, A>, _ f: @escaping (E) -> A) -> Kind<Self, A> {
-        return handleErrorWith(fa, { a in self.pure(f(a)) })
+        handleErrorWith(fa, { a in self.pure(f(a)) })
     }
 
     /// Handles errors by converting them into `Either` values in the context implementing this instance.
@@ -50,7 +50,7 @@ public extension ApplicativeError {
     /// - Parameter fea: An `Either` value.
     /// - Returns: A value in the context implementing this instance.
     static func fromEither<A>(_ fea: Either<E, A>) -> Kind<Self, A> {
-        return fea.fold(raiseError, pure)
+        fea.fold(raiseError, pure)
     }
     
     /// Converts an `Option` value into a value in the context implementing this instance.
@@ -60,7 +60,7 @@ public extension ApplicativeError {
     ///   - f: A function providing the error value in case the option is empty.
     /// - Returns: A value in the context implementing this instance.
     static func fromOption<A>(_ oa: Option<A>, _ f: () -> E) -> Kind<Self, A> {
-        return oa.fold({ Self.raiseError(f()) }, Self.pure)
+        oa.fold({ Self.raiseError(f()) }, Self.pure)
     }
     
     /// Converts a `Try` value into a value in the context implementing this instance.
@@ -70,7 +70,7 @@ public extension ApplicativeError {
     ///   - f: A function transforming the error contained in `Try` to the error type of this instance.
     /// - Returns: A value in the context implementing this instance.
     static func fromTry<A>(_ ta: Try<A>, _ f: (Error) -> E) -> Kind<Self, A> {
-        return ta.fold({ e in Self.raiseError(f(e)) }, Self.pure)
+        ta.fold({ e in Self.raiseError(f(e)) }, Self.pure)
     }
 
     /// Evaluates a throwing function, catching and mapping errors.
@@ -110,7 +110,7 @@ public extension Kind where F: ApplicativeError {
     /// - Parameter e: A value of the error type.
     /// - Returns: A value representing the error in the context implementing this instance.
     static func raiseError(_ e: F.E) -> Kind<F, A> {
-        return F.raiseError(e)
+        F.raiseError(e)
     }
 
     /// Handles an error, potentially recovering from it by mapping it to a value in the context implementing this instance.
@@ -121,7 +121,7 @@ public extension Kind where F: ApplicativeError {
     ///   - f: A recovery function.
     /// - Returns: A value where the possible errors have been recovered using the provided function.
     func handleErrorWith(_ f: @escaping (F.E) -> Kind<F, A>) -> Kind<F, A> {
-        return F.handleErrorWith(self, f)
+        F.handleErrorWith(self, f)
     }
 
     /// Handles an error, potentially recovering from it by mapping it to a value.
@@ -132,7 +132,7 @@ public extension Kind where F: ApplicativeError {
     ///   - f: A recovery function.
     /// - Returns: A value where the possible errors have been recovered using the provided function.
     func handleError(_ f: @escaping (F.E) -> A) -> Kind<F, A> {
-        return F.handleError(self, f)
+        F.handleError(self, f)
     }
 
     /// Handles errors by converting them into `Either` values in the context implementing this instance.
@@ -141,7 +141,7 @@ public extension Kind where F: ApplicativeError {
     ///
     /// - Returns: An either wrapped in the context implementing this instance.
     func attempt() -> Kind<F, Either<F.E, A>> {
-        return F.attempt(self)
+        F.attempt(self)
     }
 
     /// Converts an `Either` value into a value in the context implementing this instance.
@@ -151,7 +151,7 @@ public extension Kind where F: ApplicativeError {
     /// - Parameter fea: An `Either` value.
     /// - Returns: A value in the context implementing this instance.
     static func fromEither(_ fea: Either<F.E, A>) -> Kind<F, A> {
-        return F.fromEither(fea)
+        F.fromEither(fea)
     }
 
     /// Converts an `Option` value into a value in the context implementing this instance.
@@ -161,7 +161,7 @@ public extension Kind where F: ApplicativeError {
     ///   - f: A function providing the error value in case the option is empty.
     /// - Returns: A value in the context implementing this instance.
     static func fromOption(_ oa: Option<A>, _ f: () -> F.E) -> Kind<F, A> {
-        return F.fromOption(oa, f)
+        F.fromOption(oa, f)
     }
 
     /// Converts a `Try` value into a value in the context implementing this instance.
@@ -171,7 +171,7 @@ public extension Kind where F: ApplicativeError {
     ///   - f: A function transforming the error contained in `Try` to the error type of this instance.
     /// - Returns: A value in the context implementing this instance.
     static func fromTry(_ ta: Try<A>, _ f: (Error) -> F.E) -> Kind<F, A> {
-        return F.fromTry(ta, f)
+        F.fromTry(ta, f)
     }
     
     /// Evaluates a throwing function, catching and mapping errors.
@@ -183,7 +183,7 @@ public extension Kind where F: ApplicativeError {
     ///   - recover: A function that maps from `Error` to the type that this instance is able to handle.
     /// - Returns: A value in the context implementing this instance.
     static func catchError(_ f: () throws -> A, _ recover: (Error) -> F.E) -> Kind<F, A> {
-        return F.catchError(f, recover)
+        F.catchError(f, recover)
     }
 }
 
@@ -195,6 +195,6 @@ public extension Kind where F: ApplicativeError, F.E == Error {
     /// - Parameter f: A throwing function.
     /// - Returns: A value in the context implementing this instance.
     static func catchError(_ f: () throws -> A) -> Kind<F, A> {
-        return F.catchError(f)
+        F.catchError(f)
     }
 }

--- a/Sources/Bow/Typeclasses/Comonad.swift
+++ b/Sources/Bow/Typeclasses/Comonad.swift
@@ -18,7 +18,9 @@ public protocol Comonad: Functor {
     ///   - fa: Value in the context implementing this instance.
     ///   - f: Extracting function.
     /// - Returns: The result of extracting and transforming the value, in the context implementing this instance.
-    static func coflatMap<A, B>(_ fa: Kind<Self, A>, _ f: @escaping (Kind<Self, A>) -> B) -> Kind<Self, B>
+    static func coflatMap<A, B>(
+        _ fa: Kind<Self, A>,
+        _ f: @escaping (Kind<Self, A>) -> B) -> Kind<Self, B>
 
     /// Extracts the value contained in the context implementing this instance.
     ///
@@ -37,7 +39,7 @@ public extension Comonad {
     /// - Parameter fa: A value in the context implementing this instance.
     /// - Returns: Value wrapped in another context layer.
     static func duplicate<A>(_ fa: Kind<Self, A>) -> Kind<Self, Kind<Self, A>> {
-        return coflatMap(fa, id)
+        coflatMap(fa, id)
     }
 }
 
@@ -54,7 +56,7 @@ public extension Kind where F: Comonad {
     ///   - f: Extracting function.
     /// - Returns: The result of extracting and transforming the value, in the context implementing this instance.
     func coflatMap<B>(_ f: @escaping (Kind<F, A>) -> B) -> Kind<F, B> {
-        return F.coflatMap(self, f)
+        F.coflatMap(self, f)
     }
 
     /// Extracts the value contained in this context.
@@ -65,13 +67,13 @@ public extension Kind where F: Comonad {
     ///
     /// - Returns: A normal value.
     func extract() -> A {
-        return F.extract(self)
+        F.extract(self)
     }
 
     /// Wraps this in another layer of this context.
     ///
     /// - Returns: This value wrapped in another context layer.
     func duplicate() -> Kind<F, Kind<F, A>> {
-        return F.duplicate(self)
+        F.duplicate(self)
     }
 }

--- a/Sources/Bow/Typeclasses/Comparable.swift
+++ b/Sources/Bow/Typeclasses/Comparable.swift
@@ -8,7 +8,7 @@ public extension Comparable {
     ///   - b: 2nd value.
     /// - Returns: A tuple with the two values sorted.
     static func sort(_ a: Self, _ b: Self) -> (Self, Self) {
-        return a >= b ? (a, b) : (b, a)
+        a >= b ? (a, b) : (b, a)
     }
 
     /// Gets the maximum of two values.
@@ -18,7 +18,7 @@ public extension Comparable {
     ///   - b: 2nd value.
     /// - Returns: Maximum of both values.
     static func max(_ a: Self, _ b: Self) -> Self {
-        return a >= b ? a : b
+        a >= b ? a : b
     }
 
     /// Gets the minimum of two values.
@@ -28,6 +28,6 @@ public extension Comparable {
     ///   - b: 2nd value.
     /// - Returns: Minimum of both values.
     static func min(_ a: Self, _ b: Self) -> Self {
-        return a <= b ? a : b
+        a <= b ? a : b
     }
 }

--- a/Sources/Bow/Typeclasses/Contravariant.swift
+++ b/Sources/Bow/Typeclasses/Contravariant.swift
@@ -14,7 +14,7 @@ public protocol Contravariant: Invariant {
 public extension Contravariant {
     // Docs inherited from `Invariant`.
     static func imap<A, B>(_ fa: Kind<Self, A>, _ f: @escaping (A) -> B, _ g: @escaping (B) -> A) -> Kind<Self, B> {
-        return contramap(fa, g)
+        contramap(fa, g)
     }
 
     /// Given a function, provides a new function lifted to the context type implementing this instance of `Contravariant`, but reversing the direction of the arrow.
@@ -22,7 +22,7 @@ public extension Contravariant {
     /// - Parameter f: Function to be lifted.
     /// - Returns: Function in the context implementing this instance.
     static func contralift<A, B>(_ f: @escaping (A) -> B) -> (Kind<Self, B>) -> Kind<Self, A> {
-        return { fa in contramap(fa, f) }
+        { fa in contramap(fa, f) }
     }
 }
 
@@ -34,15 +34,15 @@ public extension Kind where F: Contravariant {
     /// - Parameters:
     ///   - f: Transforming function.
     /// - Returns: The result of transforming the value type using the provided function, maintaining the structure of the original value.
-    func contramap<B>(_ f : @escaping (B) -> A) -> Kind<F, B> {
-        return F.contramap(self, f)
+    func contramap<B>(_ f: @escaping (B) -> A) -> Kind<F, B> {
+        F.contramap(self, f)
     }
 
     /// Given a function, provides a new function lifted to the context type implementing this instance of `Contravariant`, but reversing the direction of the arrow.
     ///
     /// - Parameter f: Function to be lifted.
     /// - Returns: Function in the context implementing this instance.
-    static func contralift<B>(_ f : @escaping (A) -> B) -> (Kind<F, B>) -> Kind<F, A> {
-        return F.contralift(f)
+    static func contralift<B>(_ f: @escaping (A) -> B) -> (Kind<F, B>) -> Kind<F, A> {
+        F.contralift(f)
     }
 }

--- a/Sources/Bow/Typeclasses/EquatableK.swift
+++ b/Sources/Bow/Typeclasses/EquatableK.swift
@@ -37,15 +37,14 @@ public extension Kind where F: EquatableK, A: Equatable {
     ///   - rhs: Right hand side of the equality check.
     /// - Returns: A boolean value indicating if the two values are equal or not.
     func eq(_ rhs: Kind<F, A>) -> Bool {
-        return F.eq(self, rhs)
+        F.eq(self, rhs)
     }
 }
 
 // MARK: Syntax for Equatable
 
 extension Kind: Equatable where F: EquatableK, A: Equatable {
-    // Docs inherited from `Equatable`.
     public static func ==(lhs: Kind<F, A>, rhs: Kind<F, A>) -> Bool {
-        return F.eq(lhs, rhs)
+        F.eq(lhs, rhs)
     }
 }

--- a/Sources/Bow/Typeclasses/Functor.swift
+++ b/Sources/Bow/Typeclasses/Functor.swift
@@ -20,14 +20,19 @@ public protocol Functor: Invariant {
     ///   - fa: A value in the context of the type implementing this instance of `Functor`.
     ///   - f: A transforming function.
     /// - Returns: The result of transforming the value type using the provided function, maintaining the structure of the original value.
-    static func map<A, B>(_ fa: Kind<Self, A>, _ f: @escaping (A) -> B) -> Kind<Self, B>
+    static func map<A, B>(
+        _ fa: Kind<Self, A>,
+        _ f: @escaping (A) -> B) -> Kind<Self, B>
 }
 
 // MARK: Related functions
 public extension Functor {
     // Docs inherited from `Invariant`
-    static func imap<A, B>(_ fa: Kind<Self, A>, _ f: @escaping (A) -> B, _ g: @escaping (B) -> A) -> Kind<Self, B> {
-        return map(fa, f)
+    static func imap<A, B>(
+        _ fa: Kind<Self, A>,
+        _ f: @escaping (A) -> B,
+        _ g: @escaping (B) -> A) -> Kind<Self, B> {
+        map(fa, f)
     }
     
     /// Creates a new value transforming the type using the provided key path, preserving the structure of the original type.
@@ -36,8 +41,10 @@ public extension Functor {
     ///   - fa: A value in the context of the type implementing this instance of `Functor`.
     ///   - keyPath: A key path.
     /// - Returns: The result of transforming the value type using the provided function, maintaining the structure of the original value.
-    static func map<A, B>(_ fa: Kind<Self, A>, _ keyPath: KeyPath<A, B>) -> Kind<Self, B> {
-        return map(fa, { a in a[keyPath: keyPath] })
+    static func map<A, B>(
+        _ fa: Kind<Self, A>,
+        _ keyPath: KeyPath<A, B>) -> Kind<Self, B> {
+        map(fa, { a in a[keyPath: keyPath] })
     }
 
     /// Given a function, provides a new function lifted to the context type implementing this instance of `Functor`.
@@ -45,7 +52,7 @@ public extension Functor {
     /// - Parameter f: Function to be lifted.
     /// - Returns: Function in the context implementing this instance of `Functor`.
     static func lift<A, B>(_ f: @escaping (A) -> B) -> (Kind<Self, A>) -> Kind<Self, B> {
-        return { fa in map(fa, f) }
+        { fa in map(fa, f) }
     }
 
     /// Replaces the value type by the `Void` type.
@@ -53,7 +60,7 @@ public extension Functor {
     /// - Parameter fa: Value to be transformed.
     /// - Returns: New value in the context implementing this instance of `Functor`, with `Void` as value type.
     static func void<A>(_ fa: Kind<Self, A>) -> Kind<Self, ()> {
-        return map(fa, {_ in })
+        map(fa, {_ in })
     }
 
     /// Transforms the value type and pairs it with its original value.
@@ -62,8 +69,10 @@ public extension Functor {
     ///   - fa: Value to be transformed.
     ///   - f: Transforming function.
     /// - Returns: A pair with the original value and its transformation, in the context of the original value.
-    static func fproduct<A, B>(_ fa: Kind<Self, A>, _ f: @escaping (A) -> B) -> Kind<Self, (A, B)> {
-        return map(fa, { a in (a, f(a)) })
+    static func fproduct<A, B>(
+        _ fa: Kind<Self, A>,
+        _ f: @escaping (A) -> B) -> Kind<Self, (A, B)> {
+        map(fa, { a in (a, f(a)) })
     }
 
     /// Transforms the value type with a constant value.
@@ -72,8 +81,10 @@ public extension Functor {
     ///   - fa: Value to be transformed.
     ///   - b: Constant value to replace the value type.
     /// - Returns: A new value with the structure of the original value, with its value type transformed.
-    static func `as`<A, B>(_ fa: Kind<Self, A>, _ b: B) -> Kind<Self, B> {
-        return map(fa, { _ in b })
+    static func `as`<A, B>(
+        _ fa: Kind<Self, A>,
+        _ b: B) -> Kind<Self, B> {
+        map(fa, { _ in b })
     }
 
     /// Transforms the value type by making a tuple with a new constant value to the left of the original value type.
@@ -82,8 +93,10 @@ public extension Functor {
     ///   - fa: Value to be transformed.
     ///   - b: Constant value for the tuple.
     /// - Returns: A new value with the structure of the original value, with a tuple in its value type.
-    static func tupleLeft<A, B>(_ fa: Kind<Self, A>, _ b: B) -> Kind<Self, (B, A)> {
-        return map(fa, { a in (b, a) })
+    static func tupleLeft<A, B>(
+        _ fa: Kind<Self, A>,
+        _ b: B) -> Kind<Self, (B, A)> {
+        map(fa, { a in (b, a) })
     }
 
     /// Transforms the value type by making a tuple with a new constant value to the right of the original value type.
@@ -92,8 +105,10 @@ public extension Functor {
     ///   - fa: Value to be transformed.
     ///   - b: Constant value for the tuple.
     /// - Returns: A new value with the structure of the original value, with a tuple in its value type.
-    static func tupleRight<A, B>(_ fa: Kind<Self, A>, _ b: B) -> Kind<Self, (A, B)> {
-        return map(fa, { a in (a, b) })
+    static func tupleRight<A, B>(
+        _ fa: Kind<Self, A>,
+        _ b: B) -> Kind<Self, (A, B)> {
+        map(fa, { a in (a, b) })
     }
 }
 
@@ -108,7 +123,7 @@ public extension Kind where F: Functor {
     ///   - f: A transforming function.
     /// - Returns: The result of transforming the value type using the provided function, maintaining the structure of the original value.
     func map<B>(_ f: @escaping (A) -> B) -> Kind<F, B> {
-        return F.map(self, f)
+        F.map(self, f)
     }
     
     /// Creates a new value transforming the type using the provided key path, preserving the structure of the original type.
@@ -119,7 +134,7 @@ public extension Kind where F: Functor {
     ///   - keyPath: A key path.
     /// - Returns: The result of transforming the value type using the provided function, maintaining the structure of the original value.
     func map<B>(_ keyPath: KeyPath<A, B>) -> Kind<F, B> {
-        return F.map(self, keyPath)
+        F.map(self, keyPath)
     }
 
     /// Given a function, provides a new function lifted to the context type implementing this instance of `Functor`.
@@ -129,7 +144,7 @@ public extension Kind where F: Functor {
     /// - Parameter f: Function to be lifted.
     /// - Returns: Function in the context implementing this instance of `Functor`.
     static func lift<A, B>(_ f: @escaping (A) -> B) -> (Kind<F, A>) -> Kind<F, B> {
-        return { fa in fa.map(f) }
+        { fa in fa.map(f) }
     }
 
     /// Replaces the value type by the `Void` type.
@@ -138,7 +153,7 @@ public extension Kind where F: Functor {
     ///
     /// - Returns: New value in the context implementing this instance of `Functor`, with `Void` as value type.
     func void() -> Kind<F, ()> {
-        return F.void(self)
+        F.void(self)
     }
 
     /// Transforms the value type and pairs it with its original value.
@@ -149,7 +164,7 @@ public extension Kind where F: Functor {
     ///   - f: Transforming function.
     /// - Returns: A pair with the original value and its transformation, in the context of the original value.
     func fproduct<B>(_ f: @escaping (A) -> B) -> Kind<F, (A, B)> {
-        return F.fproduct(self, f)
+        F.fproduct(self, f)
     }
 
     /// Transforms the value type with a constant value.
@@ -160,7 +175,7 @@ public extension Kind where F: Functor {
     ///   - b: Constant value to replace the value type.
     /// - Returns: A new value with the structure of the original value, with its value type transformed.
     func `as`<B>(_ b: B) -> Kind<F, B> {
-        return F.as(self, b)
+        F.as(self, b)
     }
 
     /// Transforms the value type by making a tuple with a new constant value to the left of the original value type.
@@ -171,7 +186,7 @@ public extension Kind where F: Functor {
     ///   - b: Constant value for the tuple.
     /// - Returns: A new value with the structure of the original value, with a tuple in its value type.
     func tupleLeft<B>(_ b: B) -> Kind<F, (B, A)> {
-        return F.tupleLeft(self, b)
+        F.tupleLeft(self, b)
     }
 
     /// Transforms the value type by making a tuple with a new constant value to the right of the original value type.
@@ -182,6 +197,6 @@ public extension Kind where F: Functor {
     ///   - b: Constant value for the tuple.
     /// - Returns: A new value with the structure of the original value, with a tuple in its value type.
     func tupleRight<B>(_ b: B) -> Kind<F, (A, B)> {
-        return F.tupleRight(self, b)
+        F.tupleRight(self, b)
     }
 }

--- a/Sources/Bow/Typeclasses/FunctorFilter.swift
+++ b/Sources/Bow/Typeclasses/FunctorFilter.swift
@@ -8,7 +8,9 @@ public protocol FunctorFilter: Functor {
     ///   - fa: A value in the context implementing this instance.
     ///   - f: A function to map objects and filter them out.
     /// - Returns: Transformed and filtered values, in the context implementing this instance.
-    static func mapFilter<A, B>(_ fa: Kind<Self, A>, _ f: @escaping (A) -> OptionOf<B>) -> Kind<Self, B>
+    static func mapFilter<A, B>(
+        _ fa: Kind<Self, A>,
+        _ f: @escaping (A) -> OptionOf<B>) -> Kind<Self, B>
 }
 
 // MARK: Related functions
@@ -19,7 +21,7 @@ public extension FunctorFilter {
     /// - Parameter fa: Optional values in the context implementing this instance.
     /// - Returns: Plain values in the context implementing this instance.
     static func flattenOption<A>(_ fa: Kind<Self, OptionOf<A>>) -> Kind<Self, A> {
-        return mapFilter(fa, id)
+        mapFilter(fa, id)
     }
 
     /// Filters out the value/s in the context implementing this instance that do not match the given predicate.
@@ -28,8 +30,10 @@ public extension FunctorFilter {
     ///   - fa: Value in the context implementing this instance.
     ///   - f: Filtering predicate.
     /// - Returns: Filtered value in the context implementing this instance.
-    static func filter<A>(_ fa: Kind<Self, A>, _ f: @escaping (A) -> Bool) -> Kind<Self, A> {
-        return mapFilter(fa, { a in f(a) ? Option.some(a) : Option.none() })
+    static func filter<A>(
+        _ fa: Kind<Self, A>,
+        _ f: @escaping (A) -> Bool) -> Kind<Self, A> {
+        mapFilter(fa, { a in f(a) ? Option.some(a) : Option.none() })
     }
 }
 
@@ -44,7 +48,7 @@ public extension Kind where F: FunctorFilter {
     ///   - f: A function to map objects and filter them out.
     /// - Returns: Transformed and filtered values, in this context.
     func mapFilter<B>(_ f: @escaping (A) -> OptionOf<B>) -> Kind<F, B> {
-        return F.mapFilter(self, f)
+        F.mapFilter(self, f)
     }
 
     /// Removes the `Option.none` value/s in this context and extracts the `Option.some` ones.
@@ -54,7 +58,7 @@ public extension Kind where F: FunctorFilter {
     /// - Parameter fa: Optional values in this context.
     /// - Returns: Plain values in this context.
     static func flattenOption(_ fa: Kind<F, OptionOf<A>>) -> Kind<F, A> {
-        return F.flattenOption(fa)
+        F.flattenOption(fa)
     }
 
     /// Filters out the value/s in this context that do not match the given predicate.
@@ -65,6 +69,6 @@ public extension Kind where F: FunctorFilter {
     ///   - f: Filtering predicate.
     /// - Returns: Filtered value in this context.
     func filter(_ f: @escaping (A) -> Bool) -> Kind<F, A> {
-        return F.filter(self, f)
+        F.filter(self, f)
     }
 }

--- a/Sources/Bow/Typeclasses/Invariant.swift
+++ b/Sources/Bow/Typeclasses/Invariant.swift
@@ -14,7 +14,10 @@ public protocol Invariant {
     ///   - f: Transforming function.
     ///   - g: Transforming function.
     /// - Returns: A new value in the same context as the original value, with the value type transformed.
-    static func imap<A, B>(_ fa : Kind<Self, A>, _ f : @escaping (A) -> B, _ g : @escaping (B) -> A) -> Kind<Self, B>
+    static func imap<A, B>(
+        _ fa: Kind<Self, A>,
+        _ f: @escaping (A) -> B,
+        _ g: @escaping (B) -> A) -> Kind<Self, B>
 }
 
 // MARK: Syntax for Invariant
@@ -28,7 +31,7 @@ public extension Kind where F: Invariant {
     ///   - f: Transforming function.
     ///   - g: Transforming function.
     /// - Returns: A new value in the same context as the original value, with the value type transformed.
-    func imap<B>(_ f : @escaping (A) -> B, _ g : @escaping (B) -> A) -> Kind<F, B> {
-        return F.imap(self, f, g)
+    func imap<B>(_ f: @escaping (A) -> B, _ g: @escaping (B) -> A) -> Kind<F, B> {
+        F.imap(self, f, g)
     }
 }

--- a/Sources/Bow/Typeclasses/Monad.swift
+++ b/Sources/Bow/Typeclasses/Monad.swift
@@ -18,7 +18,9 @@ public protocol Monad: Selective {
     ///   - fa: First computation.
     ///   - f: A function describing the second computation, which depends on the value of the first.
     /// - Returns: Result of composing the two computations.
-    static func flatMap<A, B>(_ fa: Kind<Self, A>, _ f: @escaping (A) -> Kind<Self, B>) -> Kind<Self, B>
+    static func flatMap<A, B>(
+        _ fa: Kind<Self, A>,
+        _ f: @escaping (A) -> Kind<Self, B>) -> Kind<Self, B>
 
     /// Monadic tail recursion.
     ///
@@ -30,20 +32,26 @@ public protocol Monad: Selective {
     ///   - a: Initial value for the recursion.
     ///   - f: A function describing a recursive step.
     /// - Returns: Result of evaluating recursively the provided function with the initial value.
-    static func tailRecM<A, B>(_ a: A, _ f : @escaping (A) -> Kind<Self, Either<A, B>>) -> Kind<Self, B>
+    static func tailRecM<A, B>(
+        _ a: A,
+        _ f: @escaping (A) -> Kind<Self, Either<A, B>>) -> Kind<Self, B>
 }
 
 // MARK: Related functions
 
 public extension Monad {
     // Docs inherited from `Applicative`
-    static func ap<A, B>(_ ff: Kind<Self, (A) -> B>, _ fa: Kind<Self, A>) -> Kind<Self, B> {
-        return self.flatMap(ff, { f in map(fa, f) })
+    static func ap<A, B>(
+        _ ff: Kind<Self, (A) -> B>,
+        _ fa: Kind<Self, A>) -> Kind<Self, B> {
+        self.flatMap(ff, { f in map(fa, f) })
     }
 
     // Docs inherited from `Selective`
-    static func select<A, B>(_ fab: Kind<Self, Either<A, B>>, _ f: Kind<Self, (A) -> B>) -> Kind<Self, B> {
-        return flatMap(fab) { eab in eab.fold({ a in map(f, { ff in ff(a) }) },
+    static func select<A, B>(
+        _ fab: Kind<Self, Either<A, B>>,
+        _ f: Kind<Self, (A) -> B>) -> Kind<Self, B> {
+        flatMap(fab) { eab in eab.fold({ a in map(f, { ff in ff(a) }) },
                                               { b in pure(b) })}
     }
 
@@ -52,7 +60,7 @@ public extension Monad {
     /// - Parameter ffa: Value with a nested structure.
     /// - Returns: Value with a single context structure.
     static func flatten<A>(_ ffa: Kind<Self, Kind<Self, A>>) -> Kind<Self, A> {
-        return self.flatMap(ffa, id)
+        self.flatMap(ffa, id)
     }
 
     /// Sequentially compose two computations, discarding the value produced by the first.
@@ -61,8 +69,10 @@ public extension Monad {
     ///   - fa: 1st computation.
     ///   - fb: 2nd computation.
     /// - Returns: Result of running the second computation after the first one.
-    static func followedBy<A, B>(_ fa: Kind<Self, A>, _ fb: Kind<Self, B>) -> Kind<Self, B> {
-        return self.flatMap(fa, { _ in fb })
+    static func followedBy<A, B>(
+        _ fa: Kind<Self, A>,
+        _ fb: Kind<Self, B>) -> Kind<Self, B> {
+        self.flatMap(fa, { _ in fb })
     }
 
     /// Sequentially compose a computation with a potentially lazy one, discarding the value produced by the first.
@@ -71,8 +81,10 @@ public extension Monad {
     ///   - fa: Regular computation.
     ///   - fb: Potentially lazy computation.
     /// - Returns: Result of running the second computation after the first one.
-    static func followedByEval<A, B>(_ fa: Kind<Self, A>, _ fb: Eval<Kind<Self, B>>) -> Kind<Self, B> {
-        return self.flatMap(fa, { _ in fb.value() })
+    static func followedByEval<A, B>(
+        _ fa: Kind<Self, A>,
+        _ fb: Eval<Kind<Self, B>>) -> Kind<Self, B> {
+        self.flatMap(fa, { _ in fb.value() })
     }
 
     /// Sequentially compose two computations, discarding the value produced by the second.
@@ -81,8 +93,10 @@ public extension Monad {
     ///   - fa: 1st computation.
     ///   - fb: 2nd computation.
     /// - Returns: Result produced from the first computation after both are computed.
-    static func forEffect<A, B>(_ fa: Kind<Self, A>, _ fb: Kind<Self, B>) -> Kind<Self, A> {
-        return self.flatMap(fa, { a in self.map(fb, { _ in a })})
+    static func forEffect<A, B>(
+        _ fa: Kind<Self, A>,
+        _ fb: Kind<Self, B>) -> Kind<Self, A> {
+        self.flatMap(fa, { a in self.map(fb, { _ in a })})
     }
 
     /// Sequentially compose a computation with a potentially lazy one, discarding the value produced by the second.
@@ -91,8 +105,10 @@ public extension Monad {
     ///   - fa: Regular computation.
     ///   - fb: Potentially lazy computation.
     /// - Returns: Result produced from the first computation after both are computed.
-    static func forEffectEval<A, B>(_ fa: Kind<Self, A>, _ fb: Eval<Kind<Self, B>>) -> Kind<Self, A> {
-        return self.flatMap(fa, { a in self.map(fb.value(), constant(a)) })
+    static func forEffectEval<A, B>(
+        _ fa: Kind<Self, A>,
+        _ fb: Eval<Kind<Self, B>>) -> Kind<Self, A> {
+        self.flatMap(fa, { a in self.map(fb.value(), constant(a)) })
     }
 
     /// Pair the result of a computation with the result of applying a function to such result.
@@ -101,8 +117,10 @@ public extension Monad {
     ///   - fa: A computation in the context implementing this instance.
     ///   - f: A function to be applied to the result of the computation.
     /// - Returns: A tuple of the result of the computation paired with the result of the function, in the context implementing this instance.
-    static func mproduct<A, B>(_ fa: Kind<Self, A>, _ f: @escaping (A) -> Kind<Self, B>) -> Kind<Self, (A, B)> {
-        return self.flatMap(fa, { a in self.map(f(a), { b in (a, b) }) })
+    static func mproduct<A, B>(
+        _ fa: Kind<Self, A>,
+        _ f: @escaping (A) -> Kind<Self, B>) -> Kind<Self, (A, B)> {
+        self.flatMap(fa, { a in self.map(f(a), { b in (a, b) }) })
     }
 
     /// Conditionally apply a closure based on the boolean result of a computation.
@@ -112,8 +130,11 @@ public extension Monad {
     ///   - ifTrue: Closure to be applied if the computation evaluates to `true`.
     ///   - ifFalse: Closure to be applied if the computation evaluates to `false`.
     /// - Returns: Result of applying the corresponding closure based on the result of the computation.
-    static func ifM<B>(_ fa: Kind<Self, Bool>, _ ifTrue: @escaping () -> Kind<Self, B>, _ ifFalse: @escaping () -> Kind<Self, B>) -> Kind<Self, B> {
-        return flatMap(fa, { a in a ? ifTrue() : ifFalse() })
+    static func ifM<B>(
+        _ fa: Kind<Self, Bool>,
+        _ ifTrue: @escaping () -> Kind<Self, B>,
+        _ ifFalse: @escaping () -> Kind<Self, B>) -> Kind<Self, B> {
+        flatMap(fa, { a in a ? ifTrue() : ifFalse() })
     }
     
     /// Applies a monadic function and discard the result while keeping the effect.
@@ -122,7 +143,9 @@ public extension Monad {
     ///   - fa: A computation.
     ///   - f: A monadic function which result will be discarded.
     /// - Returns: A computation with the result of the initial computation and the effect caused by the function application.
-    static func flatTap<A, B>(_ fa: Kind<Self, A>, _ f: @escaping (A) -> Kind<Self, B>) -> Kind<Self, A> {
+    static func flatTap<A, B>(
+        _ fa: Kind<Self, A>,
+        _ f: @escaping (A) -> Kind<Self, B>) -> Kind<Self, A> {
         flatMap(fa) { a in f(a).as(a) }
     }
 }
@@ -138,7 +161,7 @@ public extension Kind where F: Monad {
     ///   - f: A function describing the second computation, which depends on the value of the first.
     /// - Returns: Result of composing the two computations.
     func flatMap<B>(_ f: @escaping (A) -> Kind<F, B>) -> Kind<F, B> {
-        return F.flatMap(self, f)
+        F.flatMap(self, f)
     }
 
     /// Monadic tail recursion.
@@ -149,8 +172,10 @@ public extension Kind where F: Monad {
     ///   - a: Initial value for the recursion.
     ///   - f: A function describing a recursive step.
     /// - Returns: Result of evaluating recursively the provided function with the initial value.
-    static func tailRecM<B>(_ a: A, _ f: @escaping (A) -> Kind<F, Either<A, B>>) -> Kind<F, B> {
-        return F.tailRecM(a, f)
+    static func tailRecM<B>(
+        _ a: A,
+        _ f: @escaping (A) -> Kind<F, Either<A, B>>) -> Kind<F, B> {
+        F.tailRecM(a, f)
     }
 
     /// Flattens a nested structure of the context implementing this instance into a single layer.
@@ -160,7 +185,7 @@ public extension Kind where F: Monad {
     /// - Parameter ffa: Value with a nested structure.
     /// - Returns: Value with a single context structure.
     static func flatten(_ ffa: Kind<F, Kind<F, A>>) -> Kind<F, A> {
-        return F.flatten(ffa)
+        F.flatten(ffa)
     }
 
     /// Sequentially compose with another computation, discarding the value produced by the this one.
@@ -171,7 +196,7 @@ public extension Kind where F: Monad {
     ///   - fb: A computation.
     /// - Returns: Result of running the second computation after the first one.
     func followedBy<B>(_ fb: Kind<F, B>) -> Kind<F, B> {
-        return F.followedBy(self, fb)
+        F.followedBy(self, fb)
     }
 
     /// Sequentially compose this computation with a potentially lazy one, discarding the value produced by this one.
@@ -182,7 +207,7 @@ public extension Kind where F: Monad {
     ///   - fb: Lazy computation.
     /// - Returns: Result of running the second computation after the first one.
     func followedByEval<B>(_ fb: Eval<Kind<F, B>>) -> Kind<F, B> {
-        return F.followedByEval(self, fb)
+        F.followedByEval(self, fb)
     }
 
     /// Sequentially compose with another computation, discarding the value produced by the received one.
@@ -193,7 +218,7 @@ public extension Kind where F: Monad {
     ///   - fb: A computation.
     /// - Returns: Result produced from the first computation after both are computed.
     func forEffect<B>(_ fb: Kind<F, B>) -> Kind<F, A> {
-        return F.forEffect(self, fb)
+        F.forEffect(self, fb)
     }
 
     /// Sequentially compose with a potentially lazy computation, discarding the value produced by the received one.
@@ -204,7 +229,7 @@ public extension Kind where F: Monad {
     ///   - fb: Lazy computation.
     /// - Returns: Result produced from the first computation after both are computed.
     func forEffectEval<B>(_ fb: Eval<Kind<F, B>>) -> Kind<F, A> {
-        return F.forEffectEval(self, fb)
+        F.forEffectEval(self, fb)
     }
 
     /// Pair the result of this computation with the result of applying a function to such result.
@@ -215,7 +240,7 @@ public extension Kind where F: Monad {
     ///   - f: A function to be applied to the result of the computation.
     /// - Returns: A tuple of the result of this computation paired with the result of the function, in the context implementing this instance.
     func mproduct<B>(_ f: @escaping (A) -> Kind<F, B>) -> Kind<F, (A, B)> {
-        return F.mproduct(self, f)
+        F.mproduct(self, f)
     }
     
     /// Applies a monadic function and discard the result while keeping the effect.
@@ -239,7 +264,9 @@ public extension Kind where F: Monad, A == Bool {
     ///   - ifTrue: Closure to be applied if the computation evaluates to `true`.
     ///   - ifFalse: Closure to be applied if the computation evaluates to `false`.
     /// - Returns: Result of applying the corresponding closure based on the result of the computation.
-    func ifM<B>(_ ifTrue: @escaping () -> Kind<F, B>, _ ifFalse: @escaping () -> Kind<F, B>) -> Kind<F, B> {
-        return F.ifM(self, ifTrue, ifFalse)
+    func ifM<B>(
+        _ ifTrue: @escaping () -> Kind<F, B>,
+        _ ifFalse: @escaping () -> Kind<F, B>) -> Kind<F, B> {
+        F.ifM(self, ifTrue, ifFalse)
     }
 }

--- a/Sources/Bow/Typeclasses/MonadCombine.swift
+++ b/Sources/Bow/Typeclasses/MonadCombine.swift
@@ -9,7 +9,11 @@ public extension MonadCombine {
     /// - Parameter fga: Nested contexts value.
     /// - Returns: A value in the context implementing this instance where the inner context has been folded.
     static func unite<G: Foldable, A>(_ fga: Kind<Self, Kind<G, A>>) -> Kind<Self, A> {
-        return flatMap(fga, { ga in G.foldLeft(ga, empty(), { acc, a in combineK(acc, pure(a)) })})
+        flatMap(fga, { ga in
+            G.foldLeft(ga, empty(), { acc, a in
+                combineK(acc, pure(a))
+            })
+        })
     }
 }
 
@@ -23,6 +27,6 @@ public extension Kind where F: MonadCombine {
     /// - Parameter fga: Nested contexts value.
     /// - Returns: A value in the context implementing this instance where the inner context has been folded.
     static func unite<G: Foldable>(_ fga: Kind<F, Kind<G, A>>) -> Kind<F, A> {
-        return F.unite(fga)
+        F.unite(fga)
     }
 }

--- a/Sources/Bow/Typeclasses/MonadComprehensions/BindingExpression.swift
+++ b/Sources/Bow/Typeclasses/MonadComprehensions/BindingExpression.swift
@@ -12,14 +12,14 @@ public class BindingExpression<F: Monad> {
     }
     
     internal func yield<A>(_ f: @escaping () -> A) -> Kind<F, A> {
-        return fa().map { x in
+        fa().map { x in
             self.bound.bind(x)
             return f()
         }
     }
     
     internal func bind<A>(_ partial: Eval<Kind<F, A>>) -> Kind<F, A> {
-        return fa().flatMap { x in
+        fa().flatMap { x in
             self.bound.bind(x)
             return partial.value()
         }

--- a/Sources/Bow/Typeclasses/MonadComprehensions/BindingOperator.swift
+++ b/Sources/Bow/Typeclasses/MonadComprehensions/BindingOperator.swift
@@ -2,7 +2,7 @@ infix operator <- : AssignmentPrecedence
 prefix operator |<-
 
 internal func erased<F: Functor, A>(_ value: Kind<F, A>) -> Kind<F, Any> {
-    return value.map { x in x as Any }
+    value.map { x in x as Any }
 }
 
 /// Creates a binding expression.
@@ -11,8 +11,10 @@ internal func erased<F: Functor, A>(_ value: Kind<F, A>) -> Kind<F, Any> {
 ///   - bound: Variable to be bound in the expression.
 ///   - fa: Monadic effect.
 /// - Returns: A binding expression.
-public func <-<F: Monad, A>(_ bound: BoundVar<F, A>, _ fa: @autoclosure @escaping () -> Kind<F, A>) -> BindingExpression<F> {
-    return BindingExpression(bound.erased, fa >>> erased)
+public func <-<F: Monad, A>(
+    _ bound: BoundVar<F, A>,
+    _ fa: @autoclosure @escaping () -> Kind<F, A>) -> BindingExpression<F> {
+    BindingExpression(bound.erased, fa >>> erased)
 }
 
 /// Creates a binding expression.
@@ -21,8 +23,12 @@ public func <-<F: Monad, A>(_ bound: BoundVar<F, A>, _ fa: @autoclosure @escapin
 ///   - bounds: A 2-ary tuple of variables to be bound to the values produced by the effect.
 ///   - fa: Monadic effect.
 /// - Returns: A binding expresssion.
-public func <-<F: Monad, A, B>(_ bounds: (BoundVar<F, A>, BoundVar<F, B>), _ fa: @autoclosure @escaping () -> Kind<F, (A, B)>) -> BindingExpression<F> {
-    return BindingExpression(BoundVar2(bounds.0, bounds.1).erased, fa >>> erased)
+public func <-<F: Monad, A, B>(
+    _ bounds: (BoundVar<F, A>, BoundVar<F, B>),
+    _ fa: @autoclosure @escaping () -> Kind<F, (A, B)>) -> BindingExpression<F> {
+    BindingExpression(
+        BoundVar2(bounds.0, bounds.1).erased,
+        fa >>> erased)
 }
 
 /// Creates a binding expression.
@@ -31,8 +37,12 @@ public func <-<F: Monad, A, B>(_ bounds: (BoundVar<F, A>, BoundVar<F, B>), _ fa:
 ///   - bounds: A 3-ary tuple of variables to be bound to the values produced by the effect.
 ///   - fa: Monadic effect.
 /// - Returns: A binding expresssion.
-public func <-<F: Monad, A, B, C>(_ bounds: (BoundVar<F, A>, BoundVar<F, B>, BoundVar<F, C>), _ fa: @autoclosure @escaping () -> Kind<F, (A, B, C)>) -> BindingExpression<F> {
-    return BindingExpression(BoundVar3(bounds.0, bounds.1, bounds.2).erased, fa >>> erased)
+public func <-<F: Monad, A, B, C>(
+    _ bounds: (BoundVar<F, A>, BoundVar<F, B>, BoundVar<F, C>),
+    _ fa: @autoclosure @escaping () -> Kind<F, (A, B, C)>) -> BindingExpression<F> {
+    BindingExpression(
+        BoundVar3(bounds.0, bounds.1, bounds.2).erased,
+        fa >>> erased)
 }
 
 /// Creates a binding expression.
@@ -41,8 +51,12 @@ public func <-<F: Monad, A, B, C>(_ bounds: (BoundVar<F, A>, BoundVar<F, B>, Bou
 ///   - bounds: A 4-ary tuple of variables to be bound to the values produced by the effect.
 ///   - fa: Monadic effect.
 /// - Returns: A binding expresssion.
-public func <-<F: Monad, A, B, C, D>(_ bounds: (BoundVar<F, A>, BoundVar<F, B>, BoundVar<F, C>, BoundVar<F, D>), _ fa: @autoclosure @escaping () -> Kind<F, (A, B, C, D)>) -> BindingExpression<F> {
-    return BindingExpression(BoundVar4(bounds.0, bounds.1, bounds.2, bounds.3).erased, fa >>> erased)
+public func <-<F: Monad, A, B, C, D>(
+    _ bounds: (BoundVar<F, A>, BoundVar<F, B>, BoundVar<F, C>, BoundVar<F, D>),
+    _ fa: @autoclosure @escaping () -> Kind<F, (A, B, C, D)>) -> BindingExpression<F> {
+    BindingExpression(
+        BoundVar4(bounds.0, bounds.1, bounds.2, bounds.3).erased,
+        fa >>> erased)
 }
 
 /// Creates a binding expression.
@@ -51,8 +65,12 @@ public func <-<F: Monad, A, B, C, D>(_ bounds: (BoundVar<F, A>, BoundVar<F, B>, 
 ///   - bounds: A 5-ary tuple of variables to be bound to the values produced by the effect.
 ///   - fa: Monadic effect.
 /// - Returns: A binding expresssion.
-public func <-<F: Monad, A, B, C, D, E>(_ bounds: (BoundVar<F, A>, BoundVar<F, B>, BoundVar<F, C>, BoundVar<F, D>, BoundVar<F, E>), _ fa: @autoclosure @escaping () -> Kind<F, (A, B, C, D, E)>) -> BindingExpression<F> {
-    return BindingExpression(BoundVar5(bounds.0, bounds.1, bounds.2, bounds.3, bounds.4).erased, fa >>> erased)
+public func <-<F: Monad, A, B, C, D, E>(
+    _ bounds: (BoundVar<F, A>, BoundVar<F, B>, BoundVar<F, C>, BoundVar<F, D>, BoundVar<F, E>),
+    _ fa: @autoclosure @escaping () -> Kind<F, (A, B, C, D, E)>) -> BindingExpression<F> {
+    BindingExpression(
+        BoundVar5(bounds.0, bounds.1, bounds.2, bounds.3, bounds.4).erased,
+        fa >>> erased)
 }
 
 /// Creates a binding expression.
@@ -61,8 +79,12 @@ public func <-<F: Monad, A, B, C, D, E>(_ bounds: (BoundVar<F, A>, BoundVar<F, B
 ///   - bounds: A 6-ary tuple of variables to be bound to the values produced by the effect.
 ///   - fa: Monadic effect.
 /// - Returns: A binding expresssion.
-public func <-<F: Monad, A, B, C, D, E, G>(_ bounds: (BoundVar<F, A>, BoundVar<F, B>, BoundVar<F, C>, BoundVar<F, D>, BoundVar<F, E>, BoundVar<F, G>), _ fa: @autoclosure @escaping () -> Kind<F, (A, B, C, D, E, G)>) -> BindingExpression<F> {
-    return BindingExpression(BoundVar6(bounds.0, bounds.1, bounds.2, bounds.3, bounds.4, bounds.5).erased, fa >>> erased)
+public func <-<F: Monad, A, B, C, D, E, G>(
+    _ bounds: (BoundVar<F, A>, BoundVar<F, B>, BoundVar<F, C>, BoundVar<F, D>, BoundVar<F, E>, BoundVar<F, G>),
+    _ fa: @autoclosure @escaping () -> Kind<F, (A, B, C, D, E, G)>) -> BindingExpression<F> {
+    BindingExpression(
+        BoundVar6(bounds.0, bounds.1, bounds.2, bounds.3, bounds.4, bounds.5).erased,
+        fa >>> erased)
 }
 
 /// Creates a binding expression.
@@ -71,8 +93,12 @@ public func <-<F: Monad, A, B, C, D, E, G>(_ bounds: (BoundVar<F, A>, BoundVar<F
 ///   - bounds: A 7-ary tuple of variables to be bound to the values produced by the effect.
 ///   - fa: Monadic effect.
 /// - Returns: A binding expresssion.
-public func <-<F: Monad, A, B, C, D, E, G, H>(_ bounds: (BoundVar<F, A>, BoundVar<F, B>, BoundVar<F, C>, BoundVar<F, D>, BoundVar<F, E>, BoundVar<F, G>, BoundVar<F, H>), _ fa: @autoclosure @escaping () -> Kind<F, (A, B, C, D, E, G, H)>) -> BindingExpression<F> {
-    return BindingExpression(BoundVar7(bounds.0, bounds.1, bounds.2, bounds.3, bounds.4, bounds.5, bounds.6).erased, fa >>> erased)
+public func <-<F: Monad, A, B, C, D, E, G, H>(
+    _ bounds: (BoundVar<F, A>, BoundVar<F, B>, BoundVar<F, C>, BoundVar<F, D>, BoundVar<F, E>, BoundVar<F, G>, BoundVar<F, H>),
+    _ fa: @autoclosure @escaping () -> Kind<F, (A, B, C, D, E, G, H)>) -> BindingExpression<F> {
+    BindingExpression(
+        BoundVar7(bounds.0, bounds.1, bounds.2, bounds.3, bounds.4, bounds.5, bounds.6).erased,
+        fa >>> erased)
 }
 
 /// Creates a binding expression.
@@ -81,8 +107,12 @@ public func <-<F: Monad, A, B, C, D, E, G, H>(_ bounds: (BoundVar<F, A>, BoundVa
 ///   - bounds: A 8-ary tuple of variables to be bound to the values produced by the effect.
 ///   - fa: Monadic effect.
 /// - Returns: A binding expresssion.
-public func <-<F: Monad, A, B, C, D, E, G, H, I>(_ bounds: (BoundVar<F, A>, BoundVar<F, B>, BoundVar<F, C>, BoundVar<F, D>, BoundVar<F, E>, BoundVar<F, G>, BoundVar<F, H>, BoundVar<F, I>), _ fa: @autoclosure @escaping () -> Kind<F, (A, B, C, D, E, G, H, I)>) -> BindingExpression<F> {
-    return BindingExpression(BoundVar8(bounds.0, bounds.1, bounds.2, bounds.3, bounds.4, bounds.5, bounds.6, bounds.7).erased, fa >>> erased)
+public func <-<F: Monad, A, B, C, D, E, G, H, I>(
+    _ bounds: (BoundVar<F, A>, BoundVar<F, B>, BoundVar<F, C>, BoundVar<F, D>, BoundVar<F, E>, BoundVar<F, G>, BoundVar<F, H>, BoundVar<F, I>),
+    _ fa: @autoclosure @escaping () -> Kind<F, (A, B, C, D, E, G, H, I)>) -> BindingExpression<F> {
+    BindingExpression(
+        BoundVar8(bounds.0, bounds.1, bounds.2, bounds.3, bounds.4, bounds.5, bounds.6, bounds.7).erased,
+        fa >>> erased)
 }
 
 /// Creates a binding expression.
@@ -91,8 +121,12 @@ public func <-<F: Monad, A, B, C, D, E, G, H, I>(_ bounds: (BoundVar<F, A>, Boun
 ///   - bounds: A 9-ary tuple of variables to be bound to the values produced by the effect.
 ///   - fa: Monadic effect.
 /// - Returns: A binding expresssion.
-public func <-<F: Monad, A, B, C, D, E, G, H, I, J>(_ bounds: (BoundVar<F, A>, BoundVar<F, B>, BoundVar<F, C>, BoundVar<F, D>, BoundVar<F, E>, BoundVar<F, G>, BoundVar<F, H>, BoundVar<F, I>, BoundVar<F, J>), _ fa: @autoclosure @escaping () -> Kind<F, (A, B, C, D, E, G, H, I, J)>) -> BindingExpression<F> {
-    return BindingExpression(BoundVar9(bounds.0, bounds.1, bounds.2, bounds.3, bounds.4, bounds.5, bounds.6, bounds.7, bounds.8).erased, fa >>> erased)
+public func <-<F: Monad, A, B, C, D, E, G, H, I, J>(
+    _ bounds: (BoundVar<F, A>, BoundVar<F, B>, BoundVar<F, C>, BoundVar<F, D>, BoundVar<F, E>, BoundVar<F, G>, BoundVar<F, H>, BoundVar<F, I>, BoundVar<F, J>),
+    _ fa: @autoclosure @escaping () -> Kind<F, (A, B, C, D, E, G, H, I, J)>) -> BindingExpression<F> {
+    BindingExpression(
+        BoundVar9(bounds.0, bounds.1, bounds.2, bounds.3, bounds.4, bounds.5, bounds.6, bounds.7, bounds.8).erased,
+        fa >>> erased)
 }
 
 /// Creates a binding expression.
@@ -101,8 +135,12 @@ public func <-<F: Monad, A, B, C, D, E, G, H, I, J>(_ bounds: (BoundVar<F, A>, B
 ///   - bounds: A 10-ary tuple of variables to be bound to the values produced by the effect.
 ///   - fa: Monadic effect.
 /// - Returns: A binding expresssion.
-public func <-<F: Monad, A, B, C, D, E, G, H, I, J, K>(_ bounds: (BoundVar<F, A>, BoundVar<F, B>, BoundVar<F, C>, BoundVar<F, D>, BoundVar<F, E>, BoundVar<F, G>, BoundVar<F, H>, BoundVar<F, I>, BoundVar<F, J>, BoundVar<F, K>), _ fa: @autoclosure @escaping () -> Kind<F, (A, B, C, D, E, G, H, I, J, K)>) -> BindingExpression<F> {
-    return BindingExpression(BoundVar10(bounds.0, bounds.1, bounds.2, bounds.3, bounds.4, bounds.5, bounds.6, bounds.7, bounds.8, bounds.9).erased, fa >>> erased)
+public func <-<F: Monad, A, B, C, D, E, G, H, I, J, K>(
+    _ bounds: (BoundVar<F, A>, BoundVar<F, B>, BoundVar<F, C>, BoundVar<F, D>, BoundVar<F, E>, BoundVar<F, G>, BoundVar<F, H>, BoundVar<F, I>, BoundVar<F, J>, BoundVar<F, K>),
+    _ fa: @autoclosure @escaping () -> Kind<F, (A, B, C, D, E, G, H, I, J, K)>) -> BindingExpression<F> {
+    BindingExpression(
+        BoundVar10(bounds.0, bounds.1, bounds.2, bounds.3, bounds.4, bounds.5, bounds.6, bounds.7, bounds.8, bounds.9).erased,
+        fa >>> erased)
 }
 
 /// Creates a binding expression that discards the produced value.
@@ -110,5 +148,5 @@ public func <-<F: Monad, A, B, C, D, E, G, H, I, J, K>(_ bounds: (BoundVar<F, A>
 /// - Parameter fa: Monadic effect.
 /// - Returns: A binding expression.
 public prefix func |<-<F: Monad, A>(_ fa: @autoclosure @escaping () -> Kind<F, A>) -> BindingExpression<F> {
-    return BindingExpression(BoundVar(), fa >>> erased)
+    BindingExpression(BoundVar(), fa >>> erased)
 }

--- a/Sources/Bow/Typeclasses/MonadComprehensions/BoundVar.swift
+++ b/Sources/Bow/Typeclasses/MonadComprehensions/BoundVar.swift
@@ -23,7 +23,7 @@ public class BoundVar<F: Monad, A> {
     }
     
     internal var erased: BoundVar<F, Any> {
-        return ErasedBoundVar<F, A>(self)
+        ErasedBoundVar<F, A>(self)
     }
 }
 
@@ -34,7 +34,7 @@ public extension Monad {
     /// - Parameter type: Type of the variable.
     /// - Returns: A bound variable.
     static func `var`<A>(_ type: A.Type) -> BoundVar<Self, A> {
-        return BoundVar.make()
+        BoundVar.make()
     }
 }
 
@@ -44,7 +44,7 @@ public extension Kind where F: Monad {
     ///
     /// - Returns: A bound variable.
     static func `var`() -> BoundVar<F, A> {
-        return F.var(A.self)
+        F.var(A.self)
     }
 }
 
@@ -64,7 +64,8 @@ internal class BoundVar2<F: Monad, A, B>: BoundVar<F, (A, B)> {
     let a: BoundVar<F, A>
     let b: BoundVar<F, B>
     
-    init(_ a: BoundVar<F, A>, _ b: BoundVar<F, B>) {
+    init(_ a: BoundVar<F, A>,
+         _ b: BoundVar<F, B>) {
         self.a = a
         self.b = b
     }
@@ -80,7 +81,9 @@ internal class BoundVar3<F: Monad, A, B, C>: BoundVar<F, (A, B, C)> {
     let b: BoundVar<F, B>
     let c: BoundVar<F, C>
     
-    init(_ a: BoundVar<F, A>, _ b: BoundVar<F, B>, _ c: BoundVar<F, C>) {
+    init(_ a: BoundVar<F, A>,
+         _ b: BoundVar<F, B>,
+         _ c: BoundVar<F, C>) {
         self.a = a
         self.b = b
         self.c = c
@@ -99,7 +102,10 @@ internal class BoundVar4<F: Monad, A, B, C, D>: BoundVar<F, (A, B, C, D)> {
     let c: BoundVar<F, C>
     let d: BoundVar<F, D>
     
-    init(_ a: BoundVar<F, A>, _ b: BoundVar<F, B>, _ c: BoundVar<F, C>, _ d: BoundVar<F, D>) {
+    init(_ a: BoundVar<F, A>,
+         _ b: BoundVar<F, B>,
+         _ c: BoundVar<F, C>,
+         _ d: BoundVar<F, D>) {
         self.a = a
         self.b = b
         self.c = c
@@ -121,7 +127,11 @@ internal class BoundVar5<F: Monad, A, B, C, D, E>: BoundVar<F, (A, B, C, D, E)> 
     let d: BoundVar<F, D>
     let e: BoundVar<F, E>
     
-    init(_ a: BoundVar<F, A>, _ b: BoundVar<F, B>, _ c: BoundVar<F, C>, _ d: BoundVar<F, D>, _ e: BoundVar<F, E>) {
+    init(_ a: BoundVar<F, A>,
+         _ b: BoundVar<F, B>,
+         _ c: BoundVar<F, C>,
+         _ d: BoundVar<F, D>,
+         _ e: BoundVar<F, E>) {
         self.a = a
         self.b = b
         self.c = c
@@ -146,7 +156,12 @@ internal class BoundVar6<F: Monad, A, B, C, D, E, G>: BoundVar<F, (A, B, C, D, E
     let e: BoundVar<F, E>
     let g: BoundVar<F, G>
     
-    init(_ a: BoundVar<F, A>, _ b: BoundVar<F, B>, _ c: BoundVar<F, C>, _ d: BoundVar<F, D>, _ e: BoundVar<F, E>, _ g: BoundVar<F, G>) {
+    init(_ a: BoundVar<F, A>,
+         _ b: BoundVar<F, B>,
+         _ c: BoundVar<F, C>,
+         _ d: BoundVar<F, D>,
+         _ e: BoundVar<F, E>,
+         _ g: BoundVar<F, G>) {
         self.a = a
         self.b = b
         self.c = c
@@ -174,7 +189,13 @@ internal class BoundVar7<F: Monad, A, B, C, D, E, G, H>: BoundVar<F, (A, B, C, D
     let g: BoundVar<F, G>
     let h: BoundVar<F, H>
     
-    init(_ a: BoundVar<F, A>, _ b: BoundVar<F, B>, _ c: BoundVar<F, C>, _ d: BoundVar<F, D>, _ e: BoundVar<F, E>, _ g: BoundVar<F, G>, _ h: BoundVar<F, H>) {
+    init(_ a: BoundVar<F, A>,
+         _ b: BoundVar<F, B>,
+         _ c: BoundVar<F, C>,
+         _ d: BoundVar<F, D>,
+         _ e: BoundVar<F, E>,
+         _ g: BoundVar<F, G>,
+         _ h: BoundVar<F, H>) {
         self.a = a
         self.b = b
         self.c = c
@@ -205,7 +226,14 @@ internal class BoundVar8<F: Monad, A, B, C, D, E, G, H, I>: BoundVar<F, (A, B, C
     let h: BoundVar<F, H>
     let i: BoundVar<F, I>
     
-    init(_ a: BoundVar<F, A>, _ b: BoundVar<F, B>, _ c: BoundVar<F, C>, _ d: BoundVar<F, D>, _ e: BoundVar<F, E>, _ g: BoundVar<F, G>, _ h: BoundVar<F, H>, _ i: BoundVar<F, I>) {
+    init(_ a: BoundVar<F, A>,
+         _ b: BoundVar<F, B>,
+         _ c: BoundVar<F, C>,
+         _ d: BoundVar<F, D>,
+         _ e: BoundVar<F, E>,
+         _ g: BoundVar<F, G>,
+         _ h: BoundVar<F, H>,
+         _ i: BoundVar<F, I>) {
         self.a = a
         self.b = b
         self.c = c
@@ -239,7 +267,15 @@ internal class BoundVar9<F: Monad, A, B, C, D, E, G, H, I, J>: BoundVar<F, (A, B
     let i: BoundVar<F, I>
     let j: BoundVar<F, J>
     
-    init(_ a: BoundVar<F, A>, _ b: BoundVar<F, B>, _ c: BoundVar<F, C>, _ d: BoundVar<F, D>, _ e: BoundVar<F, E>, _ g: BoundVar<F, G>, _ h: BoundVar<F, H>, _ i: BoundVar<F, I>, _ j: BoundVar<F, J>) {
+    init(_ a: BoundVar<F, A>,
+         _ b: BoundVar<F, B>,
+         _ c: BoundVar<F, C>,
+         _ d: BoundVar<F, D>,
+         _ e: BoundVar<F, E>,
+         _ g: BoundVar<F, G>,
+         _ h: BoundVar<F, H>,
+         _ i: BoundVar<F, I>,
+         _ j: BoundVar<F, J>) {
         self.a = a
         self.b = b
         self.c = c
@@ -276,7 +312,16 @@ internal class BoundVar10<F: Monad, A, B, C, D, E, G, H, I, J, K>: BoundVar<F, (
     let j: BoundVar<F, J>
     let k: BoundVar<F, K>
     
-    init(_ a: BoundVar<F, A>, _ b: BoundVar<F, B>, _ c: BoundVar<F, C>, _ d: BoundVar<F, D>, _ e: BoundVar<F, E>, _ g: BoundVar<F, G>, _ h: BoundVar<F, H>, _ i: BoundVar<F, I>, _ j: BoundVar<F, J>, _ k: BoundVar<F, K>) {
+    init(_ a: BoundVar<F, A>,
+         _ b: BoundVar<F, B>,
+         _ c: BoundVar<F, C>,
+         _ d: BoundVar<F, D>,
+         _ e: BoundVar<F, E>,
+         _ g: BoundVar<F, G>,
+         _ h: BoundVar<F, H>,
+         _ i: BoundVar<F, I>,
+         _ j: BoundVar<F, J>,
+         _ k: BoundVar<F, K>) {
         self.a = a
         self.b = b
         self.c = c

--- a/Sources/Bow/Typeclasses/MonadComprehensions/MonadComprenhensions.swift
+++ b/Sources/Bow/Typeclasses/MonadComprehensions/MonadComprenhensions.swift
@@ -1,10 +1,11 @@
 class MonadComprehension<F: Monad> {
     static func buildBlock<A>(_ children: [BindingExpression<F>], yield: @escaping () -> A) -> Kind<F, A> {
         if let last = children.last {
-            return Array(children.dropLast()).k().foldRight(
-                Eval.always { last.yield(yield) },
-                { expression, partial in Eval.always { expression.bind(partial) }
-            }).value()
+            return Array(children.dropLast()).k()
+                .foldRight(Eval.always { last.yield(yield) },
+                { expression, partial in
+                    Eval.always { expression.bind(partial) }
+                }).value()
         } else {
             return F.pure(yield())
         }
@@ -19,6 +20,8 @@ class MonadComprehension<F: Monad> {
 ///   - instructions: A variable number of binding expressions.
 ///   - value: Value to be yield by the monad comprehension.
 /// - Returns: An effect resulting from the chaining of all the effects included in this monad comprehension.
-public func binding<F: Monad, A>(_ instructions: BindingExpression<F>..., yield value: @autoclosure @escaping () -> A) -> Kind<F, A> {
-    return MonadComprehension<F>.buildBlock(instructions, yield: value)
+public func binding<F: Monad, A>(
+    _ instructions: BindingExpression<F>...,
+    yield value: @autoclosure @escaping () -> A) -> Kind<F, A> {
+    MonadComprehension<F>.buildBlock(instructions, yield: value)
 }

--- a/Sources/Bow/Typeclasses/MonadComprehensions/ReaderBindingExpression.swift
+++ b/Sources/Bow/Typeclasses/MonadComprehensions/ReaderBindingExpression.swift
@@ -2,5 +2,5 @@
 ///
 /// - Returns: Result of `MonadReader.ask`.
 public func ask<F: MonadReader>() -> Kind<F, F.D> {
-    return F.ask()
+    F.ask()
 }

--- a/Sources/Bow/Typeclasses/MonadComprehensions/StateBindingExpression.swift
+++ b/Sources/Bow/Typeclasses/MonadComprehensions/StateBindingExpression.swift
@@ -2,7 +2,7 @@
 ///
 /// - Returns: Result from `MonadState.get`.
 public func getState<F: MonadState>() -> Kind<F, F.S> {
-    return F.get()
+    F.get()
 }
 
 /// Utility function for `MonadState.set` in monad comprehensions.
@@ -10,7 +10,7 @@ public func getState<F: MonadState>() -> Kind<F, F.S> {
 /// - Parameter state: State to be set in `MonadState.set`.
 /// - Returns: A binding expression.
 public func setState<F: MonadState>(_ state: F.S) -> BindingExpression<F> {
-    return |<-F.set(state)
+    |<-F.set(state)
 }
 
 /// Utility function for `MonadState.modify` in monad comprehensions.
@@ -18,7 +18,7 @@ public func setState<F: MonadState>(_ state: F.S) -> BindingExpression<F> {
 /// - Parameter f: Function for `MonadState.modify`.
 /// - Returns: A binding expression.
 public func modifyState<F: MonadState>(_ f: @escaping (F.S) -> F.S) -> BindingExpression<F> {
-    return |<-F.modify(f)
+    |<-F.modify(f)
 }
 
 /// Utility function for `MonadState.inspect` in monad comprehensions.
@@ -26,5 +26,5 @@ public func modifyState<F: MonadState>(_ f: @escaping (F.S) -> F.S) -> BindingEx
 /// - Parameter f: Function for `MonadState.inspect`.
 /// - Returns: Result from `MonadState.inspect`.
 public func inspectState<F: MonadState, A>(_ f: @escaping (F.S) -> A) -> Kind<F, A> {
-    return F.inspect(f)
+    F.inspect(f)
 }

--- a/Sources/Bow/Typeclasses/MonadComprehensions/WriterBindingExpression.swift
+++ b/Sources/Bow/Typeclasses/MonadComprehensions/WriterBindingExpression.swift
@@ -3,5 +3,5 @@
 /// - Parameter w: Value for `MonadWriter.tell`.
 /// - Returns: A binding expression.
 public func tell<F: MonadWriter>(_ w: F.W) -> BindingExpression<F> {
-    return |<-F.tell(w)
+    |<-F.tell(w)
 }

--- a/Sources/Bow/Typeclasses/MonadError.swift
+++ b/Sources/Bow/Typeclasses/MonadError.swift
@@ -13,8 +13,11 @@ public extension MonadError {
     ///   - error: A function that produces an error of the type this instance is able to handle.
     ///   - predicate: A boolean predicate to test the value of the computation.
     /// - Returns: A value or an error in the context implementing this instance.
-    static func ensure<A>(_ fa: Kind<Self, A>, _ error: @escaping () -> E, _ predicate: @escaping (A) -> Bool) -> Kind<Self, A> {
-        return flatMap(fa, { a in
+    static func ensure<A>(
+        _ fa: Kind<Self, A>,
+        _ error: @escaping () -> E,
+        _ predicate: @escaping (A) -> Bool) -> Kind<Self, A> {
+        flatMap(fa, { a in
             predicate(a) ? pure(a) : raiseError(error())
         })
     }
@@ -31,7 +34,9 @@ public extension Kind where F: MonadError {
     ///   - error: A function that produces an error of the type this instance is able to handle.
     ///   - predicate: A boolean predicate to test the value of the computation.
     /// - Returns: A value or an error in the context implementing this instance.
-    func ensure(_ error: @escaping () -> F.E, _ predicate: @escaping (A) -> Bool) -> Kind<F, A> {
-        return F.ensure(self, error, predicate)
+    func ensure(
+        _ error: @escaping () -> F.E,
+        _ predicate: @escaping (A) -> Bool) -> Kind<F, A> {
+        F.ensure(self, error, predicate)
     }
 }

--- a/Sources/Bow/Typeclasses/MonadFilter.swift
+++ b/Sources/Bow/Typeclasses/MonadFilter.swift
@@ -14,9 +14,11 @@ public protocol MonadFilter: Monad, FunctorFilter {
 
 public extension MonadFilter {
     // Docs inherited from `FunctorFilter`
-    static func mapFilter<A, B>(_ fa : Kind<Self, A>, _ f : @escaping (A) -> OptionOf<B>) -> Kind<Self, B>{
-        return flatMap(fa, { a in
-            Option<B>.fix(f(a)).fold(self.empty, self.pure)
+    static func mapFilter<A, B>(
+        _ fa: Kind<Self, A>,
+        _ f: @escaping (A) -> OptionOf<B>) -> Kind<Self, B>{
+        flatMap(fa, { a in
+            f(a)^.fold(self.empty, self.pure)
         })
     }
 }
@@ -28,6 +30,6 @@ public extension Kind where F: MonadFilter {
     ///
     /// - Returns: Empty element.
     static var empty: Kind<F, A> {
-        return F.empty()
+        F.empty()
     }
 }

--- a/Sources/Bow/Typeclasses/MonadReader.swift
+++ b/Sources/Bow/Typeclasses/MonadReader.swift
@@ -16,7 +16,9 @@ public protocol MonadReader: Monad {
     ///   - fa: Computation to execute.
     ///   - f: Funtion to modify the environment.
     /// - Returns: Computation in the modified environment.
-    static func local<A>(_ fa: Kind<Self, A>, _ f: @escaping (D) -> D) -> Kind<Self, A>
+    static func local<A>(
+        _ fa: Kind<Self, A>,
+        _ f: @escaping (D) -> D) -> Kind<Self, A>
 }
 
 public extension MonadReader {
@@ -25,7 +27,7 @@ public extension MonadReader {
     /// - Parameter f: Selector function to apply to the environment.
     /// - Returns: A value extracted from the environment, in the context implementing this instance.
     static func reader<A>(_ f: @escaping (D) -> A) -> Kind<Self, A> {
-        return map(ask(), f)
+        map(ask(), f)
     }
 }
 
@@ -38,7 +40,7 @@ public extension Kind where F: MonadReader, A == F.D {
     ///
     /// - Returns: Shared environment.
     static func ask() -> Kind<F, F.D> {
-        return F.ask()
+        F.ask()
     }
 }
 
@@ -51,7 +53,7 @@ public extension Kind where F: MonadReader {
     ///   - f: Funtion to modify the environment.
     /// - Returns: Computation in the modified environment.
     func local(_ f: @escaping (F.D) -> F.D) -> Kind<F, A> {
-        return F.local(self, f)
+        F.local(self, f)
     }
 
     /// Retrieves a function of the current environment.
@@ -61,6 +63,6 @@ public extension Kind where F: MonadReader {
     /// - Parameter f: Selector function to apply to the environment.
     /// - Returns: A value extracted from the environment, in the context implementing this instance.
     static func reader(_ f: @escaping (F.D) -> A) -> Kind<F, A> {
-        return F.reader(f)
+        F.reader(f)
     }
 }

--- a/Sources/Bow/Typeclasses/MonadState.swift
+++ b/Sources/Bow/Typeclasses/MonadState.swift
@@ -23,7 +23,7 @@ public extension MonadState {
     /// - Parameter f: A function that receives the state and computes a value and a new state.
     /// - Returns: A value with the output of the function and the new state.
     static func state<A>(_ f: @escaping (S) -> (S, A)) -> Kind<Self, A> {
-        return flatMap(get(), { s in
+        flatMap(get(), { s in
             let result = f(s)
             return map(set(result.0), { _ in result.1 })
         })
@@ -34,7 +34,7 @@ public extension MonadState {
     /// - Parameter f: Function that modifies the state.
     /// - Returns: Unit.
     static func modify(_ f: @escaping (S) -> S) -> Kind<Self, ()> {
-        return flatMap(get(), { s in set(f(s))})
+        flatMap(get(), { s in set(f(s))})
     }
 
     /// Retrieves a specific component of the state.
@@ -42,7 +42,7 @@ public extension MonadState {
     /// - Parameter f: Projection function to obtain part of the state.
     /// - Returns: A specific part of the state.
     static func inspect<A>(_ f: @escaping (S) -> A) -> Kind<Self, A> {
-        return map(get(), f)
+        map(get(), f)
     }
 }
 
@@ -56,7 +56,7 @@ public extension Kind where F: MonadState, A == Void {
     /// - Parameter s: New state.
     /// - Returns: Unit.
     static func set(_ s: F.S) -> Kind<F, ()> {
-        return F.set(s)
+        F.set(s)
     }
     
     /// Modifies the internal state.
@@ -66,7 +66,7 @@ public extension Kind where F: MonadState, A == Void {
     /// - Parameter f: Function that modifies the state.
     /// - Returns: Unit.
     static func modify(_ f: @escaping (F.S) -> F.S) -> Kind<F, ()> {
-        return F.modify(f)
+        F.modify(f)
     }
 }
 
@@ -77,7 +77,7 @@ public extension Kind where F: MonadState, A == F.S {
     ///
     /// - Returns: Maintained state.
     static func get() -> Kind<F, F.S> {
-        return F.get()
+        F.get()
     }
 }
 
@@ -89,7 +89,7 @@ public extension Kind where F: MonadState {
     /// - Parameter f: A function that receives the state and computes a value and a new state.
     /// - Returns: A value with the output of the function and the new state.
     static func state(_ f: @escaping (F.S) -> (F.S, A)) -> Kind<F, A> {
-        return F.state(f)
+        F.state(f)
     }
 
     /// Retrieves a specific component of the state.
@@ -99,6 +99,6 @@ public extension Kind where F: MonadState {
     /// - Parameter f: Projection function to obtain part of the state.
     /// - Returns: A specific part of the state.
     static func inspect(_ f: @escaping (F.S) -> A) -> Kind<F, A> {
-        return F.inspect(f)
+        F.inspect(f)
     }
 }

--- a/Sources/Bow/Typeclasses/MonadWriter.swift
+++ b/Sources/Bow/Typeclasses/MonadWriter.swift
@@ -30,7 +30,7 @@ public extension MonadWriter {
     /// - Parameter w: New value.
     /// - Returns: Unit.
     static func tell(_ w: W) -> Kind<Self, ()> {
-        return writer((w, ()))
+        writer((w, ()))
     }
     
     /// Performs a computation and transforms the side stream of data, pairing it with the result of the computation.
@@ -39,8 +39,10 @@ public extension MonadWriter {
     ///   - fa: A computation.
     ///   - f: A function to transform the side stream of data.
     /// - Returns: A tuple of the transformation of the side stream and the result of the computation.
-    static func listens<A, B>(_ fa: Kind<Self, A>, _ f: @escaping (W) -> B) -> Kind<Self, (B, A)> {
-        return map(listen(fa), { pair in (f(pair.0), pair.1) })
+    static func listens<A, B>(
+        _ fa: Kind<Self, A>,
+        _ f: @escaping (W) -> B) -> Kind<Self, (B, A)> {
+        map(listen(fa), { pair in (f(pair.0), pair.1) })
     }
     
     /// Transforms the side stream of data of a given computation.
@@ -49,8 +51,10 @@ public extension MonadWriter {
     ///   - fa: A computation.
     ///   - f: Transforming function.
     /// - Returns: A computation with the same result as the provided one, with the transformed side stream of data.
-    static func censor<A>(_ fa: Kind<Self, A>, _ f: @escaping (W) -> W) -> Kind<Self, A> {
-        return pass(fa.map { a in (f, a) })
+    static func censor<A>(
+        _ fa: Kind<Self, A>,
+        _ f: @escaping (W) -> W) -> Kind<Self, A> {
+        pass(fa.map { a in (f, a) })
     }
 }
 
@@ -64,7 +68,7 @@ public extension Kind where F: MonadWriter, A == Void {
     /// - Parameter w: New value.
     /// - Returns: Unit.
     static func tell(_ w: F.W) -> Kind<F, ()> {
-        return F.tell(w)
+        F.tell(w)
     }
 }
 
@@ -76,7 +80,7 @@ public extension Kind where F: MonadWriter {
     /// - Parameter aw: A tupe of the writer type and a value.
     /// - Returns: The writer action embedded in the context implementing this instance.
     static func writer(_ aw: (F.W, A)) -> Kind<F, A> {
-        return F.writer(aw)
+        F.writer(aw)
     }
 
     /// Adds the side stream of data to the result of this computation.
@@ -85,7 +89,7 @@ public extension Kind where F: MonadWriter {
     ///
     /// - Returns: The result of the computation paired with the side stream of data.
     func listen() -> Kind<F, (F.W, A)> {
-        return F.listen(self)
+        F.listen(self)
     }
 
     /// Performs a computation and transforms the side stream of data.
@@ -95,7 +99,7 @@ public extension Kind where F: MonadWriter {
     /// - Parameter fa: A computation that transform the stream of data.
     /// - Returns: Result of the computation.
     static func pass(_ fa: Kind<F, ((F.W) -> F.W, A)>) -> Kind<F, A> {
-        return F.pass(fa)
+        F.pass(fa)
     }
 
     /// Performs this computation and transforms the side stream of data, pairing it with the result of this computation.
@@ -106,7 +110,7 @@ public extension Kind where F: MonadWriter {
     ///   - f: A function to transform the side stream of data.
     /// - Returns: A tuple of the transformation of the side stream and the result of the computation.
     func listens<B>(_ f: @escaping (F.W) -> B) -> Kind<F, (B, A)> {
-        return F.listens(self, f)
+        F.listens(self, f)
     }
 
     /// Transforms the side stream of data of this computation.
@@ -117,6 +121,6 @@ public extension Kind where F: MonadWriter {
     ///   - f: Transforming function.
     /// - Returns: A computation with the same result as the provided one, with the transformed side stream of data.
     func censor(_ f: @escaping (F.W) -> F.W) -> Kind<F, A> {
-        return F.censor(self, f)
+        F.censor(self, f)
     }
 }

--- a/Sources/Bow/Typeclasses/MonoidK.swift
+++ b/Sources/Bow/Typeclasses/MonoidK.swift
@@ -25,6 +25,6 @@ public extension Kind where F: MonoidK {
     ///
     /// - Returns: A value representing the empty element of this MonoidK instance.
     static func emptyK() -> Kind<F, A> {
-        return F.emptyK()
+        F.emptyK()
     }
 }

--- a/Sources/Bow/Typeclasses/Reducible.swift
+++ b/Sources/Bow/Typeclasses/Reducible.swift
@@ -9,7 +9,10 @@ public protocol Reducible: Foldable {
     ///   - f: Transforming function.
     ///   - g: Folding function.
     /// - Returns: Summary value of this reduction.
-    static func reduceLeftTo<A, B>(_ fa : Kind<Self, A>, _ f : (A) -> B, _ g : (B, A) -> B) -> B
+    static func reduceLeftTo<A, B>(
+        _ fa: Kind<Self, A>,
+        _ f: (A) -> B,
+        _ g: (B, A) -> B) -> B
     
     /// Lazily reduces a structure of values from right to left, also performing a transformation of values.
     ///
@@ -18,7 +21,10 @@ public protocol Reducible: Foldable {
     ///   - f: Transforming function.
     ///   - g: Folding function.
     /// - Returns: Potentially lazy summary value of this reduction.
-    static func reduceRightTo<A, B>(_ fa : Kind<Self, A>, _ f : (A) -> B, _ g : (A, Eval<B>) -> Eval<B>) -> Eval<B>
+    static func reduceRightTo<A, B>(
+        _ fa: Kind<Self, A>,
+        _ f: (A) -> B,
+        _ g: (A, Eval<B>) -> Eval<B>) -> Eval<B>
 }
 
 // MARK: Related methods
@@ -30,8 +36,10 @@ public extension Reducible {
     ///   - fa: Structure of values.
     ///   - f: Folding function.
     /// - Returns: Summary value of this reduction.
-    static func reduceLeft<A>(_ fa : Kind<Self, A>, _ f : (A, A) -> A) -> A {
-        return reduceLeftTo(fa, id, f)
+    static func reduceLeft<A>(
+        _ fa: Kind<Self, A>,
+        _ f: (A, A) -> A) -> A {
+        reduceLeftTo(fa, id, f)
     }
 
     /// Lazily reduces a structure of values from right to left without transforming them.
@@ -40,8 +48,10 @@ public extension Reducible {
     ///   - fa: Structure of values.
     ///   - f: Folding function.
     /// - Returns: Potentially lazy summary value of this reduction.
-    static func reduceRight<A>(_ fa : Kind<Self, A>, _ f : (A, Eval<A>) -> Eval<A>) -> Eval<A> {
-        return reduceRightTo(fa, id, f)
+    static func reduceRight<A>(
+        _ fa: Kind<Self, A>,
+        _ f: (A, Eval<A>) -> Eval<A>) -> Eval<A> {
+        reduceRightTo(fa, id, f)
     }
 
     /// Reduces the elements of a structure down to a single value by applying the provided transformation and aggregation funtions in a left-associative manner.
@@ -51,8 +61,11 @@ public extension Reducible {
     ///   - f: Transforming function.
     ///   - g: Folding function.
     /// - Returns: Optional summary value resulting from the folding process. It will be an `Option.none` if the structure is empty, or a value if not.
-    static func reduceLeftToOption<A, B>(_ fa: Kind<Self, A>, _ f: @escaping (A) -> B, _ g: @escaping (B, A) -> B) -> Option<B> {
-        return Option<B>.some(reduceLeftTo(fa, f, g))
+    static func reduceLeftToOption<A, B>(
+        _ fa: Kind<Self, A>,
+        _ f: @escaping (A) -> B,
+        _ g: @escaping (B, A) -> B) -> Option<B> {
+        Option<B>.some(reduceLeftTo(fa, f, g))
     }
 
     /// Reduces the elements of a structure down to a single value by applying the provided transformation and aggregation functions in a right-associative manner.
@@ -62,8 +75,11 @@ public extension Reducible {
     ///   - f: Transforming function.
     ///   - g: Folding function.
     /// - Returns: Optional summary value resulting from the folding process. It will be an `Option.none` if the structure is empty, or a value if not.
-    static func reduceRightToOption<A, B>(_ fa: Kind<Self, A>, _ f: @escaping (A) -> B, _ g: @escaping (A, Eval<B>) -> Eval<B>) -> Eval<Option<B>> {
-        return Eval<Option<B>>.fix(reduceRightTo(fa, f, g).map(Option<B>.some))
+    static func reduceRightToOption<A, B>(
+        _ fa: Kind<Self, A>,
+        _ f: @escaping (A) -> B,
+        _ g: @escaping (A, Eval<B>) -> Eval<B>) -> Eval<Option<B>> {
+        reduceRightTo(fa, f, g).map(Option<B>.some)^
     }
 
     /// Checks if a structure of values is empty.
@@ -73,7 +89,7 @@ public extension Reducible {
     /// - Parameter fa: Structure of values.
     /// - Returns: `false` if the structure contains any value, `true` otherwise.
     static func isEmpty<A>(_ fa: Kind<Self, A>) -> Bool {
-        return false
+        false
     }
 
     /// Checks if a structure of values is not empty.
@@ -83,7 +99,7 @@ public extension Reducible {
     /// - Parameter fa: Structure of values.
     /// - Returns: `true` if the structure contains any value, `false` otherwise.
     static func nonEmpty<A>(_ fa: Kind<Self, A>) -> Bool {
-        return true
+        true
     }
 
     /// Reduces a structure of values to a summary value using the combination capabilities of the `Semigroup` instance of the underlying type.
@@ -91,7 +107,7 @@ public extension Reducible {
     /// - Parameter fa: Structure of values.
     /// - Returns: Summary value of this reduction.
     static func reduce<A: Semigroup>(_ fa: Kind<Self, A>) -> A {
-        return reduceLeft(fa, { b, a in a.combine(b) })
+        reduceLeft(fa, { b, a in a.combine(b) })
     }
 
     /// Reduces a structure of values by mapping them to a type with a `Semigroup` instance, and using its combination capabilities.
@@ -100,8 +116,10 @@ public extension Reducible {
     ///   - fa: Structure of values.
     ///   - f: Mapping function.
     /// - Returns: Summary value of this reduction.
-    static func reduceMap<A, B: Semigroup>(_ fa: Kind<Self, A>, _ f: (A) -> B) -> B {
-        return reduceLeftTo(fa, f, { b, a in b.combine(f(a)) })
+    static func reduceMap<A, B: Semigroup>(
+        _ fa: Kind<Self, A>,
+        _ f: (A) -> B) -> B {
+        reduceLeftTo(fa, f, { b, a in b.combine(f(a)) })
     }
 }
 
@@ -114,8 +132,10 @@ public extension Kind where F: Reducible {
     ///   - f: Transforming function.
     ///   - g: Folding function.
     /// - Returns: Summary value of this reduction.
-    func reduceLeftTo<B>(_ f: (A) -> B, _ g: (B, A) -> B) -> B {
-        return F.reduceLeftTo(self, f, g)
+    func reduceLeftTo<B>(
+        _ f: (A) -> B,
+        _ g: (B, A) -> B) -> B {
+        F.reduceLeftTo(self, f, g)
     }
 
     /// Lazily reduces this structure of values from right to left, also performing a transformation of values.
@@ -124,8 +144,10 @@ public extension Kind where F: Reducible {
     ///   - f: Transforming function.
     ///   - g: Folding function.
     /// - Returns: Potentially lazy summary value of this reduction.
-    func reduceRightTo<B>(_ f : (A) -> B, _ g : (A, Eval<B>) -> Eval<B>) -> Eval<B> {
-        return F.reduceRightTo(self, f, g)
+    func reduceRightTo<B>(
+        _ f: (A) -> B,
+        _ g: (A, Eval<B>) -> Eval<B>) -> Eval<B> {
+        F.reduceRightTo(self, f, g)
     }
 
     /// Reduces this structure of values by mapping them to a type with a `Semigroup` instance, and using its combination capabilities.
@@ -133,8 +155,8 @@ public extension Kind where F: Reducible {
     /// - Parameters:
     ///   - f: Mapping function.
     /// - Returns: Summary value of this reduction.
-    func reduceMap<B: Semigroup>(_ f : (A) -> B) -> B {
-        return F.reduceMap(self, f)
+    func reduceMap<B: Semigroup>(_ f: (A) -> B) -> B {
+        F.reduceMap(self, f)
     }
 }
 
@@ -143,6 +165,6 @@ public extension Kind where F: Reducible, A: Semigroup {
     ///
     /// - Returns: Summary value of this reduction.
     func reduce() -> A {
-        return F.reduce(self)
+        F.reduce(self)
     }
 }

--- a/Sources/Bow/Typeclasses/SemigroupK.swift
+++ b/Sources/Bow/Typeclasses/SemigroupK.swift
@@ -12,7 +12,9 @@ public protocol SemigroupK {
     ///   - x: Left value in the combination.
     ///   - y: Right value in the combination.
     /// - Returns: Combination of the two values.
-    static func combineK<A>(_ x: Kind<Self, A>, _ y: Kind<Self, A>) -> Kind<Self, A>
+    static func combineK<A>(
+        _ x: Kind<Self, A>,
+        _ y: Kind<Self, A>) -> Kind<Self, A>
 }
 
 // MARK: Syntax for SemigroupK
@@ -26,6 +28,6 @@ public extension Kind where F: SemigroupK {
     ///   - y: Right value in the combination.
     /// - Returns: Combination of the two values.
     func combineK(_ y: Kind<F, A>) -> Kind<F, A> {
-        return F.combineK(self, y)
+        F.combineK(self, y)
     }
 }

--- a/Sources/Bow/Typeclasses/Semigroupal.swift
+++ b/Sources/Bow/Typeclasses/Semigroupal.swift
@@ -20,7 +20,9 @@ public protocol Semigroupal {
     ///   - x: First factor.
     ///   - y: Second factor.
     /// - Returns: Tupled result of combining the values provided by both arguments.
-	static func product<A, B>(_ x: Kind<Self, A>, _ y: Kind<Self, B>) -> Kind<Self, (A, B)>
+	static func product<A, B>(
+        _ x: Kind<Self, A>,
+        _ y: Kind<Self, B>) -> Kind<Self, (A, B)>
 }
 
 // MARK: Syntax for Semigroupal

--- a/Tests/BowLaws/SelectiveLaws.swift
+++ b/Tests/BowLaws/SelectiveLaws.swift
@@ -21,7 +21,7 @@ public class SelectiveLaws<F: Selective & EquatableK> {
             let x = F.pure(Either<Int, Int>.right(a))
             let f = F.pure(b.getArrow)
             let g = F.pure(c.getArrow)
-            return F.select(x, F.sequenceRight(f, g)) == F.sequenceRight(F.select(x, f), F.select(x, g))
+            return F.select(x, F.zipRight(f, g)) == F.zipRight(F.select(x, f), F.select(x, g))
         }
     }
 


### PR DESCRIPTION
## Goal

Cleanup code in the Typeclasses folder in the Core module by:

- Using `FOf<A>` instead of `Kind<F, A>`.
- Removing backticks in `MARK` sections as they do not render properly in Jazzy.
- Removing returns.
- Replacing `fix` by `^`.