### PR TITLE
Update swift5 2

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -11,6 +11,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+    - name: Switch Xcode version
+      run: sudo xcode-select -s /Applications/Xcode_11.4.1.app/Contents/Developer
     - name: Generate microsite
       run: |
         brew install nef

--- a/.github/workflows/nef-compile.yml
+++ b/.github/workflows/nef-compile.yml
@@ -8,6 +8,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+    - name: Switch Xcode version
+      run: sudo xcode-select -s /Applications/Xcode_11.4.1.app/Contents/Developer
     - name: Compile documentation
       run: |
         brew install nef

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -9,6 +9,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+    - name: Switch Xcode version
+      run: sudo xcode-select -s /Applications/Xcode_11.4.1.app/Contents/Developer
     - name: Run tests
       run: swift test
     - name: Generate linux tests

--- a/Bow.podspec
+++ b/Bow.podspec
@@ -24,5 +24,6 @@ Pod::Spec.new do |s|
   s.watchos.deployment_target = "2.0"
   s.source   = { :git => "https://github.com/bow-swift/bow.git", :tag => "#{s.version}" }
   s.source_files = "Sources/Bow/**/*.swift"
-  s.swift_versions = ["5.0", "5.1"]
+  s.swift_versions = ["5.2"]
+  s.pod_target_xcconfig = { 'ENABLE_TESTING_SEARCH_PATHS' => 'YES' }
 end

--- a/Bow.xcodeproj/project.pbxproj
+++ b/Bow.xcodeproj/project.pbxproj
@@ -234,7 +234,6 @@
 		11E7F5ED22D8C83800C78F06 /* Eval+Gen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11E7F5EB22D8C81B00C78F06 /* Eval+Gen.swift */; };
 		11E8E07A2395580F0029BC92 /* Array+TraverseConcurrent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11E8E0792395580F0029BC92 /* Array+TraverseConcurrent.swift */; };
 		11E9788E233A7123002AAC60 /* RxSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 11E9788D233A7123002AAC60 /* RxSwift */; };
-		11E97895233A720A002AAC60 /* SwiftCheck in Frameworks */ = {isa = PBXBuildFile; productRef = 11E97894233A720A002AAC60 /* SwiftCheck */; };
 		11ED7A2A226E094C00C27994 /* Result.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BA0F482217E2E9200969984 /* Result.swift */; };
 		11ED7A2B226E0A1F00C27994 /* ResultTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 112296D3219DC1EF006D66C5 /* ResultTest.swift */; };
 		11F0367F2327D08900B39A80 /* EffectComprehensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11F0367E2327D08900B39A80 /* EffectComprehensions.swift */; };
@@ -264,6 +263,7 @@
 		720C1DFF23FD804E001C5B7D /* Endo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 720C1DFE23FD804E001C5B7D /* Endo.swift */; };
 		720C1E0223FD808F001C5B7D /* Endo+Gen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 720C1E0023FD8079001C5B7D /* Endo+Gen.swift */; };
 		720C1E0423FD80AC001C5B7D /* EndoTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 720C1E0323FD80AB001C5B7D /* EndoTest.swift */; };
+		8B1AC5012458755D00EAC18E /* SwiftCheck in Frameworks */ = {isa = PBXBuildFile; productRef = 8B1AC5002458755D00EAC18E /* SwiftCheck */; };
 		8B79462624531CFE00547771 /* FileManager+iOS+Mac.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B79462524531CFE00547771 /* FileManager+iOS+Mac.swift */; };
 		8BA0F3E8217E2DEF00969984 /* BooleanFunctionsTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BA0F38A217E2DEF00969984 /* BooleanFunctionsTest.swift */; };
 		8BA0F3E9217E2DEF00969984 /* PartialApplicationTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BA0F38B217E2DEF00969984 /* PartialApplicationTest.swift */; };
@@ -1230,7 +1230,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 0;
 			files = (
-				11E97895233A720A002AAC60 /* SwiftCheck in Frameworks */,
+				8B1AC5012458755D00EAC18E /* SwiftCheck in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2260,7 +2260,7 @@
 			);
 			name = "Bow-Generators";
 			packageProductDependencies = (
-				11E97894233A720A002AAC60 /* SwiftCheck */,
+				8B1AC5002458755D00EAC18E /* SwiftCheck */,
 			);
 			productName = Bow;
 			productReference = 112097A922A7EBC7007F3D9C /* BowGenerators.framework */;
