### PR TITLE
Conform Option to ExpressibleByNilLiteral protocol

### DIFF
--- a/Sources/Bow/Data/Option.swift
+++ b/Sources/Bow/Data/Option.swift
@@ -39,7 +39,7 @@ public final class Option<A>: OptionOf<A> {
         Option(a)
     }
 
-    private init(_ value: A?) {
+    fileprivate init(_ value: A?) {
         self.value = value
     }
 
@@ -429,4 +429,10 @@ extension BidirectionalCollection {
     public func singleOrNone(_ predicate: (Element) -> Bool) -> Option<Element> {
         self.filter(predicate).singleOrNone
     }
+}
+
+extension Option: ExpressibleByNilLiteral {
+   public convenience init(nilLiteral: ()) {
+      self.init(nil)
+   }
 }

--- a/Tests/BowTests/Data/OptionTest.swift
+++ b/Tests/BowTests/Data/OptionTest.swift
@@ -110,4 +110,47 @@ class OptionTest: XCTestCase {
             option.exists(predicate.getArrow) == option.forall(predicate.getArrow) || option.isEmpty
         }
     }
+   
+   func testExpressibleByNilLiteralDirectNilAssignmentForLet() {
+      let none: Option<Int> = nil
+      XCTAssertEqual(none, Option<Int>.none())
+   }
+   
+   func testExpressibleByNilLiteralDirectNilAssignmentForVar() {
+      var none: Option<String> = nil
+      XCTAssertEqual(none, Option<String>.none())
+   }
+   
+   func testExpressibleByNilLiteralDefaultInitializationForEmbeddedOption() {
+      // This test is primarily for the type checker
+      let noneLet: Option<Option<[Int]>>
+      if (constant(true)()) {
+         noneLet = Option.some(Option.some([10]))
+      } else {
+         noneLet = nil
+      }
+      XCTAssertEqual(noneLet, Option.some(Option.some([10])))
+   }
+   
+   func testExpressibleByNilLiteralEquality() {
+      var optionInt: Option<Int> = nil
+      XCTAssertEqual(optionInt, nil)
+      optionInt = .some(10)
+      XCTAssertEqual(optionInt, .some(10))
+   }
+   
+   func testExpressibleByNilLiteralSwitch() {
+      let optionInt: Option<Int> = nil
+      switch optionInt {
+      case Option.some(10): XCTFail("Should not match Option.some(10)")
+      case nil: XCTAssert(true)
+      default: break
+      }
+   }
+   
+   func testExpressibleByNilLiteralInFunctionArguments() {
+      func testFn<A, B>(_ a: Option<A>, _ b: Option<B> = nil) -> Option<(A,B)> { Option.zip(a, b)^ }
+      let result: Option<(Int, String)> = testFn(nil)
+      XCTAssertEqual(result.map { (a,b) in "\(a)\(b)" }, Option<String>.none())
+   }
 }


### PR DESCRIPTION
Adds an ability to use nil values where `Option<A>` values are expected, converting them to `Option<A>.none()` automatically. 

Works in assignments, function call arguments, function default argument values, etc.

## Usage Examples

#### Nil assignment to `Option<A>`
```swift
let a: Option<A> = nil 
// is equivalent to
let a: Option<A> = Option.none()
```

#### Function call argument values
```swift
func test(a: Option<A>, b: Option<B> = nil) { ... }
test(nil) 
// is equivalent to
func test(a: Option<A>, b: Option<B> = Option.none()) { ... }
test(Option.none()) 
```

## Goal

Make Bow's `Option` type feel more native to Swift, similar to how `Optional` behaves in Bow Lite.

## Implementation details

Surprisingly simple conformance to `ExpressibleByNilLiteral` was enough to get both the nil assignment to act as `Option<A>.none()` assignment *and* default initialization values for `Option<A>` variables. I did have to change access control from private to `fileprivate` on `Option` class in order to have `ExpressibleByNilLiteral` conformance done as an extension to fit the existing code styles.

## Testing details

I was unable to compile the test suite (without my changes), due to compilation time outs in BowLaws code in the `ApplicativeLaws` class. I did however write the tests and made sure they work on a different codebase.
