### PR TITLE
Add try-with-ipad badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 <img src="https://badges.gitter.im/bowswift/bow.svg">
 </a>
 <img src="https://img.shields.io/badge/platform-macos%20%7C%20ios%20%7C%20watchos%20%7C%20tvos%20%7C%20linux-success">
+<a href="https://badge.bow-swift.io/recipe?name=bow&description=Bow%20is%20a%20cross-platform%20library%20for%20Typed%20Functional%20Programming%20in%20Swift&url=https://github.com/bow-swift/bow&owner=bow-swift&avatar=https://avatars3.githubusercontent.com/u/44965417?v=4&tag=0.8.0"><img src="https://raw.githubusercontent.com/bow-swift/bow-art/master/badges/nef-playgrounds-badge.svg" alt="bow Playground" style="height:20px"></a>
 </p>
 
 Bow is a cross-platform library for Typed Functional Programming in Swift.


### PR DESCRIPTION
Enable `try it with iPad` badge in Bow repository.

- **Repo** Bow
- **Tag** 0.8.0

![Screen Shot 2020-08-03 at 18 00 28](https://user-images.githubusercontent.com/25568562/89202437-3a2b4d00-d5b3-11ea-9d1c-4236d60d395f.png)