### PR TITLE
Swift playgrounds

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -15,7 +15,8 @@ jobs:
       run: sudo xcode-select -s /Applications/Xcode_11.4.1.app/Contents/Developer
     - name: Generate microsite
       run: |
-        brew install https://raw.githubusercontent.com/bow-swift/homebrew-nef/master/nef.rb
+        brew update
+        brew install nef
         brew install sourcekitten
         gem install bundler -v 2.0.2
         gem install cocoapods -v 1.9.1

--- a/.github/workflows/nef-compile.yml
+++ b/.github/workflows/nef-compile.yml
@@ -12,6 +12,7 @@ jobs:
       run: sudo xcode-select -s /Applications/Xcode_11.4.1.app/Contents/Developer
     - name: Compile documentation
       run: |
-        brew install https://raw.githubusercontent.com/bow-swift/homebrew-nef/master/nef.rb
+        brew update
+        brew install nef
         gem install cocoapods -v 1.9.1
         nef compile --project Documentation.app

--- a/Sources/Bow/Typeclasses/Foldable.swift
+++ b/Sources/Bow/Typeclasses/Foldable.swift
@@ -71,7 +71,7 @@ public extension Foldable {
                 option^.fold({ Eval.later({ Option.some(f(a)) }) },
                              { b in g(a, Eval.now(b)).map(Option.some)^ })
             })^
-        }).map { x in x^ }^
+        }).map { x in Option.fix(x) }^
     }
 
     /// Reduces the elements of a structure down to a single value by applying the provided aggregation function in a left-associative manner.


### PR DESCRIPTION
Make bow compatibles with Swift Playgrounds. Fix foldable inference in `reduceRightToOption` method.