### PR TITLE
Remove transitive test-only dependencies

### DIFF
--- a/Bow.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Bow.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -2,21 +2,21 @@
   "object": {
     "pins": [
       {
+        "package": "Chalk",
+        "repositoryURL": "https://github.com/mxcl/Chalk.git",
+        "state": {
+          "branch": null,
+          "revision": "9aa9f348b86db3cf6702a3e43c081ecec80cf3c7",
+          "version": "0.4.0"
+        }
+      },
+      {
         "package": "FileCheck",
         "repositoryURL": "https://github.com/llvm-swift/FileCheck.git",
         "state": {
           "branch": null,
-          "revision": "00945abac615e5203701be0f090ed0e2d2ff15bf",
-          "version": "0.2.0"
-        }
-      },
-      {
-        "package": "Rainbow",
-        "repositoryURL": "https://github.com/onevcat/Rainbow.git",
-        "state": {
-          "branch": null,
-          "revision": "9c52c1952e9b2305d4507cf473392ac2d7c9b155",
-          "version": "3.1.5"
+          "revision": "9ed91cc30a1a325d989fac117f3f3065a16b9f76",
+          "version": "0.2.3"
         }
       },
       {
@@ -29,21 +29,12 @@
         }
       },
       {
-        "package": "llbuild",
-        "repositoryURL": "https://github.com/apple/swift-llbuild.git",
+        "package": "swift-tools-support-core",
+        "repositoryURL": "https://github.com/apple/swift-tools-support-core.git",
         "state": {
           "branch": null,
-          "revision": "f1c9ad9a253cdf1aa89a7f5c99c30b4513b06ddb",
-          "version": "0.1.1"
-        }
-      },
-      {
-        "package": "SwiftPM",
-        "repositoryURL": "https://github.com/apple/swift-package-manager.git",
-        "state": {
-          "branch": null,
-          "revision": "8656a25cb906c1896339f950ac960ee1b4fe8034",
-          "version": "0.4.0"
+          "revision": "693aba4c4c9dcc4767cc853a0dd38bf90ad8c258",
+          "version": "0.0.1"
         }
       },
       {

--- a/Package.resolved
+++ b/Package.resolved
@@ -2,24 +2,6 @@
   "object": {
     "pins": [
       {
-        "package": "Chalk",
-        "repositoryURL": "https://github.com/mxcl/Chalk.git",
-        "state": {
-          "branch": null,
-          "revision": "9aa9f348b86db3cf6702a3e43c081ecec80cf3c7",
-          "version": "0.4.0"
-        }
-      },
-      {
-        "package": "FileCheck",
-        "repositoryURL": "https://github.com/llvm-swift/FileCheck.git",
-        "state": {
-          "branch": null,
-          "revision": "9ed91cc30a1a325d989fac117f3f3065a16b9f76",
-          "version": "0.2.3"
-        }
-      },
-      {
         "package": "RxSwift",
         "repositoryURL": "https://github.com/ReactiveX/RxSwift.git",
         "state": {
@@ -29,21 +11,12 @@
         }
       },
       {
-        "package": "swift-tools-support-core",
-        "repositoryURL": "https://github.com/apple/swift-tools-support-core.git",
-        "state": {
-          "branch": null,
-          "revision": "693aba4c4c9dcc4767cc853a0dd38bf90ad8c258",
-          "version": "0.0.1"
-        }
-      },
-      {
         "package": "SwiftCheck",
-        "repositoryURL": "https://github.com/truizlop/SwiftCheck.git",
+        "repositoryURL": "https://github.com/bow-swift/SwiftCheck.git",
         "state": {
           "branch": null,
-          "revision": "077c096c3ddfc38db223ac8e525ad16ffb987138",
-          "version": "0.12.0"
+          "revision": "748359f9a95edf94d0c4664102f104f56b1ff1fb",
+          "version": "0.12.1"
         }
       }
     ]

--- a/Package.resolved
+++ b/Package.resolved
@@ -2,21 +2,21 @@
   "object": {
     "pins": [
       {
+        "package": "Chalk",
+        "repositoryURL": "https://github.com/mxcl/Chalk.git",
+        "state": {
+          "branch": null,
+          "revision": "9aa9f348b86db3cf6702a3e43c081ecec80cf3c7",
+          "version": "0.4.0"
+        }
+      },
+      {
         "package": "FileCheck",
         "repositoryURL": "https://github.com/llvm-swift/FileCheck.git",
         "state": {
           "branch": null,
-          "revision": "00945abac615e5203701be0f090ed0e2d2ff15bf",
-          "version": "0.2.0"
-        }
-      },
-      {
-        "package": "Rainbow",
-        "repositoryURL": "https://github.com/onevcat/Rainbow.git",
-        "state": {
-          "branch": null,
-          "revision": "9c52c1952e9b2305d4507cf473392ac2d7c9b155",
-          "version": "3.1.5"
+          "revision": "9ed91cc30a1a325d989fac117f3f3065a16b9f76",
+          "version": "0.2.3"
         }
       },
       {
@@ -29,26 +29,17 @@
         }
       },
       {
-        "package": "llbuild",
-        "repositoryURL": "https://github.com/apple/swift-llbuild.git",
+        "package": "swift-tools-support-core",
+        "repositoryURL": "https://github.com/apple/swift-tools-support-core.git",
         "state": {
           "branch": null,
-          "revision": "f73b84bc1525998e5e267f9d830c1411487ac65e",
-          "version": "0.2.0"
-        }
-      },
-      {
-        "package": "SwiftPM",
-        "repositoryURL": "https://github.com/apple/swift-package-manager.git",
-        "state": {
-          "branch": null,
-          "revision": "9abcc2260438177cecd7cf5185b144d13e74122b",
-          "version": "0.5.0"
+          "revision": "693aba4c4c9dcc4767cc853a0dd38bf90ad8c258",
+          "version": "0.0.1"
         }
       },
       {
         "package": "SwiftCheck",
-        "repositoryURL": "https://github.com/typelift/SwiftCheck.git",
+        "repositoryURL": "https://github.com/truizlop/SwiftCheck.git",
         "state": {
           "branch": null,
           "revision": "077c096c3ddfc38db223ac8e525ad16ffb987138",

--- a/Package.swift
+++ b/Package.swift
@@ -12,14 +12,14 @@ let package = Package(
         .library(name: "BowEffects",           targets: ["BowEffects"]),
         .library(name: "BowRx",                targets: ["BowRx"]),
 
-        .library(name: "BowLaws",              targets: ["BowLaws"]),
-        .library(name: "BowOpticsLaws",        targets: ["BowOpticsLaws"]),
-        .library(name: "BowEffectsLaws",       targets: ["BowEffectsLaws"]),
+        // .library(name: "BowLaws",              targets: ["BowLaws"]),
+        // .library(name: "BowOpticsLaws",        targets: ["BowOpticsLaws"]),
+        // .library(name: "BowEffectsLaws",       targets: ["BowEffectsLaws"]),
 
-        .library(name: "BowGenerators",        targets: ["BowGenerators"]),
-        .library(name: "BowFreeGenerators",    targets: ["BowFreeGenerators"]),
-        .library(name: "BowEffectsGenerators", targets: ["BowEffectsGenerators"]),
-        .library(name: "BowRxGenerators",      targets: ["BowRxGenerators"])
+        // .library(name: "BowGenerators",        targets: ["BowGenerators"]),
+        // .library(name: "BowFreeGenerators",    targets: ["BowFreeGenerators"]),
+        // .library(name: "BowEffectsGenerators", targets: ["BowEffectsGenerators"]),
+        // .library(name: "BowRxGenerators",      targets: ["BowRxGenerators"])
     ],
 
     dependencies: [

--- a/Package.swift
+++ b/Package.swift
@@ -12,18 +12,18 @@ let package = Package(
         .library(name: "BowEffects",           targets: ["BowEffects"]),
         .library(name: "BowRx",                targets: ["BowRx"]),
 
-        // .library(name: "BowLaws",              targets: ["BowLaws"]),
-        // .library(name: "BowOpticsLaws",        targets: ["BowOpticsLaws"]),
-        // .library(name: "BowEffectsLaws",       targets: ["BowEffectsLaws"]),
-
-        // .library(name: "BowGenerators",        targets: ["BowGenerators"]),
-        // .library(name: "BowFreeGenerators",    targets: ["BowFreeGenerators"]),
-        // .library(name: "BowEffectsGenerators", targets: ["BowEffectsGenerators"]),
-        // .library(name: "BowRxGenerators",      targets: ["BowRxGenerators"])
+        .library(name: "BowLaws",              targets: ["BowLaws"]),
+        .library(name: "BowOpticsLaws",        targets: ["BowOpticsLaws"]),
+        .library(name: "BowEffectsLaws",       targets: ["BowEffectsLaws"]),
+        
+        .library(name: "BowGenerators",        targets: ["BowGenerators"]),
+        .library(name: "BowFreeGenerators",    targets: ["BowFreeGenerators"]),
+        .library(name: "BowEffectsGenerators", targets: ["BowEffectsGenerators"]),
+        .library(name: "BowRxGenerators",      targets: ["BowRxGenerators"])
     ],
 
     dependencies: [
-        .package(url: "https://github.com/typelift/SwiftCheck.git",   from: "0.12.0"),
+        .package(url: "https://github.com/truizlop/SwiftCheck.git",   from: "0.12.0"),
         .package(url: "https://github.com/ReactiveX/RxSwift.git",     from: "5.0.1"),
     ],
 

--- a/Package.swift
+++ b/Package.swift
@@ -15,7 +15,7 @@ let package = Package(
         .library(name: "BowLaws",              targets: ["BowLaws"]),
         .library(name: "BowOpticsLaws",        targets: ["BowOpticsLaws"]),
         .library(name: "BowEffectsLaws",       targets: ["BowEffectsLaws"]),
-        
+
         .library(name: "BowGenerators",        targets: ["BowGenerators"]),
         .library(name: "BowFreeGenerators",    targets: ["BowFreeGenerators"]),
         .library(name: "BowEffectsGenerators", targets: ["BowEffectsGenerators"]),
@@ -23,7 +23,7 @@ let package = Package(
     ],
 
     dependencies: [
-        .package(url: "https://github.com/truizlop/SwiftCheck.git",   from: "0.12.0"),
+        .package(url: "https://github.com/bow-swift/SwiftCheck.git",   from: "0.12.1"),
         .package(url: "https://github.com/ReactiveX/RxSwift.git",     from: "5.0.1"),
     ],
 


### PR DESCRIPTION
Currently, Bow depends on SwiftCheck to write tests and exposes some libraries for testing laws. SwiftCheck exposes dependencies that are only used for testing, but end up being fetched every time Bow is imported. One of this dependencies causes SwiftUI previews not to load at all because it encounters compilation errors when compiling this dependency.

Given the transitive dependencies for SwiftCheck are only used for testing, they should be removed. Therefore, as Swift Package Manager still does not allow to specify a dependency is only for testing, we have created a fork of SwiftCheck, where the `Package.swift` is modified to remove the test targets and the dependencies. The `Package.swift` in Bow now depends on this fork. Consumers of Bow will not fetch the transitive dependencies anymore, thus fixing the SwiftUI preview problem.