### PR TITLE
Cleanup Core laws

### DIFF
--- a/Sources/Bow/Typeclasses/Monad.swift
+++ b/Sources/Bow/Typeclasses/Monad.swift
@@ -184,8 +184,8 @@ public extension Kind where F: Monad {
     ///
     /// - Parameter ffa: Value with a nested structure.
     /// - Returns: Value with a single context structure.
-    static func flatten(_ ffa: Kind<F, Kind<F, A>>) -> Kind<F, A> {
-        F.flatten(ffa)
+    func flatten<AA>() -> Kind<F, AA> where A == Kind<F, AA> {
+        F.flatten(self)
     }
 
     /// Sequentially compose with another computation, discarding the value produced by the this one.

--- a/Tests/BowLaws/AlternativeLaws.swift
+++ b/Tests/BowLaws/AlternativeLaws.swift
@@ -11,24 +11,30 @@ public class AlternativeLaws<F: Alternative & EquatableK & ArbitraryK> {
     
     private static func rightAbsorption() {
         property("Right absorption") <~ forAll { (ff: KindOf<F, ArrowOf<Int, Int>>) in
-            return F.ap(F.emptyK(), ff.value) ==
-                F.emptyK() as Kind<F, Int>
+            
+            F.emptyK().ap(ff.value)
+                ==
+            Kind<F, Int>.emptyK()
         }
     }
     
     private static func leftDistributivity() {
         property("Left distributivity") <~ forAll { (fx: KindOf<F, Int>, fy: KindOf<F, Int>, f: ArrowOf<Int, Int>) in
-            return F.map(F.combineK(fx.value, fy.value), f.getArrow) ==
-                F.combineK(F.map(fx.value, f.getArrow), F.map(fy.value, f.getArrow))
+            
+            fx.value.combineK(fy.value).map(f.getArrow)
+                ==
+            fx.value.map(f.getArrow).combineK( fy.value.map(f.getArrow))
         }
     }
     
     private static func rightDistributivity() {
-        property("Left distributivity") <~ forAll { (fx: KindOf<F, Int>, f: ArrowOf<Int, Int>, g: ArrowOf<Int, Int>) in
-            return F.ap(F.combineK(F.pure(f.getArrow), F.pure(g.getArrow)),
-                        fx.value) ==
-                F.combineK(F.ap(F.pure(f.getArrow), fx.value),
-                           F.ap(F.pure(g.getArrow), fx.value))
+        property("Right distributivity") <~ forAll { (fx: KindOf<F, Int>, f: ArrowOf<Int, Int>, g: ArrowOf<Int, Int>) in
+            
+            F.pure(f.getArrow).combineK(F.pure(g.getArrow))
+                .ap(fx.value)
+                ==
+            F.pure(f.getArrow).ap(fx.value)
+                .combineK(F.pure(g.getArrow).ap(fx.value))
         }
     }
 }

--- a/Tests/BowLaws/ApplicativeErrorLaws.swift
+++ b/Tests/BowLaws/ApplicativeErrorLaws.swift
@@ -3,7 +3,7 @@ import Bow
 import BowGenerators
 
 public class ApplicativeErrorLaws<F: ApplicativeError & EquatableK> where F.E: Equatable & Arbitrary {
-    public static func check()  {
+    public static func check() {
         handle()
         handleWith()
         handleWithPure()
@@ -17,39 +17,57 @@ public class ApplicativeErrorLaws<F: ApplicativeError & EquatableK> where F.E: E
     private static func handle() {
         property("Applicative error handle") <~ forAll { (a: Int, error: F.E) in
             let f = { (_: F.E) in a }
-            return F.handleError(F.raiseError(error), f) == F.pure(f(error))
+            
+            return F.raiseError(error).handleError(f)
+                ==
+            F.pure(f(error))
         }
     }
     
     private static func handleWith() {
         property("Applicative error handle with") <~ forAll { (a: Int, error: F.E) in
             let f = { (_: F.E) in F.pure(a) }
-            return F.handleErrorWith(F.raiseError(error), f) == f(error)
+            
+            return Kind<F, Int>.raiseError(error).handleErrorWith(f)
+                ==
+            f(error)
         }
     }
     
     private static func handleWithPure() {
         property("Applicative error handle with pure") <~ forAll { (a: Int) in
             let f = { (_: F.E) in F.pure(a) }
-            return F.handleErrorWith(F.pure(a), f) == F.pure(a)
+            
+            return F.pure(a).handleErrorWith(f)
+                ==
+            F.pure(a)
         }
     }
     
     private static func attemptError() {
         property("Attempt error") <~ forAll { (error: F.E) in
-            return F.attempt(F.raiseError(error)) == F.pure(Either<F.E, Int>.left(error))
+            
+            F.raiseError(error).attempt()
+                ==
+            F.pure(Either<F.E, Int>.left(error))
         }
     }
     
     private static func attemptSuccess() {
         property("Attempt success") <~ forAll { (a: Int) in
-            return F.attempt(F.pure(a)) == F.pure(Either<F.E, Int>.right(a))
+            
+            F.pure(a).attempt()
+                ==
+            F.pure(Either<F.E, Int>.right(a))
         }
     }
     
     private static func attemptFromEitherConsistentWithPure() {
         property("Attempt from either consistent with pure") <~ forAll { (either: Either<F.E, Int>) in
-            return F.attempt(F.fromEither(either)) == F.pure(either)
+            
+            F.fromEither(either).attempt()
+                ==
+            F.pure(either)
         }
     }
     
@@ -57,7 +75,10 @@ public class ApplicativeErrorLaws<F: ApplicativeError & EquatableK> where F.E: E
         property("Catch") <~ forAll { (_: Int, error: F.E) in
             if error is Error {
                 let f : () throws -> Int = { throw error as! Error }
-                return F.catchError(f, { e in e as! F.E }) == F.raiseError(error)
+                
+                return Kind<F, Int>.catchError(f, { e in e as! F.E })
+                    ==
+                Kind<F, Int>.raiseError(error)
             } else {
                 return true
             }
@@ -67,7 +88,10 @@ public class ApplicativeErrorLaws<F: ApplicativeError & EquatableK> where F.E: E
     private static func catchesSuccess() {
         property("Catch") <~ forAll { (a: Int) in
             let f : () throws -> Int = { return a }
-            return F.catchError(f, { e in e as! F.E }) == F.pure(a)
+            
+            return Kind<F, Int>.catchError(f, { e in e as! F.E })
+                ==
+            F.pure(a)
         }
     }
 }
@@ -92,6 +116,9 @@ extension CategoryError: Equatable {}
 
 extension CategoryError: Arbitrary {
     static var arbitrary: Gen<CategoryError> {
-        return Gen<CategoryError>.fromElements(of: [CategoryError.common, CategoryError.fatal, CategoryError.unknown])
+        Gen<CategoryError>.fromElements(of: [
+            CategoryError.common,
+            CategoryError.fatal,
+            CategoryError.unknown])
     }
 }

--- a/Tests/BowLaws/ApplicativeLaws.swift
+++ b/Tests/BowLaws/ApplicativeLaws.swift
@@ -10,96 +10,160 @@ public class ApplicativeLaws<F: Applicative & EquatableK & ArbitraryK> {
         interchange()
         mapDerived()
         cartesianBuilderMap()
-        cartesianBuilderTupled()
-        mapWithMultipleInputs()
     }
     
     private static func apIdentity() {
         property("ap identity") <~ forAll() { (fa: KindOf<F, Int>) in
-            return F.ap(F.pure(id), fa.value) == fa.value
+            
+            F.pure(id).ap(fa.value)
+                ==
+            fa.value
         }
     }
     
     private static func homomorphism() {
         property("homomorphism") <~ forAll() { (a: Int, f: ArrowOf<Int, Int>) in
-            return F.ap(F.pure(f.getArrow), F.pure(a)) == F.pure(f.getArrow(a))
+            
+            F.pure(f.getArrow).ap(F.pure(a))
+                ==
+            F.pure(f.getArrow(a))
         }
     }
     
     private static func interchange() {
         property("interchange") <~ forAll() { (a: Int, b: Int) in
             let fa = F.pure(constant(a) as (Int) -> Int)
-            return F.ap(fa, F.pure(b)) == F.ap(F.pure({ (x: (Int) -> Int) in x(a) } ), fa)
+            
+            return fa.ap(F.pure(b))
+                ==
+            F.pure({ (x: (Int) -> Int) in x(a) } ).ap(fa)
         }
     }
     
     private static func mapDerived() {
-        property("mad derived") <~ forAll() { (fa: KindOf<F, Int>, f: ArrowOf<Int, Int>) in
-            return F.map(fa.value, f.getArrow) == F.ap(F.pure(f.getArrow), fa.value)
+        property("map derived") <~ forAll() { (fa: KindOf<F, Int>, f: ArrowOf<Int, Int>) in
+            
+            fa.value.map(f.getArrow)
+                ==
+            F.pure(f.getArrow).ap(fa.value)
         }
     }
     
     private static func cartesianBuilderMap() {
-        property("cartesian builder map") <~ forAll() { (a: Int, b: Int, c: Int, d: Int, e: Int, f: Int, g: Int) in
-            let left: Kind<F, Int> = F.map(F.pure(a), F.pure(b), F.pure(c), F.pure(d), F.pure(e), F.pure(f), { x, y, z, u, v, w in x + y + z - u - v - w })
-            let right: Kind<F, Int> = F.pure(a + b + c - d - e - f)
-            return left == right
-        }
-    }
-    
-    private static func cartesianBuilderTupled() {
-        property("cartesian builder map") <~ forAll() { (a: Int, b: Int, c: Int, d: Int, e: Int, f: Int, g: Int) in
-            let left: Kind<F, Int> = F.map(F.zip(F.pure(a), F.pure(b), F.pure(c), F.pure(d), F.pure(e), F.pure(f)), { x, y, z, u, v, w in x + y + z - u - v - w })
-            let right: Kind<F, Int> = F.pure(a + b + c - d - e - f)
-            return left == right
-        }
-    }
-    
-    private static func mapWithMultipleInputs() {
         property("Map with 2 inputs") <~ forAll { (a: Int, b: Int) in
-            return F.map(F.pure(a), F.pure(b), { a1, b1 in a1 + b1 }) == F.pure(a + b)
+            
+            Kind<F, Int>.map(
+                .pure(a),
+                .pure(b)) { a1, b1 in
+                    a1 + b1
+            }
+                ==
+            Kind<F, Int>.pure(a + b)
         }
         
         property("Map with 3 inputs") <~ forAll { (a: Int, b: Int, c: Int) in
-            let left: Kind<F, Int> = F.map(F.pure(a), F.pure(b), F.pure(c), { a1, b1, c1 in a1 + b1 + c1 })
-            let right: Kind<F, Int> = F.pure(a + b + c)
-            return left == right
+            
+            Kind<F, Int>.map(
+                .pure(a),
+                .pure(b),
+                .pure(c)) { a1, b1, c1 in
+                    a1 + b1 + c1
+            }
+                ==
+            Kind<F, Int>.pure(a + b + c)
         }
         
         property("Map with 4 inputs") <~ forAll { (a: Int, b: Int, c: Int, d: Int) in
-            let left: Kind<F, Int> = F.map(F.pure(a), F.pure(b), F.pure(c), F.pure(d), { a1, b1, c1, d1 in a1 + b1 + c1 + d1 })
-            let right: Kind<F, Int> = F.pure(a + b + c + d)
-            return left == right
+            
+            Kind<F, Int>.map(
+                .pure(a),
+                .pure(b),
+                .pure(c),
+                .pure(d)) { a1, b1, c1, d1 in
+                    a1 + b1 + c1 + d1
+            }
+                ==
+            Kind<F, Int>.pure(a + b + c + d)
         }
         
         property("Map with 5 inputs") <~ forAll { (a: Int, b: Int, c: Int, d: Int, e: Int) in
-            let left: Kind<F, Int> = F.map(F.pure(a), F.pure(b), F.pure(c), F.pure(d), F.pure(e), { a1, b1, c1, d1, e1 in a1 + b1 + c1 + d1 + e1 })
-            let right: Kind<F, Int> = F.pure(a + b + c + d + e)
-            return left == right
+            
+            Kind<F, Int>.map(
+                .pure(a),
+                .pure(b),
+                .pure(c),
+                .pure(d),
+                .pure(e)) { a1, b1, c1, d1, e1 in
+                    a1 + b1 + c1 + d1 + e1
+            }
+                ==
+            Kind<F, Int>.pure(a + b + c + d + e)
         }
 
         property("Map with 6 inputs") <~ forAll { (a: Int, b: Int, c: Int, d: Int, e: Int, f: Int) in
-            let left: Kind<F, Int> = F.map(F.pure(a), F.pure(b), F.pure(c), F.pure(d), F.pure(e), F.pure(f), { a1, b1, c1, d1, e1, f1 in a1 + b1 + c1 + d1 + e1 + f1 })
-            let right: Kind<F, Int> = F.pure(a + b + c + d + e + f)
-            return left == right
+            
+            Kind<F, Int>.map(
+                .pure(a),
+                .pure(b),
+                .pure(c),
+                .pure(d),
+                .pure(e),
+                .pure(f)) { a1, b1, c1, d1, e1, f1 in
+                    a1 + b1 + c1 + d1 + e1 + f1
+            }
+                ==
+            Kind<F, Int>.pure(a + b + c + d + e + f)
         }
         
         property("Map with 7 inputs") <~ forAll { (a: Int, b: Int, c: Int, d: Int, e: Int, f: Int, g: Int) in
-            let left: Kind<F, Int> = F.map(F.pure(a), F.pure(b), F.pure(c), F.pure(d), F.pure(e), F.pure(f), F.pure(g), { a1, b1, c1, d1, e1, f1, g1 in a1 + b1 + c1 + d1 + e1 + f1 + g1 })
-            let right: Kind<F, Int> = F.pure(a + b + c + d + e + f + g)
-            return left == right
+            
+            Kind<F, Int>.map(
+                .pure(a),
+                .pure(b),
+                .pure(c),
+                .pure(d),
+                .pure(e),
+                .pure(f),
+                .pure(g)) { a1, b1, c1, d1, e1, f1, g1 in
+                    a1 + b1 + c1 + d1 + e1 + f1 + g1
+            }
+                ==
+            Kind<F, Int>.pure(a + b + c + d + e + f + g)
         }
         
         property("Map with 8 inputs") <~ forAll { (a: Int, b: Int, c: Int, d: Int, e: Int, f: Int, g: Int, h: Int) in
-            let left: Kind<F, Int> = F.map(F.pure(a), F.pure(b), F.pure(c), F.pure(d), F.pure(e), F.pure(f), F.pure(g), F.pure(h), { a1, b1, c1, d1, e1, f1, g1, h1 in a1 + b1 + c1 + d1 + e1 + f1 + g1 + h1 })
-            let right: Kind<F, Int> = F.pure(a + b + c + d + e + f + g + h)
-            return left == right
+            
+            Kind<F, Int>.map(
+                .pure(a),
+                .pure(b),
+                .pure(c),
+                .pure(d),
+                .pure(e),
+                .pure(f),
+                .pure(g),
+                .pure(h)) { a1, b1, c1, d1, e1, f1, g1, h1 in
+                    a1 + b1 + c1 + d1 + e1 + f1 + g1 + h1
+            }
+                ==
+            Kind<F, Int>.pure(a + b + c + d + e + f + g + h)
         }
         
         property("Map with 9 inputs") <~ forAll { (a: Int, b: Int, c: Int, d: Int, e: Int, f: Int, g: Int, h: Int) in
-            let left: Kind<F, Int> = F.map(F.pure(a), F.pure(b), F.pure(c), F.pure(d), F.pure(e), F.pure(f), F.pure(g), F.pure(h), F.pure(a), { a1, b1, c1, d1, e1, f1, g1, h1, i1 in a1 + b1 + c1 + d1 + e1 + f1 + g1 + h1 + i1 })
-            let right: Kind<F, Int> = F.pure(a + b + c + d + e + f + g + h + a)
-            return left == right
+            
+            Kind<F, Int>.map(
+                .pure(a),
+                .pure(b),
+                .pure(c),
+                .pure(d),
+                .pure(e),
+                .pure(f),
+                .pure(g),
+                .pure(h),
+                .pure(a)) { a1, b1, c1, d1, e1, f1, g1, h1, i1 in
+                    a1 + b1 + c1 + d1 + e1 + f1 + g1 + h1 + i1
+            }
+                ==
+            Kind<F, Int>.pure(a + b + c + d + e + f + g + h + a)
         }
     }
 }

--- a/Tests/BowLaws/BindingOperatorOverload.swift
+++ b/Tests/BowLaws/BindingOperatorOverload.swift
@@ -8,8 +8,10 @@ infix operator <-- : AssignmentPrecedence
 ///   - bound: Variable to be bound in the expression.
 ///   - fa: Monadic effect.
 /// - Returns: A binding expression.
-public func <--<F: Monad, A>(_ bound: BoundVar<F, A>, _ fa: @autoclosure @escaping () -> Kind<F, A>) -> BindingExpression<F> {
-    return bound <- fa()
+public func <--<F: Monad, A>(
+    _ bound: BoundVar<F, A>,
+    _ fa: @autoclosure @escaping () -> Kind<F, A>) -> BindingExpression<F> {
+    bound <- fa()
 }
 
 /// Creates a binding expression.
@@ -18,8 +20,10 @@ public func <--<F: Monad, A>(_ bound: BoundVar<F, A>, _ fa: @autoclosure @escapi
 ///   - bounds: A 2-ary tuple of variables to be bound to the values produced by the effect.
 ///   - fa: Monadic effect.
 /// - Returns: A binding expresssion.
-public func <--<F: Monad, A, B>(_ bounds: (BoundVar<F, A>, BoundVar<F, B>), _ fa: @autoclosure @escaping () -> Kind<F, (A, B)>) -> BindingExpression<F> {
-    return bounds <- fa()
+public func <--<F: Monad, A, B>(
+    _ bounds: (BoundVar<F, A>, BoundVar<F, B>),
+    _ fa: @autoclosure @escaping () -> Kind<F, (A, B)>) -> BindingExpression<F> {
+    bounds <- fa()
 }
 
 /// Creates a binding expression.
@@ -28,8 +32,10 @@ public func <--<F: Monad, A, B>(_ bounds: (BoundVar<F, A>, BoundVar<F, B>), _ fa
 ///   - bounds: A 3-ary tuple of variables to be bound to the values produced by the effect.
 ///   - fa: Monadic effect.
 /// - Returns: A binding expresssion.
-public func <--<F: Monad, A, B, C>(_ bounds: (BoundVar<F, A>, BoundVar<F, B>, BoundVar<F, C>), _ fa: @autoclosure @escaping () -> Kind<F, (A, B, C)>) -> BindingExpression<F> {
-    return bounds <- fa()
+public func <--<F: Monad, A, B, C>(
+    _ bounds: (BoundVar<F, A>, BoundVar<F, B>, BoundVar<F, C>),
+    _ fa: @autoclosure @escaping () -> Kind<F, (A, B, C)>) -> BindingExpression<F> {
+    bounds <- fa()
 }
 
 /// Creates a binding expression.
@@ -38,8 +44,10 @@ public func <--<F: Monad, A, B, C>(_ bounds: (BoundVar<F, A>, BoundVar<F, B>, Bo
 ///   - bounds: A 4-ary tuple of variables to be bound to the values produced by the effect.
 ///   - fa: Monadic effect.
 /// - Returns: A binding expresssion.
-public func <--<F: Monad, A, B, C, D>(_ bounds: (BoundVar<F, A>, BoundVar<F, B>, BoundVar<F, C>, BoundVar<F, D>), _ fa: @autoclosure @escaping () -> Kind<F, (A, B, C, D)>) -> BindingExpression<F> {
-    return bounds <- fa()
+public func <--<F: Monad, A, B, C, D>(
+    _ bounds: (BoundVar<F, A>, BoundVar<F, B>, BoundVar<F, C>, BoundVar<F, D>),
+    _ fa: @autoclosure @escaping () -> Kind<F, (A, B, C, D)>) -> BindingExpression<F> {
+    bounds <- fa()
 }
 
 /// Creates a binding expression.
@@ -48,8 +56,10 @@ public func <--<F: Monad, A, B, C, D>(_ bounds: (BoundVar<F, A>, BoundVar<F, B>,
 ///   - bounds: A 5-ary tuple of variables to be bound to the values produced by the effect.
 ///   - fa: Monadic effect.
 /// - Returns: A binding expresssion.
-public func <--<F: Monad, A, B, C, D, E>(_ bounds: (BoundVar<F, A>, BoundVar<F, B>, BoundVar<F, C>, BoundVar<F, D>, BoundVar<F, E>), _ fa: @autoclosure @escaping () -> Kind<F, (A, B, C, D, E)>) -> BindingExpression<F> {
-    return bounds <- fa()
+public func <--<F: Monad, A, B, C, D, E>(
+    _ bounds: (BoundVar<F, A>, BoundVar<F, B>, BoundVar<F, C>, BoundVar<F, D>, BoundVar<F, E>),
+    _ fa: @autoclosure @escaping () -> Kind<F, (A, B, C, D, E)>) -> BindingExpression<F> {
+    bounds <- fa()
 }
 
 /// Creates a binding expression.
@@ -58,8 +68,10 @@ public func <--<F: Monad, A, B, C, D, E>(_ bounds: (BoundVar<F, A>, BoundVar<F, 
 ///   - bounds: A 6-ary tuple of variables to be bound to the values produced by the effect.
 ///   - fa: Monadic effect.
 /// - Returns: A binding expresssion.
-public func <--<F: Monad, A, B, C, D, E, G>(_ bounds: (BoundVar<F, A>, BoundVar<F, B>, BoundVar<F, C>, BoundVar<F, D>, BoundVar<F, E>, BoundVar<F, G>), _ fa: @autoclosure @escaping () -> Kind<F, (A, B, C, D, E, G)>) -> BindingExpression<F> {
-    return bounds <- fa()
+public func <--<F: Monad, A, B, C, D, E, G>(
+    _ bounds: (BoundVar<F, A>, BoundVar<F, B>, BoundVar<F, C>, BoundVar<F, D>, BoundVar<F, E>, BoundVar<F, G>),
+    _ fa: @autoclosure @escaping () -> Kind<F, (A, B, C, D, E, G)>) -> BindingExpression<F> {
+    bounds <- fa()
 }
 
 /// Creates a binding expression.
@@ -68,8 +80,10 @@ public func <--<F: Monad, A, B, C, D, E, G>(_ bounds: (BoundVar<F, A>, BoundVar<
 ///   - bounds: A 7-ary tuple of variables to be bound to the values produced by the effect.
 ///   - fa: Monadic effect.
 /// - Returns: A binding expresssion.
-public func <--<F: Monad, A, B, C, D, E, G, H>(_ bounds: (BoundVar<F, A>, BoundVar<F, B>, BoundVar<F, C>, BoundVar<F, D>, BoundVar<F, E>, BoundVar<F, G>, BoundVar<F, H>), _ fa: @autoclosure @escaping () -> Kind<F, (A, B, C, D, E, G, H)>) -> BindingExpression<F> {
-    return bounds <- fa()
+public func <--<F: Monad, A, B, C, D, E, G, H>(
+    _ bounds: (BoundVar<F, A>, BoundVar<F, B>, BoundVar<F, C>, BoundVar<F, D>, BoundVar<F, E>, BoundVar<F, G>, BoundVar<F, H>),
+    _ fa: @autoclosure @escaping () -> Kind<F, (A, B, C, D, E, G, H)>) -> BindingExpression<F> {
+    bounds <- fa()
 }
 
 /// Creates a binding expression.
@@ -78,8 +92,10 @@ public func <--<F: Monad, A, B, C, D, E, G, H>(_ bounds: (BoundVar<F, A>, BoundV
 ///   - bounds: A 8-ary tuple of variables to be bound to the values produced by the effect.
 ///   - fa: Monadic effect.
 /// - Returns: A binding expresssion.
-public func <--<F: Monad, A, B, C, D, E, G, H, I>(_ bounds: (BoundVar<F, A>, BoundVar<F, B>, BoundVar<F, C>, BoundVar<F, D>, BoundVar<F, E>, BoundVar<F, G>, BoundVar<F, H>, BoundVar<F, I>), _ fa: @autoclosure @escaping () -> Kind<F, (A, B, C, D, E, G, H, I)>) -> BindingExpression<F> {
-    return bounds <- fa()
+public func <--<F: Monad, A, B, C, D, E, G, H, I>(
+    _ bounds: (BoundVar<F, A>, BoundVar<F, B>, BoundVar<F, C>, BoundVar<F, D>, BoundVar<F, E>, BoundVar<F, G>, BoundVar<F, H>, BoundVar<F, I>),
+    _ fa: @autoclosure @escaping () -> Kind<F, (A, B, C, D, E, G, H, I)>) -> BindingExpression<F> {
+    bounds <- fa()
 }
 
 /// Creates a binding expression.
@@ -88,8 +104,10 @@ public func <--<F: Monad, A, B, C, D, E, G, H, I>(_ bounds: (BoundVar<F, A>, Bou
 ///   - bounds: A 9-ary tuple of variables to be bound to the values produced by the effect.
 ///   - fa: Monadic effect.
 /// - Returns: A binding expresssion.
-public func <--<F: Monad, A, B, C, D, E, G, H, I, J>(_ bounds: (BoundVar<F, A>, BoundVar<F, B>, BoundVar<F, C>, BoundVar<F, D>, BoundVar<F, E>, BoundVar<F, G>, BoundVar<F, H>, BoundVar<F, I>, BoundVar<F, J>), _ fa: @autoclosure @escaping () -> Kind<F, (A, B, C, D, E, G, H, I, J)>) -> BindingExpression<F> {
-    return bounds <- fa()
+public func <--<F: Monad, A, B, C, D, E, G, H, I, J>(
+    _ bounds: (BoundVar<F, A>, BoundVar<F, B>, BoundVar<F, C>, BoundVar<F, D>, BoundVar<F, E>, BoundVar<F, G>, BoundVar<F, H>, BoundVar<F, I>, BoundVar<F, J>),
+    _ fa: @autoclosure @escaping () -> Kind<F, (A, B, C, D, E, G, H, I, J)>) -> BindingExpression<F> {
+    bounds <- fa()
 }
 
 /// Creates a binding expression.
@@ -98,6 +116,8 @@ public func <--<F: Monad, A, B, C, D, E, G, H, I, J>(_ bounds: (BoundVar<F, A>, 
 ///   - bounds: A 10-ary tuple of variables to be bound to the values produced by the effect.
 ///   - fa: Monadic effect.
 /// - Returns: A binding expresssion.
-public func <--<F: Monad, A, B, C, D, E, G, H, I, J, K>(_ bounds: (BoundVar<F, A>, BoundVar<F, B>, BoundVar<F, C>, BoundVar<F, D>, BoundVar<F, E>, BoundVar<F, G>, BoundVar<F, H>, BoundVar<F, I>, BoundVar<F, J>, BoundVar<F, K>), _ fa: @autoclosure @escaping () -> Kind<F, (A, B, C, D, E, G, H, I, J, K)>) -> BindingExpression<F> {
-    return bounds <- fa()
+public func <--<F: Monad, A, B, C, D, E, G, H, I, J, K>(
+    _ bounds: (BoundVar<F, A>, BoundVar<F, B>, BoundVar<F, C>, BoundVar<F, D>, BoundVar<F, E>, BoundVar<F, G>, BoundVar<F, H>, BoundVar<F, I>, BoundVar<F, J>, BoundVar<F, K>),
+    _ fa: @autoclosure @escaping () -> Kind<F, (A, B, C, D, E, G, H, I, J, K)>) -> BindingExpression<F> {
+    bounds <- fa()
 }

--- a/Tests/BowLaws/ComonadEnvLaws.swift
+++ b/Tests/BowLaws/ComonadEnvLaws.swift
@@ -3,6 +3,7 @@ import Bow
 import BowGenerators
 
 public class ComonadEnvLaws<F: ComonadEnv & EquatableK & ArbitraryK, A: Arbitrary & CoArbitrary & Hashable> where F.E == A {
+    
     public static func check() {
         askLocal()
         extractLocal()
@@ -11,15 +12,19 @@ public class ComonadEnvLaws<F: ComonadEnv & EquatableK & ArbitraryK, A: Arbitrar
     
     static func askLocal() {
         property("Ask followed by local is equivalent to applying a function to ask") <~ forAll { (fa: KindOf<F, Int>, f: ArrowOf<A, A>) in
-            fa.value.local(f.getArrow).ask() ==
-                f.getArrow(fa.value.ask())
+            
+            fa.value.local(f.getArrow).ask()
+                ==
+            f.getArrow(fa.value.ask())
         }
     }
     
     static func extractLocal() {
         property("Local does not affect extract") <~ forAll { (fa: KindOf<F, Int>, f: ArrowOf<A, A>) in
-            fa.value.local(f.getArrow).extract() ==
-                fa.value.extract()
+            
+            fa.value.local(f.getArrow).extract()
+                ==
+            fa.value.extract()
         }
     }
     
@@ -27,8 +32,9 @@ public class ComonadEnvLaws<F: ComonadEnv & EquatableK & ArbitraryK, A: Arbitrar
         property("CoflatMap Local") <~ forAll { (fa: KindOf<F, Int>, f: ArrowOf<A, A>, g: ArrowOf<Int, Int>) in
             let h: (Kind<F, Int>) -> Int = { wa in g.getArrow(wa.extract()) }
 
-            return fa.value.local(f.getArrow).coflatMap(h) ==
-                fa.value.coflatMap(h).local(f.getArrow)
+            return fa.value.local(f.getArrow).coflatMap(h)
+                ==
+            fa.value.coflatMap(h).local(f.getArrow)
         }
     }
 }

--- a/Tests/BowLaws/ComonadLaws.swift
+++ b/Tests/BowLaws/ComonadLaws.swift
@@ -15,46 +15,67 @@ public class ComonadLaws<F: Comonad & EquatableK & ArbitraryK> {
     
     private static func duplicateThenExtractIsId() {
         property("Duplicate then extract is equivalent to id") <~ forAll { (fa: KindOf<F, Int>) in
-            return F.extract(F.duplicate(fa.value)) == fa.value
+            
+            fa.value.duplicate().extract()
+                ==
+            fa.value
         }
     }
     
     private static func duplicateThenMapExtractIsId() {
         property("Duplicate then map extract is equivalent to id") <~ forAll { (fa: KindOf<F, Int>) in
-            return F.map(F.duplicate(fa.value), F.extract) == fa.value
+            
+            fa.value.duplicate().map(F.extract)
+                ==
+            fa.value
         }
     }
     
     private static func mapAndCoflatMapCoherence() {
         property("map and coflatMap coherence") <~ forAll { (fa: KindOf<F, Int>, f: ArrowOf<Int, Int>) in
-            return F.map(fa.value, f.getArrow) == F.coflatMap(fa.value, { a in f.getArrow(F.extract(a)) })
+            
+            fa.value.map(f.getArrow)
+                ==
+            fa.value.coflatMap { a in f.getArrow(a.extract()) }
         }
     }
     
     private static func leftIdentity() {
         property("Left identity") <~ forAll { (fa: KindOf<F, Int>) in
-            return F.coflatMap(fa.value, F.extract) == fa.value
+            
+            fa.value.coflatMap(F.extract)
+                ==
+            fa.value
         }
     }
     
     private static func rightIdentity() {
         property("Right identity") <~ forAll { (fa: KindOf<F, Int>, fb: KindOf<F, Int>) in
             let f = { (_ : Kind<F, Int>) in fb.value }
-            return F.extract(F.coflatMap(fa.value, f)) == f(fa.value)
+            
+            return fa.value.coflatMap(f).extract()
+                ==
+            f(fa.value)
         }
     }
     
     private static func cokleisliLeftIdentity() {
         property("Cokleisli left identity") <~ forAll { (fa: KindOf<F, Int>, fb: KindOf<F, Int>) in
             let f = { (_: Kind<F, Int>) in fb.value }
-            return Cokleisli(F.extract).andThen(Cokleisli(f)).run(fa.value) == f(fa.value)
+            
+            return Cokleisli(F.extract).andThen(Cokleisli(f)).run(fa.value)
+                ==
+            f(fa.value)
         }
     }
     
     private static func cokleisliRightIdentity() {
         property("Cokleisli right identity") <~ forAll { (fa: KindOf<F, Int>, fb: KindOf<F, Int>) in
             let f = { (_: Kind<F, Int>) in fb.value }
-            return Cokleisli(f).andThen(Cokleisli(F.extract)).run(fa.value) == f(fa.value)
+            
+            return Cokleisli(f).andThen(Cokleisli(F.extract)).run(fa.value)
+                ==
+            f(fa.value)
         }
     }
 }

--- a/Tests/BowLaws/ComonadStoreLaws.swift
+++ b/Tests/BowLaws/ComonadStoreLaws.swift
@@ -13,14 +13,18 @@ public class ComonadStoreLaws<F: ComonadStore & EquatableK & ArbitraryK, A: Arbi
         property("coflatMap does not change position") <~ forAll { (fa: KindOf<F, Int>, f: ArrowOf<Int, Int>) in
             let ff: (Kind<F, Int>) -> Int = { wa in f.getArrow(wa.extract()) }
             
-            return fa.value.coflatMap(ff).position ==
-                fa.value.position
+            return fa.value.coflatMap(ff).position
+                ==
+            fa.value.position
         }
     }
     
     static func peekPosition() {
         property("peek at position is equal to extract") <~ forAll { (fa: KindOf<F, Int>) in
-            fa.value.peek(fa.value.position) == fa.value.extract()
+            
+            fa.value.peek(fa.value.position)
+                ==
+            fa.value.extract()
         }
     }
 }

--- a/Tests/BowLaws/ComonadTracedLaws.swift
+++ b/Tests/BowLaws/ComonadTracedLaws.swift
@@ -11,14 +11,19 @@ public class ComonadTracedLaws<F: ComonadTraced & EquatableK & ArbitraryK, M: Eq
     
     static func traceEmpty() {
         property("trace empty is equal to extract") <~ forAll { (fa: KindOf<F, Int>) in
-            fa.value.trace(.empty()) == fa.value.extract()
+            
+            fa.value.trace(.empty())
+                ==
+            fa.value.extract()
         }
     }
     
     static func sequentialTracing() {
         property("tracing twice is equal to tracing combination of values") <~ forAll { (fa: KindOf<F, Int>, s: M, t: M) in
-            fa.value.coflatMap { wa in wa.trace(t) }.trace(s) ==
-                fa.value.trace(s.combine(t))
+            
+            fa.value.coflatMap { wa in wa.trace(t) }.trace(s)
+                ==
+            fa.value.trace(s.combine(t))
         }
     }
 }

--- a/Tests/BowLaws/ComparableLaws.swift
+++ b/Tests/BowLaws/ComparableLaws.swift
@@ -25,73 +25,73 @@ public class ComparableLaws<A: Comparable & Arbitrary> {
     
     private static func reflexivityOfLessThanOrEqual() {
         property("Reflexivity of <=") <~ forAll { (x: A) in
-            return x <= x
+            x <= x
         }
     }
     
     private static func antisymmetryOfLessThanOrEqual() {
         property("Antisymetry of <=") <~ forAll { (x: A, y: A) in
-            return (x <= y && y <= x && x == y) || x != y
+            (x <= y && y <= x && x == y) || x != y
         }
     }
     
     private static func transitivityOfLessThanOrEqual() {
         property("Transitivity of <=") <~ forAll { (x: A, y: A, z: A) in
-            return !(x <= y && y <= z) || x <= z
+            !(x <= y && y <= z) || x <= z
         }
     }
     
     private static func antireflexivityOfLessThan() {
         property("Antireflexivity of <") <~ forAll { (x: A) in
-            return !(x < x)
+            !(x < x)
         }
     }
     
     private static func asymmetryOfLessThan() {
         property("Asymmetry of <") <~ forAll { (x: A, y: A) in
-            return xor(x < y, y < x) || x == y
+            xor(x < y, y < x) || x == y
         }
     }
     
     private static func transitivityOfLessThan() {
         property("Transitivity of <") <~ forAll { (x: A, y: A, z: A) in
-            return !(x < y && y < z) || x < z
+            !(x < y && y < z) || x < z
         }
     }
     
     private static func reflexivityOfGreaterThanOrEqual() {
         property("Reflexivity of >=") <~ forAll { (x: A) in
-            return x >= x
+            x >= x
         }
     }
     
     private static func antisymmetryOfGreaterThanOrEqual() {
         property("Antisymetry of >=") <~ forAll { (x: A, y: A) in
-            return (x >= y && y >= x && x == y) || x != y
+            (x >= y && y >= x && x == y) || x != y
         }
     }
     
     private static func transitivityOfGreaterThanOrEqual() {
         property("Transitivity of >=") <~ forAll { (x: A, y: A, z: A) in
-            return !(x >= y && y >= z) || x >= z
+            !(x >= y && y >= z) || x >= z
         }
     }
     
     private static func antireflexivityOfGreaterThan() {
         property("Antireflexivity of >") <~ forAll { (x: A) in
-            return !(x > x)
+            !(x > x)
         }
     }
     
     private static func asymmetryOfGreaterThan() {
         property("Asymmetry of >") <~ forAll { (x: A, y: A) in
-            return xor(x > y, y > x) || x == y
+            xor(x > y, y > x) || x == y
         }
     }
     
     private static func transitivityOfGreaterThan() {
         property("Transitivity of >") <~ forAll { (x: A, y: A, z: A) in
-            return !(x > y && y > z) || x > z
+            !(x > y && y > z) || x > z
         }
     }
     

--- a/Tests/BowLaws/ContravariantLaws.swift
+++ b/Tests/BowLaws/ContravariantLaws.swift
@@ -12,14 +12,19 @@ public class ContravariantLaws<F: Contravariant & EquatableK & ArbitraryK> {
     
     private static func identity() {
         property("Identity") <~ forAll { (fa: KindOf<F, Int>) in
-            return F.contramap(fa.value, id) == id(fa.value)
+            
+            fa.value.contramap(id)
+                ==
+            id(fa.value)
         }
     }
     
     private static func composition() {
         property("Composition") <~ forAll { (fa: KindOf<F, Int>, f: ArrowOf<Int, Int>, g: ArrowOf<Int, Int>) in
-            return F.contramap(F.contramap(fa.value, f.getArrow), g.getArrow) ==
-                F.contramap(fa.value, f.getArrow <<< g.getArrow)
+            
+            fa.value.contramap(f.getArrow).contramap(g.getArrow)
+                ==
+            fa.value.contramap(f.getArrow <<< g.getArrow)
         }
     }
 }

--- a/Tests/BowLaws/DivideLaws.swift
+++ b/Tests/BowLaws/DivideLaws.swift
@@ -3,23 +3,21 @@ import BowGenerators
 import SwiftCheck
 
 public final class DivideLaws<F: Divide & ArbitraryK & EquatableK> {
-    public static func check(
-        isEqual: @escaping (Kind<F, ((Int, Int), Int)>, Kind<F, (Int, (Int, Int))>) -> Bool
-    ) {
+    public static func check(isEqual: @escaping (Kind<F, ((Int, Int), Int)>, Kind<F, (Int, (Int, Int))>) -> Bool) {
         associativity(isEqual: isEqual)
     }
     
-    private static func associativity(
-        isEqual: @escaping (Kind<F, ((Int, Int), Int)>, Kind<F, (Int, (Int, Int))>) -> Bool
-    ) {
+    private static func associativity(isEqual: @escaping (Kind<F, ((Int, Int), Int)>, Kind<F, (Int, (Int, Int))>) -> Bool) {
         func tuple<A, B>(_ a: A, _ b: B) -> (A, B) {
             (a, b)
         }
         
-        property("Divide - Associativity") <~ forAll { (fa: KindOf<F, Int>) in
-            let a = fa.value.divide(fa.value.divide(fa.value, tuple(_:_:)), tuple(_:_:))
-            let b = F.divide(fa.value.divide(fa.value, tuple(_:_:)), fa.value, tuple(_:_:))
-            return isEqual(b, a)
+        property("Associativity") <~ forAll { (fa: KindOf<F, Int>) in
+            
+            isEqual(
+                F.divide(fa.value.divide(fa.value, tuple), fa.value, tuple),
+                fa.value.divide(fa.value.divide(fa.value, tuple), tuple)
+            )
         }
     }
 }

--- a/Tests/BowLaws/DivisibleLaws.swift
+++ b/Tests/BowLaws/DivisibleLaws.swift
@@ -9,16 +9,20 @@ public final class DivisibleLaws<F: Divisible & ArbitraryK & EquatableK> {
     }
     
     private static func leftIdentity(isEqual: @escaping (Kind<F, (Int, Int)>, Kind<F, Int>) -> Bool) {
-        property("Divisible left identity") <~ forAll { (fa: KindOf<F, Int>) in
-            let a = fa.value.divide(Kind<F, Int>.conquer(), tuple(_:_:))
-            return isEqual(a, fa.value)
+        property("Left identity") <~ forAll { (fa: KindOf<F, Int>) in
+            
+            isEqual(
+                fa.value.divide(Kind<F, Int>.conquer(), tuple),
+                fa.value)
         }
     }
     
     private static func rightIdentity(isEqual: @escaping (Kind<F, (Int, Int)>, Kind<F, Int>) -> Bool) {
-        property("Divisible right identity") <~ forAll { (fa: KindOf<F, Int>) in
-            let a = Kind<F, Int>.conquer().divide(fa.value, tuple(_:_:))
-            return isEqual(a, fa.value)
+        property("Right identity") <~ forAll { (fa: KindOf<F, Int>) in
+            
+            isEqual(
+                Kind<F, Int>.conquer().divide(fa.value, tuple),
+                fa.value)
         }
     }
 

--- a/Tests/BowLaws/EqualityFunctions.swift
+++ b/Tests/BowLaws/EqualityFunctions.swift
@@ -1,15 +1,22 @@
 import Bow
 
-public func isEqual<F: EquatableK & Functor>(_ fa: Kind<F, ()>, _ fb: Kind<F, ()>) -> Bool {
-    return fa.map { 0 } == fb.map { 0 }
+public func isEqual<F: EquatableK & Functor>(
+    _ fa: Kind<F, Void>,
+    _ fb: Kind<F, Void>) -> Bool {
+    fa.map { 0 } == fb.map { 0 }
 }
 
-public func isEqual<F: EquatableK & Functor, A: Equatable, B: Equatable>(_ fa: Kind<F, (A, B)>, _ fb: Kind<F, (A, B)>) -> Bool {
-    return fa.map { x in x.0 } == fb.map { y in y.0 } &&
-        fa.map { x in x.1 } == fb.map { y in y.1 }
+public func isEqual<F: EquatableK & Functor, A: Equatable, B: Equatable>(
+    _ fa: Kind<F, (A, B)>,
+    _ fb: Kind<F, (A, B)>) -> Bool {
+    
+    fa.map { x in x.0 } == fb.map { y in y.0 } &&
+    fa.map { x in x.1 } == fb.map { y in y.1 }
 }
 
-public func isEqual<F: EquatableK & Functor, A: Equatable, B: Equatable, C: Equatable>(_ fa: Kind<F, ((A, B), C)>, _ fb: Kind<F, (A, (B, C))>) -> Bool {
+public func isEqual<F: EquatableK & Functor, A: Equatable, B: Equatable, C: Equatable>(
+    _ fa: Kind<F, ((A, B), C)>,
+    _ fb: Kind<F, (A, (B, C))>) -> Bool {
     fa.map { x in x.0 }.map { xx in xx.0 } == fb.map { y in y.0 } &&
     fa.map { x in x.0 }.map { xx in xx.1 } == fb.map { y in y.1 }.map { yy in yy.0 } &&
     fa.map { x in x.1 } == fb.map { y in y.1 }.map { yy in yy.1 }

--- a/Tests/BowLaws/EquatableKLaws.swift
+++ b/Tests/BowLaws/EquatableKLaws.swift
@@ -12,20 +12,25 @@ public class EquatableKLaws<F: EquatableK & ArbitraryK, A: Arbitrary & Equatable
     
     private static func identity() {
         property("Identity: Every object is equal to itself") <~ forAll { (fa: KindOf<F, A>) in
-            return fa.value == fa.value
+            
+            fa.value == fa.value
         }
     }
     
     private static func commutativity() {
         property("Equality is commutative") <~ forAll { (fa: KindOf<F, A>, fb: KindOf<F, A>) in
-            return (fa.value == fb.value) == (fb.value == fa.value)
+            
+            (fa.value == fb.value)
+                ==
+            (fb.value == fa.value)
         }
     }
     
     private static func transitivity() {
         property("Equality is transitive") <~ forAll { (fa: KindOf<F, A>, fb: KindOf<F, A>, fc: KindOf<F, A>) in
+            
             // fa == fb && fb == fc --> fa == fc
-            return not((fa.value == fb.value) && (fb.value == fc.value)) || (fa.value == fc.value)
+            not((fa.value == fb.value) && (fb.value == fc.value)) || (fa.value == fc.value)
         }
     }
 }

--- a/Tests/BowLaws/EquatableLaws.swift
+++ b/Tests/BowLaws/EquatableLaws.swift
@@ -10,20 +10,25 @@ public class EquatableLaws<A: Equatable & Arbitrary> {
 
     private static func identity() {
         property("Identity: Every object is equal to itself") <~ forAll { (a: A) in
-            return a == a
+            
+            a == a
         }
     }
 
     private static func commutativity() {
         property("Equality is commutative") <~ forAll { (a: A, b: A) in
-            return (a == b) == (b == a)
+            
+            (a == b)
+                ==
+            (b == a)
         }
     }
     
     private static func transitivity() {
         property("Equality is transitive") <~ forAll { (a: A, b: A, c: A) in
+            
             // (a == b) && (b == c) --> (a == c)
-            return not((a == b) && (b == c)) || (a == c)
+            not((a == b) && (b == c)) || (a == c)
         }
     }
 }

--- a/Tests/BowLaws/FoldableLaws.swift
+++ b/Tests/BowLaws/FoldableLaws.swift
@@ -16,20 +16,31 @@ public class FoldableLaws<F: Foldable & EquatableK & ArbitraryK> {
     
     private static func leftFoldConsistentWithFoldMap() {
         property("Left fold consistent with foldMap") <~ forAll { (input: KindOf<F, Int>, f: ArrowOf<Int, Int>) in
-            return F.foldMap(input.value, f.getArrow) == F.foldLeft(input.value, Int.empty(), { b, a in b.combine(f.getArrow(a)) })
+            
+            input.value.foldMap(f.getArrow)
+                ==
+            input.value.foldLeft(.empty()) { b, a in b.combine(f.getArrow(a))
+            }
         }
     }
     
     private static func rightFoldConsistentWithFoldMap() {
         property("Right fold consistent with folMap") <~ forAll { (f: ArrowOf<Int, Int>, fa: KindOf<F, Int>) in
-            return fa.value.foldMap(f.getArrow) ==
-                fa.value.foldRight(Eval.later { Int.empty() }, { a, lb in lb.map { b in f.getArrow(a).combine(b) }^ }).value()
+            
+            fa.value.foldMap(f.getArrow)
+                ==
+            fa.value.foldRight(Eval.later { .empty() }) { a, lb in lb.map { b in f.getArrow(a).combine(b) }^
+            }.value()
         }
     }
     
     private static func existsConsistentWithFind() {
         property("Exists consistent with find") <~ forAll { (input: KindOf<F, Int>, predicate: ArrowOf<Int, Bool>) in
-            return F.exists(input.value, predicate.getArrow) == F.find(input.value, predicate.getArrow).fold(constant(false), constant(true))
+            
+            input.value.exists(predicate.getArrow)
+                ==
+            input.value.find(predicate.getArrow)
+                .fold(constant(false), constant(true))
         }
     }
     
@@ -53,9 +64,9 @@ public class FoldableLaws<F: Foldable & EquatableK & ArbitraryK> {
     
     private static func forallConsistentWithExists() {
         property("Forall consistent with exists") <~ forAll { (input: KindOf<F, Int>, predicate: ArrowOf<Int, Bool>) in
-            if F.forall(input.value, predicate.getArrow) {
-                let negationExists = F.exists(input.value, predicate.getArrow >>> not)
-                return !negationExists && (F.isEmpty(input.value) || F.exists(input.value, predicate.getArrow))
+            if input.value.forall(predicate.getArrow) {
+                let negationExists = input.value.exists(predicate.getArrow >>> not)
+                return !negationExists && (F.isEmpty(input.value) || input.value.exists(predicate.getArrow))
             } else {
                 return true
             }
@@ -64,15 +75,18 @@ public class FoldableLaws<F: Foldable & EquatableK & ArbitraryK> {
     
     private static func forallReturnsTrueIfEmpty() {
         property("Forall returns true if empty") <~ forAll { (input: KindOf<F, Int>, predicate: ArrowOf<Int, Bool>) in
-            return !F.isEmpty(input.value) || F.forall(input.value, predicate.getArrow)
+            input.value.nonEmpty || input.value.forall(predicate.getArrow)
         }
     }
     
     private static func foldMIdIsFoldL()  {
         property("Exists consistent with find") <~ forAll { (input: KindOf<F, Int>, f: ArrowOf<Int, Int>) in
-            let foldL = F.foldLeft(input.value, Int.empty(), { b, a in b.combine(f.getArrow(a)) })
-            let foldM = Id.fix(F.foldM(input.value, Int.empty(), { b, a in Id(b.combine(f.getArrow(a))) })).value
-            return foldL == foldM
+            
+            input.value.foldLeft(.empty()) { b, a in b.combine(f.getArrow(a))
+            }
+                ==
+            input.value.foldM(.empty()) { b, a in Id(b.combine(f.getArrow(a)))
+            }^.value
         }
     }
 }

--- a/Tests/BowLaws/FunctorFilterLaws.swift
+++ b/Tests/BowLaws/FunctorFilterLaws.swift
@@ -10,14 +10,22 @@ public class FunctorFilterLaws<F: FunctorFilter & EquatableK & ArbitraryK> {
     
     private static func mapFilterComposition() {
         property("MapFilter composition") <~ forAll { (fa: KindOf<F, Int>, f: ArrowOf<Int, Option<Int>>, g: ArrowOf<Int, Option<Int>>) in
-            return F.mapFilter(F.mapFilter(fa.value, f.getArrow), g.getArrow) == F.mapFilter(fa.value, { x in f.getArrow(x).flatMap(g.getArrow) })
+            
+            fa.value.mapFilter(f.getArrow).mapFilter(g.getArrow)
+                ==
+            fa.value.mapFilter { x in
+                f.getArrow(x).flatMap(g.getArrow)
+            }
         }
     }
     
     private static func mapFilterMapConsistency() {
         property("Consistency between mapFilter and map") <~ forAll { (fa: KindOf<F, Int>, b: Int) in
             let f: (Int) -> Int = constant(b)
-            return F.mapFilter(fa.value, { x in Option.some(f(x)) }) == F.map(fa.value, f)
+            
+            return fa.value.mapFilter { x in Option.some(f(x)) }
+                ==
+            fa.value.map(f)
         }
     }
 }

--- a/Tests/BowLaws/FunctorLaws.swift
+++ b/Tests/BowLaws/FunctorLaws.swift
@@ -15,41 +15,54 @@ public class FunctorLaws<F: Functor & EquatableK & ArbitraryK> {
 
     private static func covariantIdentity() {
         property("Identity is preserved under functor transformation") <~ forAll() { (fa: KindOf<F, Int>) in
-            return F.map(fa.value, id) == id(fa.value)
+            fa.value.map(id)
+                ==
+            id(fa.value)
         }
     }
     
     private static func covariantComposition() {
         property("Composition is preserved under functor transformation") <~ forAll() { (fa: KindOf<F, Int>, f: ArrowOf<Int, Int>, g: ArrowOf<Int, Int>) in
-            return F.map(F.map(fa.value, f.getArrow), g.getArrow) ==
-                F.map(fa.value, f.getArrow >>> g.getArrow)
+            
+            fa.value.map(f.getArrow).map(g.getArrow)
+                ==
+            fa.value.map(f.getArrow >>> g.getArrow)
         }
     }
     
     private static func void() {
         property("Void") <~ forAll() { (fa: KindOf<F, Int>, f: ArrowOf<Int, Int>) in
-            return isEqual(F.void(fa.value), F.void(F.map(fa.value, f.getArrow)))
+            
+            isEqual(
+                fa.value.void(),
+                fa.value.map(f.getArrow).void())
         }
     }
     
     private static func fproduct() {
         property("fproduct") <~ forAll { (fa: KindOf<F, Int>, f: ArrowOf<Int, Int>) in
-            return F.map(F.fproduct(fa.value, f.getArrow), { x in x.1 }) ==
-                F.map(fa.value, f.getArrow)
+            
+            fa.value.fproduct(f.getArrow).map { x in x.1 }
+                ==
+            fa.value.map(f.getArrow)
         }
     }
     
     private static func tupleLeft() {
         property("tuple left") <~ forAll { (fa: KindOf<F, Int>, b: Int) in
-            return F.map(F.tupleLeft(fa.value, b), { x in x.0 }) ==
-                F.as(fa.value, b)
+            
+            fa.value.tupleLeft(b).map { x in x.0 }
+                ==
+            fa.value.as(b)
         }
     }
     
     private static func tupleRight() {
         property("tuple right") <~ forAll { (fa: KindOf<F, Int>, b: Int) in
-            return F.map(F.tupleRight(fa.value, b), { x in x.1 }) ==
-                F.as(fa.value, b)
+            
+            fa.value.tupleRight(b).map { x in x.1 }
+                ==
+            fa.value.as(b)
         }
     }
 }

--- a/Tests/BowLaws/InvariantLaws.swift
+++ b/Tests/BowLaws/InvariantLaws.swift
@@ -10,15 +10,20 @@ public class InvariantLaws<F: Invariant & EquatableK & ArbitraryK> {
     
     private static func identity() {
         property("Identity") <~ forAll { (fa: KindOf<F, Int>) in
-            return F.imap(fa.value, id, id) == fa.value
+            fa.value.imap(id, id)
+                ==
+            fa.value
         }
     }
     
     private static func composition() {
         property("Composition") <~ forAll { (fa: KindOf<F, Int>, f1: ArrowOf<Int, Int>, f2: ArrowOf<Int, Int>, g1: ArrowOf<Int, Int>, g2: ArrowOf<Int, Int>) in
-            let left = F.imap(F.imap(fa.value, f1.getArrow, f2.getArrow), g1.getArrow, g2.getArrow)
-            let right = F.imap(fa.value, g1.getArrow <<< f1.getArrow, f2.getArrow <<< g2.getArrow)
-            return left == right
+            
+            fa.value.imap(f1.getArrow, f2.getArrow)
+                    .imap(g1.getArrow, g2.getArrow)
+                ==
+            fa.value.imap(g1.getArrow <<< f1.getArrow,
+                          f2.getArrow <<< g2.getArrow)
         }
     }
 }

--- a/Tests/BowLaws/MonadErrorLaws.swift
+++ b/Tests/BowLaws/MonadErrorLaws.swift
@@ -11,13 +11,21 @@ public class MonadErrorLaws<F: MonadError & EquatableK & ArbitraryK> where F.E: 
     private static func leftZero() {
         property("Left zero") <~ forAll { (a: Int, g: ArrowOf<Int, Int>, error: F.E) in
             let f = g.getArrow >>> F.pure
-            return F.flatMap(F.raiseError(error), f) == F.raiseError(error)
+            
+            return F.raiseError(error).flatMap(f)
+                ==
+            F.raiseError(error)
         }
     }
     
     private static func ensureConsistency() {
         property("Ensure consistency") <~ forAll { (fa: KindOf<F, Int>, p: ArrowOf<Int, Bool>, error: F.E) in
-            return F.ensure(fa.value, constant(error), p.getArrow) == F.flatMap(fa.value, { a in p.getArrow(a) ? F.pure(a) : F.raiseError(error) })
+            
+            fa.value.ensure(constant(error), p.getArrow)
+                ==
+            fa.value.flatMap { a in
+                p.getArrow(a) ? F.pure(a) : F.raiseError(error)
+            }
         }
     }
 }

--- a/Tests/BowLaws/MonadFilterLaws.swift
+++ b/Tests/BowLaws/MonadFilterLaws.swift
@@ -13,32 +13,50 @@ public class MonadFilterLaws<F: MonadFilter & EquatableK & ArbitraryK> {
     
     private static func leftEmpty() {
         property("Left empty") <~ forAll { (f: ArrowOf<Int, Int>) in
-            return F.flatMap(F.empty(), f.getArrow >>> F.pure) == F.empty()
+            
+            Kind<F, Int>.empty.flatMap(f.getArrow >>> F.pure)
+                ==
+            Kind<F, Int>.empty
         }
     }
     
     private static func rightEmpty() {
         property("Right empty") <~ forAll { (fa: KindOf<F, Int>) in
-            return F.flatMap(fa.value, constant(F.empty())) == F.empty() as Kind<F, Int>
+            
+            fa.value.followedBy(Kind<F, Int>.empty)
+                ==
+            Kind<F, Int>.empty
         }
     }
     
     private static func consistency()  {
         property("Consistency") <~ forAll { (fa: KindOf<F, Int>, f: ArrowOf<Int, Bool>) in
-            return F.filter(fa.value, f.getArrow) == F.flatMap(fa.value, { a in f.getArrow(a) ? F.pure(a) : F.empty() })
+            
+            fa.value.filter(f.getArrow)
+                ==
+            fa.value.flatMap { a in
+                f.getArrow(a) ? F.pure(a) : F.empty()
+            }
         }
     }
     
     private static func mapFilter() {
         property("mapFilter") <~ forAll { (flag: Bool, n: Int) in
-            return F.pure(()).mapFilter { _ in flag ? Option.some(n) : Option.none() } ==
-                (flag ? F.pure(n) : F.empty())
+            
+            F.pure(()).mapFilter { _ in
+                flag ? Option.some(n) : Option.none()
+            }
+                ==
+            (flag ? F.pure(n) : F.empty())
         }
     }
     
     private static func filter() {
         property("filter") <~ forAll { (flag: Bool, n: Int) in
-            return F.pure(n).filter(constant(flag)) == (flag ? F.pure(n) : F.empty())
+            
+            F.pure(n).filter(constant(flag))
+                ==
+            (flag ? F.pure(n) : F.empty())
         }
     }
 }

--- a/Tests/BowLaws/MonadStateLaws.swift
+++ b/Tests/BowLaws/MonadStateLaws.swift
@@ -12,31 +12,43 @@ public class MonadStateLaws<F: MonadState & EquatableK> where F.S == Int {
     
     private static func getIdempotent() {
         property("Idempotence") <~ forAll { (_: Int) in
-            return F.flatMap(F.get(), { _ in F.get() }) == F.get()
+            
+            F.get().flatMap { _ in F.get() }
+                ==
+            F.get()
         }
     }
     
     private static func setTwice() {
         property("Set twice is equivalent to set only the second") <~ forAll { (s: Int, t: Int) in
-            return isEqual(F.flatMap(F.set(s), { _ in F.set(t) }), F.set(t))
+            
+            isEqual(
+                F.set(s).flatMap { _ in F.set(t) },
+                F.set(t))
         }
     }
     
     private static func setGet() {
         property("Get after set retrieves the original value") <~ forAll { (s: Int) in
-            return F.flatMap(F.set(s), { _ in F.get() }) == F.flatMap(F.set(s), { _ in F.pure(s) })
+            
+            F.set(s).flatMap { _ in F.get() }
+                ==
+            F.set(s).flatMap { _ in F.pure(s) }
         }
     }
     
     private static func getSet() {
         property("Get set") <~ forAll { (_: Int) in
-            return isEqual(F.flatMap(F.get(), F.set), F.pure(()))
+            
+            isEqual(
+                F.get().flatMap(F.set),
+                F.pure(()))
         }
     }
     
     private static func comprehensions() {
         property("Set twice") <~ forAll { (s: Int, t: Int) in
-            let x: Kind<F, ()> = binding(
+            let x: Kind<F, Void> = binding(
                 setState(s),
                 setState(t),
                 yield: ())
@@ -52,6 +64,7 @@ public class MonadStateLaws<F: MonadState & EquatableK> where F.S == Int {
                 a <-- getState(),
                 yield: a.get)
             let y = F.set(s).flatMap { _ in F.pure(s) }
+            
             return x == y
         }
         
@@ -67,6 +80,7 @@ public class MonadStateLaws<F: MonadState & EquatableK> where F.S == Int {
                 yield: b.get)
             
             let y = F.set(2 * s).flatMap { _ in F.pure("State: \(2 * s)") }
+            
             return x == y
         }
     }

--- a/Tests/BowLaws/MonadWriterLaws.swift
+++ b/Tests/BowLaws/MonadWriterLaws.swift
@@ -12,34 +12,47 @@ public class MonadWriterLaws<F: MonadWriter & EquatableK> where F.W == Int {
     
     private static func writerPure() {
         property("Writer pure") <~ forAll { (a: Int) in
-            return F.writer((Int.empty(), a)) == F.pure(a)
+            
+            F.writer((.empty(), a))
+                ==
+            F.pure(a)
         }
     }
     
     private static func tellFusion() {
         property("Tell fusion") <~ forAll { (a: Int, b: Int) in
-            return isEqual(F.flatMap(F.tell(a), { _ in F.tell(b) }),
-                           F.tell(a.combine(b)))
+            
+            isEqual(
+                F.tell(a).flatMap { _ in F.tell(b) },
+                F.tell(a.combine(b)))
         }
     }
     
     private static func listenPure() {
         property("Listen pure") <~ forAll { (a: Int) in
-            return isEqual(F.listen(F.pure(a)), F.pure((Int.empty(), a)))
+            
+            isEqual(
+                F.pure(a).listen(),
+                F.pure((.empty(), a)))
         }
     }
     
     private static func listenWriterProperty() {
         property("Listen writer") <~ forAll { (a: Int, w: Int) in
             let tuple = (w, a)
-            return isEqual(F.listen(F.writer(tuple)), F.map(F.tell(tuple.0), { _ in tuple }))
+            
+            return isEqual(
+                F.writer(tuple).listen(),
+                F.tell(tuple.0).map { _ in tuple })
         }
     }
     
     private static func censorTell() {
         property("Censor tell") <~ forAll { (a: Int, w: Int, f: ArrowOf<Int, Int>) in
-            isEqual(F.writer((f.getArrow(w), a)).listen(),
-                    F.writer((w, a)).censor(f.getArrow).listen())
+            
+            isEqual(
+                F.writer((f.getArrow(w), a)).listen(),
+                F.writer((w, a)).censor(f.getArrow).listen())
         }
     }
     

--- a/Tests/BowLaws/MonoidKLaws.swift
+++ b/Tests/BowLaws/MonoidKLaws.swift
@@ -11,19 +11,27 @@ public class MonoidKLaws<F: MonoidK & EquatableK & ArbitraryK> {
     
     private static func leftIdentity() {
         property("MonoidK left identity") <~ forAll { (fa: KindOf<F, Int>) in
-            return F.emptyK().combineK(fa.value) == fa.value
+            
+            Kind<F, Int>.emptyK().combineK(fa.value)
+                ==
+            fa.value
         }
     }
     
     private static func rightIdentity() {
         property("MonoidK left identity") <~ forAll { (fa: KindOf<F, Int>) in
-            return fa.value.combineK(F.emptyK()) == fa.value
+            
+            fa.value.combineK(Kind<F, Int>.emptyK())
+                ==
+            fa.value
         }
     }
     
     private static func fold() {
         property("MonoidK fold") <~ forAll { (fa: KindOf<F, Int>) in
-            return ArrayK(fa.value).foldK() == fa.value
+            ArrayK(fa.value).foldK()
+                ==
+            fa.value
         }
     }
 }

--- a/Tests/BowLaws/MonoidLaws.swift
+++ b/Tests/BowLaws/MonoidLaws.swift
@@ -9,13 +9,13 @@ public class MonoidLaws<A: Monoid & Equatable & Arbitrary> {
     
     private static func leftIdentity() {
         property("Left identity") <~ forAll { (a: A) in
-            return A.empty().combine(a) == a
+            A.empty().combine(a) == a
         }
     }
     
     private static func rightIdentity() {
         property("Right identity") <~ forAll { (a: A) in
-            return a.combine(A.empty()) == a
+            a.combine(A.empty()) == a
         }
     }
 }

--- a/Tests/BowLaws/MonoidalLaws.swift
+++ b/Tests/BowLaws/MonoidalLaws.swift
@@ -10,15 +10,19 @@ public final class MonoidalLaws<F: Monoidal & ArbitraryK & EquatableK> {
     
     private static func leftIdentity(isEqual: @escaping (Kind<F, (Int, Int)>, Kind<F, Int>) -> Bool) {
         property("Monoidal left identity") <~ forAll { (fa: KindOf<F, Int>) in
-            isEqual(Kind<F, Int>.identity().product(fa.value),
-                    Kind<F, Int>.identity())
+            
+            isEqual(
+                Kind<F, Int>.identity().product(fa.value),
+                Kind<F, Int>.identity())
         }
     }
     
     private static func rightIdentity(isEqual: @escaping (Kind<F, (Int, Int)>, Kind<F, Int>) -> Bool) {
         property("Monoidal right identity") <~ forAll { (fa: KindOf<F, Int>) in
-            isEqual(fa.value.product(Kind<F, Int>.identity()),
-                    Kind<F, Int>.identity())
+            
+            isEqual(
+                fa.value.product(Kind<F, Int>.identity()),
+                Kind<F, Int>.identity())
         }
     }
 }

--- a/Tests/BowLaws/PropertyOperatorOverload.swift
+++ b/Tests/BowLaws/PropertyOperatorOverload.swift
@@ -3,17 +3,17 @@ import SwiftCheck
 infix operator <~
 
 public func <~(checker: AssertiveQuickCheck, test: @autoclosure @escaping () -> Testable) {
-    return checker <- test
+    checker <- test
 }
 
 public func <~(checker: AssertiveQuickCheck, test: () -> Testable) {
-    return checker <- test
+    checker <- test
 }
 
 public func <~(checker: ReportiveQuickCheck, test: () -> Testable) {
-    return checker <- test
+    checker <- test
 }
 
 public func <~(checker: ReportiveQuickCheck, test: @autoclosure @escaping () -> Testable) {
-    return checker <~ test
+    checker <~ test
 }

--- a/Tests/BowLaws/SemigroupKLaws.swift
+++ b/Tests/BowLaws/SemigroupKLaws.swift
@@ -9,7 +9,10 @@ public class SemigroupKLaws<F: SemigroupK & EquatableK & ArbitraryK> {
     
     private static func associative() {
         property("SemigroupK combine is associative") <~ forAll { (fa: KindOf<F, Int>, fb: KindOf<F, Int>, fc: KindOf<F, Int>) in
-            return fa.value.combineK(fb.value.combineK(fc.value)) == fa.value.combineK(fb.value).combineK(fc.value)
+            
+            fa.value.combineK(fb.value.combineK(fc.value))
+                ==
+            fa.value.combineK(fb.value).combineK(fc.value)
         }
     }
 }

--- a/Tests/BowLaws/SemigroupLaws.swift
+++ b/Tests/BowLaws/SemigroupLaws.swift
@@ -9,13 +9,17 @@ public class SemigroupLaws<A: Semigroup & Arbitrary & Equatable> {
     
     private static func associativity() {
         property("Associativity") <~ forAll { (a: A, b: A, c: A) in
-            return a.combine(b).combine(c) == a.combine(b.combine(c))
+            a.combine(b).combine(c)
+                ==
+            a.combine(b.combine(c))
         }
     }
     
     private static func reduction() {
         property("Reduction") <~ forAll { (a: A, b: A, c: A) in
-            return A.combineAll(a, b, c) == a.combine(b).combine(c)
+            A.combineAll(a, b, c)
+                ==
+            a.combine(b).combine(c)
         }
     }
 }

--- a/Tests/BowLaws/SemigroupalLaws.swift
+++ b/Tests/BowLaws/SemigroupalLaws.swift
@@ -3,18 +3,16 @@ import BowGenerators
 import SwiftCheck
 
 public final class SemigroupalLaws<F: Semigroupal & ArbitraryK & EquatableK> {
-	public static func check(
-		isEqual: @escaping (Kind<F, ((Int, Int), Int)>, Kind<F, (Int, (Int, Int))>) -> Bool
-	) {
+	public static func check(isEqual: @escaping (Kind<F, ((Int, Int), Int)>, Kind<F, (Int, (Int, Int))>) -> Bool) {
         associativity(isEqual: isEqual)
 	}
 	
-	private static func associativity(
-        isEqual: @escaping (Kind<F, ((Int, Int), Int)>, Kind<F, (Int, (Int, Int))>) -> Bool
-	) {
+	private static func associativity(isEqual: @escaping (Kind<F, ((Int, Int), Int)>, Kind<F, (Int, (Int, Int))>) -> Bool) {
         property("Associativity") <~ forAll { (fa: KindOf<F, Int>, fb: KindOf<F, Int>, fc: KindOf<F, Int>) in
-            isEqual(fa.value.product(fb.value).product(fc.value),
-                    fa.value.product(fb.value.product(fc.value)))
+            
+            isEqual(
+                fa.value.product(fb.value).product(fc.value),
+                fa.value.product(fb.value.product(fc.value)))
         }
 	}
 }

--- a/Tests/BowLaws/SemiringLaws.swift
+++ b/Tests/BowLaws/SemiringLaws.swift
@@ -16,49 +16,57 @@ public class SemiringLaws<A: Semiring & Equatable & Arbitrary> {
     
     private static func commutativityForCombining() {
         property("Commutativity for combining") <~ forAll { (a: A) in
-            return A.zero().combine(a) == a.combine(.zero())
+            A.zero().combine(a)
+                ==
+            a.combine(.zero())
         }
     }
     
     private static func associativityForMultiplying() {
         property("Ascociativity for multiplying") <~ forAll { (a: A, b: A, c: A) in
-            return (a.multiply(b)).multiply(c) == a.multiply(b.multiply(c))
+            a.multiply(b).multiply(c)
+                ==
+            a.multiply(b.multiply(c))
         }
     }
     
     private static func leftIdentityForMultiplying() {
         property("Left identity for multiplying") <~ forAll { (a: A) in
-            return A.one().multiply(a) == a
+            A.one().multiply(a) == a
         }
     }
     
     private static func rightIdentityForMultiplying() {
         property("Right identity for multiplying") <~ forAll { (a: A) in
-            return a.multiply(.one()) == a
+            a.multiply(.one()) == a
         }
     }
     
     private static func leftDistribution() {
         property("Left distribution") <~ forAll { (a: A, b: A, c: A) in
-            return a.multiply(b.combine(c)) == (a.multiply(b)).combine(a.multiply(c))
+            a.multiply(b.combine(c))
+                ==
+            (a.multiply(b)).combine(a.multiply(c))
        }
     }
     
     private static func rightDistribution() {
         property("Right distribution") <~ forAll { (a: A, b: A, c: A) in
-            return (a.combine(b)).multiply(c) == (a.multiply(c)).combine(b.multiply(c))
+            a.combine(b).multiply(c)
+                ==
+            a.multiply(c).combine(b.multiply(c))
        }
     }
 
     private static func leftAnnihilation() {
         property("Left Annihilation") <~ forAll { (a: A) in
-            return A.zero().multiply(a) == .zero()
+            A.zero().multiply(a) == .zero()
        }
     }
     
     private static func rightAnnihilation() {
         property("Right Annihilation") <~ forAll { (a: A) in
-            return a.multiply(.zero()) == .zero()
+            a.multiply(.zero()) == .zero()
        }
     }
 }

--- a/Tests/BowLaws/TraverseFilterLaws.swift
+++ b/Tests/BowLaws/TraverseFilterLaws.swift
@@ -11,14 +11,26 @@ public class TraverseFilterLaws<F: TraverseFilter & Applicative & EquatableK & A
     private static func identityTraverseFilter() {
         property("identity traverse filter") <~ forAll { (x: Int) in
             let input = F.pure(x)
-            return F.traverseFilter(input, { a in F.pure(Option<Int>.some(a)) }) == F.pure(input)
+            
+            return input.traverseFilter { a in
+                F.pure(Option.some(a))
+            }
+                ==
+            F.pure(input)
         }
     }
     
     private static func filterAConsistentWithTraverseFilter() {
         property("filterA consistent with traverseFilter") <~ forAll { (input: KindOf<F, Int>, bool: KindOf<F, Bool>) in
             let f = { (_ : Int) in bool.value }
-            return F.filterA(input.value, f) == F.traverseFilter(input.value, { a in F.map(f(a)){ b in b ? Option<Int>.some(a) : Option<Int>.none()} })
+            
+            return input.value.filterA(f)
+                ==
+            input.value.traverseFilter { a in
+                f(a).map { b in
+                    b ? Option.some(a) : Option.none()
+                }
+            }
         }
     }
 }

--- a/Tests/BowLaws/TraverseLaws.swift
+++ b/Tests/BowLaws/TraverseLaws.swift
@@ -13,42 +13,56 @@ public class TraverseLaws<F: Traverse & EquatableK & ArbitraryK> {
     private static func identityTraverse() {
         property("Identity traverse") <~ forAll { (fa: KindOf<F, Int>, y: Int) in
             let f: (Int) -> Kind<ForId, Int> = { _ in Id<Int>(y) }
-            return Id.fix(F.traverse(fa.value, f)).value == F.map(F.map(fa.value, f), { a in Id.fix(a).value })
+            
+            return fa.value.traverse(f)^.value
+                ==
+            fa.value.map(f).map { a in a^.value }
         }
     }
     
     private static func sequentialComposition() {
         property("Sequential composition") <~ forAll { (f: ArrowOf<Int, Id<Int>>, g: ArrowOf<Int, Id<Int>>, x: KindOf<F, Int>) in
             let fa = x.value.traverse(f.getArrow)
-            let composed = fa.map { a in a.traverse(g.getArrow) }^.value^.value
-            let expected = x.value.traverse { a in f.getArrow(a).map(g.getArrow) }^.value.map { a in a.value }
-            return composed == expected
+            
+            return fa.map { a in a.traverse(g.getArrow) }^.value^.value
+                ==
+            x.value.traverse { a in
+                f.getArrow(a).map(g.getArrow)
+            }^.value.map { a in a.value }
         }
     }
     
     private static func parallelComposition() {
         property("Parallel composition") <~ forAll { (f: ArrowOf<Int, Id<Int>>, g: ArrowOf<Int, Id<Int>>, x: KindOf<F, Int>) in
-            let actual = TupleK.fix(x.value.traverse { a in TupleK((f.getArrow(a), g.getArrow(a))) })
-            let expected = TupleK((x.value.traverse(f.getArrow)^, x.value.traverse(g.getArrow)^))
-            return actual == expected
+            
+            x.value.traverse { a in
+                TupleK((f.getArrow(a), g.getArrow(a)))
+            }^
+                ==
+            TupleK((x.value.traverse(f.getArrow)^,
+                    x.value.traverse(g.getArrow)^))
         }
     }
     
     private static func foldMapDerived() {
         property("foldMap derived") <~ forAll { (f: ArrowOf<Int, Int>, fa: KindOf<F, Int>) in
-            let traversed = fa.value.traverse { a in Const<Int, Int>(f.getArrow(a)) }^.value
-            let mapped = fa.value.foldMap(f.getArrow)
-            return traversed == mapped
+            
+            fa.value.traverse { a in
+                Const<Int, Int>(f.getArrow(a))
+            }^.value
+                ==
+            fa.value.foldMap(f.getArrow)
         }
     }
 }
 
 private final class ForTupleK {}
-private class TupleK<A>: Kind<ForTupleK, A> {
+private typealias TupleKOf<A> = Kind<ForTupleK, A>
+private class TupleK<A>: TupleKOf<A> {
     let value: (Id<A>, Id<A>)
     
-    static func fix(_ value: Kind<ForTupleK, A>) -> TupleK<A> {
-        return value as! TupleK<A>
+    static func fix(_ value: TupleKOf<A>) -> TupleK<A> {
+        value as! TupleK<A>
     }
     
     init(_ value: (Id<A>, Id<A>)) {
@@ -56,27 +70,36 @@ private class TupleK<A>: Kind<ForTupleK, A> {
     }
 }
 
+private postfix func ^<A>(_ value: TupleKOf<A>) -> TupleK<A> {
+    TupleK.fix(value)
+}
+
 extension ForTupleK: Applicative {
-    static func pure<A>(_ a: A) -> Kind<ForTupleK, A> {
-        return TupleK((Id(a), Id(a)))
+    static func pure<A>(_ a: A) -> TupleKOf<A> {
+        TupleK((Id(a), Id(a)))
     }
     
-    static func ap<A, B>(_ ff: Kind<ForTupleK, (A) -> B>, _ fa: Kind<ForTupleK, A>) -> Kind<ForTupleK, B> {
-        let tuplef = TupleK.fix(ff)
-        let tuplea = TupleK.fix(fa)
-        return TupleK((tuplea.value.0.map(tuplef.value.0.value)^, tuplea.value.1.map(tuplef.value.1.value)^))
+    static func ap<A, B>(
+        _ ff: TupleKOf<(A) -> B>,
+        _ fa: TupleKOf<A>) -> Kind<ForTupleK, B> {
+        
+        TupleK((fa^.value.0.map(ff^.value.0.value)^,
+                fa^.value.1.map(ff^.value.1.value)^))
     }
     
-    static func map<A, B>(_ fa: Kind<ForTupleK, A>, _ f: @escaping (A) -> B) -> Kind<ForTupleK, B> {
-        let tuple = TupleK<A>.fix(fa)
-        return TupleK((tuple.value.0.map(f)^, tuple.value.1.map(f)^))
+    static func map<A, B>(
+        _ fa: TupleKOf<A>,
+        _ f: @escaping (A) -> B) -> TupleKOf<B> {
+        TupleK((fa^.value.0.map(f)^,
+                fa^.value.1.map(f)^))
     }
 }
 
 extension ForTupleK: EquatableK {
-    static func eq<A: Equatable>(_ lhs: Kind<ForTupleK, A>, _ rhs: Kind<ForTupleK, A>) -> Bool {
-        let x = TupleK.fix(lhs)
-        let y = TupleK.fix(rhs)
-        return x.value.0 == y.value.0 && x.value.1 == y.value.1
+    static func eq<A: Equatable>(
+        _ lhs: TupleKOf<A>,
+        _ rhs: TupleKOf<A>) -> Bool {
+        lhs^.value.0 == rhs^.value.0 &&
+        lhs^.value.1 == rhs^.value.1
     }
 }


### PR DESCRIPTION
## Goal

Cleanup code in the Core Typeclass Laws module by:

- Using `FOf<A>` instead of `Kind<F, A>`.
- Removing backticks in `MARK` sections as they do not render properly in Jazzy.
- Removing returns.
- Replacing `fix` by `^`.