### PR TITLE
Cleanup Data folder in Effects module

### DIFF
--- a/Sources/BowEffects/Data/Array+TraverseConcurrent.swift
+++ b/Sources/BowEffects/Data/Array+TraverseConcurrent.swift
@@ -14,7 +14,8 @@ public extension Array {
     /// Evaluate each effect in this array in parallel of values and collects the results.
     ///
     /// - Returns: Results collected under the context of the effects.
-    func parSequence<G: Concurrent, A>() -> Kind<G, [A]> where Element == Kind<G, A> {
+    func parSequence<G: Concurrent, A>() -> Kind<G, [A]>
+        where Element == Kind<G, A> {
         self.k().parSequence().map { array in array^.asArray }
     }
     
@@ -24,7 +25,8 @@ public extension Array {
     ///   - f: A transforming function yielding nested effects.
     /// - Returns: Results collected and flattened under the context of the effects.
     func parFlatTraverse<G: Concurrent, B>(_ f: @escaping (Element) -> Kind<G, [B]>) -> Kind<G, [B]> {
-        self.k().parFlatTraverse { element in f(element).map { x in x.k() } }
-            .map { array in array^.asArray }
+        self.k().parFlatTraverse { element in
+            f(element).map { x in x.k() }
+        }.map { array in array^.asArray }
     }
 }

--- a/Sources/BowEffects/Data/Atomic.swift
+++ b/Sources/BowEffects/Data/Atomic.swift
@@ -15,7 +15,7 @@ public final class Atomic<A> {
     /// Gets or sets the underlying value in a thread-safe manner.
     public var value: A {
         get {
-            return queue.sync { self._value }
+            queue.sync { self._value }
         }
         set {
             self._value = newValue
@@ -62,7 +62,7 @@ public final class Atomic<A> {
     /// - Parameter newValue: Value to be set in this atomic reference.
     /// - Returns: Newly set value.
     public func setAndGet(_ newValue: A) -> A {
-        return updateAndGet { _ in newValue }
+        updateAndGet { _ in newValue }
     }
     
     /// Sets a new value transforming the underlying one using a function and gets the new value.

--- a/Sources/BowEffects/Data/EnvIO.swift
+++ b/Sources/BowEffects/Data/EnvIO.swift
@@ -26,7 +26,8 @@ public extension Kleisli {
     ///
     /// - Parameter f: Side-effectful function. Errors thrown from this function must be of type `E`; otherwise, a fatal error will happen.
     /// - Returns: An EnvIO value suspending the execution of the side effect.
-    static func invoke<E: Error>(_ f: @escaping (D) throws -> A) -> EnvIO<D, E, A> where F == IOPartial<E> {
+    static func invoke<E: Error>(_ f: @escaping (D) throws -> A) -> EnvIO<D, E, A>
+        where F == IOPartial<E> {
         EnvIO { env in IO.invoke { try f(env) } }
     }
     
@@ -34,7 +35,8 @@ public extension Kleisli {
     ///
     /// - Parameter f: Side-effectful function.
     /// - Returns: An EnvIO value suspending the execution of the side effect.
-    static func invokeEither<E: Error>(_ f: @escaping (D) -> Either<E, A>) -> EnvIO<D, E, A> where F == IOPartial<E> {
+    static func invokeEither<E: Error>(_ f: @escaping (D) -> Either<E, A>) -> EnvIO<D, E, A>
+        where F == IOPartial<E> {
         EnvIO { env in IO.invokeEither { f(env) } }
     }
     
@@ -42,7 +44,8 @@ public extension Kleisli {
     ///
     /// - Parameter f: Side-effectful function.
     /// - Returns: An EnvIO value suspending the execution of the side effect.
-    static func invokeResult<E: Error>(_ f: @escaping (D) -> Result<A, E>) -> EnvIO<D, E, A> where F == IOPartial<E> {
+    static func invokeResult<E: Error>(_ f: @escaping (D) -> Result<A, E>) -> EnvIO<D, E, A>
+        where F == IOPartial<E> {
         EnvIO { env in IO.invokeResult { f(env) } }
     }
     
@@ -50,7 +53,8 @@ public extension Kleisli {
     ///
     /// - Parameter f: Side-effectful function.
     /// - Returns: An EnvIO value suspending the execution of the side effect.
-    static func invokeValidated<E: Error>(_ f: @escaping (D) -> Validated<E, A>) -> EnvIO<D, E, A> {
+    static func invokeValidated<E: Error>(_ f: @escaping (D) -> Validated<E, A>) -> EnvIO<D, E, A>
+        where F == IOPartial<E> {
         EnvIO { env in IO.invokeValidated { f(env) } }
     }
     
@@ -58,16 +62,18 @@ public extension Kleisli {
     ///
     /// - Parameter f: Function transforming the error.
     /// - Returns: An EnvIO value with the new error type.
-    func mapError<E: Error, EE: Error>(_ f: @escaping (E) -> EE) -> EnvIO<D, EE, A> where F == IOPartial<E> {
-        return EnvIO { env in self.run(env)^.mapError(f) }
+    func mapError<E: Error, EE: Error>(_ f: @escaping (E) -> EE) -> EnvIO<D, EE, A>
+        where F == IOPartial<E> {
+        EnvIO { env in self.run(env)^.mapError(f) }
     }
     
     /// Provides the required environment.
     ///
     /// - Parameter d: Environment.
     /// - Returns: An IO resulting from running this computation with the provided environment.
-    func provide<E: Error>(_ d: D) -> IO<E, A> where F == IOPartial<E> {
-        return self.run(d)^
+    func provide<E: Error>(_ d: D) -> IO<E, A>
+        where F == IOPartial<E> {
+        self.run(d)^
     }
     
     /// Folds over the result of this computation by accepting an effect to execute in case of error, and another one in the case of success.
@@ -76,7 +82,10 @@ public extension Kleisli {
     ///   - f: Function to run in case of error.
     ///   - g: Function to run in case of success.
     /// - Returns: A computation from the result of applying the provided functions to the result of this computation.
-    func foldM<B, E: Error>(_ f: @escaping (E) -> EnvIO<D, E, B>, _ g: @escaping (A) -> EnvIO<D, E, B>) -> EnvIO<D, E, B> where F == IOPartial<E> {
+    func foldM<B, E: Error>(
+        _ f: @escaping (E) -> EnvIO<D, E, B>,
+        _ g: @escaping (A) -> EnvIO<D, E, B>) -> EnvIO<D, E, B>
+        where F == IOPartial<E> {
         self.flatMap(g).handleErrorWith(f)^
     }
     
@@ -86,7 +95,8 @@ public extension Kleisli {
     ///
     /// - Parameter policy: Retrial policy.
     /// - Returns: A computation that is retried based on the provided policy when it fails.
-    func retry<S, O, E: Error>(_ policy: Schedule<D, E, S, O>) -> EnvIO<D, E, A> where F == IOPartial<E> {
+    func retry<S, O, E: Error>(_ policy: Schedule<D, E, S, O>) -> EnvIO<D, E, A>
+        where F == IOPartial<E> {
         retry(policy, orElse: { e, _ in EnvIO.raiseError(e)^ })
             .map { x in x.merge() }^
     }
@@ -99,7 +109,10 @@ public extension Kleisli {
     ///   - policy: Retrial policy.
     ///   - orElse: Function to handle errors after retrying.
     /// - Returns: A computation that is retried based on the provided policy when it fails.
-    func retry<S, O, B, E: Error>(_ policy: Schedule<D, E, S, O>, orElse: @escaping (E, O) -> EnvIO<D, E, B>) -> EnvIO<D, E, Either<B, A>> where F == IOPartial<E> {
+    func retry<S, O, B, E: Error>(
+        _ policy: Schedule<D, E, S, O>,
+        orElse: @escaping (E, O) -> EnvIO<D, E, B>) -> EnvIO<D, E, Either<B, A>>
+        where F == IOPartial<E> {
         func loop(_ state: S) -> EnvIO<D, E, Either<B, A>> {
             self.foldM(
                 { err in
@@ -125,7 +138,10 @@ public extension Kleisli {
     ///   - policy: Repeating policy.
     ///   - onUpdateError: A function providing an error in case the policy fails to update properly.
     /// - Returns: A computation that is repeated based on the provided policy when it succeeds.
-    func `repeat`<S, O, E: Error>(_ policy: Schedule<D, A, S, O>, onUpdateError: @escaping () -> E) -> EnvIO<D, E, O> where F == IOPartial<E> {
+    func `repeat`<S, O, E: Error>(
+        _ policy: Schedule<D, A, S, O>,
+        onUpdateError: @escaping () -> E = { fatalError("Impossible to update error on repeat.") }) -> EnvIO<D, E, O>
+        where F == IOPartial<E> {
         self.repeat(policy, onUpdateError: onUpdateError) { e, _ in
             EnvIO<D, E, O>.raiseError(e)^
         }.map { x in x.merge() }^
@@ -138,7 +154,11 @@ public extension Kleisli {
     ///   - onUpdateError: A function providing an error in case the policy fails to update properly.
     ///   - orElse: A function to return a computation in case of error.
     /// - Returns: A computation that is repeated based on the provided policy when it succeeds.
-    func `repeat`<S, O, B, E: Error>(_ policy: Schedule<D, A, S, O>, onUpdateError: @escaping () -> E, orElse: @escaping (E, O?) -> EnvIO<D, E, B>) -> EnvIO<D, E, Either<B, O>> where F == IOPartial<E> {
+    func `repeat`<S, O, B, E: Error>(
+        _ policy: Schedule<D, A, S, O>,
+        onUpdateError: @escaping () -> E = { fatalError("Impossible to update error on repeat.") },
+        orElse: @escaping (E, O?) -> EnvIO<D, E, B>) -> EnvIO<D, E, Either<B, O>>
+        where F == IOPartial<E> {
         func loop(_ last: A, _ state: S) -> EnvIO<D, E, Either<B, O>> {
             policy.update(last, state)
                 .mapError { _ in onUpdateError() }
@@ -164,7 +184,10 @@ public extension Kleisli {
     ///   - fe: Function to transform the error type argument.
     ///   - fa: Function to transform the output type argument.
     /// - Returns: An EnvIO with both type arguments transformed.
-    func bimap<E: Error, EE: Error, B>(_ fe: @escaping (E) -> EE, _ fa: @escaping (A) -> B) -> EnvIO<D, EE, B> where F == IOPartial<E> {
+    func bimap<E: Error, EE: Error, B>(
+        _ fe: @escaping (E) -> EE,
+        _ fa: @escaping (A) -> B) -> EnvIO<D, EE, B>
+        where F == IOPartial<E> {
         mapError(fe).map(fa)^
     }
     
@@ -175,7 +198,10 @@ public extension Kleisli {
     ///   - queue: Dispatch queue used to execute the side effects. Defaults to the main queue.
     /// - Returns: Value produced after running the suspended side effects.
     /// - Throws: Error of type `E` that may happen during the evaluation of the side-effects. Errors of other types thrown from the evaluation of this IO will cause a fatal error.
-    func unsafeRunSync<E: Error>(with d: D, on queue: DispatchQueue = .main) throws -> A where F == IOPartial<E> {
+    func unsafeRunSync<E: Error>(
+        with d: D,
+        on queue: DispatchQueue = .main) throws -> A
+        where F == IOPartial<E> {
         try self.provide(d).unsafeRunSync(on: queue)
     }
     
@@ -185,7 +211,10 @@ public extension Kleisli {
     ///   - d: Dependencies needed in this operation.
     ///   - queue: Dispatch queue used to execute the side effects. Defaults to the main queue.
     /// - Returns: An Either wrapping errors in the left side and values on the right side. Errors of other types thrown from the evaluation of this IO will cause a fatal error.
-    func unsafeRunSyncEither<E: Error>(with d: D, on queue: DispatchQueue = .main) -> Either<E, A> where F == IOPartial<E> {
+    func unsafeRunSyncEither<E: Error>(
+        with d: D,
+        on queue: DispatchQueue = .main) -> Either<E, A>
+        where F == IOPartial<E> {
         self.provide(d).unsafeRunSyncEither(on: queue)
     }
     
@@ -195,7 +224,11 @@ public extension Kleisli {
     ///   - d: Dependencies needed in this operation.
     ///   - queue: Dispatch queue used to execute the side effects. Defaults to the main queue.
     ///   - callback: A callback function to receive the results of the evaluation. Errors of other types thrown from the evaluation of this IO will cause a fatal error.
-    func unsafeRunAsync<E: Error>(with d: D, on queue: DispatchQueue = .main, _ callback: @escaping Callback<E, A> = { _ in }) where F == IOPartial<E> {
+    func unsafeRunAsync<E: Error>(
+        with d: D,
+        on queue: DispatchQueue = .main,
+        _ callback: @escaping Callback<E, A> = { _ in })
+        where F == IOPartial<E> {
         self.provide(d).unsafeRunAsync(on: queue, callback)
     }
 }
@@ -216,7 +249,8 @@ public extension Kleisli where D == Any {
     /// - Parameter queue: Dispatch queue used to execute the side effects. Defaults to the main queue.
     /// - Returns: Value produced after running the suspended side effects.
     /// - Throws: Error of type `E` that may happen during the evaluation of the side-effects. Errors of other types thrown from the evaluation of this IO will cause a fatal error.
-    func unsafeRunSync<E: Error>(on queue: DispatchQueue = .main) throws -> A where F == IOPartial<E> {
+    func unsafeRunSync<E: Error>(on queue: DispatchQueue = .main) throws -> A
+        where F == IOPartial<E> {
         try self.provide(()).unsafeRunSync(on: queue)
     }
     
@@ -224,7 +258,8 @@ public extension Kleisli where D == Any {
     ///
     /// - Parameter queue: Dispatch queue used to execute the side effects. Defaults to the main queue.
     /// - Returns: An Either wrapping errors in the left side and values on the right side. Errors of other types thrown from the evaluation of this IO will cause a fatal error.
-    func unsafeRunSyncEither<E: Error>(on queue: DispatchQueue = .main) -> Either<E, A> where F == IOPartial<E> {
+    func unsafeRunSyncEither<E: Error>(on queue: DispatchQueue = .main) -> Either<E, A>
+        where F == IOPartial<E> {
         self.provide(()).unsafeRunSyncEither(on: queue)
     }
     
@@ -233,7 +268,10 @@ public extension Kleisli where D == Any {
     /// - Parameters:
     ///   - queue: Dispatch queue used to execute the side effects. Defaults to the main queue.
     ///   - callback: A callback function to receive the results of the evaluation. Errors of other types thrown from the evaluation of this IO will cause a fatal error.
-    func unsafeRunAsync<E: Error>(on queue: DispatchQueue = .main, _ callback: @escaping Callback<E, A> = { _ in }) where F == IOPartial<E> {
+    func unsafeRunAsync<E: Error>(
+        on queue: DispatchQueue = .main,
+        _ callback: @escaping Callback<E, A> = { _ in })
+        where F == IOPartial<E> {
         self.provide(()).unsafeRunAsync(on: queue, callback)
     }
 }
@@ -243,7 +281,8 @@ public extension Kleisli where A == Void {
     ///
     /// - Parameter interval: Time to sleep.
     /// - Returns: A computation that sleeps for the specified amount of time.
-    static func sleep<E: Error>(_ interval: DispatchTimeInterval) -> EnvIO<D, E, Void> where F == IOPartial<E> {
+    static func sleep<E: Error>(_ interval: DispatchTimeInterval) -> EnvIO<D, E, Void>
+        where F == IOPartial<E> {
         EnvIO { _ in IO.sleep(interval) }
     }
     
@@ -251,23 +290,24 @@ public extension Kleisli where A == Void {
     ///
     /// - Parameter interval: Time to sleep.
     /// - Returns: A computation that sleeps for the specified amount of time.
-    static func sleep<E: Error>(_ interval: TimeInterval) -> EnvIO<D, E, Void> where F == IOPartial<E> {
+    static func sleep<E: Error>(_ interval: TimeInterval) -> EnvIO<D, E, Void>
+        where F == IOPartial<E> {
         EnvIO { _ in IO.sleep(interval) }
     }
 }
 
-// MARK: Instance of `MonadDefer` for `Kleisli`
+// MARK: Instance of MonadDefer for Kleisli
 
 extension KleisliPartial: MonadDefer where F: MonadDefer {
-    public static func `defer`<A>(_ fa: @escaping () -> Kind<KleisliPartial<F, D>, A>) -> Kind<KleisliPartial<F, D>, A> {
+    public static func `defer`<A>(_ fa: @escaping () -> KleisliOf<F, D, A>) -> KleisliOf<F, D, A> {
         Kleisli { d in F.defer { fa()^.run(d) } }
     }
 }
 
-// MARK: Instance of `Async` for `Kleisli`
+// MARK: Instance of Async for Kleisli
 
 extension KleisliPartial: Async where F: Async {
-    public static func asyncF<A>(_ procf: @escaping (@escaping (Either<F.E, A>) -> ()) -> Kind<KleisliPartial<F, D>, ()>) -> Kind<KleisliPartial<F, D>, A> {
+    public static func asyncF<A>(_ procf: @escaping (@escaping (Either<F.E, A>) -> ()) -> KleisliOf<F, D, ()>) -> KleisliOf<F, D, A> {
         Kleisli { d in
             F.asyncF { callback in
                 procf(callback)^.run(d)
@@ -275,29 +315,40 @@ extension KleisliPartial: Async where F: Async {
         }
     }
     
-    public static func continueOn<A>(_ fa: Kind<KleisliPartial<F, D>, A>, _ queue: DispatchQueue) -> Kind<KleisliPartial<F, D>, A> {
+    public static func continueOn<A>(
+        _ fa: KleisliOf<F, D, A>,
+        _ queue: DispatchQueue) -> KleisliOf<F, D, A> {
         Kleisli { d in
             fa^.run(d).continueOn(queue)
         }
     }
 }
 
-// MARK: Instance of `Concurrent` for `Kleisli`
+// MARK: Instance of Concurrent for Kleisli
 
 extension KleisliPartial: Concurrent where F: Concurrent {
-    public static func race<A, B>(_ fa: Kind<KleisliPartial<F, D>, A>, _ fb: Kind<KleisliPartial<F, D>, B>) -> Kind<KleisliPartial<F, D>, Either<A, B>> {
+    public static func race<A, B>(
+        _ fa: KleisliOf<F, D, A>,
+        _ fb: KleisliOf<F, D, B>) -> KleisliOf<F, D, Either<A, B>> {
         Kleisli { d in
             F.race(fa^.run(d), fb^.run(d))
         }
     }
     
-    public static func parMap<A, B, Z>(_ fa: Kind<KleisliPartial<F, D>, A>, _ fb: Kind<KleisliPartial<F, D>, B>, _ f: @escaping (A, B) -> Z) -> Kind<KleisliPartial<F, D>, Z> {
+    public static func parMap<A, B, Z>(
+        _ fa: KleisliOf<F, D, A>,
+        _ fb: KleisliOf<F, D, B>,
+        _ f: @escaping (A, B) -> Z) -> KleisliOf<F, D, Z> {
         Kleisli { d in
             F.parMap(fa^.run(d), fb^.run(d), f)
         }
     }
     
-    public static func parMap<A, B, C, Z>(_ fa: Kind<KleisliPartial<F, D>, A>, _ fb: Kind<KleisliPartial<F, D>, B>, _ fc: Kind<KleisliPartial<F, D>, C>, _ f: @escaping (A, B, C) -> Z) -> Kind<KleisliPartial<F, D>, Z> {
+    public static func parMap<A, B, C, Z>(
+        _ fa: KleisliOf<F, D, A>,
+        _ fb: KleisliOf<F, D, B>,
+        _ fc: KleisliOf<F, D, C>,
+        _ f: @escaping (A, B, C) -> Z) -> KleisliOf<F, D, Z> {
         Kleisli { d in
             F.parMap(fa^.run(d), fb^.run(d), fc^.run(d), f)
         }

--- a/Sources/BowEffects/Data/IO.swift
+++ b/Sources/BowEffects/Data/IO.swift
@@ -98,7 +98,9 @@ public class IO<E: Error, A>: IOOf<E, A> {
     ///   - fe: Function to transform the error type argument.
     ///   - fa: Function to transform the output type argument.
     /// - Returns: An IO with both type arguments transformed.
-    func bimap<EE: Error, B>(_ fe: @escaping (E) -> EE, _ fa: @escaping (A) -> B) -> IO<EE, B> {
+    func bimap<EE: Error, B>(
+        _ fe: @escaping (E) -> EE,
+        _ fa: @escaping (A) -> B) -> IO<EE, B> {
         mapError(fe).map(fa)^
     }
     
@@ -108,8 +110,9 @@ public class IO<E: Error, A>: IOOf<E, A> {
     ///   - fa: 1st side-effectful function.
     ///   - fb: 2nd side-effectful function.
     /// - Returns: An IO suspending the execution of the side effects.
-    public static func merge<Z, B>(_ fa: @escaping () throws -> Z,
-                                   _ fb: @escaping () throws -> B) -> IO<E, (Z, B)> where A == (Z, B) {
+    public static func merge<Z, B>(
+        _ fa: @escaping () throws -> Z,
+        _ fb: @escaping () throws -> B) -> IO<E, (Z, B)> where A == (Z, B) {
         IO.zip(IO<E, Z>.invoke(fa),
                IO<E, B>.invoke(fb))^
     }
@@ -121,9 +124,10 @@ public class IO<E: Error, A>: IOOf<E, A> {
     ///   - fb: 2nd side-effectful function.
     ///   - fc: 3rd side-effectful function.
     /// - Returns: An IO suspending the execution of the side effects.
-    public static func merge<Z, B, C>(_ fa: @escaping () throws -> Z,
-                                      _ fb: @escaping () throws -> B,
-                                      _ fc: @escaping () throws -> C) -> IO<E, (Z, B, C)> where A == (Z, B, C) {
+    public static func merge<Z, B, C>(
+        _ fa: @escaping () throws -> Z,
+        _ fb: @escaping () throws -> B,
+        _ fc: @escaping () throws -> C) -> IO<E, (Z, B, C)> where A == (Z, B, C) {
         IO.zip(IO<E, Z>.invoke(fa),
                IO<E, B>.invoke(fb),
                IO<E, C>.invoke(fc))^
@@ -137,10 +141,11 @@ public class IO<E: Error, A>: IOOf<E, A> {
     ///   - fc: 3rd side-effectful function.
     ///   - fd: 4th side-effectful function.
     /// - Returns: An IO suspending the execution of the side effects.
-    public static func merge<Z, B, C, D>(_ fa: @escaping () throws -> Z,
-                                         _ fb: @escaping () throws -> B,
-                                         _ fc: @escaping () throws -> C,
-                                         _ fd: @escaping () throws -> D) -> IO<E, (Z, B, C, D)> where A == (Z, B, C, D) {
+    public static func merge<Z, B, C, D>(
+        _ fa: @escaping () throws -> Z,
+        _ fb: @escaping () throws -> B,
+        _ fc: @escaping () throws -> C,
+        _ fd: @escaping () throws -> D) -> IO<E, (Z, B, C, D)> where A == (Z, B, C, D) {
         IO.zip(IO<E, Z>.invoke(fa),
                IO<E, B>.invoke(fb),
                IO<E, C>.invoke(fc),
@@ -156,11 +161,12 @@ public class IO<E: Error, A>: IOOf<E, A> {
     ///   - fd: 4th side-effectful function.
     ///   - ff: 5th side-effectful function.
     /// - Returns: An IO suspending the execution of the side effects.
-    public static func merge<Z, B, C, D, F>(_ fa: @escaping () throws -> Z,
-                                            _ fb: @escaping () throws -> B,
-                                            _ fc: @escaping () throws -> C,
-                                            _ fd: @escaping () throws -> D,
-                                            _ ff: @escaping () throws -> F) -> IO<E, (Z, B, C, D, F)> where A == (Z, B, C, D, F) {
+    public static func merge<Z, B, C, D, F>(
+        _ fa: @escaping () throws -> Z,
+        _ fb: @escaping () throws -> B,
+        _ fc: @escaping () throws -> C,
+        _ fd: @escaping () throws -> D,
+        _ ff: @escaping () throws -> F) -> IO<E, (Z, B, C, D, F)> where A == (Z, B, C, D, F) {
         IO.zip(IO<E, Z>.invoke(fa),
                IO<E, B>.invoke(fb),
                IO<E, C>.invoke(fc),
@@ -178,12 +184,13 @@ public class IO<E: Error, A>: IOOf<E, A> {
     ///   - ff: 5th side-effectful function.
     ///   - fg: 6th side-effectful function.
     /// - Returns: An IO suspending the execution of the side effects.
-    public static func merge<Z, B, C, D, F, G>(_ fa: @escaping () throws -> Z,
-                                               _ fb: @escaping () throws -> B,
-                                               _ fc: @escaping () throws -> C,
-                                               _ fd: @escaping () throws -> D,
-                                               _ ff: @escaping () throws -> F,
-                                               _ fg: @escaping () throws -> G) -> IO<E, (Z, B, C, D, F, G)> where A == (Z, B, C, D, F, G){
+    public static func merge<Z, B, C, D, F, G>(
+        _ fa: @escaping () throws -> Z,
+        _ fb: @escaping () throws -> B,
+        _ fc: @escaping () throws -> C,
+        _ fd: @escaping () throws -> D,
+        _ ff: @escaping () throws -> F,
+        _ fg: @escaping () throws -> G) -> IO<E, (Z, B, C, D, F, G)> where A == (Z, B, C, D, F, G){
         IO.zip(IO<E, Z>.invoke(fa),
                IO<E, B>.invoke(fb),
                IO<E, C>.invoke(fc),
@@ -203,13 +210,14 @@ public class IO<E: Error, A>: IOOf<E, A> {
     ///   - fg: 6th side-effectful function.
     ///   - fh: 7th side-effectful function.
     /// - Returns: An IO suspending the execution of the side effects.
-    public static func merge<Z, B, C, D, F, G, H>(_ fa: @escaping () throws -> Z,
-                                                  _ fb: @escaping () throws -> B,
-                                                  _ fc: @escaping () throws -> C,
-                                                  _ fd: @escaping () throws -> D,
-                                                  _ ff: @escaping () throws -> F,
-                                                  _ fg: @escaping () throws -> G,
-                                                  _ fh: @escaping () throws -> H ) -> IO<E, (Z, B, C, D, F, G, H)> where A == (Z, B, C, D, F, G, H) {
+    public static func merge<Z, B, C, D, F, G, H>(
+        _ fa: @escaping () throws -> Z,
+        _ fb: @escaping () throws -> B,
+        _ fc: @escaping () throws -> C,
+        _ fd: @escaping () throws -> D,
+        _ ff: @escaping () throws -> F,
+        _ fg: @escaping () throws -> G,
+        _ fh: @escaping () throws -> H ) -> IO<E, (Z, B, C, D, F, G, H)> where A == (Z, B, C, D, F, G, H) {
         IO.zip(IO<E, Z>.invoke(fa),
                IO<E, B>.invoke(fb),
                IO<E, C>.invoke(fc),
@@ -231,14 +239,15 @@ public class IO<E: Error, A>: IOOf<E, A> {
     ///   - fh: 7th side-effectful function.
     ///   - fi: 8th side-effectful function.
     /// - Returns: An IO suspending the execution of the side effects.
-    public static func merge<Z, B, C, D, F, G, H, I>(_ fa: @escaping () throws -> Z,
-                                                     _ fb: @escaping () throws -> B,
-                                                     _ fc: @escaping () throws -> C,
-                                                     _ fd: @escaping () throws -> D,
-                                                     _ ff: @escaping () throws -> F,
-                                                     _ fg: @escaping () throws -> G,
-                                                     _ fh: @escaping () throws -> H,
-                                                     _ fi: @escaping () throws -> I) -> IO<E, (Z, B, C, D, F, G, H, I)> where A == (Z, B, C, D, F, G, H, I) {
+    public static func merge<Z, B, C, D, F, G, H, I>(
+        _ fa: @escaping () throws -> Z,
+        _ fb: @escaping () throws -> B,
+        _ fc: @escaping () throws -> C,
+        _ fd: @escaping () throws -> D,
+        _ ff: @escaping () throws -> F,
+        _ fg: @escaping () throws -> G,
+        _ fh: @escaping () throws -> H,
+        _ fi: @escaping () throws -> I) -> IO<E, (Z, B, C, D, F, G, H, I)> where A == (Z, B, C, D, F, G, H, I) {
         IO.zip(IO<E, Z>.invoke(fa),
                IO<E, B>.invoke(fb),
                IO<E, C>.invoke(fc),
@@ -262,15 +271,16 @@ public class IO<E: Error, A>: IOOf<E, A> {
     ///   - fi: 8th side-effectful function.
     ///   - fj: 9th side-effectful function.
     /// - Returns: An IO suspending the execution of the side effects.
-    public static func merge<Z, B, C, D, F, G, H, I, J>(_ fa: @escaping () throws -> Z,
-                                                        _ fb: @escaping () throws -> B,
-                                                        _ fc: @escaping () throws -> C,
-                                                        _ fd: @escaping () throws -> D,
-                                                        _ ff: @escaping () throws -> F,
-                                                        _ fg: @escaping () throws -> G,
-                                                        _ fh: @escaping () throws -> H,
-                                                        _ fi: @escaping () throws -> I,
-                                                        _ fj: @escaping () throws -> J ) -> IO<E, (Z, B, C, D, F, G, H, I, J)> where A == (Z, B, C, D, F, G, H, I, J) {
+    public static func merge<Z, B, C, D, F, G, H, I, J>(
+        _ fa: @escaping () throws -> Z,
+        _ fb: @escaping () throws -> B,
+        _ fc: @escaping () throws -> C,
+        _ fd: @escaping () throws -> D,
+        _ ff: @escaping () throws -> F,
+        _ fg: @escaping () throws -> G,
+        _ fh: @escaping () throws -> H,
+        _ fi: @escaping () throws -> I,
+        _ fj: @escaping () throws -> J ) -> IO<E, (Z, B, C, D, F, G, H, I, J)> where A == (Z, B, C, D, F, G, H, I, J) {
         IO.zip(IO<E, Z>.invoke(fa),
                IO<E, B>.invoke(fb),
                IO<E, C>.invoke(fc),
@@ -370,7 +380,9 @@ public class IO<E: Error, A>: IOOf<E, A> {
     ///   - f: Function to run in case of error.
     ///   - g: Function to run in case of success.
     /// - Returns: A computation from the result of applying the provided functions to the result of this computation.
-    public func foldM<B>(_ f: @escaping (E) -> IO<E, B>, _ g: @escaping (A) -> IO<E, B>) -> IO<E, B> {
+    public func foldM<B>(
+        _ f: @escaping (E) -> IO<E, B>,
+        _ g: @escaping (A) -> IO<E, B>) -> IO<E, B> {
         self.flatMap(g).handleErrorWith(f)^
     }
     
@@ -392,8 +404,12 @@ public class IO<E: Error, A>: IOOf<E, A> {
     ///   - policy: Retrial policy.
     ///   - orElse: Function to handle errors after retrying.
     /// - Returns: A computation that is retried based on the provided policy when it fails.
-    public func retry<S, O, B>(_ policy: Schedule<Any, E, S, O>, orElse: @escaping (E, O) -> IO<E, B>) -> IO<E, Either<B, A>> {
-        self.env().retry(policy, orElse: { e, o in orElse(e, o).env() }).provide(())
+    public func retry<S, O, B>(
+        _ policy: Schedule<Any, E, S, O>,
+        orElse: @escaping (E, O) -> IO<E, B>) -> IO<E, Either<B, A>> {
+        self.env().retry(
+            policy,
+            orElse: { e, o in orElse(e, o).env() }).provide(())
     }
     
     /// Repeats this computation until the provided repeating policy completes, or until it fails.
@@ -404,8 +420,12 @@ public class IO<E: Error, A>: IOOf<E, A> {
     ///   - policy: Repeating policy.
     ///   - onUpdateError: A function providing an error in case the policy fails to update properly.
     /// - Returns: A computation that is repeated based on the provided policy when it succeeds.
-    public func `repeat`<S, O>(_ policy: Schedule<Any, A, S, O>, onUpdateError: @escaping () -> E) -> IO<E, O> {
-        self.env().repeat(policy, onUpdateError: onUpdateError).provide(())
+    public func `repeat`<S, O>(
+        _ policy: Schedule<Any, A, S, O>,
+        onUpdateError: @escaping () -> E = { fatalError("Impossible to update error on repeat.") }) -> IO<E, O> {
+        self.env().repeat(
+            policy,
+            onUpdateError: onUpdateError).provide(())
     }
     
     /// Repeats this computation until the provided repeating policy completes, or until it fails, with a function to handle potential failures.
@@ -415,8 +435,14 @@ public class IO<E: Error, A>: IOOf<E, A> {
     ///   - onUpdateError: A function providing an error in case the policy fails to update properly.
     ///   - orElse: A function to return a computation in case of error.
     /// - Returns: A computation that is repeated based on the provided policy when it succeeds.
-    public func `repeat`<S, O, B>(_ policy: Schedule<Any, A, S, O>, onUpdateError: @escaping () -> E, orElse: @escaping (E, O?) -> IO<E, B>) -> IO<E, Either<B, O>> {
-        self.env().repeat(policy, onUpdateError: onUpdateError, orElse: { e, o in orElse(e, o).env() }).provide(())
+    public func `repeat`<S, O, B>(
+        _ policy: Schedule<Any, A, S, O>,
+        onUpdateError: @escaping () -> E = { fatalError("Impossible to update error on repeat.") },
+        orElse: @escaping (E, O?) -> IO<E, B>) -> IO<E, Either<B, O>> {
+        self.env().repeat(
+            policy,
+            onUpdateError: onUpdateError,
+            orElse: { e, o in orElse(e, o).env() }).provide(())
     }
 }
 
@@ -478,10 +504,10 @@ internal class Pure<E: Error, A>: IO<E, A> {
     }
 }
 
-internal class RaiseError<E: Error, A> : IO<E, A> {
+internal class RaiseError<E: Error, A>: IO<E, A> {
     let error: E
     
-    init(_ error : E) {
+    init(_ error: E) {
         self.error = error
     }
     
@@ -509,7 +535,7 @@ internal class HandleErrorWith<E: Error, A>: IO<E, A> {
     }
 }
 
-internal class FMap<E: Error, A, B> : IO<E, B> {
+internal class FMap<E: Error, A, B>: IO<E, B> {
     let f: (A) -> B
     let action: IO<E, A>
     
@@ -545,7 +571,7 @@ internal class FErrorMap<E: Error, A, EE: Error>: IO<EE, A> {
     }
 }
 
-internal class Join<E: Error, A> : IO<E, A> {
+internal class Join<E: Error, A>: IO<E, A> {
     let io: IO<E, IO<E, A>>
     
     init(_ io: IO<E, IO<E, A>>) {
@@ -809,30 +835,36 @@ internal class Suspend<E: Error, A>: IO<E, A> {
     }
 }
 
-// MARK: Instance of `Functor` for `IO`
+// MARK: Instance of Functor for IO
 extension IOPartial: Functor {
-    public static func map<A, B>(_ fa: IOOf<E, A>, _ f: @escaping (A) -> B) -> IOOf<E, B> {
+    public static func map<A, B>(
+        _ fa: IOOf<E, A>,
+        _ f: @escaping (A) -> B) -> IOOf<E, B> {
         FMap(f, fa^)
     }
 }
 
-// MARK: Instance of `Applicative` for `IO`
+// MARK: Instance of Applicative for IO
 extension IOPartial: Applicative {
     public static func pure<A>(_ a: A) -> IOOf<E, A> {
         Pure(a)
     }
 }
 
-// MARK: Instance of `Selective` for `IO`
+// MARK: Instance of Selective for IO
 extension IOPartial: Selective {}
 
-// MARK: Instance of `Monad` for `IO`
+// MARK: Instance of Monad for IO
 extension IOPartial: Monad {
-    public static func flatMap<A, B>(_ fa: IOOf<E, A>, _ f: @escaping (A) -> IOOf<E, B>) -> IOOf<E, B> {
+    public static func flatMap<A, B>(
+        _ fa: IOOf<E, A>,
+        _ f: @escaping (A) -> IOOf<E, B>) -> IOOf<E, B> {
         Join(fa^.map { x in f(x)^ }^)
     }
     
-    public static func tailRecM<A, B>(_ a: A, _ f: @escaping (A) -> IOOf<E, Either<A, B>>) -> IOOf<E, B> {
+    public static func tailRecM<A, B>(
+        _ a: A,
+        _ f: @escaping (A) -> IOOf<E, Either<A, B>>) -> IOOf<E, B> {
         f(a)^.flatMap { either in
             either.fold({ a in tailRecM(a, f) },
                         { b in IO.pure(b) })
@@ -840,74 +872,97 @@ extension IOPartial: Monad {
     }
 }
 
-// MARK: Instance of `ApplicativeError` for `IO`
+// MARK: Instance of ApplicativeError for IO
 extension IOPartial: ApplicativeError {
     public static func raiseError<A>(_ e: E) -> IOOf<E, A> {
         RaiseError(e)
     }
     
-    public static func handleErrorWith<A>(_ fa: IOOf<E, A>, _ f: @escaping (E) -> IOOf<E, A>) -> IOOf<E, A> {
+    public static func handleErrorWith<A>(
+        _ fa: IOOf<E, A>,
+        _ f: @escaping (E) -> IOOf<E, A>) -> IOOf<E, A> {
         HandleErrorWith(fa^) { e in f(e)^ }
     }
 }
 
-// MARK: Instance of `MonadError` for `IO`
+// MARK: Instance of MonadError for IO
 extension IOPartial: MonadError {}
 
-// MARK: Instance of `Bracket` for `IO`
+// MARK: Instance of Bracket for IO
 extension IOPartial: Bracket {
-    public static func bracketCase<A, B>(acquire fa: IOOf<E, A>, release: @escaping (A, ExitCase<E>) -> IOOf<E, ()>, use: @escaping (A) throws -> IOOf<E, B>) -> IOOf<E, B> {
+    public static func bracketCase<A, B>(
+        acquire fa: IOOf<E, A>,
+        release: @escaping (A, ExitCase<E>) -> IOOf<E, ()>,
+        use: @escaping (A) throws -> IOOf<E, B>) -> IOOf<E, B> {
         BracketIO<E, A, B>(fa^, release, use)
     }
 }
 
-// MARK: Instance of `MonadDefer` for `IO`
+// MARK: Instance of MonadDefer for IO
 extension IOPartial: MonadDefer {
     public static func `defer`<A>(_ fa: @escaping () -> IOOf<E, A>) -> IOOf<E, A> {
         Suspend(fa)
     }
 }
 
-// MARK: Instance of `Async` for `IO`
+// MARK: Instance of Async for IO
 extension IOPartial: Async {
     public static func asyncF<A>(_ procf: @escaping (@escaping (Either<E, A>) -> ()) -> IOOf<E, ()>) -> IOOf<E, A> {
         AsyncIO(procf)
     }
     
-    public static func continueOn<A>(_ fa: IOOf<E, A>, _ queue: DispatchQueue) -> IOOf<E, A> {
+    public static func continueOn<A>(
+        _ fa: IOOf<E, A>,
+        _ queue: DispatchQueue) -> IOOf<E, A> {
         ContinueOn(fa^, queue)
     }
 }
 
-// MARK: Instance of `Concurrent` for `IO`
+// MARK: Instance of Concurrent for IO
 extension IOPartial: Concurrent {
-    public static func race<A, B>(_ fa: Kind<IOPartial<E>, A>, _ fb: Kind<IOPartial<E>, B>) -> Kind<IOPartial<E>, Either<A, B>> {
+    public static func race<A, B>(
+        _ fa: Kind<IOPartial<E>, A>,
+        _ fb: Kind<IOPartial<E>, B>) -> Kind<IOPartial<E>, Either<A, B>> {
         Race(fa^, fb^)
     }
     
-    public static func parMap<A, B, Z>(_ fa: Kind<IOPartial<E>, A>, _ fb: Kind<IOPartial<E>, B>, _ f: @escaping (A, B) -> Z) -> Kind<IOPartial<E>, Z> {
+    public static func parMap<A, B, Z>(
+        _ fa: Kind<IOPartial<E>, A>,
+        _ fb: Kind<IOPartial<E>, B>,
+        _ f: @escaping (A, B) -> Z) -> Kind<IOPartial<E>, Z> {
         ParMap2<E, A, B, Z>(fa^, fb^, f)
     }
     
-    public static func parMap<A, B, C, Z>(_ fa: Kind<IOPartial<E>, A>, _ fb: Kind<IOPartial<E>, B>, _ fc: Kind<IOPartial<E>, C>, _ f: @escaping (A, B, C) -> Z) -> Kind<IOPartial<E>, Z> {
+    public static func parMap<A, B, C, Z>(
+        _ fa: Kind<IOPartial<E>, A>,
+        _ fb: Kind<IOPartial<E>, B>,
+        _ fc: Kind<IOPartial<E>, C>,
+        _ f: @escaping (A, B, C) -> Z) -> Kind<IOPartial<E>, Z> {
         ParMap3<E, A, B, C, Z>(fa^, fb^, fc^, f)
     }
 }
 
-// MARK: Instance of `Effect` for `IO`
+// MARK: Instance of Effect for IO
 extension IOPartial: Effect {
-    public static func runAsync<A>(_ fa: IOOf<E, A>, _ callback: @escaping (Either<E, A>) -> IOOf<E, ()>) -> IOOf<E, ()> {
+    public static func runAsync<A>(
+        _ fa: IOOf<E, A>,
+        _ callback: @escaping (Either<E, A>) -> IOOf<E, ()>) -> IOOf<E, ()> {
         IOEffect(fa^, callback)
     }
 }
 
-// MARK: Instance of `UnsafeRun` for `IO`
+// MARK: Instance of UnsafeRun for IO
 extension IOPartial: UnsafeRun {
-    public static func runBlocking<A>(on queue: DispatchQueue, _ fa: @escaping () -> Kind<IOPartial<E>, A>) throws -> A {
+    public static func runBlocking<A>(
+        on queue: DispatchQueue,
+        _ fa: @escaping () -> Kind<IOPartial<E>, A>) throws -> A {
         try fa()^.unsafeRunSync(on: queue)
     }
     
-    public static func runNonBlocking<A>(on queue: DispatchQueue, _ fa: @escaping () -> Kind<IOPartial<E>, A>, _ callback: @escaping (Either<E, A>) -> ()) {
+    public static func runNonBlocking<A>(
+        on queue: DispatchQueue,
+        _ fa: @escaping () -> Kind<IOPartial<E>, A>,
+        _ callback: @escaping (Either<E, A>) -> ()) {
         fa()^.unsafeRunAsync(on: queue, callback)
     }
 }

--- a/Sources/BowEffects/Data/Internal/Dictionary+Extensions.swift
+++ b/Sources/BowEffects/Data/Internal/Dictionary+Extensions.swift
@@ -14,6 +14,6 @@ func +<K: Hashable, V>(lhs: Dictionary<K, V>, rhs: (K, V)) -> Dictionary<K, V> {
 
 extension Dictionary {
     var arrayValues: [Value] {
-        return Array(values)
+        Array(values)
     }
 }

--- a/Sources/BowEffects/Data/Resource.swift
+++ b/Sources/BowEffects/Data/Resource.swift
@@ -16,7 +16,7 @@ public class Resource<F: Bracket, A>: ResourceOf<F, A> {
     /// - Parameter value: Value in higher kinded form.
     /// - Returns: Value casted to Resource.
     public static func fix(_ value: ResourceOf<F, A>) -> Resource<F, A> {
-        return value as! Resource<F, A>
+        value as! Resource<F, A>
     }
     
     /// Initializes a resource.
@@ -25,8 +25,10 @@ public class Resource<F: Bracket, A>: ResourceOf<F, A> {
     ///   - acquire: Function to acquire the resource.
     ///   - release: Function to release the resource.
     /// - Returns: A Resource that will run the provided functions to acquire and release it.
-    public static func from(acquire: @escaping () -> Kind<F, A>, release: @escaping (A, ExitCase<F.E>) -> Kind<F, ()>) -> Resource<F, A> {
-        return RegularResource(acquire, release)
+    public static func from(
+        acquire: @escaping () -> Kind<F, A>,
+        release: @escaping (A, ExitCase<F.E>) -> Kind<F, ()>) -> Resource<F, A> {
+        RegularResource(acquire, release)
     }
     
     /// Uses the resource.
@@ -43,47 +45,53 @@ public class Resource<F: Bracket, A>: ResourceOf<F, A> {
 /// - Parameter value: Value in higher kinded form.
 /// - Returns: Value casted to Resource.
 public postfix func ^<F: Bracket, A>(_ value: ResourceOf<F, A>) -> Resource<F, A> {
-    return Resource.fix(value)
+    Resource.fix(value)
 }
 
-// MARK: Instance of `Functor` for `Resource`
+// MARK: Instance of Functor for Resource
 extension ResourcePartial: Functor {
-    public static func map<A, B>(_ fa: ResourceOf<F, A>, _ f: @escaping (A) -> B) -> ResourceOf<F, B> {
-        return fa.flatMap { a in pure(f(a)) }
+    public static func map<A, B>(
+        _ fa: ResourceOf<F, A>,
+        _ f: @escaping (A) -> B) -> ResourceOf<F, B> {
+        fa.flatMap { a in pure(f(a)) }
     }
 }
 
-// MARK: Instance of `Applicative` for `Resource`
+// MARK: Instance of Applicative for Resource
 extension ResourcePartial: Applicative {
     public static func pure<A>(_ a: A) -> ResourceOf<F, A> {
-        return RegularResource({ F.pure(a) }, { _, _ in F.pure(()) })
+        RegularResource({ F.pure(a) }, { _, _ in F.pure(()) })
     }
 }
 
-// MARK: Instance of `Monad` for `Resource`
+// MARK: Instance of Monad for Resource
 extension ResourcePartial: Monad {
-    public static func flatMap<A, B>(_ fa: ResourceOf<F, A>, _ f: @escaping (A) -> ResourceOf<F, B>) -> ResourceOf<F, B> {
-        return BindResource<F, A, B>(fa, f)
+    public static func flatMap<A, B>(
+        _ fa: ResourceOf<F, A>,
+        _ f: @escaping (A) -> ResourceOf<F, B>) -> ResourceOf<F, B> {
+        BindResource<F, A, B>(fa, f)
     }
     
-    public static func tailRecM<A, B>(_ a: A, _ f: @escaping (A) -> ResourceOf<F, Either<A, B>>) -> ResourceOf<F, B> {
-        return f(a)^.flatMap { either in
+    public static func tailRecM<A, B>(
+        _ a: A,
+        _ f: @escaping (A) -> ResourceOf<F, Either<A, B>>) -> ResourceOf<F, B> {
+        f(a)^.flatMap { either in
             either.fold({ a in tailRecM(a, f)^ }, pure)
         }
     }
 }
 
-// MARK: Instance of `Semigroup` for `Resource`
+// MARK: Instance of Semigroup for Resource
 extension Resource where A: Semigroup {
     public func combine(_ other: Resource<F, A>) -> Resource<F, A> {
-        return flatMap { r in other.map { r2 in r.combine(r2) }^ }^
+        flatMap { r in other.map { r2 in r.combine(r2) }^ }^
     }
 }
 
-// MARK: Instance of `Monoid` for `Resource`
+// MARK: Instance of Monoid for Resource
 extension Resource where A: Monoid {
     public static func empty() -> Resource<F, A> {
-        return pure(A.empty())^
+        pure(A.empty())^
     }
 }
 
@@ -101,7 +109,7 @@ private class RegularResource<F: Bracket, A>: Resource<F, A> {
     }
     
     override func use<C>(_ f: @escaping (A) -> Kind<F, C>) -> Kind<F, C> {
-        return acquire().bracketCase(release: release, use: f)
+        acquire().bracketCase(release: release, use: f)
     }
 }
 
@@ -115,16 +123,17 @@ private class BindResource<F: Bracket, A, B>: Resource<F, B> {
     }
     
     override func use<C>(_ f: @escaping (B) -> Kind<F, C>) -> Kind<F, C> {
-        return resource^.use { a in
+        resource^.use { a in
             self.f(a)^.use(f)
         }
     }
 }
 
-// Syntax for `Resource`
+// MARK: Syntax for Resource
+
 public extension Kind where F: Bracket {
     /// Converts this computation into a Resource.
     var asResource: Resource<F, A> {
-        return RegularResource({ self }, { _ in F.pure(()) })
+        RegularResource({ self }, { _ in F.pure(()) })
     }
 }


### PR DESCRIPTION
## Goal

Cleanup code in the Data folder in the Effects module by:

- Using `FOf<A>` instead of `Kind<F, A>`.
- Removing backticks in `MARK` sections as they do not render properly in Jazzy.
- Removing returns.
- Replacing `fix` by `^`.