### PR TITLE
Include Generic module in Package

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,218 +1,26 @@
 // swift-tools-version:5.2
 import PackageDescription
 
-extension Target {
-    var asDependency: Target.Dependency {
-        .target(name: name)
-    }
-}
-
-// MARK: - Libraries
-extension Target {
-    static var libraries: [Target] {
-        [
-            .bow,
-            .bowOptics,
-            .bowRecursionSchemes,
-            .bowFree,
-            .bowGeneric,
-            .bowEffects,
-            .bowRx,
-        ]
-    }
-
-    static var bow: Target {
-        .target(name: "Bow")
-    }
-
-    static var bowOptics: Target {
-        .target(name: "BowOptics",
-                dependencies: [Target.bow.asDependency])
-    }
-
-    static var bowEffects: Target {
-        #if os(Linux)
-        return .target(name: "BowEffects",
-                       dependencies: [Target.bow.asDependency],
-                       exclude: ["Foundation/FileManager+iOS+Mac.swift"])
-        #else
-        return .target(name: "BowEffects",
-                       dependencies: [Target.bow.asDependency])
-        #endif
-    }
-
-    static var bowRecursionSchemes: Target {
-        .target(name: "BowRecursionSchemes",
-                dependencies: [Target.bow.asDependency])
-    }
-
-    static var bowFree: Target {
-        .target(name: "BowFree",
-                dependencies: [Target.bow.asDependency])
-    }
-
-    static var bowGeneric: Target {
-        .target(name: "BowGeneric",
-                dependencies: [Target.bow.asDependency])
-    }
-
-    static var bowRx: Target {
-        .target(name: "BowRx",
-                dependencies: [Target.bow.asDependency,
-                               Target.bowEffects.asDependency,
-                               .product(name: "RxSwift", package: "RxSwift"),
-                               .product(name: "RxCocoa", package: "RxSwift")])
-    }
-}
-
-// MARK: - Laws
-extension Target {
-    static var laws: [Target] {
-        [
-            .bowLaws,
-            .bowEffectsLaws,
-            .bowOpticsLaws,
-        ]
-    }
-
-    static var bowLaws: Target {
-        .target(name:"BowLaws",
-                dependencies: [Target.bowGenerators.asDependency],
-                path: "Tests/BowLaws")
-    }
-
-    static var bowEffectsLaws: Target {
-        .target(name:"BowEffectsLaws",
-                dependencies: [Target.bowEffects.asDependency,
-                               Target.bowLaws.asDependency],
-                path: "Tests/BowEffectsLaws")
-    }
-
-    static var bowOpticsLaws: Target {
-        .target(name:"BowOpticsLaws",
-                dependencies: [Target.bowOptics.asDependency,
-                               Target.bowLaws.asDependency],
-                path: "Tests/BowOpticsLaws")
-
-    }
-}
-
-// MARK: - Generators
-extension Target {
-    static var generators: [Target] {
-        [
-            .bowGenerators,
-            .bowFreeGenerators,
-            .bowEffectsGenerators,
-            .bowRxGenerators,
-        ]
-    }
-
-    static var bowGenerators: Target {
-        .target(name: "BowGenerators",
-                dependencies: [Target.bow.asDependency,
-                               .product(name: "SwiftCheck", package: "SwiftCheck")],
-                path: "Tests/BowGenerators")
-    }
-
-    static var bowFreeGenerators: Target {
-        .target(name: "BowFreeGenerators",
-                dependencies: [Target.bowFree.asDependency,
-                               Target.bowGenerators.asDependency],
-                path: "Tests/BowFreeGenerators")
-    }
-
-    static var bowEffectsGenerators: Target {
-        .target(name: "BowEffectsGenerators",
-                dependencies: [Target.bowEffects.asDependency,
-                               Target.bowGenerators.asDependency],
-                path: "Tests/BowEffectsGenerators")
-    }
-
-    static var bowRxGenerators: Target {
-        .target(name: "BowRxGenerators",
-                dependencies: [Target.bowRx.asDependency,
-                               Target.bowGenerators.asDependency],
-                path: "Tests/BowRxGenerators")
-    }
-}
-
-// MARK:  - Tests
-extension Target {
-    static var tests: [Target] {
-        [
-            .bowTests,
-            .bowOpticsTests,
-            .bowRecursionSchemesTests,
-            .bowFreeTests,
-            .bowGenericTests,
-            .bowEffectsTests,
-            .bowRxTests,
-        ]
-    }
-
-    static var bowTests: Target {
-        .testTarget(name: "BowTests",
-                    dependencies: [Target.bowLaws.asDependency])
-    }
-
-    static var bowOpticsTests: Target {
-        .testTarget(name: "BowOpticsTests",
-                    dependencies: [Target.bowOpticsLaws.asDependency])
-    }
-
-    static var bowRecursionSchemesTests: Target {
-        .testTarget(name: "BowRecursionSchemesTests",
-                    dependencies: [Target.bowRecursionSchemes.asDependency,
-                                   Target.bowLaws.asDependency])
-    }
-
-    static var bowFreeTests: Target {
-        .testTarget(name: "BowFreeTests",
-                    dependencies: [Target.bowFreeGenerators.asDependency,
-                                   Target.bowLaws.asDependency])
-    }
-
-    static var bowGenericTests: Target {
-        .testTarget(name: "BowGenericTests",
-                    dependencies: [Target.bowGeneric.asDependency])
-    }
-
-    static var bowEffectsTests: Target {
-        .testTarget(name: "BowEffectsTests",
-                    dependencies: [Target.bowEffectsGenerators.asDependency,
-                                   Target.bowEffectsLaws.asDependency])
-    }
-
-    static var bowRxTests: Target {
-        .testTarget(name: "BowRxTests",
-                    dependencies: [Target.bowRxGenerators.asDependency,
-                                   Target.bowEffectsGenerators.asDependency,
-                                   Target.bowEffectsLaws.asDependency])
-    }
-}
-
-
-// MARK: - Package
 let package = Package(
     name: "Bow",
 
     products: [
-        .library(name: Target.bow.name,                  targets: [Target.bow.name]),
-        .library(name: Target.bowOptics.name,            targets: [Target.bowOptics.name]),
-        .library(name: Target.bowRecursionSchemes.name,  targets: [Target.bowRecursionSchemes.name]),
-        .library(name: Target.bowFree.name,              targets: [Target.bowFree.name]),
-        .library(name: Target.bowEffects.name,           targets: [Target.bowEffects.name]),
-        .library(name: Target.bowRx.name,                targets: [Target.bowRx.name]),
+        .core,
+        .optics,
+        .effects,
+        .rx,
+        .free,
+        .generic,
+        .recursionSchemes,
 
-        .library(name: Target.bowLaws.name,              targets: [Target.bowLaws.name]),
-        .library(name: Target.bowOpticsLaws.name,        targets: [Target.bowOpticsLaws.name]),
-        .library(name: Target.bowEffectsLaws.name,       targets: [Target.bowEffectsLaws.name]),
+        .laws,
+        .opticsLaws,
+        .effectsLaws,
 
-        .library(name: Target.bowGenerators.name,        targets: [Target.bowGenerators.name]),
-        .library(name: Target.bowFreeGenerators.name,    targets: [Target.bowFreeGenerators.name]),
-        .library(name: Target.bowEffectsGenerators.name, targets: [Target.bowEffectsGenerators.name]),
-        .library(name: Target.bowRxGenerators.name,      targets: [Target.bowRxGenerators.name])
+        .generators,
+        .freeGenerators,
+        .effectsGenerators,
+        .rxGenerators,
     ],
 
     dependencies: [
@@ -221,9 +29,358 @@ let package = Package(
     ],
 
     targets: [
-        Target.libraries,
-        Target.laws,
-        Target.generators,
-        Target.tests,
-    ].flatMap { $0 }
+        // Main targets
+        .bow,
+        .bowEffects,
+        .bowRx,
+        .bowOptics,
+        .bowRecursionSchemes,
+        .bowFree,
+        .bowGeneric,
+        
+        // Laws
+        .bowLaws,
+        .bowEffectsLaws,
+        .bowOpticsLaws,
+        
+        // Generators
+        .bowGenerators,
+        .bowEffectsGenerators,
+        .bowRxGenerators,
+        .bowFreeGenerators,
+        
+        // Test targets
+        .bowTests,
+        .bowOpticsTests,
+        .bowEffectsTests,
+        .bowRxTests,
+        .bowRecursionSchemesTests,
+        .bowFreeTests,
+        .bowGenericTests,
+    ]
 )
