### PR TITLE
BracketIO - defer execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,6 @@
 ![](https://github.com/bow-swift/bow-art/blob/master/assets/bow-header-github.png?raw=true)
 
 <p align="center">
-<a href="https://travis-ci.org/bow-swift/bow">
-<img src="https://travis-ci.org/bow-swift/bow.svg?branch=master">
-</a>
 <a href="https://codecov.io/gh/bow-swift/bow">
 <img src="https://codecov.io/gh/bow-swift/bow/branch/master/graph/badge.svg">
 </a>

--- a/Sources/BowEffects/Data/IO.swift
+++ b/Sources/BowEffects/Data/IO.swift
@@ -653,7 +653,8 @@ internal class BracketIO<E: Error, A, B>: IO<E, B> {
                 { res in
                     do {
                         return try self.use(res)
-                            .flatTap { _ in self.release(res, .completed) }^
+                            .flatTap { _ in self.release(res, .completed) }
+                            .flatTapError { e in self.release(res, .error(e)) }^
                             ._unsafeRunSyncEither(on: queue)
                     } catch let error as E {
                         let _ = self.release(res, .error(error))^._unsafeRunSyncEither(on: queue)

--- a/Sources/BowEffects/Data/IO.swift
+++ b/Sources/BowEffects/Data/IO.swift
@@ -652,9 +652,9 @@ internal class BracketIO<E: Error, A, B>: IO<E, B> {
                 { e in Trampoline.done((.left(e), ioRes.1)) },
                 { res in
                     do {
-                        let useResult = try self.use(res)^._unsafeRunSyncEither(on: queue)
-                        let _ = self.release(res, .completed)^._unsafeRunSyncEither(on: queue)
-                        return useResult
+                        return try self.use(res)
+                            .flatTap { _ in self.release(res, .completed) }^
+                            ._unsafeRunSyncEither(on: queue)
                     } catch let error as E {
                         let _ = self.release(res, .error(error))^._unsafeRunSyncEither(on: queue)
                         return .done((.left(error), queue))


### PR DESCRIPTION
## Goal

This PR fixes a bug in IO resources execution. `BracketIO` should execute `release` after `use` execution has been completed.
