### PR TITLE
Fix IO parallelism

### DIFF
--- a/Sources/BowEffects/Data/IO.swift
+++ b/Sources/BowEffects/Data/IO.swift
@@ -760,9 +760,9 @@ internal class ParMap3<E: Error, A, B, C, Z>: IO<E, Z> {
     }
     
     override func _unsafeRunSyncEither(on queue: Queue = .queue()) -> Trampoline<(Either<E, Z>, Queue)> {
-        var a: Trampoline<(Either<E, A>, Queue)>?
-        var b: Trampoline<(Either<E, B>, Queue)>?
-        var c: Trampoline<(Either<E, C>, Queue)>?
+        var a: (Either<E, A>, Queue)?
+        var b: (Either<E, B>, Queue)?
+        var c: (Either<E, C>, Queue)?
         let group = DispatchGroup()
         let parQueue1: Queue = .queue(label: queue.label + "parMap1", qos: queue.qos)
         let parQueue2: Queue = .queue(label: queue.label + "parMap2", qos: queue.qos)
@@ -770,31 +770,25 @@ internal class ParMap3<E: Error, A, B, C, Z>: IO<E, Z> {
         
         group.enter()
         parQueue1.async {
-            a = self.fa._unsafeRunSyncEither(on: parQueue1)
+            a = self.fa._unsafeRunSyncEither(on: parQueue1).run()
             group.leave()
         }
         
         group.enter()
         parQueue2.async {
-            b = self.fb._unsafeRunSyncEither(on: parQueue2)
+            b = self.fb._unsafeRunSyncEither(on: parQueue2).run()
             group.leave()
         }
         
         group.enter()
         parQueue3.async {
-            c = self.fc._unsafeRunSyncEither(on: parQueue3)
+            c = self.fc._unsafeRunSyncEither(on: parQueue3).run()
             group.leave()
         }
         
         group.wait()
         if let aa = a, let bb = b, let cc = c {
-            return aa.flatMap { a in
-                bb.flatMap { b in
-                    cc.map { c in
-                        (Either<E, Z>.map(a.0, b.0, c.0, self.f)^, queue)
-                    }
-                }
-            }
+            return .done((Either.map(aa.0, bb.0, cc.0, self.f)^, queue))
         } else {
             fatalError("An operation finished without producing a result.") // Should never happen
         }


### PR DESCRIPTION
## Related issues

Introducing trampolining broke the parallelism in IO, as execution is sequenced in the suspension induced by the Trampoline.

## Goal

This PR brings back the parallelism to `race`, `parMap2` and `parMap3` implementations in `IO`. 