### PR TITLE
Queue sync operation

### DIFF
--- a/Sources/BowEffects/Data/Internal/Queue.swift
+++ b/Sources/BowEffects/Data/Internal/Queue.swift
@@ -83,10 +83,6 @@ internal extension DispatchQueue {
 
 internal extension DispatchQueue {
     static var currentLabel: String {
-        guard let label = DispatchQueue.getSpecific(key: Queue.Key.threadLabel) else {
-            fatalError("BowEffects must use internally 'Queue' instead of 'DispatchQueue'")
-        }
-        
-        return label
+        DispatchQueue.getSpecific(key: Queue.Key.threadLabel) ?? "unknown-\(Date().timeIntervalSince1970)"
     }
 }


### PR DESCRIPTION
## Details
Remove insecure code in `Queue`. 

Changes:
1. **sync** work: in case of **unknown** thread, we will run work in a given queue.
2. `DispatchQueue.currentLabel` gives you a random value. 

**BowEffectsLaws** guarantees we are using the Queue constructors (internally in the lib)