+
+enum Module {
+    static let core = "Bow"
+    static let optics = "BowOptics"
+    static let effects = "BowEffects"
+    static let rx = "BowRx"
+    static let recursionSchemes = "BowRecursionSchemes"
+    static let free = "BowFree"
+    static let generic = "BowGeneric"
+    
+    static let laws = "BowLaws"
+    static let effectsLaws = "BowEffectsLaws"
+    static let opticsLaws = "BowOpticsLaws"
+    
+    static let generators = "BowGenerators"
+    static let effectsGenerators = "BowEffectsGenerators"
+    static let rxGenerators = "BowRxGenerators"
+    static let freeGenerators = "BowFreeGenerators"
+}
+
+enum Test {
+    static let core = "BowTests"
+    static let effects = "BowEffectsTests"
+    static let rx = "BowRxTests"
+    static let optics = "BowOpticsTests"
+    static let recursionSchemes = "BowRecursionSchemesTests"
+    static let free = "BowFreeTests"
+    static let generic = "BowGenericTests"
+}
+
+extension Product {
+    static var core: Product {
+        .library(
+            name: Module.core,
+            targets: [Module.core])
+    }
+    
+    static var effects: Product {
+        .library(
+            name: Module.effects,
+            targets: [Module.effects])
+    }
+    
+    static var optics: Product {
+        .library(
+            name: Module.optics,
+            targets: [Module.optics])
+    }
+    
+    static var rx: Product {
+        .library(
+            name: Module.rx,
+            targets: [Module.rx])
+    }
+    
+    static var generic: Product {
+        .library(
+            name: Module.generic,
+            targets: [Module.generic])
+    }
+    
+    static var free: Product {
+        .library(
+            name: Module.free,
+            targets: [Module.free])
+    }
+    
+    static var recursionSchemes: Product {
+        .library(
+            name: Module.recursionSchemes,
+            targets: [Module.recursionSchemes])
+    }
+    
+    static var laws: Product {
+        .library(
+            name: Module.laws,
+            targets: [Module.laws])
+    }
+    
+    static var effectsLaws: Product {
+        .library(
+            name: Module.effectsLaws,
+            targets: [Module.effectsLaws])
+    }
+    
+    static var opticsLaws: Product {
+        .library(
+            name: Module.opticsLaws,
+            targets: [Module.opticsLaws])
+    }
+    
+    static var generators: Product {
+        .library(
+            name: Module.generators,
+            targets: [Module.generators])
+    }
+    
+    static var effectsGenerators: Product {
+        .library(
+            name: Module.effectsGenerators,
+            targets: [Module.effectsGenerators])
+    }
+    
+    static var rxGenerators: Product {
+        .library(
+            name: Module.rxGenerators,
+            targets: [Module.rxGenerators])
+    }
+    
+    static var freeGenerators: Product {
+        .library(
+            name: Module.freeGenerators,
+            targets: [Module.freeGenerators])
+    }
+}
+
+extension Target {
+    static var bow: Target {
+        .target(name: Module.core)
+    }
+
+    static var bowOptics: Target {
+        .target(
+            name: Module.optics,
+            dependencies: [.core])
+    }
+
+    static var bowEffects: Target {
+        #if os(Linux)
+        return .target(
+            name: Module.effects,
+            dependencies: [.core],
+            exclude: ["Foundation/FileManager+iOS+Mac.swift"])
+        #else
+        return .target(
+            name: Module.effects,
+            dependencies: [.core])
+        #endif
+    }
+
+    static var bowRecursionSchemes: Target {
+        .target(
+            name: Module.recursionSchemes,
+            dependencies: [.core])
+    }
+
+    static var bowFree: Target {
+        .target(
+            name: Module.free,
+            dependencies: [.core])
+    }
+
+    static var bowGeneric: Target {
+        .target(
+            name: Module.generic,
+            dependencies: [.core])
+    }
+
+    static var bowRx: Target {
+        .target(
+            name: Module.rx,
+            dependencies: [.core, .effects, .rxSwift, .rxCocoa])
+    }
+
+    static var bowLaws: Target {
+        .target(
+            name: Module.laws,
+            dependencies: [.generators],
+            path: "Tests/BowLaws")
+    }
+
+    static var bowEffectsLaws: Target {
+        .target(
+            name: Module.effectsLaws,
+            dependencies: [.effects, .laws],
+            path: "Tests/BowEffectsLaws")
+    }
+
+    static var bowOpticsLaws: Target {
+        .target(
+            name: Module.opticsLaws,
+            dependencies: [.optics, .laws],
+            path: "Tests/BowOpticsLaws")
+    }
+    
+    static var bowGenerators: Target {
+        .target(
+            name: Module.generators,
+            dependencies: [.core, .swiftCheck],
+            path: "Tests/BowGenerators")
+    }
+
+    static var bowFreeGenerators: Target {
+        .target(
+            name: Module.freeGenerators,
+            dependencies: [.free, .generators],
+            path: "Tests/BowFreeGenerators")
+    }
+
+    static var bowEffectsGenerators: Target {
+        .target(
+            name: Module.effectsGenerators,
+            dependencies: [.effects, .generators],
+            path: "Tests/BowEffectsGenerators")
+    }
+
+    static var bowRxGenerators: Target {
+        .target(
+            name: Module.rxGenerators,
+            dependencies: [.rx, .generators],
+            path: "Tests/BowRxGenerators")
+    }
+
+    static var bowTests: Target {
+        .testTarget(
+            name: Test.core,
+            dependencies: [.laws])
+    }
+
+    static var bowOpticsTests: Target {
+        .testTarget(
+            name: Test.optics,
+            dependencies: [.opticsLaws])
+    }
+
+    static var bowRecursionSchemesTests: Target {
+        .testTarget(
+            name: Test.recursionSchemes,
+            dependencies: [.recursionSchemes, .laws])
+    }
+
+    static var bowFreeTests: Target {
+        .testTarget(
+            name: Test.free,
+            dependencies: [.freeGenerators, .laws])
+    }
+
+    static var bowGenericTests: Target {
+        .testTarget(
+            name: Test.generic,
+            dependencies: [.generic])
+    }
+
+    static var bowEffectsTests: Target {
+        .testTarget(
+            name: Test.effects,
+            dependencies: [.effectsGenerators, .effectsLaws])
+    }
+
+    static var bowRxTests: Target {
+        .testTarget(
+            name: Test.rx,
+            dependencies: [.rxGenerators, .effectsGenerators, .effectsLaws])
+    }
+}
+
+extension Target.Dependency {
+    static var core: Target.Dependency {
+        .target(name: Module.core)
+    }
+    
+    static var effects: Target.Dependency {
+        .target(name: Module.effects)
+    }
+    
+    static var optics: Target.Dependency {
+        .target(name: Module.optics)
+    }
+    
+    static var rx: Target.Dependency {
+        .target(name: Module.rx)
+    }
+    
+    static var free: Target.Dependency {
+        .target(name: Module.free)
+    }
+    
+    static var generic: Target.Dependency {
+        .target(name: Module.generic)
+    }
+    
+    static var recursionSchemes: Target.Dependency {
+        .target(name: Module.recursionSchemes)
+    }
+    
+    static var laws: Target.Dependency {
+        .target(name: Module.laws)
+    }
+    
+    static var opticsLaws: Target.Dependency {
+        .target(name: Module.opticsLaws)
+    }
+    
+    static var effectsLaws: Target.Dependency {
+        .target(name: Module.effectsLaws)
+    }
+    
+    static var generators: Target.Dependency {
+        .target(name: Module.generators)
+    }
+    
+    static var effectsGenerators: Target.Dependency {
+        .target(name: Module.effectsGenerators)
+    }
+    
+    static var rxGenerators: Target.Dependency {
+        .target(name: Module.rxGenerators)
+    }
+    
+    static var freeGenerators: Target.Dependency {
+        .target(name: Module.freeGenerators)
+    }
+    
+    static var rxSwift: Target.Dependency {
+        .product(name: "RxSwift", package: "RxSwift")
+    }
+    
+    static var rxCocoa: Target.Dependency {
+        .product(name: "RxCocoa", package: "RxSwift")
+    }
+    
+    static var swiftCheck: Target.Dependency {
+        .product(name: "SwiftCheck", package: "SwiftCheck")
+    }
+}

