### PR TITLE
Leverage Swift 5.2 features

### DIFF
--- a/Sources/Bow/Arrow/Cokleisli.swift
+++ b/Sources/Bow/Arrow/Cokleisli.swift
@@ -38,6 +38,14 @@ public class Cokleisli<F, A, B>: CokleisliOf<F, A, B> {
     public func contramapValue<C>(_ f: @escaping (Kind<F, C>) -> Kind<F, A>) -> Cokleisli<F, C, B> {
         Cokleisli<F, C, B> { fc in self.run(f(fc)) }
     }
+    
+    /// Invokes this function.
+    ///
+    /// - Parameter value: Input to the function.
+    /// - Returns: Output of the function.
+    public func callAsFunction(_ value: Kind<F, A>) -> B {
+        run(value)
+    }
 }
 
 /// Safe downcast.

--- a/Sources/Bow/Arrow/Function0.swift
+++ b/Sources/Bow/Arrow/Function0.swift
@@ -34,6 +34,13 @@ public final class Function0<A>: Function0Of<A> {
     public func invoke() -> A {
         f()
     }
+    
+    /// Invokes the function.
+    ///
+    /// - Returns: Value produced by this function.
+    public func callAsFunction() -> A {
+        f()
+    }
 }
 
 /// Safe downcast.

