### PR TITLE
Revamp Free

### DIFF
--- a/Bow.xcodeproj/project.pbxproj
+++ b/Bow.xcodeproj/project.pbxproj
@@ -1728,8 +1728,8 @@
 				8BA0F440217E2E9200969984 /* Cofree.swift */,
 				8BA0F43F217E2E9200969984 /* Coyoneda.swift */,
 				8BA0F441217E2E9200969984 /* Free.swift */,
-				8BA0F43E217E2E9200969984 /* Yoneda.swift */,
 				11D894FB251CEB58006A65EC /* FunctionK+Free.swift */,
+				8BA0F43E217E2E9200969984 /* Yoneda.swift */,
 			);
 			path = BowFree;
 			sourceTree = "<group>";

--- a/Bow.xcodeproj/project.pbxproj
+++ b/Bow.xcodeproj/project.pbxproj
@@ -180,6 +180,7 @@
 		11BA21C523D83EA100F3EE78 /* Zipper+Gen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1171ED5F23C636A9005362E0 /* Zipper+Gen.swift */; };
 		11D36A19223261EC00CBD85F /* Selective.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11D36A18223261EC00CBD85F /* Selective.swift */; };
 		11D36A1C2232789900CBD85F /* SelectiveLaws.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11D36A1A2232787A00CBD85F /* SelectiveLaws.swift */; };
+		11D894FC251CEB58006A65EC /* FunctionK+Free.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11D894FB251CEB58006A65EC /* FunctionK+Free.swift */; };
 		11D97EF2219EBC0F008FC004 /* AsyncLaws.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BA0F3A2217E2DEF00969984 /* AsyncLaws.swift */; };
 		11DDCD1C217F171900844D9D /* Memoization.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11DDCD1B217F171900844D9D /* Memoization.swift */; };
 		11DDCD21217F194B00844D9D /* MemoizationTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11DDCD20217F194B00844D9D /* MemoizationTest.swift */; };
@@ -954,6 +955,7 @@
 		11BA21C123D75B5200F3EE78 /* ZipperTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ZipperTest.swift; sourceTree = "<group>"; };
 		11D36A18223261EC00CBD85F /* Selective.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Selective.swift; sourceTree = "<group>"; };
 		11D36A1A2232787A00CBD85F /* SelectiveLaws.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectiveLaws.swift; sourceTree = "<group>"; };
+		11D894FB251CEB58006A65EC /* FunctionK+Free.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FunctionK+Free.swift"; sourceTree = "<group>"; };
 		11D97EEA219EBAA1008FC004 /* BowEffectsLaws.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = BowEffectsLaws.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		11DDCD1B217F171900844D9D /* Memoization.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Memoization.swift; sourceTree = "<group>"; };
 		11DDCD20217F194B00844D9D /* MemoizationTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemoizationTest.swift; sourceTree = "<group>"; };
@@ -1727,6 +1729,7 @@
 				8BA0F43F217E2E9200969984 /* Coyoneda.swift */,
 				8BA0F441217E2E9200969984 /* Free.swift */,
 				8BA0F43E217E2E9200969984 /* Yoneda.swift */,
+				11D894FB251CEB58006A65EC /* FunctionK+Free.swift */,
 			);
 			path = BowFree;
 			sourceTree = "<group>";
@@ -3152,6 +3155,7 @@
 				11E7188F219D82BD00B94845 /* Coyoneda.swift in Sources */,
 				11E71890219D82BD00B94845 /* Free.swift in Sources */,
 				11E71891219D82BD00B94845 /* Yoneda.swift in Sources */,