@@ -2773,7 +2773,7 @@
 			mainGroup = OBJ_5;
 			packageReferences = (
 				11E9788C233A7123002AAC60 /* XCRemoteSwiftPackageReference "RxSwift" */,
-				11E97891233A71E1002AAC60 /* XCRemoteSwiftPackageReference "SwiftCheck" */,
+				8B1AC4FF2458755D00EAC18E /* XCRemoteSwiftPackageReference "SwiftCheck" */,
 			);
 			productRefGroup = OBJ_218 /* Products */;
 			projectDirPath = "";
@@ -4612,6 +4612,7 @@
 				ENABLE_NS_ASSERTIONS = YES;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
+				ENABLE_TESTING_SEARCH_PATHS = YES;
 				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_OPTIMIZATION_LEVEL = 0;
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
@@ -4703,6 +4704,7 @@
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTING_SEARCH_PATHS = YES;
 				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_OPTIMIZATION_LEVEL = s;
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
@@ -4942,15 +4944,15 @@
 			repositoryURL = "https://github.com/ReactiveX/RxSwift";
 			requirement = {
 				kind = exactVersion;
-				version = 5.0.1;
+				version = 5.1.1;
 			};
 		};
-		11E97891233A71E1002AAC60 /* XCRemoteSwiftPackageReference "SwiftCheck" */ = {
+		8B1AC4FF2458755D00EAC18E /* XCRemoteSwiftPackageReference "SwiftCheck" */ = {
 			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/typelift/SwiftCheck";
+			repositoryURL = "https://github.com/bow-swift/SwiftCheck.git";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 0.12.0;
+				minimumVersion = 0.12.1;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */
@@ -4961,9 +4963,9 @@
 			package = 11E9788C233A7123002AAC60 /* XCRemoteSwiftPackageReference "RxSwift" */;
 			productName = RxSwift;
 		};
-		11E97894233A720A002AAC60 /* SwiftCheck */ = {
+		8B1AC5002458755D00EAC18E /* SwiftCheck */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 11E97891233A71E1002AAC60 /* XCRemoteSwiftPackageReference "SwiftCheck" */;
+			package = 8B1AC4FF2458755D00EAC18E /* XCRemoteSwiftPackageReference "SwiftCheck" */;
 			productName = SwiftCheck;
 		};
 /* End XCSwiftPackageProductDependency section */

--- a/Bow.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Bow.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -2,48 +2,21 @@
   "object": {
     "pins": [
       {
-        "package": "Chalk",
-        "repositoryURL": "https://github.com/mxcl/Chalk.git",
-        "state": {
-          "branch": null,
-          "revision": "9aa9f348b86db3cf6702a3e43c081ecec80cf3c7",
-          "version": "0.4.0"
-        }
-      },
-      {
-        "package": "FileCheck",
-        "repositoryURL": "https://github.com/llvm-swift/FileCheck.git",
-        "state": {
-          "branch": null,
-          "revision": "9ed91cc30a1a325d989fac117f3f3065a16b9f76",
-          "version": "0.2.3"
-        }
-      },
-      {
         "package": "RxSwift",
         "repositoryURL": "https://github.com/ReactiveX/RxSwift",
         "state": {
           "branch": null,
-          "revision": "b3e888b4972d9bc76495dd74d30a8c7fad4b9395",
-          "version": "5.0.1"
-        }
-      },
-      {
-        "package": "swift-tools-support-core",
-        "repositoryURL": "https://github.com/apple/swift-tools-support-core.git",
-        "state": {
-          "branch": null,
-          "revision": "693aba4c4c9dcc4767cc853a0dd38bf90ad8c258",
-          "version": "0.0.1"
+          "revision": "002d325b0bdee94e7882e1114af5ff4fe1e96afa",
+          "version": "5.1.1"
         }
       },
       {
         "package": "SwiftCheck",
-        "repositoryURL": "https://github.com/typelift/SwiftCheck",
+        "repositoryURL": "https://github.com/bow-swift/SwiftCheck.git",
         "state": {
           "branch": null,
-          "revision": "077c096c3ddfc38db223ac8e525ad16ffb987138",
-          "version": "0.12.0"
+          "revision": "748359f9a95edf94d0c4664102f104f56b1ff1fb",
+          "version": "0.12.1"
         }
       }
     ]

--- a/BowEffects.podspec
+++ b/BowEffects.podspec
@@ -25,5 +25,6 @@ Pod::Spec.new do |s|
   s.source   = { :git => "https://github.com/bow-swift/bow.git", :tag => "#{s.version}" }
   s.source_files = "Sources/BowEffects/**/*.swift"
   s.dependency "Bow", "~> #{s.version}"
-  s.swift_versions = ["5.0", "5.1"]
+  s.swift_versions = ["5.2"]
+  s.pod_target_xcconfig = { 'ENABLE_TESTING_SEARCH_PATHS' => 'YES' }
 end

--- a/BowEffectsGenerators.podspec
+++ b/BowEffectsGenerators.podspec
@@ -26,6 +26,6 @@ Pod::Spec.new do |s|
   s.dependency "Bow", "~> #{s.version}"
   s.dependency "BowGenerators", "~> #{s.version}"
   s.dependency "BowEffects", "~> #{s.version}"
-  s.dependency "SwiftCheck", "~> 0.12.0"
-  s.swift_versions = ["5.0", "5.1"]
+  s.swift_versions = ["5.2"]
+  s.pod_target_xcconfig = { 'ENABLE_TESTING_SEARCH_PATHS' => 'YES' }
 end

--- a/BowEffectsLaws.podspec
+++ b/BowEffectsLaws.podspec
@@ -26,6 +26,6 @@ Pod::Spec.new do |s|
   s.dependency "Bow", "~> #{s.version}"
   s.dependency "BowEffects", "~> #{s.version}"
   s.dependency "BowLaws", "~> #{s.version}"
-  s.dependency "SwiftCheck", "~> 0.12.0"
-  s.swift_versions = ["5.0", "5.1"]
+  s.swift_versions = ["5.2"]
+  s.pod_target_xcconfig = { 'ENABLE_TESTING_SEARCH_PATHS' => 'YES' }
 end

--- a/BowFree.podspec
+++ b/BowFree.podspec
@@ -25,5 +25,6 @@ Pod::Spec.new do |s|
   s.source   = { :git => "https://github.com/bow-swift/bow.git", :tag => "#{s.version}" }
   s.source_files = "Sources/BowFree/**/*.swift"
   s.dependency "Bow", "~> #{s.version}"
-  s.swift_versions = ["5.0", "5.1"]
+  s.swift_versions = ["5.2"]
+  s.pod_target_xcconfig = { 'ENABLE_TESTING_SEARCH_PATHS' => 'YES' }
 end

--- a/BowFreeGenerators.podspec
+++ b/BowFreeGenerators.podspec
@@ -26,6 +26,6 @@ Pod::Spec.new do |s|
   s.dependency "Bow", "~> #{s.version}"
   s.dependency "BowGenerators", "~> #{s.version}"
   s.dependency "BowFree", "~> #{s.version}"
-  s.dependency "SwiftCheck", "~> 0.12.0"
-  s.swift_versions = ["5.0", "5.1"]
+  s.swift_versions = ["5.2"]
+  s.pod_target_xcconfig = { 'ENABLE_TESTING_SEARCH_PATHS' => 'YES' }
 end

--- a/BowGenerators.podspec
+++ b/BowGenerators.podspec
@@ -25,5 +25,6 @@ Pod::Spec.new do |s|
   s.source_files = "Tests/BowGenerators/**/*.swift"
   s.dependency "Bow", "~> #{s.version}"
   s.dependency "SwiftCheck", "~> 0.12.0"
-  s.swift_versions = ["5.0", "5.1"]
+  s.swift_versions = ["5.2"]
+  s.pod_target_xcconfig = { 'ENABLE_TESTING_SEARCH_PATHS' => 'YES' }
 end

--- a/BowGeneric.podspec
+++ b/BowGeneric.podspec
@@ -25,5 +25,6 @@ Pod::Spec.new do |s|
   s.source   = { :git => "https://github.com/bow-swift/bow.git", :tag => "#{s.version}" }
   s.source_files = "Sources/BowGeneric/**/*.swift"
   s.dependency "Bow", "~> #{s.version}"
-  s.swift_versions = ["5.0", "5.1"]
+  s.swift_versions = ["5.2"]
+  s.pod_target_xcconfig = { 'ENABLE_TESTING_SEARCH_PATHS' => 'YES' }
 end

--- a/BowLaws.podspec
+++ b/BowLaws.podspec
@@ -25,6 +25,6 @@ Pod::Spec.new do |s|
   s.source_files = "Tests/BowLaws/**/*.swift"
   s.dependency "Bow", "~> #{s.version}"
   s.dependency "BowGenerators", "~> #{s.version}"
-  s.dependency "SwiftCheck", "~> 0.12.0"
-  s.swift_versions = ["5.0", "5.1"]
+  s.swift_versions = ["5.2"]
+  s.pod_target_xcconfig = { 'ENABLE_TESTING_SEARCH_PATHS' => 'YES' }
 end

--- a/BowOptics.podspec
+++ b/BowOptics.podspec
@@ -25,5 +25,6 @@ Pod::Spec.new do |s|
   s.source   = { :git => "https://github.com/bow-swift/bow.git", :tag => "#{s.version}" }
   s.source_files = "Sources/BowOptics/**/*.swift"
   s.dependency "Bow", "~> #{s.version}"
-  s.swift_versions = ["5.0", "5.1"]
+  s.swift_versions = ["5.2"]
+  s.pod_target_xcconfig = { 'ENABLE_TESTING_SEARCH_PATHS' => 'YES' }
 end

--- a/BowOpticsLaws.podspec
+++ b/BowOpticsLaws.podspec
@@ -26,6 +26,6 @@ Pod::Spec.new do |s|
   s.dependency "Bow", "~> #{s.version}"
   s.dependency "BowOptics", "~> #{s.version}"
   s.dependency "BowLaws", "~> #{s.version}"
-  s.dependency "SwiftCheck", "~> 0.12.0"
-  s.swift_versions = ["5.0", "5.1"]
+  s.swift_versions = ["5.2"]
+  s.pod_target_xcconfig = { 'ENABLE_TESTING_SEARCH_PATHS' => 'YES' }
 end

--- a/BowRecursionSchemes.podspec
+++ b/BowRecursionSchemes.podspec
@@ -25,5 +25,6 @@ Pod::Spec.new do |s|
   s.source   = { :git => "https://github.com/bow-swift/bow.git", :tag => "#{s.version}" }
   s.source_files = "Sources/BowRecursionSchemes/**/*.swift"
   s.dependency "Bow", "~> #{s.version}"
-  s.swift_versions = ["5.0", "5.1"]
+  s.swift_versions = ["5.2"]
+  s.pod_target_xcconfig = { 'ENABLE_TESTING_SEARCH_PATHS' => 'YES' }
 end

--- a/BowRx.podspec
+++ b/BowRx.podspec
@@ -24,8 +24,9 @@ Pod::Spec.new do |s|
   #s.watchos.deployment_target = "3.0"
   s.source   = { :git => "https://github.com/bow-swift/bow.git", :tag => "#{s.version}" }
   s.source_files = "Sources/BowRx/**/*.swift"
-  s.dependency "RxSwift", "~> 5.0.0"
+  s.dependency "RxSwift", "~> 5.1.1"
   s.dependency "Bow", "~> #{s.version}"
   s.dependency "BowEffects", "~> #{s.version}"
-  s.swift_versions = ["5.0", "5.1"]
+  s.swift_versions = ["5.2"]
+  s.pod_target_xcconfig = { 'ENABLE_TESTING_SEARCH_PATHS' => 'YES' }
 end

--- a/BowRxGenerators.podspec
+++ b/BowRxGenerators.podspec
@@ -26,6 +26,6 @@ Pod::Spec.new do |s|
   s.dependency "Bow", "~> #{s.version}"
   s.dependency "BowGenerators", "~> #{s.version}"
   s.dependency "BowRx", "~> #{s.version}"
-  s.dependency "SwiftCheck", "~> 0.12.0"
-  s.swift_versions = ["5.0", "5.1"]
+  s.swift_versions = ["5.2"]
+  s.pod_target_xcconfig = { 'ENABLE_TESTING_SEARCH_PATHS' => 'YES' }
 end

--- a/Documentation.app/Contents/MacOS/Documentation.xcodeproj/project.pbxproj
+++ b/Documentation.app/Contents/MacOS/Documentation.xcodeproj/project.pbxproj
@@ -70,7 +70,6 @@
 				E7F0426F773A6391A13F562E /* Pods-Documentation.debug.xcconfig */,
 				1454FD0611377949FA76450F /* Pods-Documentation.release.xcconfig */,
 			);
-			name = Pods;
 			path = Pods;
 			sourceTree = "<group>";
 		};
