### PR TITLE
Cleanup Typeclasses folder in Effects module

### DIFF
--- a/Sources/BowEffects/Typeclasses/Bracket.swift
+++ b/Sources/BowEffects/Typeclasses/Bracket.swift
@@ -17,7 +17,10 @@ public enum ExitCase<E> {
     ///   - ifCanceled: Function to be applied if this value is canceled.
     ///   - ifError: Function to be applied if this value is errored.
     /// - Returns: Result of applying the corresponding function based on the content of this value.
-    public func fold<A>(_ ifCompleted: () -> A, _ ifCanceled: () -> A, _ ifError: (E) -> A) -> A {
+    public func fold<A>(
+        _ ifCompleted: () -> A,
+        _ ifCanceled: () -> A,
+        _ ifError: (E) -> A) -> A {
         switch self {
         case .completed: return ifCompleted()
         case .canceled: return ifCanceled()
@@ -54,9 +57,10 @@ public protocol Bracket: MonadError {
     ///   - release: Function to release the acquired resource.
     ///   - use: Function to use the acquired resource.
     /// - Returns: Computation describing the result of using the resource.
-    static func bracketCase<A, B>(acquire fa: Kind<Self, A>,
-                                  release: @escaping (A, ExitCase<Self.E>) -> Kind<Self, ()>,
-                                  use: @escaping (A) throws -> Kind<Self, B>) -> Kind<Self, B>
+    static func bracketCase<A, B>(
+        acquire fa: Kind<Self, A>,
+        release: @escaping (A, ExitCase<Self.E>) -> Kind<Self, Void>,
+        use: @escaping (A) throws -> Kind<Self, B>) -> Kind<Self, B>
 }
 
 // MARK: Related functions
@@ -69,10 +73,14 @@ public extension Bracket {
     ///   - release: Function to release the acquired resource, ignoring the outcome of the release of the resource.
     ///   - use: Function to use the acquired resource.
     /// - Returns: Computation describing the result of using the resource.
-    static func bracket<A, B>(acquire fa: Kind<Self, A>,
-                              release: @escaping (A) -> Kind<Self, ()>,
-                              use: @escaping (A) throws -> Kind<Self, B>) -> Kind<Self, B> {
-        return bracketCase(acquire: fa, release: { a, _ in release(a) }, use: use)
+    static func bracket<A, B>(
+        acquire fa: Kind<Self, A>,
+        release: @escaping (A) -> Kind<Self, Void>,
+        use: @escaping (A) throws -> Kind<Self, B>) -> Kind<Self, B> {
+        bracketCase(
+            acquire: fa,
+            release: { a, _ in release(a) },
+            use: use)
     }
     
     /// Forces a resource to be uncancelable even when an interruption happens.
@@ -80,7 +88,10 @@ public extension Bracket {
     /// - Parameter fa: Computation describing the acquisition of the resource.
     /// - Returns: An uncancelable computation.
     static func uncancelable<A>(_ fa: Kind<Self, A>) -> Kind<Self, A> {
-        return bracket(acquire: fa, release: constant(pure(())), use: { x in pure(x) })
+        bracket(
+            acquire: fa,
+            release: constant(pure(())),
+            use: { x in pure(x) })
     }
     
     /// Executes the given finalizer when the source is finished, either in success, error or cancelation.
@@ -89,9 +100,12 @@ public extension Bracket {
     ///   - fa: Computation describing the acquisition of the resource.
     ///   - finalizer: Finalizer function to be invoked when the resource is released.
     /// - Returns: A computation describing the resouce that will invoke the finalizer when it is released.
-    static func guarantee<A>(_ fa: Kind<Self, A>,
-                             finalizer: Kind<Self, ()>) -> Kind<Self, A> {
-        return guaranteeCase(fa, finalizer: constant(finalizer))
+    static func guarantee<A>(
+        _ fa: Kind<Self, A>,
+        finalizer: Kind<Self, Void>) -> Kind<Self, A> {
+        guaranteeCase(
+            fa,
+            finalizer: constant(finalizer))
     }
     
     /// Executes the given finalizer when the source is finished, either in success, error or cancelation, alowing to differentiate between exit conditions.
@@ -100,9 +114,13 @@ public extension Bracket {
     ///   - fa: Computation describing the acquisition of the resource.
     ///   - finalizer: Finalizer function to be invoked when the resource is released, distinguishing the exit case.
     /// - Returns: A computation describing the resource that will invoke the finalizer when it is released.
-    static func guaranteeCase<A>(_ fa: Kind<Self, A>,
-                                 finalizer: @escaping (ExitCase<Self.E>) -> Kind<Self, ()>) -> Kind<Self, A> {
-        return bracketCase(acquire: pure(()), release: { _, e in finalizer(e) }, use: { fa })
+    static func guaranteeCase<A>(
+        _ fa: Kind<Self, A>,
+        finalizer: @escaping (ExitCase<Self.E>) -> Kind<Self, Void>) -> Kind<Self, A> {
+        bracketCase(
+            acquire: pure(()),
+            release: { _, e in finalizer(e) },
+            use: { fa })
     }
 }
 
@@ -115,9 +133,13 @@ public extension Kind where F: Bracket {
     ///   - release: Function to release the acquired resource.
     ///   - use: Function to use the acquired resource.
     /// - Returns: Computation describing the result of using the resource.
-    func bracketCase<B>(release: @escaping (A, ExitCase<F.E>) -> Kind<F, ()>,
-                        use: @escaping (A) throws -> Kind<F, B>) -> Kind<F, B> {
-        return F.bracketCase(acquire: self, release: release, use: use)
+    func bracketCase<B>(
+        release: @escaping (A, ExitCase<F.E>) -> Kind<F, Void>,
+        use: @escaping (A) throws -> Kind<F, B>) -> Kind<F, B> {
+        F.bracketCase(
+            acquire: self,
+            release: release,
+            use: use)
     }
     
     /// A way to safely acquire a resource and release in the face of errors and cancellations. It uses `ExitCase` to distinguish between different exit cases when releasing the acquired resource.
@@ -126,31 +148,35 @@ public extension Kind where F: Bracket {
     ///   - release: Function to release the acquired resource, ignoring the outcome of the release of the resource.
     ///   - use: Function to use the acquired resource.
     /// - Returns: Computation describing the result of using the resource.
-    func bracket<B>(release: @escaping (A) -> Kind<F, ()>,
-                    use: @escaping (A) throws -> Kind<F, B>) -> Kind<F, B> {
-        return F.bracket(acquire: self, release: release, use: use)
+    func bracket<B>(
+        release: @escaping (A) -> Kind<F, Void>,
+        use: @escaping (A) throws -> Kind<F, B>) -> Kind<F, B> {
+        F.bracket(
+            acquire: self,
+            release: release,
+            use: use)
     }
     
     /// Forces this resource to be uncancelable even when an interruption happens.
     ///
     /// - Returns: An uncancelable computation.
     func uncancelable() -> Kind<F, A> {
-        return F.uncancelable(self)
+        F.uncancelable(self)
     }
     
     /// Executes the given finalizer when the source is finished, either in success, error or cancelation.
     ///
     /// - Parameter finalizer: Finalizer function to be invoked when the resource is released.
     /// - Returns: A computation describing the resouce that will invoke the finalizer when it is released.
-    func guarantee(_ finalizer: Kind<F, ()>) -> Kind<F, A> {
-        return F.guarantee(self, finalizer: finalizer)
+    func guarantee(_ finalizer: Kind<F, Void>) -> Kind<F, A> {
+        F.guarantee(self, finalizer: finalizer)
     }
     
     /// Executes the given finalizer when the source is finished, either in success, error or cancelation, alowing to differentiate between exit conditions.
     ///
     /// - Parameter finalizer: Finalizer function to be invoked when the resource is released, distinguishing the exit case.
     /// - Returns: A computation describing the resource that will invoke the finalizer when it is released.
-    func guaranteeCase(_ finalizer: @escaping (ExitCase<F.E>) -> Kind<F, ()>) -> Kind<F, A> {
-        return F.guaranteeCase(self, finalizer: finalizer)
+    func guaranteeCase(_ finalizer: @escaping (ExitCase<F.E>) -> Kind<F, Void>) -> Kind<F, A> {
+        F.guaranteeCase(self, finalizer: finalizer)
     }
 }

--- a/Sources/BowEffects/Typeclasses/Concurrent.swift
+++ b/Sources/BowEffects/Typeclasses/Concurrent.swift
@@ -10,9 +10,10 @@ public protocol Concurrent: Async {
     ///   - fb: 2nd computation.
     ///   - f: Combination function.
     /// - Returns: A computation that describes the parallel execution.
-    static func parMap<A, B, Z>(_ fa: Kind<Self, A>,
-                                _ fb: Kind<Self, B>,
-                                _ f: @escaping (A, B) -> Z) -> Kind<Self, Z>
+    static func parMap<A, B, Z>(
+        _ fa: Kind<Self, A>,
+        _ fb: Kind<Self, B>,
+        _ f: @escaping (A, B) -> Z) -> Kind<Self, Z>
     
     /// Runs 3 computations in parallel and combines their results using the provided function.
     ///
@@ -22,10 +23,11 @@ public protocol Concurrent: Async {
     ///   - fc: 3rd computation.
     ///   - f: Combination function.
     /// - Returns: A computation that describes the parallel execution.
-    static func parMap<A, B, C, Z>(_ fa: Kind<Self, A>,
-                                   _ fb: Kind<Self, B>,
-                                   _ fc: Kind<Self, C>,
-                                   _ f: @escaping (A, B, C) -> Z) -> Kind<Self, Z>
+    static func parMap<A, B, C, Z>(
+        _ fa: Kind<Self, A>,
+        _ fb: Kind<Self, B>,
+        _ fc: Kind<Self, C>,
+        _ f: @escaping (A, B, C) -> Z) -> Kind<Self, Z>
     
     /// Runs 2 computations in parallel and returns the result of the first one finishing.
     ///
@@ -33,8 +35,9 @@ public protocol Concurrent: Async {
     ///   - fa: 1st computation
     ///   - fb: 2nd computation
     /// - Returns: A computation with the result of the first computation that finished.
-    static func race<A, B>(_ fa: Kind<Self, A>,
-                           _ fb: Kind<Self, B>) -> Kind<Self, Either<A, B>>
+    static func race<A, B>(
+        _ fa: Kind<Self, A>,
+        _ fb: Kind<Self, B>) -> Kind<Self, Either<A, B>>
 }
 
 // MARK: Related functions
@@ -46,9 +49,12 @@ public extension Concurrent {
     ///   - fa: 1st computation.
     ///   - fb: 2nd computation.
     /// - Returns: A computation that describes the parallel execution.
-    static func parZip<A, B>(_ fa: Kind<Self, A>,
-                             _ fb: Kind<Self, B>) -> Kind<Self, (A, B)> {
-        return Self.parMap(fa, fb, { a, b in (a, b) })
+    static func parZip<A, B>(
+        _ fa: Kind<Self, A>,
+        _ fb: Kind<Self, B>) -> Kind<Self, (A, B)> {
+        Self.parMap(fa, fb) { a, b in
+            (a, b)
+        }
     }
     
     /// Runs 3 computations in parallel and tuples their results.
@@ -58,10 +64,13 @@ public extension Concurrent {
     ///   - fb: 2nd computation.
     ///   - fc: 3rd computation.
     /// - Returns: A computation that describes the parallel execution.
-    static func parZip<A, B, C>(_ fa: Kind<Self, A>,
-                                _ fb: Kind<Self, B>,
-                                _ fc: Kind<Self, C>) -> Kind<Self, (A, B, C)> {
-        return Self.parMap(fa, fb, fc) { a, b, c in (a, b, c) }
+    static func parZip<A, B, C>(
+        _ fa: Kind<Self, A>,
+        _ fb: Kind<Self, B>,
+        _ fc: Kind<Self, C>) -> Kind<Self, (A, B, C)> {
+        Self.parMap(fa, fb, fc) { a, b, c in
+            (a, b, c)
+        }
     }
     
     /// Runs 4 computations in parallel and tuples their results.
@@ -72,11 +81,14 @@ public extension Concurrent {
     ///   - fc: 3rd computation.
     ///   - fd: 4th computation.
     /// - Returns: A computation that describes the parallel execution.
-    static func parZip<A, B, C, D>(_ fa: Kind<Self, A>,
-                                   _ fb: Kind<Self, B>,
-                                   _ fc: Kind<Self, C>,
-                                   _ fd: Kind<Self, D>) -> Kind<Self, (A, B, C, D)> {
-        return Self.parMap(fa, fb, fc, fd, { a, b, c, d in (a, b, c, d) })
+    static func parZip<A, B, C, D>(
+        _ fa: Kind<Self, A>,
+        _ fb: Kind<Self, B>,
+        _ fc: Kind<Self, C>,
+        _ fd: Kind<Self, D>) -> Kind<Self, (A, B, C, D)> {
+        Self.parMap(fa, fb, fc, fd) { a, b, c, d in
+            (a, b, c, d)
+        }
     }
     
     /// Runs 5 computations in parallel and tuples their results.
@@ -88,12 +100,15 @@ public extension Concurrent {
     ///   - fd: 4th computation.
     ///   - fe: 5th computation.
     /// - Returns: A computation that describes the parallel execution.
-    static func parZip<A, B, C, D, E>(_ fa: Kind<Self, A>,
-                                      _ fb: Kind<Self, B>,
-                                      _ fc: Kind<Self, C>,
-                                      _ fd: Kind<Self, D>,
-                                      _ fe: Kind<Self, E>) -> Kind<Self, (A, B, C, D, E)> {
-        return Self.parMap(fa, fb, fc, fd, fe, { a, b, c, d, e in (a, b, c, d, e) })
+    static func parZip<A, B, C, D, E>(
+        _ fa: Kind<Self, A>,
+        _ fb: Kind<Self, B>,
+        _ fc: Kind<Self, C>,
+        _ fd: Kind<Self, D>,
+        _ fe: Kind<Self, E>) -> Kind<Self, (A, B, C, D, E)> {
+        Self.parMap(fa, fb, fc, fd, fe) { a, b, c, d, e in
+            (a, b, c, d, e)
+        }
     }
     
     /// Runs 6 computations in parallel and tuples their results.
@@ -106,13 +121,16 @@ public extension Concurrent {
     ///   - fe: 5th computation.
     ///   - fg: 6th computation.
     /// - Returns: A computation that describes the parallel execution.
-    static func parZip<A, B, C, D, E, G>(_ fa: Kind<Self, A>,
-                                         _ fb: Kind<Self, B>,
-                                         _ fc: Kind<Self, C>,
-                                         _ fd: Kind<Self, D>,
-                                         _ fe: Kind<Self, E>,
-                                         _ fg: Kind<Self, G>) -> Kind<Self, (A, B, C, D, E, G)> {
-        return Self.parMap(fa, fb, fc, fd, fe, fg, { a, b, c, d, e, g in (a, b, c, d, e, g) })
+    static func parZip<A, B, C, D, E, G>(
+        _ fa: Kind<Self, A>,
+        _ fb: Kind<Self, B>,
+        _ fc: Kind<Self, C>,
+        _ fd: Kind<Self, D>,
+        _ fe: Kind<Self, E>,
+        _ fg: Kind<Self, G>) -> Kind<Self, (A, B, C, D, E, G)> {
+        Self.parMap(fa, fb, fc, fd, fe, fg) { a, b, c, d, e, g in
+            (a, b, c, d, e, g)
+        }
     }
     
     /// Runs 7 computations in parallel and tuples their results.
@@ -126,14 +144,17 @@ public extension Concurrent {
     ///   - fg: 6th computation.
     ///   - fh: 7th computation.
     /// - Returns: A computation that describes the parallel execution.
-    static func parZip<A, B, C, D, E, G, H>(_ fa: Kind<Self, A>,
-                                            _ fb: Kind<Self, B>,
-                                            _ fc: Kind<Self, C>,
-                                            _ fd: Kind<Self, D>,
-                                            _ fe: Kind<Self, E>,
-                                            _ fg: Kind<Self, G>,
-                                            _ fh: Kind<Self, H>) -> Kind<Self, (A, B, C, D, E, G, H)> {
-        return Self.parMap(fa, fb, fc, fd, fe, fg, fh, { a, b, c, d, e, g, h in (a, b, c, d, e, g, h) })
+    static func parZip<A, B, C, D, E, G, H>(
+        _ fa: Kind<Self, A>,
+        _ fb: Kind<Self, B>,
+        _ fc: Kind<Self, C>,
+        _ fd: Kind<Self, D>,
+        _ fe: Kind<Self, E>,
+        _ fg: Kind<Self, G>,
+        _ fh: Kind<Self, H>) -> Kind<Self, (A, B, C, D, E, G, H)> {
+        Self.parMap(fa, fb, fc, fd, fe, fg, fh) { a, b, c, d, e, g, h in
+            (a, b, c, d, e, g, h)
+        }
     }
     
     /// Runs 8 computations in parallel and tuples their results.
@@ -148,15 +169,18 @@ public extension Concurrent {
     ///   - fh: 7th computation.
     ///   - fi: 8th computation.
     /// - Returns: A computation that describes the parallel execution.
-    static func parZip<A, B, C, D, E, G, H, I>(_ fa: Kind<Self, A>,
-                                               _ fb: Kind<Self, B>,
-                                               _ fc: Kind<Self, C>,
-                                               _ fd: Kind<Self, D>,
-                                               _ fe: Kind<Self, E>,
-                                               _ fg: Kind<Self, G>,
-                                               _ fh: Kind<Self, H>,
-                                               _ fi: Kind<Self, I>) -> Kind<Self, (A, B, C, D, E, G, H, I)> {
-        return Self.parMap(fa, fb, fc, fd, fe, fg, fh, fi, { a, b, c, d, e, g, h, i in (a, b, c, d, e, g, h, i) })
+    static func parZip<A, B, C, D, E, G, H, I>(
+        _ fa: Kind<Self, A>,
+        _ fb: Kind<Self, B>,
+        _ fc: Kind<Self, C>,
+        _ fd: Kind<Self, D>,
+        _ fe: Kind<Self, E>,
+        _ fg: Kind<Self, G>,
+        _ fh: Kind<Self, H>,
+        _ fi: Kind<Self, I>) -> Kind<Self, (A, B, C, D, E, G, H, I)> {
+        Self.parMap(fa, fb, fc, fd, fe, fg, fh, fi) { a, b, c, d, e, g, h, i in
+            (a, b, c, d, e, g, h, i)
+        }
     }
     
     /// Runs 9 computations in parallel and tuples their results.
@@ -172,16 +196,19 @@ public extension Concurrent {
     ///   - fi: 8th computation.
     ///   - fj: 9th computation.
     /// - Returns: A computation that describes the parallel execution.
-    static func parZip<A, B, C, D, E, G, H, I, J>(_ fa: Kind<Self, A>,
-                                                  _ fb: Kind<Self, B>,
-                                                  _ fc: Kind<Self, C>,
-                                                  _ fd: Kind<Self, D>,
-                                                  _ fe: Kind<Self, E>,
-                                                  _ fg: Kind<Self, G>,
-                                                  _ fh: Kind<Self, H>,
-                                                  _ fi: Kind<Self, I>,
-                                                  _ fj: Kind<Self, J>) -> Kind<Self, (A, B, C, D, E, G, H, I, J)> {
-        return Self.parMap(fa, fb, fc, fd, fe, fg, fh, fi, fj, { a, b, c, d, e, g, h, i, j in (a, b, c, d, e, g, h, i, j) })
+    static func parZip<A, B, C, D, E, G, H, I, J>(
+        _ fa: Kind<Self, A>,
+        _ fb: Kind<Self, B>,
+        _ fc: Kind<Self, C>,
+        _ fd: Kind<Self, D>,
+        _ fe: Kind<Self, E>,
+        _ fg: Kind<Self, G>,
+        _ fh: Kind<Self, H>,
+        _ fi: Kind<Self, I>,
+        _ fj: Kind<Self, J>) -> Kind<Self, (A, B, C, D, E, G, H, I, J)> {
+        Self.parMap(fa, fb, fc, fd, fe, fg, fh, fi, fj) { a, b, c, d, e, g, h, i, j in
+            (a, b, c, d, e, g, h, i, j)
+        }
     }
     
     /// Runs 4 computations in parallel and combines their results using the provided function.
@@ -193,14 +220,15 @@ public extension Concurrent {
     ///   - fd: 4th computation.
     ///   - f: Combination function.
     /// - Returns: A computation that describes the parallel execution.
-    static func parMap<A, B, C, D, Z>(_ fa: Kind<Self, A>,
-                                      _ fb: Kind<Self, B>,
-                                      _ fc: Kind<Self, C>,
-                                      _ fd: Kind<Self, D>,
-                                      _ f: @escaping (A, B, C, D) -> Z) -> Kind<Self, Z> {
-        return Self.parMap(Self.parMap(fa, fb, { a, b in (a, b) }),
-                           Self.parMap(fc, fd, { c, d in (c, d) }),
-                           { x, y in f(x.0, x.1, y.0, y.1) })
+    static func parMap<A, B, C, D, Z>(
+        _ fa: Kind<Self, A>,
+        _ fb: Kind<Self, B>,
+        _ fc: Kind<Self, C>,
+        _ fd: Kind<Self, D>,
+        _ f: @escaping (A, B, C, D) -> Z) -> Kind<Self, Z> {
+        Self.parMap(Self.parMap(fa, fb, { a, b in (a, b) }),
+                    Self.parMap(fc, fd, { c, d in (c, d) }))
+                    { x, y in f(x.0, x.1, y.0, y.1) }
     }
     
     /// Runs 5 computations in parallel and combines their results using the provided function.
@@ -213,15 +241,16 @@ public extension Concurrent {
     ///   - fe: 5th computation.
     ///   - f: Combination function.
     /// - Returns: A computation that describes the parallel execution.
-    static func parMap<A, B, C, D, E, Z>(_ fa: Kind<Self, A>,
-                                         _ fb: Kind<Self, B>,
-                                         _ fc: Kind<Self, C>,
-                                         _ fd: Kind<Self, D>,
-                                         _ fe: Kind<Self, E>,
-                                         _ f: @escaping (A, B, C, D, E) -> Z) -> Kind<Self, Z> {
-        return Self.parMap(Self.parMap(fa, fb, fc, { a, b, c in (a, b, c) }),
-                           Self.parMap(fd, fe, { d, e in (d, e) }),
-                           { x, y in f(x.0, x.1, x.2, y.0, y.1) })
+    static func parMap<A, B, C, D, E, Z>(
+        _ fa: Kind<Self, A>,
+        _ fb: Kind<Self, B>,
+        _ fc: Kind<Self, C>,
+        _ fd: Kind<Self, D>,
+        _ fe: Kind<Self, E>,
+        _ f: @escaping (A, B, C, D, E) -> Z) -> Kind<Self, Z> {
+        Self.parMap(Self.parMap(fa, fb, fc, { a, b, c in (a, b, c) }),
+                    Self.parMap(fd, fe, { d, e in (d, e) }))
+                    { x, y in f(x.0, x.1, x.2, y.0, y.1) }
     }
     
     /// Runs 6 computations in parallel and combines their results using the provided function.
@@ -235,16 +264,17 @@ public extension Concurrent {
     ///   - fg: 6th computation.
     ///   - f: Combination function.
     /// - Returns: A computation that describes the parallel execution.
-    static func parMap<A, B, C, D, E, G, Z>(_ fa: Kind<Self, A>,
-                                            _ fb: Kind<Self, B>,
-                                            _ fc: Kind<Self, C>,
-                                            _ fd: Kind<Self, D>,
-                                            _ fe: Kind<Self, E>,
-                                            _ fg: Kind<Self, G>,
-                                            _ f: @escaping (A, B, C, D, E, G) -> Z) -> Kind<Self, Z> {
-        return Self.parMap(Self.parMap(fa, fb, fc, { a, b, c in (a, b, c) }),
-                           Self.parMap(fd, fe, fg, { d, e, g in (d, e, g) }),
-                           { x, y in f(x.0, x.1, x.2, y.0, y.1, y.2) })
+    static func parMap<A, B, C, D, E, G, Z>(
+        _ fa: Kind<Self, A>,
+        _ fb: Kind<Self, B>,
+        _ fc: Kind<Self, C>,
+        _ fd: Kind<Self, D>,
+        _ fe: Kind<Self, E>,
+        _ fg: Kind<Self, G>,
+        _ f: @escaping (A, B, C, D, E, G) -> Z) -> Kind<Self, Z> {
+        Self.parMap(Self.parMap(fa, fb, fc, { a, b, c in (a, b, c) }),
+                    Self.parMap(fd, fe, fg, { d, e, g in (d, e, g) }))
+                    { x, y in f(x.0, x.1, x.2, y.0, y.1, y.2) }
     }
     
     /// Runs 7 computations in parallel and combines their results using the provided function.
@@ -259,19 +289,19 @@ public extension Concurrent {
     ///   - fh: 7th computation.
     ///   - f: Combination function.
     /// - Returns: A computation that describes the parallel execution.
-    static func parMap<A, B, C, D, E, G, H, Z>(_ fa: Kind<Self, A>,
-                                               _ fb: Kind<Self, B>,
-                                               _ fc: Kind<Self, C>,
-                                               _ fd: Kind<Self, D>,
-                                               _ fe: Kind<Self, E>,
-                                               _ fg: Kind<Self, G>,
-                                               _ fh: Kind<Self, H>,
-                                               _ f: @escaping (A, B, C, D, E, G, H) -> Z) -> Kind<Self, Z> {
-        return Self.parMap(Self.parMap(fa, fb, fc, { a, b, c in (a, b, c) }),
-                           Self.parMap(fd, fe, { d, e in (d, e) }),
-                           Self.parMap(fg, fh, { g, h in (g, h) }),
-                           { x, y, z in f(x.0, x.1, x.2, y.0, y.1, z.0, z.1) }
-        )
+    static func parMap<A, B, C, D, E, G, H, Z>(
+        _ fa: Kind<Self, A>,
+        _ fb: Kind<Self, B>,
+        _ fc: Kind<Self, C>,
+        _ fd: Kind<Self, D>,
+        _ fe: Kind<Self, E>,
+        _ fg: Kind<Self, G>,
+        _ fh: Kind<Self, H>,
+        _ f: @escaping (A, B, C, D, E, G, H) -> Z) -> Kind<Self, Z> {
+        Self.parMap(Self.parMap(fa, fb, fc, { a, b, c in (a, b, c) }),
+                    Self.parMap(fd, fe, { d, e in (d, e) }),
+                    Self.parMap(fg, fh, { g, h in (g, h) }))
+                    { x, y, z in f(x.0, x.1, x.2, y.0, y.1, z.0, z.1) }
     }
     
     /// Runs 8 computations in parallel and combines their results using the provided function.
@@ -287,19 +317,20 @@ public extension Concurrent {
     ///   - fi: 8th computation.
     ///   - f: Combination function.
     /// - Returns: A computation that describes the parallel execution.
-    static func parMap<A, B, C, D, E, G, H, I, Z>(_ fa: Kind<Self, A>,
-                                                  _ fb: Kind<Self, B>,
-                                                  _ fc: Kind<Self, C>,
-                                                  _ fd: Kind<Self, D>,
-                                                  _ fe: Kind<Self, E>,
-                                                  _ fg: Kind<Self, G>,
-                                                  _ fh: Kind<Self, H>,
-                                                  _ fi: Kind<Self, I>,
-                                                  _ f: @escaping (A, B, C, D, E, G, H, I) -> Z) -> Kind<Self, Z> {
-        return Self.parMap(Self.parMap(fa, fb, fc, { a, b, c in (a, b, c) }),
-                           Self.parMap(fd, fe, fg, { d, e, g in (d, e, g) }),
-                           Self.parMap(fh, fi, { h, i in (h, i) }),
-                           { x, y, z in f(x.0, x.1, x.2, y.0, y.1, y.2, z.0, z.1) })
+    static func parMap<A, B, C, D, E, G, H, I, Z>(
+        _ fa: Kind<Self, A>,
+        _ fb: Kind<Self, B>,
+        _ fc: Kind<Self, C>,
+        _ fd: Kind<Self, D>,
+        _ fe: Kind<Self, E>,
+        _ fg: Kind<Self, G>,
+        _ fh: Kind<Self, H>,
+        _ fi: Kind<Self, I>,
+        _ f: @escaping (A, B, C, D, E, G, H, I) -> Z) -> Kind<Self, Z> {
+        Self.parMap(Self.parMap(fa, fb, fc, { a, b, c in (a, b, c) }),
+                    Self.parMap(fd, fe, fg, { d, e, g in (d, e, g) }),
+                    Self.parMap(fh, fi, { h, i in (h, i) }))
+                    { x, y, z in f(x.0, x.1, x.2, y.0, y.1, y.2, z.0, z.1) }
     }
     
     /// Runs 9 computations in parallel and combines their results using the provided function.
@@ -316,20 +347,21 @@ public extension Concurrent {
     ///   - fj: 9th computation.
     ///   - f: Combination function.
     /// - Returns: A computation that describes the parallel execution.
-    static func parMap<A, B, C, D, E, G, H, I, J, Z>(_ fa: Kind<Self, A>,
-                                                     _ fb: Kind<Self, B>,
-                                                     _ fc: Kind<Self, C>,
-                                                     _ fd: Kind<Self, D>,
-                                                     _ fe: Kind<Self, E>,
-                                                     _ fg: Kind<Self, G>,
-                                                     _ fh: Kind<Self, H>,
-                                                     _ fi: Kind<Self, I>,
-                                                     _ fj: Kind<Self, J>,
-                                                     _ f: @escaping (A, B, C, D, E, G, H, I, J) -> Z) -> Kind<Self, Z> {
-        return Self.parMap(Self.parMap(fa, fb, fc, { a, b, c in (a, b, c) }),
-                           Self.parMap(fd, fe, fg, { d, e, g in (d, e, g) }),
-                           Self.parMap(fh, fi, fj, { h, i, j in (h, i, j) }),
-                           { x, y, z in f(x.0, x.1, x.2, y.0, y.1, y.2, z.0, z.1, z.2) })
+    static func parMap<A, B, C, D, E, G, H, I, J, Z>(
+        _ fa: Kind<Self, A>,
+        _ fb: Kind<Self, B>,
+        _ fc: Kind<Self, C>,
+        _ fd: Kind<Self, D>,
+        _ fe: Kind<Self, E>,
+        _ fg: Kind<Self, G>,
+        _ fh: Kind<Self, H>,
+        _ fi: Kind<Self, I>,
+        _ fj: Kind<Self, J>,
+        _ f: @escaping (A, B, C, D, E, G, H, I, J) -> Z) -> Kind<Self, Z> {
+        Self.parMap(Self.parMap(fa, fb, fc, { a, b, c in (a, b, c) }),
+                    Self.parMap(fd, fe, fg, { d, e, g in (d, e, g) }),
+                    Self.parMap(fh, fi, fj, { h, i, j in (h, i, j) }))
+                    { x, y, z in f(x.0, x.1, x.2, y.0, y.1, y.2, z.0, z.1, z.2) }
     }
 }
 
@@ -342,9 +374,11 @@ public extension Kind where F: Concurrent {
     ///   - fa: 1st computation.
     ///   - fb: 2nd computation.
     /// - Returns: A computation that describes the parallel execution.
-    static func parZip<Z, B>(_ fa: Kind<F, Z>,
-                             _ fb: Kind<F, B>) -> Kind<F, (Z, B)> where A == (Z, B) {
-        return F.parMap(fa, fb, { a, b in (a, b) })
+    static func parZip<Z, B>(
+        _ fa: Kind<F, Z>,
+        _ fb: Kind<F, B>) -> Kind<F, (Z, B)>
+        where A == (Z, B) {
+        F.parZip(fa, fb)
     }
     
     /// Runs 3 computations in parallel and tuples their results.
@@ -354,10 +388,12 @@ public extension Kind where F: Concurrent {
     ///   - fb: 2nd computation.
     ///   - fc: 3rd computation.
     /// - Returns: A computation that describes the parallel execution.
-    static func parZip<Z, B, C>(_ fa: Kind<F, Z>,
-                                _ fb: Kind<F, B>,
-                                _ fc: Kind<F, C>) -> Kind<F, (Z, B, C)> where A == (Z, B, C) {
-        return F.parMap(fa, fb, fc) { a, b, c in (a, b, c) }
+    static func parZip<Z, B, C>(
+        _ fa: Kind<F, Z>,
+        _ fb: Kind<F, B>,
+        _ fc: Kind<F, C>) -> Kind<F, (Z, B, C)>
+        where A == (Z, B, C) {
+        F.parZip(fa, fb, fc)
     }
     
     /// Runs 4 computations in parallel and tuples their results.
@@ -368,11 +404,13 @@ public extension Kind where F: Concurrent {
     ///   - fc: 3rd computation.
     ///   - fd: 4th computation.
     /// - Returns: A computation that describes the parallel execution.
-    static func parZip<Z, B, C, D>(_ fa: Kind<F, Z>,
-                                   _ fb: Kind<F, B>,
-                                   _ fc: Kind<F, C>,
-                                   _ fd: Kind<F, D>) -> Kind<F, (Z, B, C, D)> where A == (Z, B, C, D) {
-        return F.parMap(fa, fb, fc, fd, { a, b, c, d in (a, b, c, d) })
+    static func parZip<Z, B, C, D>(
+        _ fa: Kind<F, Z>,
+        _ fb: Kind<F, B>,
+        _ fc: Kind<F, C>,
+        _ fd: Kind<F, D>) -> Kind<F, (Z, B, C, D)>
+        where A == (Z, B, C, D) {
+        F.parZip(fa, fb, fc, fd)
     }
     
     /// Runs 5 computations in parallel and tuples their results.
@@ -384,12 +422,14 @@ public extension Kind where F: Concurrent {
     ///   - fd: 4th computation.
     ///   - fe: 5th computation.
     /// - Returns: A computation that describes the parallel execution.
-    static func parZip<Z, B, C, D, E>(_ fa: Kind<F, Z>,
-                                      _ fb: Kind<F, B>,
-                                      _ fc: Kind<F, C>,
-                                      _ fd: Kind<F, D>,
-                                      _ fe: Kind<F, E>) -> Kind<F, (Z, B, C, D, E)> where A == (Z, B, C, D, E) {
-        return F.parMap(fa, fb, fc, fd, fe, { a, b, c, d, e in (a, b, c, d, e) })
+    static func parZip<Z, B, C, D, E>(
+        _ fa: Kind<F, Z>,
+        _ fb: Kind<F, B>,
+        _ fc: Kind<F, C>,
+        _ fd: Kind<F, D>,
+        _ fe: Kind<F, E>) -> Kind<F, (Z, B, C, D, E)>
+        where A == (Z, B, C, D, E) {
+        F.parZip(fa, fb, fc, fd, fe)
     }
     
     /// Runs 6 computations in parallel and tuples their results.
@@ -402,13 +442,15 @@ public extension Kind where F: Concurrent {
     ///   - fe: 5th computation.
     ///   - fg: 6th computation.
     /// - Returns: A computation that describes the parallel execution.
-    static func parZip<Z, B, C, D, E, G>(_ fa: Kind<F, Z>,
-                                         _ fb: Kind<F, B>,
-                                         _ fc: Kind<F, C>,
-                                         _ fd: Kind<F, D>,
-                                         _ fe: Kind<F, E>,
-                                         _ fg: Kind<F, G>) -> Kind<F, (Z, B, C, D, E, G)> where A == (Z, B, C, D, E, G) {
-        return F.parMap(fa, fb, fc, fd, fe, fg, { a, b, c, d, e, g in (a, b, c, d, e, g) })
+    static func parZip<Z, B, C, D, E, G>(
+        _ fa: Kind<F, Z>,
+        _ fb: Kind<F, B>,
+        _ fc: Kind<F, C>,
+        _ fd: Kind<F, D>,
+        _ fe: Kind<F, E>,
+        _ fg: Kind<F, G>) -> Kind<F, (Z, B, C, D, E, G)>
+        where A == (Z, B, C, D, E, G) {
+        F.parZip(fa, fb, fc, fd, fe, fg)
     }
     
     /// Runs 7 computations in parallel and tuples their results.
@@ -422,14 +464,16 @@ public extension Kind where F: Concurrent {
     ///   - fg: 6th computation.
     ///   - fh: 7th computation.
     /// - Returns: A computation that describes the parallel execution.
-    static func parZip<Z, B, C, D, E, G, H>(_ fa: Kind<F, Z>,
-                                            _ fb: Kind<F, B>,
-                                            _ fc: Kind<F, C>,
-                                            _ fd: Kind<F, D>,
-                                            _ fe: Kind<F, E>,
-                                            _ fg: Kind<F, G>,
-                                            _ fh: Kind<F, H>) -> Kind<F, (Z, B, C, D, E, G, H)> where A == (Z, B, C, D, E, G, H) {
-        return F.parMap(fa, fb, fc, fd, fe, fg, fh, { a, b, c, d, e, g, h in (a, b, c, d, e, g, h) })
+    static func parZip<Z, B, C, D, E, G, H>(
+        _ fa: Kind<F, Z>,
+        _ fb: Kind<F, B>,
+        _ fc: Kind<F, C>,
+        _ fd: Kind<F, D>,
+        _ fe: Kind<F, E>,
+        _ fg: Kind<F, G>,
+        _ fh: Kind<F, H>) -> Kind<F, (Z, B, C, D, E, G, H)>
+        where A == (Z, B, C, D, E, G, H) {
+        F.parZip(fa, fb, fc, fd, fe, fg, fh)
     }
     
     /// Runs 8 computations in parallel and tuples their results.
@@ -444,15 +488,17 @@ public extension Kind where F: Concurrent {
     ///   - fh: 7th computation.
     ///   - fi: 8th computation.
     /// - Returns: A computation that describes the parallel execution.
-    static func parZip<Z, B, C, D, E, G, H, I>(_ fa: Kind<F, Z>,
-                                               _ fb: Kind<F, B>,
-                                               _ fc: Kind<F, C>,
-                                               _ fd: Kind<F, D>,
-                                               _ fe: Kind<F, E>,
-                                               _ fg: Kind<F, G>,
-                                               _ fh: Kind<F, H>,
-                                               _ fi: Kind<F, I>) -> Kind<F, (Z, B, C, D, E, G, H, I)> where A == (Z, B, C, D, E, G, H, I) {
-        return F.parMap(fa, fb, fc, fd, fe, fg, fh, fi, { a, b, c, d, e, g, h, i in (a, b, c, d, e, g, h, i) })
+    static func parZip<Z, B, C, D, E, G, H, I>(
+        _ fa: Kind<F, Z>,
+        _ fb: Kind<F, B>,
+        _ fc: Kind<F, C>,
+        _ fd: Kind<F, D>,
+        _ fe: Kind<F, E>,
+        _ fg: Kind<F, G>,
+        _ fh: Kind<F, H>,
+        _ fi: Kind<F, I>) -> Kind<F, (Z, B, C, D, E, G, H, I)>
+        where A == (Z, B, C, D, E, G, H, I) {
+        F.parZip(fa, fb, fc, fd, fe, fg, fh, fi)
     }
     
     /// Runs 9 computations in parallel and tuples their results.
@@ -468,16 +514,18 @@ public extension Kind where F: Concurrent {
     ///   - fi: 8th computation.
     ///   - fj: 9th computation.
     /// - Returns: A computation that describes the parallel execution.
-    static func parZip<Z, B, C, D, E, G, H, I, J>(_ fa: Kind<F, Z>,
-                                                  _ fb: Kind<F, B>,
-                                                  _ fc: Kind<F, C>,
-                                                  _ fd: Kind<F, D>,
-                                                  _ fe: Kind<F, E>,
-                                                  _ fg: Kind<F, G>,
-                                                  _ fh: Kind<F, H>,
-                                                  _ fi: Kind<F, I>,
-                                                  _ fj: Kind<F, J>) -> Kind<F, (Z, B, C, D, E, G, H, I, J)> where A == (Z, B, C, D, E, G, H, I, J) {
-        F.parMap(fa, fb, fc, fd, fe, fg, fh, fi, fj, { a, b, c, d, e, g, h, i, j in (a, b, c, d, e, g, h, i, j) })
+    static func parZip<Z, B, C, D, E, G, H, I, J>(
+        _ fa: Kind<F, Z>,
+        _ fb: Kind<F, B>,
+        _ fc: Kind<F, C>,
+        _ fd: Kind<F, D>,
+        _ fe: Kind<F, E>,
+        _ fg: Kind<F, G>,
+        _ fh: Kind<F, H>,
+        _ fi: Kind<F, I>,
+        _ fj: Kind<F, J>) -> Kind<F, (Z, B, C, D, E, G, H, I, J)>
+        where A == (Z, B, C, D, E, G, H, I, J) {
+        F.parZip(fa, fb, fc, fd, fe, fg, fh, fi, fj)
     }
     
     /// Runs 2 computations in parallel and returns the result of the first one finishing.
@@ -486,8 +534,10 @@ public extension Kind where F: Concurrent {
     ///   - fb: 1st computation
     ///   - fc: 2nd computation
     /// - Returns: A computation with the result of the first computation that finished.
-    static func race<B, C>(_ fb: Kind<F, B>,
-                           _ fc: Kind<F, C>) -> Kind<F, A> where A == Either<B, C> {
+    static func race<B, C>(
+        _ fb: Kind<F, B>,
+        _ fc: Kind<F, C>) -> Kind<F, A>
+        where A == Either<B, C> {
         F.race(fb, fc)
     }
     
@@ -498,9 +548,10 @@ public extension Kind where F: Concurrent {
     ///   - fb: 2nd computation.
     ///   - f: Combination function.
     /// - Returns: A computation that describes the parallel execution.
-    static func parMap<B, Z>(_ fa: Kind<F, Z>,
-                            _ fb: Kind<F, B>,
-                            _ f: @escaping (Z, B) -> A) -> Kind<F, A> {
+    static func parMap<B, Z>(
+        _ fa: Kind<F, Z>,
+        _ fb: Kind<F, B>,
+        _ f: @escaping (Z, B) -> A) -> Kind<F, A> {
         F.parMap(fa, fb, f)
     }
     
@@ -512,10 +563,11 @@ public extension Kind where F: Concurrent {
     ///   - fc: 3rd computation.
     ///   - f: Combination function.
     /// - Returns: A computation that describes the parallel execution.
-    static func parMap<B, C, Z>(_ fa: Kind<F, Z>,
-                                _ fb: Kind<F, B>,
-                                _ fc: Kind<F, C>,
-                                _ f: @escaping (Z, B, C) -> A) -> Kind<F, A> {
+    static func parMap<B, C, Z>(
+        _ fa: Kind<F, Z>,
+        _ fb: Kind<F, B>,
+        _ fc: Kind<F, C>,
+        _ f: @escaping (Z, B, C) -> A) -> Kind<F, A> {
         F.parMap(fa, fb, fc, f)
     }
     
@@ -528,11 +580,12 @@ public extension Kind where F: Concurrent {
     ///   - fd: 4th computation.
     ///   - f: Combination function.
     /// - Returns: A computation that describes the parallel execution.
-    static func parMap<B, C, D, Z>(_ fa: Kind<F, Z>,
-                                   _ fb: Kind<F, B>,
-                                   _ fc: Kind<F, C>,
-                                   _ fd: Kind<F, D>,
-                                   _ f: @escaping (Z, B, C, D) -> A) -> Kind<F, A> {
+    static func parMap<B, C, D, Z>(
+        _ fa: Kind<F, Z>,
+        _ fb: Kind<F, B>,
+        _ fc: Kind<F, C>,
+        _ fd: Kind<F, D>,
+        _ f: @escaping (Z, B, C, D) -> A) -> Kind<F, A> {
         F.parMap(fa, fb, fc, fd, f)
     }
     
@@ -546,12 +599,13 @@ public extension Kind where F: Concurrent {
     ///   - fe: 5th computation.
     ///   - f: Combination function.
     /// - Returns: A computation that describes the parallel execution.
-    static func parMap<B, C, D, E, Z>(_ fa: Kind<F, Z>,
-                                      _ fb: Kind<F, B>,
-                                      _ fc: Kind<F, C>,
-                                      _ fd: Kind<F, D>,
-                                      _ fe: Kind<F, E>,
-                                      _ f: @escaping (Z, B, C, D, E) -> A) -> Kind<F, A> {
+    static func parMap<B, C, D, E, Z>(
+        _ fa: Kind<F, Z>,
+        _ fb: Kind<F, B>,
+        _ fc: Kind<F, C>,
+        _ fd: Kind<F, D>,
+        _ fe: Kind<F, E>,
+        _ f: @escaping (Z, B, C, D, E) -> A) -> Kind<F, A> {
         F.parMap(fa, fb, fc, fd, fe, f)
     }
     
@@ -566,13 +620,14 @@ public extension Kind where F: Concurrent {
     ///   - fg: 6th computation.
     ///   - f: Combination function.
     /// - Returns: A computation that describes the parallel execution.
-    static func parMap<B, C, D, E, G, Z>(_ fa: Kind<F, Z>,
-                                         _ fb: Kind<F, B>,
-                                         _ fc: Kind<F, C>,
-                                         _ fd: Kind<F, D>,
-                                         _ fe: Kind<F, E>,
-                                         _ fg: Kind<F, G>,
-                                         _ f: @escaping (Z, B, C, D, E, G) -> A) -> Kind<F, A> {
+    static func parMap<B, C, D, E, G, Z>(
+        _ fa: Kind<F, Z>,
+        _ fb: Kind<F, B>,
+        _ fc: Kind<F, C>,
+        _ fd: Kind<F, D>,
+        _ fe: Kind<F, E>,
+        _ fg: Kind<F, G>,
+        _ f: @escaping (Z, B, C, D, E, G) -> A) -> Kind<F, A> {
         F.parMap(fa, fb, fc, fd, fe, fg, f)
     }
     
@@ -588,14 +643,15 @@ public extension Kind where F: Concurrent {
     ///   - fh: 7th computation.
     ///   - f: Combination function.
     /// - Returns: A computation that describes the parallel execution.
-    static func parMap<B, C, D, E, G, H, Z>(_ fa: Kind<F, Z>,
-                                            _ fb: Kind<F, B>,
-                                            _ fc: Kind<F, C>,
-                                            _ fd: Kind<F, D>,
-                                            _ fe: Kind<F, E>,
-                                            _ fg: Kind<F, G>,
-                                            _ fh: Kind<F, H>,
-                                            _ f: @escaping (Z, B, C, D, E, G, H) -> A) -> Kind<F, A> {
+    static func parMap<B, C, D, E, G, H, Z>(
+        _ fa: Kind<F, Z>,
+        _ fb: Kind<F, B>,
+        _ fc: Kind<F, C>,
+        _ fd: Kind<F, D>,
+        _ fe: Kind<F, E>,
+        _ fg: Kind<F, G>,
+        _ fh: Kind<F, H>,
+        _ f: @escaping (Z, B, C, D, E, G, H) -> A) -> Kind<F, A> {
         F.parMap(fa, fb, fc, fd, fe, fg, fh, f)
     }
     
@@ -612,15 +668,16 @@ public extension Kind where F: Concurrent {
     ///   - fi: 8th computation.
     ///   - f: Combination function.
     /// - Returns: A computation that describes the parallel execution.
-    static func parMap<B, C, D, E, G, H, I, Z>(_ fa: Kind<F, Z>,
-                                               _ fb: Kind<F, B>,
-                                               _ fc: Kind<F, C>,
-                                               _ fd: Kind<F, D>,
-                                               _ fe: Kind<F, E>,
-                                               _ fg: Kind<F, G>,
-                                               _ fh: Kind<F, H>,
-                                               _ fi: Kind<F, I>,
-                                               _ f: @escaping (Z, B, C, D, E, G, H, I) -> A) -> Kind<F, A> {
+    static func parMap<B, C, D, E, G, H, I, Z>(
+        _ fa: Kind<F, Z>,
+        _ fb: Kind<F, B>,
+        _ fc: Kind<F, C>,
+        _ fd: Kind<F, D>,
+        _ fe: Kind<F, E>,
+        _ fg: Kind<F, G>,
+        _ fh: Kind<F, H>,
+        _ fi: Kind<F, I>,
+        _ f: @escaping (Z, B, C, D, E, G, H, I) -> A) -> Kind<F, A> {
         F.parMap(fa, fb, fc, fd, fe, fg, fh, fi, f)
     }
     
@@ -638,16 +695,17 @@ public extension Kind where F: Concurrent {
     ///   - fj: 9th computation.
     ///   - f: Combination function.
     /// - Returns: A computation that describes the parallel execution.
-    static func parMap<B, C, D, E, G, H, I, J, Z>(_ fa: Kind<F, Z>,
-                                                  _ fb: Kind<F, B>,
-                                                  _ fc: Kind<F, C>,
-                                                  _ fd: Kind<F, D>,
-                                                  _ fe: Kind<F, E>,
-                                                  _ fg: Kind<F, G>,
-                                                  _ fh: Kind<F, H>,
-                                                  _ fi: Kind<F, I>,
-                                                  _ fj: Kind<F, J>,
-                                                  _ f: @escaping (Z, B, C, D, E, G, H, I, J) -> A) -> Kind<F, A> {
+    static func parMap<B, C, D, E, G, H, I, J, Z>(
+        _ fa: Kind<F, Z>,
+        _ fb: Kind<F, B>,
+        _ fc: Kind<F, C>,
+        _ fd: Kind<F, D>,
+        _ fe: Kind<F, E>,
+        _ fg: Kind<F, G>,
+        _ fh: Kind<F, H>,
+        _ fi: Kind<F, I>,
+        _ fj: Kind<F, J>,
+        _ f: @escaping (Z, B, C, D, E, G, H, I, J) -> A) -> Kind<F, A> {
         F.parMap(fa, fb, fc, fd, fe, fg, fh, fi, fj, f)
     }
 }

--- a/Sources/BowEffects/Typeclasses/ConcurrentEffect.swift
+++ b/Sources/BowEffects/Typeclasses/ConcurrentEffect.swift
@@ -2,7 +2,7 @@ import Foundation
 import Bow
 
 /// Describes a function to cancel an effect
-public typealias Disposable = () -> ()
+public typealias Disposable = () -> Void
 
 /// ConcurrentEffect describes computations that can be cancelled and evaluated concurrently.
 public protocol ConcurrentEffect: Effect {
@@ -12,7 +12,9 @@ public protocol ConcurrentEffect: Effect {
     ///   - fa: Computation.
     ///   - callback: Callback to process the result of the evaluation.
     /// - Returns: A computation describing the evaluation, providing a means to cancel it.
-    static func runAsyncCancellable<A>(_ fa: Kind<Self, A>, _ callback: @escaping (Either<E, A>) -> Kind<Self, ()>) -> Kind<Self, Disposable>
+    static func runAsyncCancellable<A>(
+        _ fa: Kind<Self, A>,
+        _ callback: @escaping (Either<E, A>) -> Kind<Self, Void>) -> Kind<Self, Disposable>
 }
 
 // MARK: Syntax for ConcurrentEffect
@@ -21,7 +23,7 @@ public extension Kind where F: ConcurrentEffect {
     ///
     /// - Parameter callback: Callback to process the result of the evaluation.
     /// - Returns: A computation describing the evaluation, providing a means to cancel it.
-    func runAsyncCancellable(_ callback: @escaping (Either<F.E, A>) -> Kind<F, ()>) -> Kind<F, Disposable> {
-        return F.runAsyncCancellable(self, callback)
+    func runAsyncCancellable(_ callback: @escaping (Either<F.E, A>) -> Kind<F, Void>) -> Kind<F, Disposable> {
+        F.runAsyncCancellable(self, callback)
     }
 }

--- a/Sources/BowEffects/Typeclasses/Effect.swift
+++ b/Sources/BowEffects/Typeclasses/Effect.swift
@@ -9,7 +9,9 @@ public protocol Effect: Async {
     ///   - fa: Computation to be evaluated.
     ///   - callback: Callback to process the result of the computation.
     /// - Returns: A computation describing the evaluation.
-    static func runAsync<A>(_ fa: Kind<Self, A>, _ callback: @escaping (Either<E, A>) -> Kind<Self, ()>) -> Kind<Self, ()>
+    static func runAsync<A>(
+        _ fa: Kind<Self, A>,
+        _ callback: @escaping (Either<E, A>) -> Kind<Self, Void>) -> Kind<Self, Void>
 }
 
 // MARK: Syntax for Effect
@@ -18,7 +20,7 @@ public extension Kind where F: Effect {
     ///
     /// - Parameter callback: Callback to process the result of the computation.
     /// - Returns: A computation describing the evaluation.
-    func runAsync(_ callback: @escaping (Either<F.E, A>) -> Kind<F, ()>) -> Kind<F, ()> {
-        return F.runAsync(self, callback)
+    func runAsync(_ callback: @escaping (Either<F.E, A>) -> Kind<F, ()>) -> Kind<F, Void> {
+        F.runAsync(self, callback)
     }
 }

--- a/Sources/BowEffects/Typeclasses/EffectComprehensions.swift
+++ b/Sources/BowEffects/Typeclasses/EffectComprehensions.swift
@@ -8,7 +8,7 @@ import Foundation
 /// - Parameter queue: Queue where to run the effects from that point on.
 /// - Returns: A binding expression to be used in a Monad comprehension.
 public func continueOn<F: Async>(_ queue: DispatchQueue) -> BindingExpression<F> {
-    return BoundVar<F, ()>.make() <- queue.shift()
+    BoundVar<F, ()>.make() <- queue.shift()
 }
 
 /// Runs 2 computations in parallel and tuples their results.
@@ -17,9 +17,10 @@ public func continueOn<F: Async>(_ queue: DispatchQueue) -> BindingExpression<F>
 ///   - fa: 1st computation.
 ///   - fb: 2nd computation.
 /// - Returns: A computation that describes the parallel execution.
-public func parallel<F: Concurrent, A, B>(_ fa: Kind<F, A>,
-                                          _ fb: Kind<F, B>) -> Kind<F, (A, B)> {
-    return F.parZip(fa, fb)
+public func parallel<F: Concurrent, A, B>(
+    _ fa: Kind<F, A>,
+    _ fb: Kind<F, B>) -> Kind<F, (A, B)> {
+    F.parZip(fa, fb)
 }
 
 /// Runs 3 computations in parallel and tuples their results.
@@ -29,10 +30,11 @@ public func parallel<F: Concurrent, A, B>(_ fa: Kind<F, A>,
 ///   - fb: 2nd computation.
 ///   - fc: 3rd computation.
 /// - Returns: A computation that describes the parallel execution.
-public func parallel<F: Concurrent, A, B, C>(_ fa: Kind<F, A>,
-                                             _ fb: Kind<F, B>,
-                                             _ fc: Kind<F, C>) -> Kind<F, (A, B, C)> {
-    return F.parZip(fa, fb, fc)
+public func parallel<F: Concurrent, A, B, C>(
+    _ fa: Kind<F, A>,
+    _ fb: Kind<F, B>,
+    _ fc: Kind<F, C>) -> Kind<F, (A, B, C)> {
+    F.parZip(fa, fb, fc)
 }
 
 /// Runs 4 computations in parallel and tuples their results.
@@ -43,11 +45,12 @@ public func parallel<F: Concurrent, A, B, C>(_ fa: Kind<F, A>,
 ///   - fc: 3rd computation.
 ///   - fd: 4th computation.
 /// - Returns: A computation that describes the parallel execution.
-public func parallel<F: Concurrent, A, B, C, D>(_ fa: Kind<F, A>,
-                                                _ fb: Kind<F, B>,
-                                                _ fc: Kind<F, C>,
-                                                _ fd: Kind<F, D>) -> Kind<F, (A, B, C, D)> {
-    return F.parZip(fa, fb, fc, fd)
+public func parallel<F: Concurrent, A, B, C, D>(
+    _ fa: Kind<F, A>,
+    _ fb: Kind<F, B>,
+    _ fc: Kind<F, C>,
+    _ fd: Kind<F, D>) -> Kind<F, (A, B, C, D)> {
+    F.parZip(fa, fb, fc, fd)
 }
 
 /// Runs 5 computations in parallel and tuples their results.
@@ -59,12 +62,13 @@ public func parallel<F: Concurrent, A, B, C, D>(_ fa: Kind<F, A>,
 ///   - fd: 4th computation.
 ///   - fe: 5th computation.
 /// - Returns: A computation that describes the parallel execution.
-public func parallel<F: Concurrent, A, B, C, D, E>(_ fa: Kind<F, A>,
-                                                   _ fb: Kind<F, B>,
-                                                   _ fc: Kind<F, C>,
-                                                   _ fd: Kind<F, D>,
-                                                   _ fe: Kind<F, E>) -> Kind<F, (A, B, C, D, E)> {
-    return F.parZip(fa, fb, fc, fd, fe)
+public func parallel<F: Concurrent, A, B, C, D, E>(
+    _ fa: Kind<F, A>,
+    _ fb: Kind<F, B>,
+    _ fc: Kind<F, C>,
+    _ fd: Kind<F, D>,
+    _ fe: Kind<F, E>) -> Kind<F, (A, B, C, D, E)> {
+    F.parZip(fa, fb, fc, fd, fe)
 }
 
 /// Runs 6 computations in parallel and tuples their results.
@@ -77,13 +81,14 @@ public func parallel<F: Concurrent, A, B, C, D, E>(_ fa: Kind<F, A>,
 ///   - fe: 5th computation.
 ///   - fg: 6th computation.
 /// - Returns: A computation that describes the parallel execution.
-public func parallel<F: Concurrent, A, B, C, D, E, G>(_ fa: Kind<F, A>,
-                                                      _ fb: Kind<F, B>,
-                                                      _ fc: Kind<F, C>,
-                                                      _ fd: Kind<F, D>,
-                                                      _ fe: Kind<F, E>,
-                                                      _ fg: Kind<F, G>) -> Kind<F, (A, B, C, D, E, G)> {
-    return F.parZip(fa, fb, fc, fd, fe, fg)
+public func parallel<F: Concurrent, A, B, C, D, E, G>(
+    _ fa: Kind<F, A>,
+    _ fb: Kind<F, B>,
+    _ fc: Kind<F, C>,
+    _ fd: Kind<F, D>,
+    _ fe: Kind<F, E>,
+    _ fg: Kind<F, G>) -> Kind<F, (A, B, C, D, E, G)> {
+    F.parZip(fa, fb, fc, fd, fe, fg)
 }
 
 /// Runs 7 computations in parallel and tuples their results.
@@ -97,14 +102,15 @@ public func parallel<F: Concurrent, A, B, C, D, E, G>(_ fa: Kind<F, A>,
 ///   - fg: 6th computation.
 ///   - fh: 7th computation.
 /// - Returns: A computation that describes the parallel execution.
-public func parallel<F: Concurrent, A, B, C, D, E, G, H>(_ fa: Kind<F, A>,
-                                                         _ fb: Kind<F, B>,
-                                                         _ fc: Kind<F, C>,
-                                                         _ fd: Kind<F, D>,
-                                                         _ fe: Kind<F, E>,
-                                                         _ fg: Kind<F, G>,
-                                                         _ fh: Kind<F, H>) -> Kind<F, (A, B, C, D, E, G, H)> {
-    return F.parZip(fa, fb, fc, fd, fe, fg, fh)
+public func parallel<F: Concurrent, A, B, C, D, E, G, H>(
+    _ fa: Kind<F, A>,
+    _ fb: Kind<F, B>,
+    _ fc: Kind<F, C>,
+    _ fd: Kind<F, D>,
+    _ fe: Kind<F, E>,
+    _ fg: Kind<F, G>,
+    _ fh: Kind<F, H>) -> Kind<F, (A, B, C, D, E, G, H)> {
+    F.parZip(fa, fb, fc, fd, fe, fg, fh)
 }
 
 /// Runs 8 computations in parallel and tuples their results.
@@ -119,15 +125,16 @@ public func parallel<F: Concurrent, A, B, C, D, E, G, H>(_ fa: Kind<F, A>,
 ///   - fh: 7th computation.
 ///   - fi: 8th computation.
 /// - Returns: A computation that describes the parallel execution.
-public func parallel<F: Concurrent, A, B, C, D, E, G, H, I>(_ fa: Kind<F, A>,
-                                                            _ fb: Kind<F, B>,
-                                                            _ fc: Kind<F, C>,
-                                                            _ fd: Kind<F, D>,
-                                                            _ fe: Kind<F, E>,
-                                                            _ fg: Kind<F, G>,
-                                                            _ fh: Kind<F, H>,
-                                                            _ fi: Kind<F, I>) -> Kind<F, (A, B, C, D, E, G, H, I)> {
-    return F.parZip(fa, fb, fc, fd, fe, fg, fh, fi)
+public func parallel<F: Concurrent, A, B, C, D, E, G, H, I>(
+    _ fa: Kind<F, A>,
+    _ fb: Kind<F, B>,
+    _ fc: Kind<F, C>,
+    _ fd: Kind<F, D>,
+    _ fe: Kind<F, E>,
+    _ fg: Kind<F, G>,
+    _ fh: Kind<F, H>,
+    _ fi: Kind<F, I>) -> Kind<F, (A, B, C, D, E, G, H, I)> {
+    F.parZip(fa, fb, fc, fd, fe, fg, fh, fi)
 }
 
 /// Runs 9 computations in parallel and tuples their results.
@@ -143,15 +150,16 @@ public func parallel<F: Concurrent, A, B, C, D, E, G, H, I>(_ fa: Kind<F, A>,
 ///   - fi: 8th computation.
 ///   - fj: 9th computation.
 /// - Returns: A computation that describes the parallel execution.
-public func parallel<F: Concurrent, A, B, C, D, E, G, H, I, J>(_ fa: Kind<F, A>,
-                                                               _ fb: Kind<F, B>,
-                                                               _ fc: Kind<F, C>,
-                                                               _ fd: Kind<F, D>,
-                                                               _ fe: Kind<F, E>,
-                                                               _ fg: Kind<F, G>,
-                                                               _ fh: Kind<F, H>,
-                                                               _ fi: Kind<F, I>,
-                                                               _ fj: Kind<F, J>) -> Kind<F, (A, B, C, D, E, G, H, I, J)> {
-    return F.parZip(fa, fb, fc, fd, fe, fg, fh, fi, fj)
+public func parallel<F: Concurrent, A, B, C, D, E, G, H, I, J>(
+    _ fa: Kind<F, A>,
+    _ fb: Kind<F, B>,
+    _ fc: Kind<F, C>,
+    _ fd: Kind<F, D>,
+    _ fe: Kind<F, E>,
+    _ fg: Kind<F, G>,
+    _ fh: Kind<F, H>,
+    _ fi: Kind<F, I>,
+    _ fj: Kind<F, J>) -> Kind<F, (A, B, C, D, E, G, H, I, J)> {
+    F.parZip(fa, fb, fc, fd, fe, fg, fh, fi, fj)
 }
 

--- a/Sources/BowEffects/Typeclasses/MonadDefer.swift
+++ b/Sources/BowEffects/Typeclasses/MonadDefer.swift
@@ -18,7 +18,7 @@ public extension MonadDefer {
     /// - Parameter f: Function returning a value.
     /// - Returns: A computation that defers the execution of the provided function.
     static func later<A>(_ f: @escaping () throws -> A) -> Kind<Self, A> {
-        return self.defer {
+        self.defer {
             do {
                 return try pure(f())
             } catch {
@@ -32,14 +32,14 @@ public extension MonadDefer {
     /// - Parameter fa: A value describing a computation to be deferred.
     /// - Returns: A computation that defers the execution of the provided value.
     static func later<A>(_ fa: Kind<Self, A>) -> Kind<Self, A> {
-        return self.defer { fa }
+        self.defer { fa }
     }
     
     /// Provides a lazy computation that returns void.
     ///
     /// - Returns: A deferred computation of the void value.
-    static func lazy() -> Kind<Self, ()> {
-        return later { }
+    static func lazy() -> Kind<Self, Void> {
+        later { }
     }
     
     /// Provides a computation that evaluates the provided function on every run.
@@ -47,8 +47,8 @@ public extension MonadDefer {
     /// - Parameter f: A function that provides a value or an error.
     /// - Returns: A computation that defers the execution of the provided value.
     static func laterOrRaise<A>(_ f: @escaping () -> Either<E, A>) -> Kind<Self, A> {
-        return self.defer { f().fold({ e in self.raiseError(e) },
-                                     { a in self.pure(a) }) }
+        self.defer { f().fold({ e in self.raiseError(e) },
+                              { a in self.pure(a) }) }
     }
 }
 
@@ -60,21 +60,21 @@ public extension Kind where F: MonadDefer {
     /// - Parameter fa: Function returning a computation to be deferred.
     /// - Returns: A computation that defers the execution of the provided function.
     static func `defer`(_ fa: @escaping () -> Kind<F, A>) -> Kind<F, A> {
-        return F.defer(fa)
+        F.defer(fa)
     }
     
     /// Provides a computation that evaluates the provided function on every run.
     ///
     /// - Returns: A computation that defers the execution of the provided function.
     static func later(_ f: @escaping () throws -> A) -> Kind<F, A> {
-        return F.later(f)
+        F.later(f)
     }
     
     /// Provides a computation that evaluates this computation on every run.
     ///
     /// - Returns: A computation that defers the execution of the provided value.
     func later() -> Kind<F, A> {
-        return F.later(self)
+        F.later(self)
     }
     
     /// Provides a computation that evaluates the provided function on every run.
@@ -82,7 +82,7 @@ public extension Kind where F: MonadDefer {
     /// - Parameter f: A function that provides a value or an error.
     /// - Returns: A computation that defers the execution of the provided value.
     static func laterOrRaise(_ f: @escaping () -> Either<F.E, A>) -> Kind<F, A> {
-        return F.laterOrRaise(f)
+        F.laterOrRaise(f)
     }
 }
 
@@ -91,6 +91,6 @@ public extension Kind where F: MonadDefer, A == Void {
     ///
     /// - Returns: A deferred computation of the void value.
     static func lazy() -> Kind<F, Void> {
-        return F.lazy()
+        F.lazy()
     }
 }

--- a/Sources/BowEffects/Typeclasses/UnsafeRun.swift
+++ b/Sources/BowEffects/Typeclasses/UnsafeRun.swift
@@ -10,7 +10,9 @@ public protocol UnsafeRun: MonadError {
     ///   - fa: Computation to be run.
     /// - Returns: Result of running the computation.
     /// - Throws: Error happened during the execution of the computation, of the error type of the underlying `MonadError`.
-    static func runBlocking<A>(on queue: DispatchQueue, _ fa: @escaping () -> Kind<Self, A>) throws -> A
+    static func runBlocking<A>(
+        on queue: DispatchQueue,
+        _ fa: @escaping () -> Kind<Self, A>) throws -> A
     
     /// Unsafely runs a computation in an asynchronous manner.
     ///
@@ -18,7 +20,10 @@ public protocol UnsafeRun: MonadError {
     ///   - queue: Dispatch queue used to run the computation.
     ///   - fa: Computation to be run.
     ///   - callback: Callback to report the result of the evaluation.
-    static func runNonBlocking<A>(on queue: DispatchQueue, _ fa: @escaping () -> Kind<Self, A>, _ callback: @escaping Callback<E, A>)
+    static func runNonBlocking<A>(
+        on queue: DispatchQueue,
+        _ fa: @escaping () -> Kind<Self, A>,
+        _ callback: @escaping Callback<E, A>)
 }
 
 // MARK: Syntax for UnsafeRun
@@ -31,7 +36,7 @@ public extension Kind where F: UnsafeRun {
     /// - Returns: Result of running the computation.
     /// - Throws: Error happened during the execution of the computation, of the error type of the underlying `MonadError`.
     func runBlocking(on queue: DispatchQueue = .main) throws -> A {
-        return try F.runBlocking(on: queue, { self })
+        try F.runBlocking(on: queue, { self })
     }
 
     /// Unsafely runs a computation in an asynchronous manner.
@@ -39,8 +44,10 @@ public extension Kind where F: UnsafeRun {
     /// - Parameters:
     ///   - queue: Dispatch queue used to run the computation. Defaults to the main queue.
     ///   - callback: Callback to report the result of the evaluation.
-    func runNonBlocking(on queue: DispatchQueue = .main, _ callback: @escaping Callback<F.E, A> = { _ in }) {
-        return F.runNonBlocking(on: queue, { self }, callback)
+    func runNonBlocking(
+        on queue: DispatchQueue = .main,
+        _ callback: @escaping Callback<F.E, A> = { _ in }) {
+        F.runNonBlocking(on: queue, { self }, callback)
     }
 }
 
@@ -52,8 +59,9 @@ public extension DispatchQueue {
     /// - Parameter fa: Computation to be run.
     /// - Returns: Result of running the computation.
     /// - Throws: Error happened during the execution of the computation, of the error type of the underlying `MonadError`.
-    func runBlocking<F: UnsafeRun, A>(_ fa: @escaping () -> Kind<F, A>) throws -> A {
-        return try F.runBlocking(on: self, fa)
+    func runBlocking<F: UnsafeRun, A>(
+        _ fa: @escaping () -> Kind<F, A>) throws -> A {
+        try F.runBlocking(on: self, fa)
     }
     
     /// Unsafely runs a computation in an asynchronous manner.
@@ -61,7 +69,9 @@ public extension DispatchQueue {
     /// - Parameters:
     ///   - fa: Computation to be run.
     ///   - callback: Callback to report the result of the evaluation.
-    func runNonBlocking<F: UnsafeRun, A>(_ fa: @escaping () -> Kind<F, A>, _ callback: @escaping Callback<F.E, A>) {
-        return F.runNonBlocking(on: self, fa, callback)
+    func runNonBlocking<F: UnsafeRun, A>(
+        _ fa: @escaping () -> Kind<F, A>,
+        _ callback: @escaping Callback<F.E, A> = { _ in }) {
+        F.runNonBlocking(on: self, fa, callback)
     }
 }


### PR DESCRIPTION
## Goal

Cleanup code in the Typeclasses folder in the Effects module by:

- Using `FOf<A>` instead of `Kind<F, A>`.
- Removing backticks in `MARK` sections as they do not render properly in Jazzy.
- Removing returns.
- Replacing `fix` by `^`.