### PR TITLE
Cleanup Foundation folder in Effects module

### DIFF
--- a/Sources/BowEffects/Foundation/ConsoleIO.swift
+++ b/Sources/BowEffects/Foundation/ConsoleIO.swift
@@ -3,12 +3,22 @@ import Foundation
 /// Utilities to read and write to the standard input/output in a functional manner.
 public enum ConsoleIO {
     /// IO suspended version of `Swift.print(_:separator:terminator:)`. Refer to that function for further documentation.
-    public static func print<E: Error>(_ line: @escaping @autoclosure () -> Any, separator: @escaping @autoclosure () -> CustomStringConvertible = " ", terminator: @escaping @autoclosure () -> CustomStringConvertible = "\n") -> IO<E, ()> {
-        return IO.invoke { Swift.print(line(), separator: "\(separator())", terminator: "\(terminator())") }
+    public static func print<E: Error>(
+        _ line: @escaping @autoclosure () -> Any,
+        separator: @escaping @autoclosure () -> CustomStringConvertible = " ",
+        terminator: @escaping @autoclosure () -> CustomStringConvertible = "\n") -> IO<E, ()> {
+        IO.invoke {
+            Swift.print(
+                line(),
+                separator: "\(separator())",
+                terminator: "\(terminator())")
+        }
     }
     
     /// IO suspended version of `Swift.readLine(strippingNewline:)`. Refer to that function for further documentation.
     public static func readLine<E: Error>(strippingNewline: Bool = true) -> IO<E, String?> {
-        return IO.invoke { Swift.readLine(strippingNewline: strippingNewline) }
+        IO.invoke {
+            Swift.readLine(strippingNewline: strippingNewline)
+        }
     }
 }

--- a/Sources/BowEffects/Foundation/FileManager.swift
+++ b/Sources/BowEffects/Foundation/FileManager.swift
@@ -7,109 +7,182 @@ public extension FileManager {
     // MARK: Locating System Directories
     
     /// IO suspended version of `FileManager.url(for:in:appropriateFor:create:)`. Refer to that method for further documentation.
-    func urlIO(for directory: FileManager.SearchPathDirectory, in domain: FileManager.SearchPathDomainMask, appropriateFor url: URL, create shouldCreate: Bool) -> IO<Error, URL> {
-        return IO.invoke { try self.url(for: directory, in: domain, appropriateFor: url, create: shouldCreate) }
+    func urlIO(
+        for directory: FileManager.SearchPathDirectory,
+        in domain: FileManager.SearchPathDomainMask,
+        appropriateFor url: URL,
+        create shouldCreate: Bool) -> IO<Error, URL> {
+        IO.invoke {
+            try self.url(for: directory, in: domain, appropriateFor: url, create: shouldCreate)
+        }
     }
     
     // MARK: Discovering Directory Contents
     
     /// IO suspended version of `FileManager.contensOfDirectory(at:includingPropertiesForKeys:options:)`. Refer to that method for further documentation.
-    func contentsOfDirectoryIO(at url: URL, includingPropertiesForKeys keys: [URLResourceKey]?, options mask: FileManager.DirectoryEnumerationOptions = []) -> IO<Error, [URL]> {
-        return IO.invoke { try self.contentsOfDirectory(at: url, includingPropertiesForKeys: keys, options: mask) }
+    func contentsOfDirectoryIO(
+        at url: URL,
+        includingPropertiesForKeys keys: [URLResourceKey]?,
+        options mask: FileManager.DirectoryEnumerationOptions = []) -> IO<Error, [URL]> {
+        IO.invoke {
+            try self.contentsOfDirectory(at: url, includingPropertiesForKeys: keys, options: mask)
+        }
     }
     
     /// IO suspended version of `FileManager.contentsOfDirectory(atPath:)`. Refer to that method for further documentation.
     func contentsOfDirectoryIO(atPath path: String) -> IO<Error, [String]> {
-        return IO.invoke { try self.contentsOfDirectory(atPath: path) }
+        IO.invoke {
+            try self.contentsOfDirectory(atPath: path)
+        }
     }
     
     /// IO suspended version of `FileManager.subpathsOfDirectory(atPath:)`. Refer to that method for further documentation.
     func subpathsOfDirectoryIO(atPath path: String) -> IO<Error, [String]> {
-        return IO.invoke { try self.subpathsOfDirectory(atPath: path) }
+        IO.invoke {
+            try self.subpathsOfDirectory(atPath: path)
+        }
     }
     
     // MARK: Creating and Deleting Items
     
     /// IO suspended version of `FileManager.createDirectory(at:withIntermediateDirectories:attributes:)`. Refer to that method for further documentation.
-    func createDirectoryIO(at url: URL, withIntermediateDirectories createIntermediates: Bool, attributes: [FileAttributeKey: Any]? = nil) -> IO<Error, ()> {
-        return IO.invoke { try self.createDirectory(at: url, withIntermediateDirectories: createIntermediates, attributes: attributes) }
+    func createDirectoryIO(
+        at url: URL,
+        withIntermediateDirectories createIntermediates: Bool,
+        attributes: [FileAttributeKey: Any]? = nil) -> IO<Error, ()> {
+        IO.invoke {
+            try self.createDirectory(at: url, withIntermediateDirectories: createIntermediates, attributes: attributes)
+        }
     }
     
     /// IO suspended version of `FileManager.createDirectory(atPath:withIntermediateDirectories:attributes:)`. Refer to that method for further documentation.
-    func createDirectoryIO(atPath path: String, withIntermediateDirectories createIntermediates: Bool, attributes: [FileAttributeKey: Any]? = nil) -> IO<Error, ()> {
-        return IO.invoke { try self.createDirectory(atPath: path, withIntermediateDirectories: createIntermediates, attributes: attributes) }
+    func createDirectoryIO(
+        atPath path: String,
+        withIntermediateDirectories createIntermediates: Bool,
+        attributes: [FileAttributeKey: Any]? = nil) -> IO<Error, ()> {
+        IO.invoke {
+            try self.createDirectory(atPath: path, withIntermediateDirectories: createIntermediates, attributes: attributes)
+        }
     }
     
     /// IO suspended version of `FileManager.createFile(atPath:contents:attributes:)`. Refer to that method for further documentation.
-    func createFileIO(atPath path: String, contents: Data?, attributes: [FileAttributeKey: Any]? = nil) -> IO<Error, Bool> {
-        return IO.invoke { self.createFile(atPath: path, contents: contents, attributes: attributes) }
+    func createFileIO(
+        atPath path: String,
+        contents: Data?,
+        attributes: [FileAttributeKey: Any]? = nil) -> IO<Error, Bool> {
+        IO.invoke {
+            self.createFile(atPath: path, contents: contents, attributes: attributes)
+        }
     }
     
     /// IO suspended version of `FileManager.removeItem(at:)`. Refer to that method for further documentation.
     func removeItemIO(at url: URL) -> IO<Error, ()> {
-        return IO.invoke { try self.removeItem(at: url) }
+        IO.invoke {
+            try self.removeItem(at: url)
+        }
     }
     
     /// IO suspended version of `FileManager.removeItem(atPath:)`. Refer to that method for further documentation.
     func removeItemIO(atPath path: String) -> IO<Error, ()> {
-        return IO.invoke { try self.removeItem(atPath: path) }
+        IO.invoke {
+            try self.removeItem(atPath: path)
+        }
     }
     
     /// IO suspended version of `FileManager.trashItem(at:resultingItemURL:)`. Refer to that method for further documentation.
     @available(iOS 11.0, *)
-    func trashItemIO(at url: URL, resultingItemURL outResultingURL: AutoreleasingUnsafeMutablePointer<NSURL?>?) -> IO<Error, ()> {
-        return IO.invoke { try self.trashItem(at: url, resultingItemURL: outResultingURL) }
+    func trashItemIO(
+        at url: URL,
+        resultingItemURL outResultingURL: AutoreleasingUnsafeMutablePointer<NSURL?>?) -> IO<Error, ()> {
+        IO.invoke {
+            try self.trashItem(at: url, resultingItemURL: outResultingURL)
+        }
     }
     
     // MARK: Replacing Items
     
     /// IO suspended version of `FileManager.replaceItemAt(_:withItemAt:backupItemName:options:)`. Refer to that method for further documentation.
-    func replaceItemIO(at originalItemURL: URL, withItemAt newItemURL: URL, backupItemName: String? = nil, options: FileManager.ItemReplacementOptions = []) -> IO<Error, URL?> {
-        return IO.invoke { try self.replaceItemAt(originalItemURL, withItemAt: newItemURL, backupItemName: backupItemName, options: options) }
+    func replaceItemIO(
+        at originalItemURL: URL,
+        withItemAt newItemURL: URL,
+        backupItemName: String? = nil,
+        options: FileManager.ItemReplacementOptions = []) -> IO<Error, URL?> {
+        IO.invoke {
+            try self.replaceItemAt(originalItemURL, withItemAt: newItemURL, backupItemName: backupItemName, options: options)
+        }
     }
     
     // MARK: Moving and Copying Items
     
     /// IO suspended version of `FileManager.copyItem(at:to:)`. Refer to that method for further documentation.
-    func copyItemIO(at originalItemURL: URL, to newItemURL: URL) -> IO<Error, ()> {
-        return IO.invoke { try self.copyItem(at: originalItemURL, to: newItemURL) }
+    func copyItemIO(
+        at originalItemURL: URL,
+        to newItemURL: URL) -> IO<Error, ()> {
+        IO.invoke {
+            try self.copyItem(at: originalItemURL, to: newItemURL)
+        }
     }
     
     /// IO suspended version of `FileManager.copyItem(atPath:toPath:)`. Refer to that method for further documentation.
-    func copyItemIO(atPath originalItemPath: String, toPath newItemPath: String) -> IO<Error, ()> {
-        return IO.invoke { try self.copyItem(atPath: originalItemPath, toPath: newItemPath) }
+    func copyItemIO(
+        atPath originalItemPath: String,
+        toPath newItemPath: String) -> IO<Error, ()> {
+        IO.invoke {
+            try self.copyItem(atPath: originalItemPath, toPath: newItemPath)
+        }
     }
     
     /// IO suspended version of `FileManager.moveItem(at:to:)`. Refer to that method for further documentation.
-    func moveItemIO(at originalItemURL: URL, to newItemURL: URL) -> IO<Error, ()> {
-        return IO.invoke { try self.moveItem(at: originalItemURL, to: newItemURL) }
+    func moveItemIO(
+        at originalItemURL: URL,
+        to newItemURL: URL) -> IO<Error, ()> {
+        IO.invoke {
+            try self.moveItem(at: originalItemURL, to: newItemURL)
+        }
     }
     
     /// IO suspended version of `FileManager.moveItem(atPath:toPath:)`. Refer to that method for further documentation.
-    func moveItemIO(atPath originalItemPath: String, to newItemPath: String) -> IO<Error, ()> {
-        return IO.invoke { try self.moveItem(atPath: originalItemPath, toPath: newItemPath) }
+    func moveItemIO(
+        atPath originalItemPath: String,
+        to newItemPath: String) -> IO<Error, ()> {
+        IO.invoke {
+            try self.moveItem(atPath: originalItemPath, toPath: newItemPath)
+        }
     }
     
     // MARK: Managing iCloud-Based Items
     
     /// IO suspended version of `FileManager.setUbiquitous(_:itemAt:destinationURL:)`. Refer to that method for further documentation.
-    func setUbiquitousIO(_ flag: Bool, itemAt url: URL, destinationURL: URL) -> IO<Error, ()> {
-        return IO.invoke { try self.setUbiquitous(flag, itemAt: url, destinationURL: destinationURL) }
+    func setUbiquitousIO(
+        _ flag: Bool,
+        itemAt url: URL,
+        destinationURL: URL) -> IO<Error, ()> {
+        IO.invoke {
+            try self.setUbiquitous(flag, itemAt: url, destinationURL: destinationURL)
+        }
     }
     
     /// IO suspended version of `FileManager.startDownloadingUbiquitousItem(at:)`. Refer to that method for further documentation.
     func startDownloadingUbiquitousItemIO(at url: URL) -> IO<Error, ()> {
-        return IO.invoke { try self.startDownloadingUbiquitousItem(at: url) }
+        IO.invoke {
+            try self.startDownloadingUbiquitousItem(at: url)
+        }
     }
     
     /// IO suspended version of `FileManager.evictUbiquitousItem(at:)`. Refer to that method for further documentation.
     func evictUbiquitousItemIO(at url: URL) -> IO<Error, ()> {
-        return IO.invoke { try self.evictUbiquitousItem(at: url) }
+        IO.invoke {
+            try self.evictUbiquitousItem(at: url)
+        }
     }
     
     /// IO suspended version of `FileManager.url(forPublishingUbiquitousItemAt:expiration:)`. Refer to that method for further documentation.
-    func urlIO(forPublishingUbiquitousItemAt url: URL, expiration outDate: AutoreleasingUnsafeMutablePointer<NSDate?>?) -> IO<Error, URL> {
-        return IO.invoke { try self.url(forPublishingUbiquitousItemAt: url, expiration: outDate) }
+    func urlIO(
+        forPublishingUbiquitousItemAt url: URL,
+        expiration outDate: AutoreleasingUnsafeMutablePointer<NSDate?>?) -> IO<Error, URL> {
+        IO.invoke {
+            try self.url(forPublishingUbiquitousItemAt: url, expiration: outDate)
+        }
     }
     
     // MARK: Accessing File Provider Services
@@ -118,7 +191,7 @@ public extension FileManager {
     @available(OSX 10.13, *)
     @available(iOS 11.0, *)
     func getFileProviderServicesForItemIO(at url: URL) -> IO<Error, [NSFileProviderServiceName: NSFileProviderService]> {
-        return IO.async { callback in
+        IO.async { callback in
             self.getFileProviderServicesForItem(at: url) { services, error in
                 if let services = services {
                     callback(.right(services))
@@ -132,73 +205,111 @@ public extension FileManager {
     // MARK: Creating Symbolic and Hard Links
     
     /// IO suspended version of `FileManager.createSymbolicLink(at:withDestinationPath:)`. Refer to that method for further documentation.
-    func createSymbolicLinkIO(at url: URL, withDestinationURL destinationURL: URL) -> IO<Error, ()> {
-        return IO.invoke { try self.createSymbolicLink(at: url, withDestinationURL: destinationURL) }
+    func createSymbolicLinkIO(
+        at url: URL,
+        withDestinationURL destinationURL: URL) -> IO<Error, ()> {
+        IO.invoke {
+            try self.createSymbolicLink(at: url, withDestinationURL: destinationURL)
+        }
     }
     
     /// IO suspended version of `FileManager.createSymbolicLink(atPath:withDestinationPath:)`. Refer to that method for further documentation.
-    func createSymbolicLinkIO(atPath path: String, withDestinationPath destinationPath: String) -> IO<Error, ()> {
-        return IO.invoke { try self.createSymbolicLink(atPath: path, withDestinationPath: destinationPath) }
+    func createSymbolicLinkIO(
+        atPath path: String,
+        withDestinationPath destinationPath: String) -> IO<Error, ()> {
+        IO.invoke {
+            try self.createSymbolicLink(atPath: path, withDestinationPath: destinationPath)
+        }
     }
     
     /// IO suspended version of `FileManager.linkItem(at:to:)`. Refer to that method for further documentation.
-    func linkItemIO(at url: URL, to destinationURL: URL) -> IO<Error, ()> {
-        return IO.invoke { try self.linkItem(at: url, to: destinationURL) }
+    func linkItemIO(
+        at url: URL,
+        to destinationURL: URL) -> IO<Error, ()> {
+        IO.invoke {
+            try self.linkItem(at: url, to: destinationURL)
+        }
     }
     
     /// IO suspended version of `FileManager.linkItem(atPath:toPath:)`. Refer to that method for further documentation.
-    func linkItemIO(atPath path: String, toPath destinationPath: String) -> IO<Error, ()> {
-        return IO.invoke { try self.linkItem(atPath: path, toPath: destinationPath) }
+    func linkItemIO(
+        atPath path: String,
+        toPath destinationPath: String) -> IO<Error, ()> {
+        IO.invoke {
+            try self.linkItem(atPath: path, toPath: destinationPath)
+        }
     }
     
     /// IO suspended version of `FileManager.destinationOfSymbolicLink(atPath:)`. Refer to that method for further documentation.
     func destinationOfSymbolicLinkIO(atPath path: String) -> IO<Error, String> {
-        return IO.invoke { try self.destinationOfSymbolicLink(atPath: path) }
+        IO.invoke {
+            try self.destinationOfSymbolicLink(atPath: path)
+        }
     }
     
     // MARK: Getting and Setting Attributes
     
     /// IO suspended version of `FileManager.componentsToDisplay(forPath:)`. Refer to that method for further documentation.
     func componentsToDisplayIO(forPath path: String) -> IO<Error, [String]?> {
-        return IO.invoke { self.componentsToDisplay(forPath: path) }
+        IO.invoke {
+            self.componentsToDisplay(forPath: path)
+        }
     }
     
     /// IO suspended version of `FileManager.displayName(atPath:)`. Refer to that method for further documentation.
     func displayNameIO(atPath path: String) -> IO<Error, String> {
-        return IO.invoke { self.displayName(atPath: path) }
+        IO.invoke {
+            self.displayName(atPath: path)
+        }
     }
     
     /// IO suspended version of `FileManager.attributesOfItem(atPath:)`. Refer to that method for further documentation.
     func attributesOfItemIO(atPath path: String) -> IO<Error, [FileAttributeKey: Any]> {
-        return IO.invoke { try self.attributesOfItem(atPath: path) }
+        IO.invoke {
+            try self.attributesOfItem(atPath: path)
+        }
     }
     
     /// IO suspended version of `FileManager.attributesOfFileSystem(forPath:)`. Refer to that method for further documentation.
     func attributesOfFileSystemIO(forPath path: String) -> IO<Error, [FileAttributeKey: Any]> {
-        return IO.invoke { try self.attributesOfFileSystem(forPath: path) }
+        IO.invoke {
+            try self.attributesOfFileSystem(forPath: path)
+        }
     }
     
     /// IO suspended version of `FileManager.setAttributes(_:ofItemAtPath:)`. Refer to that method for further documentation.
-    func setAttributesIO(_ attrs: [FileAttributeKey: Any], ofItemAtPath path: String) -> IO<Error, ()> {
-        return IO.invoke { try self.setAttributes(attrs, ofItemAtPath: path) }
+    func setAttributesIO(
+        _ attrs: [FileAttributeKey: Any],
+        ofItemAtPath path: String) -> IO<Error, ()> {
+        IO.invoke {
+            try self.setAttributes(attrs, ofItemAtPath: path)
+        }
     }
     
     // MARK: Getting and Comparing File Contents
     
     /// IO suspended version of `FileManager.contents(atPath:)`. Refer to that method for further documentation.
     func contentsIO(atPath path: String) -> IO<Error, Data?> {
-        return IO.invoke { self.contents(atPath: path) }
+        IO.invoke {
+            self.contents(atPath: path)
+        }
     }
     
     /// IO suspended version of `FileManager.contentsEqual(atPath:andPath:)`. Refer to that method for further documentation.
-    func contentsEqualIO(atPath path: String, andPath otherPath: String) -> IO<Error, Bool> {
-        return IO.invoke { self.contentsEqual(atPath: path, andPath: otherPath) }
+    func contentsEqualIO(
+        atPath path: String,
+        andPath otherPath: String) -> IO<Error, Bool> {
+        IO.invoke {
+            self.contentsEqual(atPath: path, andPath: otherPath)
+        }
     }
     
     // MARK: Managing the Current Directory
     
     /// IO suspended version of `FileManager.changeCurrentDirectoryPath(_:)`. Refer to that method for further documentation.
     func changeCurrentDirectoryPathIO(_ path: String) -> IO<Error, Bool> {
-        return IO.invoke { self.changeCurrentDirectoryPath(path) }
+        IO.invoke {
+            self.changeCurrentDirectoryPath(path)
+        }
     }
 }

--- a/Sources/BowEffects/Foundation/URLSession.swift
+++ b/Sources/BowEffects/Foundation/URLSession.swift
@@ -10,14 +10,14 @@ public extension URLSession {
     
     /// IO suspended version of `URLSession.dataTask(with:)`. Refer to that function for further documentation.
     func dataTaskIO(with url: URL) -> DataIO {
-        return IO.async { callback in
+        IO.async { callback in
             self.dataTask(with: url, completionHandler: self.onResponse(callback)).resume()
         }^
     }
     
     /// IO suspended version of `URLSession.dataTask(with:)`. Refer to that function for further documentation.
     func dataTaskIO(with request: URLRequest) -> DataIO {
-        return IO.async { callback in
+        IO.async { callback in
             self.dataTask(with: request, completionHandler: self.onResponse(callback)).resume()
         }^
     }
@@ -26,21 +26,21 @@ public extension URLSession {
     
     /// IO suspended version of `URLSession.downloadTask(with:)`. Refer to that function for further documentation.
     func downloadTaskIO(with url: URL) -> DownloadIO {
-        return IO.async { callback in
+        IO.async { callback in
             self.downloadTask(with: url, completionHandler: self.onResponse(callback)).resume()
         }^
     }
     
     /// IO suspended version of `URLSession.downloadTask(with:)`. Refer to that function for further documentation.
     func downloadTaskIO(with request: URLRequest) -> DownloadIO {
-        return IO.async { callback in
+        IO.async { callback in
             self.downloadTask(with: request, completionHandler: self.onResponse(callback)).resume()
         }^
     }
     
     /// IO suspended version of `URLSession.downloadTask(withResumeData:)`. Refer to that function for further documentation.
     func downloadTaskIO(withResumeData data: Data) -> DownloadIO {
-        return IO.async { callback in
+        IO.async { callback in
             self.downloadTask(withResumeData: data, completionHandler: self.onResponse(callback)).resume()
         }^
     }
@@ -48,21 +48,25 @@ public extension URLSession {
     // MARK: Adding Upload Tasks to a Session
     
     /// IO suspended version of `URLSession.uploadTask(with:from:)`. Refer to that function for further documentation.
-    func uploadTaskIO(with request: URLRequest, from data: Data) -> DataIO {
-        return IO.async { callback in
+    func uploadTaskIO(
+        with request: URLRequest,
+        from data: Data) -> DataIO {
+        IO.async { callback in
             self.uploadTask(with: request, from: data, completionHandler: self.onResponse(callback)).resume()
         }^
     }
     
     /// IO suspended version of `URLSession.uploadTask(with:fromFile:)`. Refer to that function for further documentation.
-    func uploadTaskIO(with request: URLRequest, fromFile url: URL) -> DataIO {
-        return IO.async { callback in
+    func uploadTaskIO(
+        with request: URLRequest,
+        fromFile url: URL) -> DataIO {
+        IO.async { callback in
             self.uploadTask(with: request, fromFile: url, completionHandler: self.onResponse(callback)).resume()
         }^
     }
     
     private func onResponse(_ callback: @escaping (Either<Error, (response: URLResponse, data: Data)>) -> ()) -> (Data?, URLResponse?, Error?) -> () {
-        return { data, response, error in
+        { data, response, error in
             if let data = data, let response = response {
                 callback(.right((response, data)))
             } else if let error = error {
@@ -72,7 +76,7 @@ public extension URLSession {
     }
     
     private func onResponse(_ callback: @escaping (Either<Error, (response: URLResponse, url: URL)>) -> ()) -> (URL?, URLResponse?, Error?) -> () {
-        return { url, response, error in
+        { url, response, error in
             if let url = url, let response = response {
                 callback(.right((response, url)))
             } else if let error = error {


### PR DESCRIPTION
## Goal

Cleanup code in the Foundation folder in the Effects module by:

- Using `FOf<A>` instead of `Kind<F, A>`.
- Removing backticks in `MARK` sections as they do not render properly in Jazzy.
- Removing returns.
- Replacing `fix` by `^`.