--- a/Sources/Bow/Arrow/Function1.swift
+++ b/Sources/Bow/Arrow/Function1.swift
@@ -35,6 +35,14 @@ public final class Function1<I, O>: Function1Of<I, O> {
     public func invoke(_ value: I) -> O {
         f(value)
     }
+    
+    /// Invokes this function.
+    ///
+    /// - Parameter value: Input to the function.
+    /// - Returns: Result of invoking the function.
+    public func callAsFunction(_ value: I) -> O {
+        f(value)
+    }
 
     /// Composes with another function.
     ///

--- a/Sources/Bow/Arrow/FunctionK.swift
+++ b/Sources/Bow/Arrow/FunctionK.swift
@@ -14,6 +14,14 @@ open class FunctionK<F, G> {
     open func invoke<A>(_ fa: Kind<F, A>) -> Kind<G, A> {
         fatalError("FunctionK.invoke must be implemented in subclasses")
     }
+    
+    /// Invokes this transformation.
+    ///
+    /// - Parameter fa: Input to this function
+    /// - Returns: Transformed input.
+    public func callAsFunction<A>(_ fa: Kind<F, A>) -> Kind<G, A> {
+        invoke(fa)
+    }
 
     /// Composes this function with another one.
     ///

--- a/Sources/Bow/Arrow/Kleisli.swift
+++ b/Sources/Bow/Arrow/Kleisli.swift
@@ -50,12 +50,20 @@ public final class Kleisli<F, D, A>: KleisliOf<F, D, A> {
         f(value)
     }
     
+    /// Inkoves this Kleisli function with an input value.
+    ///
+    /// - Parameter value: Input to the function.
+    /// - Returns: Output of the Kleisli.
+    public func callAsFunction(_ value: D) -> Kind<F, A> {
+        f(value)
+    }
+    
     /// Pre-composes this Kleisli function with a function transforming the input type.
     ///
     /// - Parameter f: Transforming function.
     /// - Returns: Composition of the two functions.
     public func contramap<DD>(_ f: @escaping (DD) -> D) -> Kleisli<F, DD, A> {
-        Kleisli<F, DD, A> { d in self.run(f(d)) }
+        Kleisli<F, DD, A> { d in self(f(d)) }
     }
     
     /// Narrows the scope of the context of this Kleisli from `Any` to a concrete type

--- a/Sources/Bow/Arrow/Kleisli.swift
+++ b/Sources/Bow/Arrow/Kleisli.swift
@@ -58,14 +58,6 @@ public final class Kleisli<F, D, A>: KleisliOf<F, D, A> {
         Kleisli<F, DD, A> { d in self.run(f(d)) }
     }
     
-    /// Pre-composes this Kleisli function with a function transforming the input type obtained from a key path.
-    ///
-    /// - Parameter f: Transforming function.
-    /// - Returns: Composition of the two functions.
-    public func contramap<DD>(_ keyPath: KeyPath<DD, D>) -> Kleisli<F, DD, A> {
-        Kleisli<F, DD, A> { d in self.run(d[keyPath: keyPath]) }
-    }
-    
     /// Narrows the scope of the context of this Kleisli from `Any` to a concrete type
     ///
     /// - Returns: A copy of this Kleisli working on a more precise context.

--- a/Sources/Bow/Data/Endo.swift
+++ b/Sources/Bow/Data/Endo.swift
@@ -25,6 +25,14 @@ public final class Endo<A>: EndoOf<A> {
     public init(_ run: @escaping (A) -> A) {
         self.run = run
     }
+    
+    /// Invokes this endo-function.
+    ///
+    /// - Parameter value: Input to the function.
+    /// - Returns: Output of the function.
+    public func callAsFunction(_ value: A) -> A {
+        run(value)
+    }
 }
 
 // MARK: Instance of `Semigroup` for `Endo`

--- a/Sources/Bow/Transformers/TracedT.swift
+++ b/Sources/Bow/Transformers/TracedT.swift
@@ -66,6 +66,14 @@ extension TracedT where W == ForId {
     public convenience init(_ f: @escaping (M) -> A) {
         self.init(Id(f))
     }
+    
+    /// Invokes this function.
+    ///
+    /// - Parameter input: Input to the function.
+    /// - Returns: Output of the function.
+    public func callAsFunction(_ input: M) -> A {
+        self.value^.value(input)
+    }
 }
 
 // MARK: Instance of Invariant for TracedT

--- a/Sources/Bow/Typeclasses/Functor.swift
+++ b/Sources/Bow/Typeclasses/Functor.swift
@@ -34,18 +34,6 @@ public extension Functor {
         _ g: @escaping (B) -> A) -> Kind<Self, B> {
         map(fa, f)
     }
-    
-    /// Creates a new value transforming the type using the provided key path, preserving the structure of the original type.
-    ///
-    /// - Parameters:
-    ///   - fa: A value in the context of the type implementing this instance of `Functor`.
-    ///   - keyPath: A key path.
-    /// - Returns: The result of transforming the value type using the provided function, maintaining the structure of the original value.
-    static func map<A, B>(
-        _ fa: Kind<Self, A>,
-        _ keyPath: KeyPath<A, B>) -> Kind<Self, B> {
-        map(fa, { a in a[keyPath: keyPath] })
-    }
 
     /// Given a function, provides a new function lifted to the context type implementing this instance of `Functor`.
     ///
@@ -124,17 +112,6 @@ public extension Kind where F: Functor {
     /// - Returns: The result of transforming the value type using the provided function, maintaining the structure of the original value.
     func map<B>(_ f: @escaping (A) -> B) -> Kind<F, B> {
         F.map(self, f)
-    }
-    
-    /// Creates a new value transforming the type using the provided key path, preserving the structure of the original type.
-    ///
-    /// This is a convenience method to call `Functor.map` as an instance method in this type.
-    ///
-    /// - Parameters:
-    ///   - keyPath: A key path.
-    /// - Returns: The result of transforming the value type using the provided function, maintaining the structure of the original value.
-    func map<B>(_ keyPath: KeyPath<A, B>) -> Kind<F, B> {
-        F.map(self, keyPath)
     }
 
     /// Given a function, provides a new function lifted to the context type implementing this instance of `Functor`.


### PR DESCRIPTION
## Goal

Take advantage of features introduced in Swift 5.2, such as:

- KeyPaths as functions: this was already supported, in some types in Bow, so these specific overloads are removed as the default, function-based ones are compatible with KeyPaths.
- `callAsFunction`: types wrapping functions include this feature to be able to be invoked as a function. For instance, a Kleisli function can be invoked as `kleisli(x)` instead of `kleisli.run(x)`.