--- a/Tests/BowLaws/ApplicativeLaws.swift
+++ b/Tests/BowLaws/ApplicativeLaws.swift
@@ -89,77 +89,77 @@ public class ApplicativeLaws<F: Applicative & EquatableK & ArbitraryK> {
         property("Map with 5 inputs") <~ forAll { (a: Int, b: Int, c: Int, d: Int, e: Int) in
             
             Kind<F, Int>.map(
-                .pure(a),
-                .pure(b),
-                .pure(c),
-                .pure(d),
-                .pure(e)) { a1, b1, c1, d1, e1 in
+                Kind<F, Int>.pure(a),
+                Kind<F, Int>.pure(b),
+                Kind<F, Int>.pure(c),
+                Kind<F, Int>.pure(d),
+                Kind<F, Int>.pure(e)) { a1, b1, c1, d1, e1 in
                     a1 + b1 + c1 + d1 + e1
             }
                 ==
             Kind<F, Int>.pure(a + b + c + d + e)
         }
 
-        property("Map with 6 inputs") <~ forAll { (a: Int, b: Int, c: Int, d: Int, e: Int, f: Int) in
+        property("Map with 6 inputs") <~ forAll { (a: Int, b: Int, c: Int, d: Int, e: Int, f: Int) -> Bool in
             
             Kind<F, Int>.map(
-                .pure(a),
-                .pure(b),
-                .pure(c),
-                .pure(d),
-                .pure(e),
-                .pure(f)) { a1, b1, c1, d1, e1, f1 in
+                Kind<F, Int>.pure(a),
+                Kind<F, Int>.pure(b),
+                Kind<F, Int>.pure(c),
+                Kind<F, Int>.pure(d),
+                Kind<F, Int>.pure(e),
+                Kind<F, Int>.pure(f)) { (a1: Int, b1: Int, c1: Int, d1: Int, e1: Int, f1: Int) -> Int in
                     a1 + b1 + c1 + d1 + e1 + f1
             }
                 ==
             Kind<F, Int>.pure(a + b + c + d + e + f)
         }
         
-        property("Map with 7 inputs") <~ forAll { (a: Int, b: Int, c: Int, d: Int, e: Int, f: Int, g: Int) in
+        property("Map with 7 inputs") <~ forAll { (a: Int, b: Int, c: Int, d: Int, e: Int, f: Int, g: Int) -> Bool in
             
             Kind<F, Int>.map(
-                .pure(a),
-                .pure(b),
-                .pure(c),
-                .pure(d),
-                .pure(e),
-                .pure(f),
-                .pure(g)) { a1, b1, c1, d1, e1, f1, g1 in
+                Kind<F, Int>.pure(a),
+                Kind<F, Int>.pure(b),
+                Kind<F, Int>.pure(c),
+                Kind<F, Int>.pure(d),
+                Kind<F, Int>.pure(e),
+                Kind<F, Int>.pure(f),
+                Kind<F, Int>.pure(g)) { (a1: Int, b1: Int, c1: Int, d1: Int, e1: Int, f1: Int, g1: Int) -> Int in
                     a1 + b1 + c1 + d1 + e1 + f1 + g1
             }
                 ==
             Kind<F, Int>.pure(a + b + c + d + e + f + g)
         }
         
-        property("Map with 8 inputs") <~ forAll { (a: Int, b: Int, c: Int, d: Int, e: Int, f: Int, g: Int, h: Int) in
+        property("Map with 8 inputs") <~ forAll { (a: Int, b: Int, c: Int, d: Int, e: Int, f: Int, g: Int, h: Int) -> Bool in
             
             Kind<F, Int>.map(
-                .pure(a),
-                .pure(b),
-                .pure(c),
-                .pure(d),
-                .pure(e),
-                .pure(f),
-                .pure(g),
-                .pure(h)) { a1, b1, c1, d1, e1, f1, g1, h1 in
+                Kind<F, Int>.pure(a),
+                Kind<F, Int>.pure(b),
+                Kind<F, Int>.pure(c),
+                Kind<F, Int>.pure(d),
+                Kind<F, Int>.pure(e),
+                Kind<F, Int>.pure(f),
+                Kind<F, Int>.pure(g),
+                Kind<F, Int>.pure(h)) { (a1: Int, b1: Int, c1: Int, d1: Int, e1: Int, f1: Int, g1: Int, h1: Int) -> Int in
                     a1 + b1 + c1 + d1 + e1 + f1 + g1 + h1
             }
                 ==
             Kind<F, Int>.pure(a + b + c + d + e + f + g + h)
         }
         
-        property("Map with 9 inputs") <~ forAll { (a: Int, b: Int, c: Int, d: Int, e: Int, f: Int, g: Int, h: Int) in
+        property("Map with 9 inputs") <~ forAll { (a: Int, b: Int, c: Int, d: Int, e: Int, f: Int, g: Int, h: Int) -> Bool in
             
             Kind<F, Int>.map(
-                .pure(a),
-                .pure(b),
-                .pure(c),
-                .pure(d),
-                .pure(e),
-                .pure(f),
-                .pure(g),
-                .pure(h),
-                .pure(a)) { a1, b1, c1, d1, e1, f1, g1, h1, i1 in
+                Kind<F, Int>.pure(a),
+                Kind<F, Int>.pure(b),
+                Kind<F, Int>.pure(c),
+                Kind<F, Int>.pure(d),
+                Kind<F, Int>.pure(e),
+                Kind<F, Int>.pure(f),
+                Kind<F, Int>.pure(g),
+                Kind<F, Int>.pure(h),
+                Kind<F, Int>.pure(a)) { (a1: Int, b1: Int, c1: Int, d1: Int, e1: Int, f1: Int, g1: Int, h1: Int, i1: Int) -> Int in
                     a1 + b1 + c1 + d1 + e1 + f1 + g1 + h1 + i1
             }
                 ==


### PR DESCRIPTION
## Related issues

#613: Missing Generic module
#610: Unable to run tests on Xcode 12 due to a timeout in type inference

## Goal

- Refactor `Package.swift` and include missing package `BowGeneric`.
- Add type annotations to avoid type inference timeouts.