@@ -222,6 +221,7 @@
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
+				ENABLE_TESTING_SEARCH_PATHS = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_NO_COMMON_BLOCKS = YES;
@@ -283,6 +283,7 @@
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTING_SEARCH_PATHS = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;

--- a/Documentation.app/Contents/MacOS/Podfile.lock
+++ b/Documentation.app/Contents/MacOS/Podfile.lock
@@ -12,7 +12,6 @@ PODS:
   - BowLaws (0.7.0):
     - Bow (~> 0.7.0)
     - BowGenerators (~> 0.7.0)
-    - SwiftCheck (~> 0.12.0)
   - BowOptics (0.7.0):
     - Bow (~> 0.7.0)
   - BowRecursionSchemes (0.7.0):
@@ -20,8 +19,8 @@ PODS:
   - BowRx (0.7.0):
     - Bow (~> 0.7.0)
     - BowEffects (~> 0.7.0)
-    - RxSwift (~> 5.0.0)
-  - RxSwift (5.0.1)
+    - RxSwift (~> 5.1.1)
+  - RxSwift (5.1.1)
   - SwiftCheck (0.12.0)
 
 DEPENDENCIES:
@@ -61,16 +60,16 @@ EXTERNAL SOURCES:
     :path: "../../.."
 
 SPEC CHECKSUMS:
