### PR TITLE
New tailRecM laws + Bug fixes 🐞

### DIFF
--- a/Sources/Bow/Data/Ior.swift
+++ b/Sources/Bow/Data/Ior.swift
@@ -276,7 +276,7 @@ extension IorPartial: Monad where L: Semigroup {
                     { left, right in
                         right.fold({ a in
                             f(a).fold({ aLeft in .done(.left(aLeft.combine(left))) },
-                                      { aRight in loop(.both(left, aRight), f) },
+                                      { aRight in loop(.right(aRight), f) },
                                       { aLeft, aRight in loop(.both(left.combine(aLeft), aRight), f) })
                         },
                                    { b in .done(.both(left, b)) })

--- a/Sources/Bow/Data/Ior.swift
+++ b/Sources/Bow/Data/Ior.swift
@@ -268,19 +268,25 @@ extension IorPartial: Monad where L: Semigroup {
         _ v: Ior<L, Either<A, B>>,
         _ f: @escaping (A) -> Ior<L, Either<A, B>>) -> Trampoline<Ior<L, B>> {
         .defer {
-             v.fold({ left in .done(.left(left)) },
-                    { right in
-                        right.fold({ a in loop(f(a), f) },
-                                   { b in .done(.right(b)) })
-             },
-                    { left, right in
-                        right.fold({ a in
-                            f(a).fold({ aLeft in .done(.left(aLeft.combine(left))) },
-                                      { aRight in loop(.right(aRight), f) },
-                                      { aLeft, aRight in loop(.both(left.combine(aLeft), aRight), f) })
+            v.fold(
+                { left in .done(.left(left)) },
+                { right in
+                    right.fold({ a in loop(f(a), f) },
+                               { b in .done(.right(b)) })
+                },
+                { left, right in
+                    right.fold(
+                        { a in
+                            f(a).fold(
+                                { aLeft in .done(.left(aLeft.combine(left))) },
+                                { aRight in loop(.right(aRight), f) },
+                                { aLeft, aRight in loop(.both(left.combine(aLeft), aRight), f) }
+                            )
                         },
-                                   { b in .done(.both(left, b)) })
-            })
+                        { b in .done(.both(left, b)) }
+                    )
+                }
+            )
         }
     }
 

--- a/Tests/BowLaws/MonadLaws.swift
+++ b/Tests/BowLaws/MonadLaws.swift
@@ -14,6 +14,7 @@ public class MonadLaws<F: Monad & EquatableK & ArbitraryK> {
             stackSafety()
         }
         tailRecMConsistentFlatMap()
+        tailRecMConsistentFlatMapAndMap()
         monadComprehensions()
         flatten()
     }
@@ -96,12 +97,28 @@ public class MonadLaws<F: Monad & EquatableK & ArbitraryK> {
         /// or we compute it with plain `flatMap`.
         /// We test only for 3 `flatMap` calls, but since `bounce(n) = bounce(n-1).flatMap(f)` we deduce by induction
         /// that the `tailRecM` and the plain `flatMap` computations are equivalent for any `n`.
-        property("tailRecMConsistentFlatMap") <~ forAll { (a: Int, f: ArrowOf<Int, KindOf<F, Int>>) in
+        property("tailRecM is consistent with flatMap") <~ forAll { (a: Int, f: ArrowOf<Int, KindOf<F, Int>>) in
             let f = { f.getArrow($0).value }
             let bounce1 = bounce(n: 1, a: a, f: f)
             let bounce0 = bounce(n: 0, a: a, f: f).flatMap(f)
             let flat = F.pure(a).flatMap(f).flatMap(f)
             return bounce1 == bounce0 && bounce0 == flat
+        }
+    }
+
+    /// It is possible to implement flatMap from tailRecM and map
+    /// and it should agree with the flatMap implementation.
+    private static func tailRecMConsistentFlatMapAndMap() {
+        property("tailRecM is consistent with flatMap and map") <~ forAll { (fa: KindOf<F, Int>, f: ArrowOf<Int, KindOf<F, String>>) in
+            let f = { f.getArrow($0).value }
+            let tailRecAndMap = F.tailRecM(Option<Int>.empty()) { (w: Option<Int>) -> Kind<F, Either<Option<Int>, String>> in
+                w.fold({
+                    F.map(fa.value) { .left(.some($0)) }
+                }) { i in
+                    F.map(f(i)) { .right($0) }
+                }
+            }
+            return F.flatMap(fa.value, f) == tailRecAndMap
         }
     }
 

--- a/Tests/BowLaws/MonadLaws.swift
+++ b/Tests/BowLaws/MonadLaws.swift
@@ -13,6 +13,7 @@ public class MonadLaws<F: Monad & EquatableK & ArbitraryK> {
         if withStackSafety { 
             stackSafety()
         }
+        tailRecMConsistentFlatMap()
         monadComprehensions()
         flatten()
     }
@@ -78,7 +79,32 @@ public class MonadLaws<F: Monad & EquatableK & ArbitraryK> {
         
         XCTAssertEqual(res, F.pure(iterations))
     }
-    
+
+    private static func tailRecMConsistentFlatMap() {
+        func bounce(n: Int, a: Int, f: @escaping (Int) -> Kind<F, Int>) -> Kind<F, Int> {
+            F.tailRecM((a, n)) { arg in
+                let (a0, i) = arg
+                return (i > 0)
+                    ? F.map(f(a0)) { Either.left(($0, i - 1)) }
+                    : F.map(f(a0), Either.right)
+            }
+        }
+
+        /// The `bounce(n, a, f)` function uses `tailRecM` to compute `F.pure(a).flatMap(f).flatMap(f)...` where `.flatMap(f)`
+        /// is applied `n+1` times.
+        /// We want to assert that this computation gives the same result whether we compute it with `tailRecM`
+        /// or we compute it with plain `flatMap`.
+        /// We test only for 3 `flatMap` calls, but since `bounce(n) = bounce(n-1).flatMap(f)` we deduce by induction
+        /// that the `tailRecM` and the plain `flatMap` computations are equivalent for any `n`.
+        property("tailRecMConsistentFlatMap") <~ forAll { (a: Int, f: ArrowOf<Int, KindOf<F, Int>>) in
+            let f = { f.getArrow($0).value }
+            let bounce1 = bounce(n: 1, a: a, f: f)
+            let bounce0 = bounce(n: 0, a: a, f: f).flatMap(f)
+            let flat = F.pure(a).flatMap(f).flatMap(f)
+            return bounce1 == bounce0 && bounce0 == flat
+        }
+    }
+
     private static func monadComprehensions() {
         property("Monad comprehensions") <~ forAll { (a: Int, b: Int, c: Int, d: Int) in
             let fa = F.pure(a)

--- a/Tests/BowTests/Data/IorTest.swift
+++ b/Tests/BowTests/Data/IorTest.swift
@@ -38,7 +38,7 @@ class IorTest: XCTestCase {
         }
     }
     
-    func testBimapConsitent() {
+    func testBimapConsistent() {
         property("bimap is equivalent to map and mapLeft") <~ forAll { (input: Ior<Int, Int>, f: ArrowOf<Int, Int>, g: ArrowOf<Int, Int>) in
             return input.bimap(f.getArrow, g.getArrow) == Ior.fix(input.map(g.getArrow)).mapLeft(f.getArrow)
         }


### PR DESCRIPTION
I added two new laws to test `tailRecM` (I took them [from Scala](https://github.com/typelevel/cats/blob/master/laws/src/main/scala/cats/laws/FlatMapLaws.scala#L33)).

With the new `tailRecMConsistentFlatMap` law I discovered and fixed bugs in the implementation of `tailRecM` for `Ior` and `WriterT`.

- In `Ior`, when flatMapping on a `Both` value, when the new value is `Right`, we were returning `Both` (correct value is `Right`).
- In `WriterT` we were not combining the old `W` with the new `W` obtained after flatmapping.