### PR TITLE
Add aliases for Ref and Resource

### DIFF
--- a/Sources/Bow/Arrow/Kleisli.swift
+++ b/Sources/Bow/Arrow/Kleisli.swift
@@ -143,6 +143,21 @@ extension Kleisli where F: Monad {
     }
 }
 
+// MARK: Functions when F has an instance of Monad.
+extension Kleisli where F: MonadError {
+    /// Folds over the result of this computation by accepting an effect to execute in case of error, and another one in the case of success.
+    ///
+    /// - Parameters:
+    ///   - f: Function to run in case of error.
+    ///   - g: Function to run in case of success.
+    /// - Returns: A computation from the result of applying the provided functions to the result of this computation.
+    func foldM<B>(
+        _ f: @escaping (F.E) -> Kleisli<F, D, B>,
+        _ g: @escaping (A) -> Kleisli<F, D, B>) -> Kleisli<F, D, B> {
+        self.flatMap(g).handleErrorWith(f)^
+    }
+}
+
 // MARK: Instance of Invariant for Kleisli
 extension KleisliPartial: Invariant where F: Functor {}
 

--- a/Sources/Bow/Arrow/Kleisli.swift
+++ b/Sources/Bow/Arrow/Kleisli.swift
@@ -145,13 +145,27 @@ extension Kleisli where F: Monad {
 
 // MARK: Functions when F has an instance of Monad.
 extension Kleisli where F: MonadError {
+    /// Folds over the result of this computation by accepting a function to execute in case of error, and another one in the case of success.
+    ///
+    /// - Parameters:
+    ///   - f: Function to run in case of error.
+    ///   - g: Function to run in case of success.
+    /// - Returns: A computation from the result of applying the provided functions to the result of this computation.
+    public func foldA<B>(
+        _ f: @escaping (F.E) -> B,
+        _ g: @escaping (A) -> B
+    ) -> Kleisli<F, D, B> {
+        foldM(f >>> Kleisli<F, D, B>.pure >>> Kleisli<F, D, B>.fix,
+              g >>> Kleisli<F, D, B>.pure >>> Kleisli<F, D, B>.fix)
+    }
+    
     /// Folds over the result of this computation by accepting an effect to execute in case of error, and another one in the case of success.
     ///
     /// - Parameters:
     ///   - f: Function to run in case of error.
     ///   - g: Function to run in case of success.
     /// - Returns: A computation from the result of applying the provided functions to the result of this computation.
-    func foldM<B>(
+    public func foldM<B>(
         _ f: @escaping (F.E) -> Kleisli<F, D, B>,
         _ g: @escaping (A) -> Kleisli<F, D, B>) -> Kleisli<F, D, B> {
         self.flatMap(g).handleErrorWith(f)^

--- a/Sources/BowEffects/Data/EnvIO.swift
+++ b/Sources/BowEffects/Data/EnvIO.swift
@@ -76,19 +76,6 @@ public extension Kleisli {
         self.run(d)^
     }
     
-    /// Folds over the result of this computation by accepting an effect to execute in case of error, and another one in the case of success.
-    ///
-    /// - Parameters:
-    ///   - f: Function to run in case of error.
-    ///   - g: Function to run in case of success.
-    /// - Returns: A computation from the result of applying the provided functions to the result of this computation.
-    func foldM<B, E: Error>(
-        _ f: @escaping (E) -> EnvIO<D, E, B>,
-        _ g: @escaping (A) -> EnvIO<D, E, B>) -> EnvIO<D, E, B>
-        where F == IOPartial<E> {
-        self.flatMap(g).handleErrorWith(f)^
-    }
-    
     /// Retries this computation if it fails based on the provided retrial policy.
     ///
     /// This computation will be at least executed once, and if it fails, it will be retried according to the policy.

--- a/Sources/BowEffects/Data/Ref.swift
+++ b/Sources/BowEffects/Data/Ref.swift
@@ -1,5 +1,11 @@
 import Bow
 
+/// IORef is an asynchronous, concurrent, mutable reference backed by IO, holding a value of type A. Provides safe concurrent access and modification of its content.
+public typealias IORef<E: Error, A> = Ref<IOPartial<E>, A>
+
+/// EnvIORef is an asynchronous, concurrent, mutable reference backed by EnvIO, holding a value of type A. Provides safe concurrent access and modification of its content.
+public typealias EnvIORef<D, E: Error, A> = Ref<EnvIOPartial<D, E>, A>
+
 /// Ref is an asynchronous, concurrent mutable reference in the context of `F` holding a value of type `A`. Provides safe concurrent access and modification of its content. `Ref`is a purely functional wrapper over an `Atomic<A>` in context `F` that is always initialized to a value.
 public class Ref<F, A> {
     /// Obtains the current value. Since `Ref` is always guaranteed to have a value, the returned action completes immetiately after being bound.

--- a/Sources/BowEffects/Data/Resource.swift
+++ b/Sources/BowEffects/Data/Resource.swift
@@ -1,5 +1,8 @@
 import Bow
 
+/// A Resource backed by IO
+public typealias IOResource<E: Error, A> = Resource<IOPartial<E>, A>
+
 /// Witness for the `Resource<F, A>` type. To be used in simulated Higher Data Types.
 public final class ForResource {}
 


### PR DESCRIPTION
## Goal

In order to enhance the ergonomics of using `Ref` and `Resource` when they are backed by `IO`, a couple of type aliases are introduced.

Besides this, `foldM` is moved from `EnvIO` to `Kleisli`, as it is applicable on more types than only `EnvIO`. A utility `foldA` is added as an alias to `foldM` for non-effectful functions.