-  Bow: 3561cae6b993e4c37f507e03dd89859538d8ec12
-  BowEffects: 235d503f2e438ab9fdf84e074f586c806d8dec31
-  BowFree: 2c0ef44f40bf12f63edc8b60ec881fada1145dfd
-  BowGenerators: 479762cf6c53823839c94064030c6c1b3a422000
-  BowGeneric: 8ad67728410b2a50cf681b3bfbf92b86b6b8a07b
-  BowLaws: f19bd7a14facb1a244f27ae6a682a070830adcf4
-  BowOptics: 1d6c742c8144117b7ff76d2ce14839aac2619d82
-  BowRecursionSchemes: a62b201be5440e95e2e514b08c163e55e5dc9195
-  BowRx: 9b0e395c92f47f2c7f6f8b4a42adf37ffd5c897a
-  RxSwift: e2dc62b366a3adf6a0be44ba9f405efd4c94e0c4
+  Bow: 127c3610954b35c8c6ce658c7a848e9531ca21c7
+  BowEffects: 07cd4ea94b5dbe5099cff4b38e65d3166964a1b5
+  BowFree: fa1dde3f87dac4f4cae04d2edcdc1f1c104b17ab
+  BowGenerators: ef32524d1b7a50b8a81811dddcfe9396a71b1a45
+  BowGeneric: c98295526a7b343bc54e983e84f726f60072fd94
+  BowLaws: 610f7b92204521645ef7ff32908f21698f1a3bff
+  BowOptics: f5852ef0b4f1a150462e73719d4f06d57c2e2389
+  BowRecursionSchemes: dbb39bf4cb2366abe57f63726381f93a98faf591
+  BowRx: 11afda46a34f1aa65e84134e7828d70df8fe862a
+  RxSwift: 81470a2074fa8780320ea5fe4102807cb7118178
   SwiftCheck: d1dd04d955cc76620b0f84e087536bd059a11c24
 
 PODFILE CHECKSUM: efc76df00ffc116ebc2aec3dee074047d2d970d0

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.1
+// swift-tools-version:5.2
 import PackageDescription
 
 extension Target {

--- a/Tests/BowOpticsTests/PrismTest.swift
+++ b/Tests/BowOpticsTests/PrismTest.swift
@@ -133,6 +133,13 @@ class PrismTest: XCTestCase {
         let result = prism.getOption(.authorized(8, "information")).toOptional() ?? (0, "")
         XCTAssertTrue(result == (8, "information"))
     }
+    
+    func testAutoDerivatePrism_WithComplexAssociatedTypes() {
+        let auto = ParentAction.prism(for: ParentAction.child)
+        let action = ParentAction.child(child: .changeColor)
+        let c1 = auto.getOptional(action)
+        XCTAssertEqual(c1, .changeColor)
+    }
 
     func testAutoDerivatePrism_WithLabeledAssociatedTypes() {
         let prism = Authentication.prism(for: Authentication.requested)

--- a/Tests/BowOpticsTests/TestDomain.swift
+++ b/Tests/BowOpticsTests/TestDomain.swift
@@ -98,10 +98,17 @@ enum StringStyle {
 }
 
 
-// MARK: - Authentication <testing>
+// MARK: - Prism models <testing>
 enum Authentication: AutoPrism {
     case unathorized(String)
     case authorized(Int, String)
     case requested(Int, info: String)
     case unkown
+}
+
+enum ChildAction {
+    case changeColor
+}
+enum ParentAction: AutoPrism {
+    case child(child: ChildAction)
 }


### PR DESCRIPTION
## Details
Fix Xcode project to support Swift 5.2+. Also, if solves a bug in enums -previous version of Swift 5.2- it affects to auto-prisms.

## CI
**nef compiler** is failing because we need to release a new nef version to support link to XCTestSwiftSupport lib [currently work in progress]