### PR TITLE
Cleanup Core Generators

### DIFF
--- a/Tests/BowGenerators/Arrow/Function0+Gen.swift
+++ b/Tests/BowGenerators/Arrow/Function0+Gen.swift
@@ -9,7 +9,7 @@ extension Function0: Arbitrary where A: Arbitrary {
     }
 }
 
-// MARK: Instance of `ArbitraryK` for `Function0`
+// MARK: Instance of ArbitraryK for Function0
 
 extension Function0Partial: ArbitraryK {
     public static func generate<A: Arbitrary>() -> Function0Of<A> {

--- a/Tests/BowGenerators/Arrow/Function1+Gen.swift
+++ b/Tests/BowGenerators/Arrow/Function1+Gen.swift
@@ -5,14 +5,16 @@ import SwiftCheck
 
 extension Function1: Arbitrary where I: CoArbitrary & Hashable, O: Arbitrary {
     public static var arbitrary: Gen<Function1<I, O>> {
-        return ArrowOf<I, O>.arbitrary.map { arrow in Function1(arrow.getArrow) }
+        ArrowOf<I, O>.arbitrary.map { arrow in
+            Function1(arrow.getArrow)
+        }
     }
 }
 
-// MARK: Instance of `ArbitraryK` for `Function1`
+// MARK: Instance of ArbitraryK for Function1
 
 extension Function1Partial: ArbitraryK where I: CoArbitrary & Hashable {
-    public static func generate<A: Arbitrary>() -> Kind<Function1Partial<I>, A> {
-        return Function1.arbitrary.generate
+    public static func generate<A: Arbitrary>() -> Function1Of<I, A> {
+        Function1.arbitrary.generate
     }
 }

--- a/Tests/BowGenerators/Arrow/Kleisli+Gen.swift
+++ b/Tests/BowGenerators/Arrow/Kleisli+Gen.swift
@@ -5,14 +5,14 @@ import SwiftCheck
 
 extension Kleisli: Arbitrary where F: ArbitraryK, A: Arbitrary {
     public static var arbitrary: Gen<Kleisli<F, D, A>> {
-        return Gen.from(KleisliPartial.generate >>> Kleisli.fix)
+        Gen.from(KleisliPartial.generate >>> Kleisli.fix)
     }
 }
 
-// MARK: Instance of `ArbitraryK` for `Kleisli`
+// MARK: Instance of ArbitraryK for Kleisli
 
 extension KleisliPartial: ArbitraryK where F: ArbitraryK {
-    public static func generate<A: Arbitrary>() -> Kind<KleisliPartial<F, D>, A> {
+    public static func generate<A: Arbitrary>() -> KleisliOf<F, D, A> {
         let x: Kind<F, A> = F.generate()
         return Kleisli { _ in x }
     }

--- a/Tests/BowGenerators/Data/ArrayK+Gen.swift
+++ b/Tests/BowGenerators/Data/ArrayK+Gen.swift
@@ -9,7 +9,7 @@ extension ArrayK: Arbitrary where A: Arbitrary {
     }
 }
 
-// MARK: Instance of `ArbitraryK` for `ArrayK`
+// MARK: Instance of ArbitraryK for ArrayK
 
 extension ArrayKPartial: ArbitraryK {
     public static func generate<A: Arbitrary>() -> ArrayKOf<A> {

--- a/Tests/BowGenerators/Data/Const+Gen.swift
+++ b/Tests/BowGenerators/Data/Const+Gen.swift
@@ -5,14 +5,14 @@ import SwiftCheck
 
 extension Const: Arbitrary where A: Arbitrary {
     public static var arbitrary: Gen<Const<A, T>> {
-        return A.arbitrary.map(Const.init)
+        A.arbitrary.map(Const.init)
     }
 }
 
-// MARK: Instance of `ArbitraryK` for `Const`
+// MARK: Instance of ArbitraryK for Const
 
 extension ConstPartial: ArbitraryK where A: Arbitrary {
-    public static func generate<T: Arbitrary>() -> Kind<ConstPartial<A>, T> {
-        return Const.arbitrary.generate
+    public static func generate<T: Arbitrary>() -> ConstOf<A, T> {
+        Const.arbitrary.generate
     }
 }

--- a/Tests/BowGenerators/Data/Day+Gen.swift
+++ b/Tests/BowGenerators/Data/Day+Gen.swift
@@ -1,7 +1,7 @@
 import Bow
 import SwiftCheck
 
-// MARK: Instance of `ArbitraryK` for `Day`
+// MARK: Instance of ArbitraryK for Day
 
 extension DayPartial: ArbitraryK where F: ArbitraryK, G: ArbitraryK {
     public static func generate<A: Arbitrary>() -> DayOf<F, G, A> {

--- a/Tests/BowGenerators/Data/Day+Gen.swift
+++ b/Tests/BowGenerators/Data/Day+Gen.swift
@@ -4,7 +4,7 @@ import SwiftCheck
 // MARK: Instance of `ArbitraryK` for `Day`
 
 extension DayPartial: ArbitraryK where F: ArbitraryK, G: ArbitraryK {
-    public static func generate<A: Arbitrary>() -> Kind<DayPartial<F, G>, A> {
+    public static func generate<A: Arbitrary>() -> DayOf<F, G, A> {
         let left = F.generate().map { (a: A) in a as Any}
         let right = G.generate().map { (a: A) in a as Any }
         let f = (Int.arbitrary.generate % 2 == 0) ? { (x: Any, _: Any) in x as! A } : { (_: Any, x: Any) in x as! A }

--- a/Tests/BowGenerators/Data/DictionaryK+Gen.swift
+++ b/Tests/BowGenerators/Data/DictionaryK+Gen.swift
@@ -9,7 +9,7 @@ extension DictionaryK: Arbitrary where A: Arbitrary, K: Arbitrary {
     }
 }
 
-// MARK: Instance of `ArbitraryK` for `DictionaryK`
+// MARK: Instance of ArbitraryK for DictionaryK
 
 extension DictionaryKPartial: ArbitraryK where K: Hashable & Arbitrary {
     public static func generate<A: Arbitrary>() -> DictionaryKOf<K, A> {

--- a/Tests/BowGenerators/Data/DictionaryK+Gen.swift
+++ b/Tests/BowGenerators/Data/DictionaryK+Gen.swift
@@ -5,14 +5,14 @@ import SwiftCheck
 
 extension DictionaryK: Arbitrary where A: Arbitrary, K: Arbitrary {
     public static var arbitrary: Gen<DictionaryK<K, A>> {
-        return Dictionary.arbitrary.map(DictionaryK.init)
+        Dictionary.arbitrary.map(DictionaryK.init)
     }
 }
 
 // MARK: Instance of `ArbitraryK` for `DictionaryK`
 
 extension DictionaryKPartial: ArbitraryK where K: Hashable & Arbitrary {
-    public static func generate<A: Arbitrary>() -> Kind<DictionaryKPartial<K>, A> {
-        return DictionaryK.arbitrary.generate
+    public static func generate<A: Arbitrary>() -> DictionaryKOf<K, A> {
+        DictionaryK.arbitrary.generate
     }
 }

--- a/Tests/BowGenerators/Data/Either+Gen.swift
+++ b/Tests/BowGenerators/Data/Either+Gen.swift
@@ -14,7 +14,7 @@ extension Either: Arbitrary where A: Arbitrary, B: Arbitrary {
 // MARK: Instance of `ArbitraryK` for `Either`
 
 extension EitherPartial: ArbitraryK where L: Arbitrary {
-    public static func generate<A: Arbitrary>() -> Kind<EitherPartial<L>, A> {
-        return Either.arbitrary.generate
+    public static func generate<A: Arbitrary>() -> EitherOf<L, A> {
+        Either.arbitrary.generate
     }
 }

--- a/Tests/BowGenerators/Data/Either+Gen.swift
+++ b/Tests/BowGenerators/Data/Either+Gen.swift
@@ -11,7 +11,7 @@ extension Either: Arbitrary where A: Arbitrary, B: Arbitrary {
     }
 }
 
-// MARK: Instance of `ArbitraryK` for `Either`
+// MARK: Instance of ArbitraryK for Either
 
 extension EitherPartial: ArbitraryK where L: Arbitrary {
     public static func generate<A: Arbitrary>() -> EitherOf<L, A> {

--- a/Tests/BowGenerators/Data/EitherK+Gen.swift
+++ b/Tests/BowGenerators/Data/EitherK+Gen.swift
@@ -5,14 +5,14 @@ import SwiftCheck
 
 extension EitherK: Arbitrary where F: ArbitraryK, G: ArbitraryK, A: Arbitrary {
     public static var arbitrary: Gen<EitherK<F, G, A>> {
-        return Gen.from(EitherKPartial.generate >>> EitherK.fix)
+        Gen.from(EitherKPartial.generate >>> EitherK.fix)
     }
 }
 
 // MARK: Instance of `ArbitraryK` for `EitherK`
 
 extension EitherKPartial: ArbitraryK where F: ArbitraryK, G: ArbitraryK {
-    public static func generate<A: Arbitrary>() -> Kind<EitherKPartial<F, G>, A> {
+    public static func generate<A: Arbitrary>() -> EitherKOf<F, G, A> {
         let left = EitherK<F, G, A>(F.generate())
         let right = EitherK<F, G, A>(G.generate())
         return Gen.one(of: [Gen.pure(left), Gen.pure(right)]).generate

--- a/Tests/BowGenerators/Data/EitherK+Gen.swift
+++ b/Tests/BowGenerators/Data/EitherK+Gen.swift
@@ -9,7 +9,7 @@ extension EitherK: Arbitrary where F: ArbitraryK, G: ArbitraryK, A: Arbitrary {
     }
 }
 
-// MARK: Instance of `ArbitraryK` for `EitherK`
+// MARK: Instance of ArbitraryK for EitherK
 
 extension EitherKPartial: ArbitraryK where F: ArbitraryK, G: ArbitraryK {
     public static func generate<A: Arbitrary>() -> EitherKOf<F, G, A> {

--- a/Tests/BowGenerators/Data/Eval+Gen.swift
+++ b/Tests/BowGenerators/Data/Eval+Gen.swift
@@ -1,6 +1,8 @@
 import Bow
 import SwiftCheck
 
+// MARK: Generator for Property-based Testing
+
 extension EvalPartial: ArbitraryK {
     public static func generate<A: Arbitrary>() -> EvalOf<A> {
         let nowGen = A.arbitrary.map(Eval.now)

--- a/Tests/BowGenerators/Data/Id+Gen.swift
+++ b/Tests/BowGenerators/Data/Id+Gen.swift
@@ -9,7 +9,7 @@ extension Id: Arbitrary where A: Arbitrary {
     }
 }
 
-// MARK: Instance of `ArbitraryK` for `Id`
+// MARK: Instance of ArbitraryK for Id
 
 extension IdPartial: ArbitraryK {
     public static func generate<A: Arbitrary>() -> IdOf<A> {

--- a/Tests/BowGenerators/Data/Ior+Gen.swift
+++ b/Tests/BowGenerators/Data/Ior+Gen.swift
@@ -12,10 +12,10 @@ extension Ior: Arbitrary where A: Arbitrary, B: Arbitrary {
     }
 }
 
-// MARK: Instance of `ArbitraryK` for `Ior`
+// MARK: Instance of ArbitraryK for Ior
 
 extension IorPartial: ArbitraryK where L: Arbitrary {
-    public static func generate<A: Arbitrary>() -> Kind<IorPartial<L>, A> {
-        return Ior.arbitrary.generate
+    public static func generate<A: Arbitrary>() -> IorOf<L, A> {
+        Ior.arbitrary.generate
     }
 }

--- a/Tests/BowGenerators/Data/Moore+Gen.swift
+++ b/Tests/BowGenerators/Data/Moore+Gen.swift
@@ -5,16 +5,16 @@ import SwiftCheck
 
 extension Moore: Arbitrary where E: CoArbitrary & Hashable, V: Arbitrary {
     public static var arbitrary: Gen<Moore<E, V>> {
-        return Gen.from(MoorePartial.generate >>> Moore.fix)
+        Gen.from(MoorePartial.generate >>> Moore.fix)
     }
 }
 
-// MARK: Instance of `ArbitraryK` for `Moore`
+// MARK: Instance of ArbitraryK for Moore
 
 extension MoorePartial: ArbitraryK where E: CoArbitrary & Hashable {
-    public static func generate<A: Arbitrary>() -> Kind<MoorePartial<E>, A> {
+    public static func generate<A: Arbitrary>() -> MooreOf<E, A> {
         func handle(_ x: E) -> Moore<E, A> {
-            return Moore(view: A.arbitrary.generate, handle: handle)
+            Moore(view: A.arbitrary.generate, handle: handle)
         }
         
         return Moore(view: A.arbitrary.generate, handle: handle)

--- a/Tests/BowGenerators/Data/NonEmptyArray+Gen.swift
+++ b/Tests/BowGenerators/Data/NonEmptyArray+Gen.swift
@@ -11,7 +11,7 @@ extension NonEmptyArray: Arbitrary where A: Arbitrary {
     }
 }
 
-// MARK: Instance of `ArbitraryK` for `NonEmptyArray`
+// MARK: Instance of ArbitraryK for NonEmptyArray
 
 extension NonEmptyArrayPartial: ArbitraryK {
     public static func generate<A: Arbitrary>() -> NonEmptyArrayOf<A> {

--- a/Tests/BowGenerators/Data/Option+Gen.swift
+++ b/Tests/BowGenerators/Data/Option+Gen.swift
@@ -11,7 +11,7 @@ extension Option: Arbitrary where A: Arbitrary {
     }
 }
 
-// MARK: Instance of `ArbitraryK` for `Option`
+// MARK: Instance of ArbitraryK for Option
 
 extension OptionPartial: ArbitraryK {
     public static func generate<A: Arbitrary>() -> OptionOf<A> {

--- a/Tests/BowGenerators/Data/Sum+Gen.swift
+++ b/Tests/BowGenerators/Data/Sum+Gen.swift
@@ -5,14 +5,14 @@ import SwiftCheck
 
 extension Sum: Arbitrary where F: ArbitraryK, G: ArbitraryK, V: Arbitrary {
     public static var arbitrary: Gen<Sum<F, G, V>> {
-        return Gen.from(SumPartial.generate >>> Sum.fix)
+        Gen.from(SumPartial.generate >>> Sum.fix)
     }
 }
 
-// MARK: Instance of `ArbitraryK` for `Sum`
+// MARK: Instance of ArbitraryK for Sum
 
 extension SumPartial: ArbitraryK where F: ArbitraryK, G: ArbitraryK {
-    public static func generate<A: Arbitrary>() -> Kind<SumPartial<F, G>, A> {
+    public static func generate<A: Arbitrary>() -> SumOf<F, G, A> {
         let fa: Kind<F, A> = F.generate()
         let ga: Kind<G, A> = G.generate()
         let left = Sum.left(fa, ga)

--- a/Tests/BowGenerators/Data/Try+Gen.swift
+++ b/Tests/BowGenerators/Data/Try+Gen.swift
@@ -11,7 +11,7 @@ extension Try: Arbitrary where A: Arbitrary {
     }
 }
 
-// MARK: Instance of `ArbitraryK` for `Try`
+// MARK: Instance of ArbitraryK for Try
 
 extension TryPartial: ArbitraryK {
     public static func generate<A: Arbitrary>() -> TryOf<A> {

--- a/Tests/BowGenerators/Data/Validated+Gen.swift
+++ b/Tests/BowGenerators/Data/Validated+Gen.swift
@@ -11,10 +11,10 @@ extension Validated: Arbitrary where E: Arbitrary, A: Arbitrary {
     }
 }
 
-// MARK: Instance of `ArbitraryK` for `Validated`
+// MARK: Instance of ArbitraryK for Validated
 
 extension ValidatedPartial: ArbitraryK where I: Arbitrary {
-    public static func generate<A: Arbitrary>() -> Kind<ValidatedPartial<I>, A> {
-        return Validated.arbitrary.generate
+    public static func generate<A: Arbitrary>() -> ValidatedOf<I, A> {
+        Validated.arbitrary.generate
     }
 }

--- a/Tests/BowGenerators/Data/Zipper+Gen.swift
+++ b/Tests/BowGenerators/Data/Zipper+Gen.swift
@@ -10,7 +10,7 @@ extension Zipper: Arbitrary where A: Arbitrary {
     }
 }
 
-// MARK: Instance of `ArbitraryK` for `ArrayK`
+// MARK: Instance of ArbitraryK for ArrayK
 
 extension ZipperPartial: ArbitraryK {
     public static func generate<A: Arbitrary>() -> ZipperOf<A> {

--- a/Tests/BowGenerators/Transformers/EitherT+Gen.swift
+++ b/Tests/BowGenerators/Transformers/EitherT+Gen.swift
@@ -5,14 +5,14 @@ import SwiftCheck
 
 extension EitherT: Arbitrary where F: ArbitraryK, A: Arbitrary, B: Arbitrary {
     public static var arbitrary: Gen<EitherT<F, A, B>> {
-        return Gen.from(EitherTPartial.generate >>> EitherT.fix)
+        Gen.from(EitherTPartial.generate >>> EitherT.fix)
     }
 }
 
-// MARK: Instance of `ArbitraryK` for `EitherT`
+// MARK: Instance of ArbitraryK for EitherT
 
 extension EitherTPartial: ArbitraryK where F: ArbitraryK, L: Arbitrary {
-    public static func generate<A: Arbitrary>() -> Kind<EitherTPartial<F, L>, A> {
-        return EitherT(F.generate())
+    public static func generate<A: Arbitrary>() -> EitherTOf<F, L, A> {
+        EitherT(F.generate())
     }
 }

--- a/Tests/BowGenerators/Transformers/EnvT+Gen.swift
+++ b/Tests/BowGenerators/Transformers/EnvT+Gen.swift
@@ -9,7 +9,7 @@ extension EnvT: Arbitrary where E: Arbitrary, W: ArbitraryK, A: Arbitrary {
     }
 }
 
-// MARK: Instance of `ArbitraryK` for `EnvT`
+// MARK: Instance of ArbitraryK for EnvT
 
 extension EnvTPartial: ArbitraryK where E: Arbitrary, W: ArbitraryK {
     public static func generate<A: Arbitrary>() -> EnvTOf<E, W, A> {

--- a/Tests/BowGenerators/Transformers/OptionT+Gen.swift
+++ b/Tests/BowGenerators/Transformers/OptionT+Gen.swift
@@ -5,14 +5,14 @@ import SwiftCheck
 
 extension OptionT: Arbitrary where F: ArbitraryK, A: Arbitrary {
     public static var arbitrary: Gen<OptionT<F, A>> {
-        return Gen.from(OptionTPartial.generate >>> OptionT.fix)
+        Gen.from(OptionTPartial.generate >>> OptionT.fix)
     }
 }
 
-// MARK: Instance of `ArbitraryK` for `OptionT`
+// MARK: Instance of ArbitraryK for OptionT
 
 extension OptionTPartial: ArbitraryK where F: ArbitraryK {
-    public static func generate<A: Arbitrary>() -> Kind<OptionTPartial<F>, A> {
-        return OptionT(F.generate())
+    public static func generate<A: Arbitrary>() -> OptionTOf<F, A> {
+        OptionT(F.generate())
     }
 }

--- a/Tests/BowGenerators/Transformers/StateT+Gen.swift
+++ b/Tests/BowGenerators/Transformers/StateT+Gen.swift
@@ -5,14 +5,14 @@ import SwiftCheck
 
 extension StateT: Arbitrary where F: ArbitraryK & Applicative, S: Arbitrary, A: Arbitrary {
     public static var arbitrary: Gen<StateT<F, S, A>> {
-        return Gen.from(StateTPartial.generate >>> StateT.fix)
+        Gen.from(StateTPartial.generate >>> StateT.fix)
     }
 }
 
-// MARK: Instance of `ArbitraryK` for `StateT`
+// MARK: Instance of ArbitraryK for StateT
 
 extension StateTPartial: ArbitraryK where F: ArbitraryK & Applicative, S: Arbitrary {
-    public static func generate<A: Arbitrary>() -> Kind<StateTPartial<F, S>, A> {
+    public static func generate<A: Arbitrary>() -> StateTOf<F, S, A> {
         let a = A.arbitrary.generate
         let f: (S) -> Kind<F, (S, A)> = { s in F.pure((s, a)) }
         return StateT(f)

--- a/Tests/BowGenerators/Transformers/StoreT+Gen.swift
+++ b/Tests/BowGenerators/Transformers/StoreT+Gen.swift
@@ -9,10 +9,10 @@ extension StoreT: Arbitrary where S: CoArbitrary & Hashable & Arbitrary, W: Func
     }
 }
 
-// MARK: Instance of `ArbitraryK` for `Store`
+// MARK: Instance of ArbitraryK for Store
 
 extension StoreTPartial: ArbitraryK where S: CoArbitrary & Hashable & Arbitrary, W: Functor & ArbitraryK {
-    public static func generate<A: Arbitrary>() -> Kind<StoreTPartial<S, W>, A> {
+    public static func generate<A: Arbitrary>() -> StoreTOf<S, W, A> {
         StoreT(S.arbitrary.generate,
                KindOf<W, ArrowOf<S, A>>.arbitrary.generate.value.map { f in f.getArrow })
     }

--- a/Tests/BowGenerators/Transformers/TracedT+Gen.swift
+++ b/Tests/BowGenerators/Transformers/TracedT+Gen.swift
@@ -9,7 +9,7 @@ extension TracedT: Arbitrary where M: Arbitrary & Hashable & CoArbitrary, W: Arb
     }
 }
 
-// MARK: Instance of `ArbitraryK` for `TracedT`
+// MARK: Instance of ArbitraryK for TracedT
 
 extension TracedTPartial: ArbitraryK where M: Arbitrary & Hashable & CoArbitrary, W: ArbitraryK & Functor {
     

--- a/Tests/BowGenerators/Transformers/WriterT+Gen.swift
+++ b/Tests/BowGenerators/Transformers/WriterT+Gen.swift
@@ -5,14 +5,14 @@ import SwiftCheck
 
 extension WriterT: Arbitrary where F: ArbitraryK & Applicative, W: Arbitrary, A: Arbitrary {
     public static var arbitrary: Gen<WriterT<F, W, A>> {
-        return Gen.from(WriterTPartial.generate >>> WriterT.fix)
+        Gen.from(WriterTPartial.generate >>> WriterT.fix)
     }
 }
 
-// MARK: Instance of `ArbitraryK` for `WriterT`
+// MARK: Instance of ArbitraryK for WriterT
 
 extension WriterTPartial: ArbitraryK where F: ArbitraryK & Applicative, W: Arbitrary {
-    public static func generate<A: Arbitrary>() -> Kind<WriterTPartial<F, W>, A> {
-        return WriterT(F.pure((W.arbitrary.generate, A.arbitrary.generate)))
+    public static func generate<A: Arbitrary>() -> WriterTOf<F, W, A> {
+        WriterT(F.pure((W.arbitrary.generate, A.arbitrary.generate)))
     }
 }

--- a/Tests/BowGenerators/Typeclasses/ArbitraryK.swift
+++ b/Tests/BowGenerators/Typeclasses/ArbitraryK.swift
@@ -7,7 +7,7 @@ public protocol ArbitraryK {
 
 public struct KindOf<F, A>: Arbitrary where F: ArbitraryK, A: Arbitrary {
     public static var arbitrary: Gen<KindOf<F, A>> {
-        return Gen.pure(()).map { _ in KindOf(F.generate()) }
+        Gen.from { KindOf(F.generate()) }
     }
     
     public let value: Kind<F, A>
@@ -19,6 +19,6 @@ public struct KindOf<F, A>: Arbitrary where F: ArbitraryK, A: Arbitrary {
 
 extension Gen {
     static func from(_ generator: @escaping () -> A) -> Gen<A> {
-        return Gen<()>.pure(()).map(generator)
+        Gen<Void>.pure(()).map(generator)
     }
 }


### PR DESCRIPTION
## Goal

Cleanup code in the Core Generators module by:

- Using `FOf<A>` instead of `Kind<F, A>`.
- Removing backticks in `MARK` sections as they do not render properly in Jazzy.
- Removing returns.
- Replacing `fix` by `^`.