+				11D894FC251CEB58006A65EC /* FunctionK+Free.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Sources/Bow/Arrow/FunctionK.swift
+++ b/Sources/Bow/Arrow/FunctionK.swift
@@ -40,6 +40,16 @@ open class FunctionK<F, G> {
     }
 }
 
+public extension FunctionK {
+    /// Combines this natural transformation with another one targetting the same Functor.
+    ///
+    /// - Parameter h: Natural transformation to be combined.
+    /// - Returns: A natural transformation that goes from the sum of both Functors into the same target Functor.
+    func sum<H: Functor>(_ h: FunctionK<H, G>) -> FunctionK<EitherKPartial<F, H>, G> {
+        SumFunctionK(self, h)
+    }
+}
+
 // MARK: Identity FunctionK
 
 public extension FunctionK where F == G {
@@ -70,5 +80,21 @@ private class ComposedFunctionK<F, G, H>: FunctionK<F, H> {
 
     override func invoke<A>(_ fa: Kind<F, A>) -> Kind<H, A> {
         g.invoke(f.invoke(fa))
+    }
+}
+
+private class SumFunctionK<F, H, G>: FunctionK<EitherKPartial<F, H>, G> {
+    private let f: FunctionK<F, G>
+    private let h: FunctionK<H, G>
+    
+    init(_ f: FunctionK<F, G>, _ h: FunctionK<H, G>) {
+        self.f = f
+        self.h = h
+    }
+    
+    override func invoke<A>(
+        _ fa: EitherKOf<F, H, A>
+    ) -> Kind<G, A> {
+        fa^.fold(f, h)
     }
 }

--- a/Sources/BowFree/FunctionK+Free.swift
+++ b/Sources/BowFree/FunctionK+Free.swift
@@ -1,0 +1,31 @@
+import Bow
+
+public extension FunctionK where F: Functor, G: Functor {
+    /// Obtains a natural transformation for the Free Monads of the Functors from this natural transformation.
+    ///
+    /// - Returns: A natural transformation for the Free Monads.
+    func free() -> FunctionK<FreePartial<F>, FreePartial<G>> {
+        FreeFunctionK(self)
+    }
+}
+
+private class FreeFunctionK<F: Functor, G: Functor>: FunctionK<FreePartial<F>, FreePartial<G>> {
+    private let f: FunctionK<F, G>
+    
+    init(_ f: FunctionK<F, G>) {
+        self.f = f
+    }
+    
+    override func invoke<A>(
+        _ fa: FreeOf<F, A>
+    ) -> FreeOf<G, A> {
+        switch fa^.value {
+        case let .pure(a):
+            return Free<G, A>.pure(a)
+        case let .free(fa):
+            return Free<G, A>.free(f.invoke(fa.map { free in
+                self.invoke(free)^
+            }))
+        }
+    }
+}

--- a/Sources/BowFree/FunctionK+Free.swift
+++ b/Sources/BowFree/FunctionK+Free.swift
@@ -27,6 +27,24 @@ public extension FunctionK where F: Functor, G: Monad {
     }
 }
 
+public extension FunctionK {
+    /// Obtains a natural transformation from a Free Monad to another one that sums two Functors, placing the underlying functor on the left-hand side of the sum.
+    ///
+    /// - Returns: A natural transformation.
+    static func left<FF, GG>() -> FunctionK<F, G>
+    where F == FreePartial<FF>, G == FreePartial<EitherKPartial<FF, GG>> {
+        LeftFunctionK().free()
+    }
+    
+    /// Obtains a natural transformation from a Free Monad to another one that sums two Functors, placing the underlying functor on the right-hand side of the sum.
+    ///
+    /// - Returns: A natural transformation.
+    static func right<FF, GG>() -> FunctionK<F, G>
+    where F == FreePartial<GG>, G == FreePartial<EitherKPartial<FF, GG>> {
+        RightFunctionK().free()
+    }
+}
+
 private class FreeFunctionK<F: Functor, G: Functor>: FunctionK<FreePartial<F>, FreePartial<G>> {
     private let f: FunctionK<F, G>
     
@@ -73,5 +91,21 @@ private class InterpreterFunctionK<F: Functor, G: Monad>: FunctionK<FreePartial<
     ) -> Kind<G, A> {
         FunctionK<FreePartial<G>, G>.monad()
             .invoke(f.free().invoke(fa))
+    }
+}
+
+private class LeftFunctionK<F, G>: FunctionK<F, EitherKPartial<F, G>> {
+    override func invoke<A>(
+        _ fa: Kind<F, A>
+    ) -> EitherKOf<F, G, A> {
+        EitherK(fa)
+    }
+}
+
+private class RightFunctionK<F, G>: FunctionK<G, EitherKPartial<F, G>> {
+    override func invoke<A>(
+        _ ga: Kind<G, A>
+    ) -> EitherKOf<F, G, A> {
+        EitherK(ga)
     }
 }

--- a/Tests/BowFreeGenerators/Free+Gen.swift
+++ b/Tests/BowFreeGenerators/Free+Gen.swift
@@ -5,8 +5,17 @@ import SwiftCheck
 
 // MARK: Instance of `ArbitraryK` for `Free`
 
-extension FreePartial: ArbitraryK where S: ArbitraryK {
-    public static func generate<A: Arbitrary>() -> Kind<FreePartial<S>, A> {
-        return Free.liftF(S.generate())
+extension FreePartial: ArbitraryK where F: ArbitraryK {
+    public static func generate<A: Arbitrary>() -> FreeOf<F, A> {
+        Free<F, A>.arbitrary.generate
+    }
+}
+
+extension Free: Arbitrary where F: ArbitraryK, A: Arbitrary {
+    public static var arbitrary: Gen<Free<F, A>> {
+        let pureGen: Gen<Free<F, A>> = A.arbitrary.map(Free<F, A>.pure >>> Free.fix)
+        let liftGen: Gen<Free<F, A>> = Gen.from(F.generate).map(Free<F, A>.free)
+        
+        return Gen.one(of: [pureGen, liftGen])
     }
 }

--- a/Tests/BowGenerators/Typeclasses/ArbitraryK.swift
+++ b/Tests/BowGenerators/Typeclasses/ArbitraryK.swift
@@ -17,7 +17,7 @@ public struct KindOf<F, A>: Arbitrary where F: ArbitraryK, A: Arbitrary {
     }
 }
 
-extension Gen {
+public extension Gen {
     static func from(_ generator: @escaping () -> A) -> Gen<A> {
         Gen<Void>.pure(()).map(generator)
     }


### PR DESCRIPTION
## Related issues

Closes #286 

## Goal

Provide a better, more robust implementation for `Free`.

## Implementation details

Free is a type that, given any Functor, it is able to provide a Monad for it. This Monad can be later interpreted into different, less restrictive Monads. Free is modeled as a sum type where the two cases roughly correspond to the `pure` and `flatten` methods in Monad. From there, instances of Functor, Applicative, Selective, and Monad are able to be provided.

This PR also includes some utilities in terms of natural transformations (extensions to FunctionK) that will help in the interpretation of Free Monads.

## Testing details

Type class laws and general behavior of the Free implementation are tested.
