### PR TITLE
Introduce Program type for free-er monads

### DIFF
--- a/Bow.xcodeproj/project.pbxproj
+++ b/Bow.xcodeproj/project.pbxproj
@@ -363,6 +363,9 @@
 		8BA0F65B217E2E9200969984 /* FunctorFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BA0F4AE217E2E9200969984 /* FunctorFilter.swift */; };
 		8BB969AD2398661D005520D6 /* Queue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BB969AB239863F0005520D6 /* Queue.swift */; };
 		B507D2BE252A347A002541E4 /* CoyonedaNaturalTransformationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B507D290252A315C002541E4 /* CoyonedaNaturalTransformationTests.swift */; };
+		B55BE657252332BA005297CA /* Program.swift in Sources */ = {isa = PBXBuildFile; fileRef = B55BE656252332BA005297CA /* Program.swift */; };
+		B55BE68525234AD1005297CA /* ProgramTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = B55BE68425234AD1005297CA /* ProgramTest.swift */; };
+		B55F53BC2524D7F3001979EE /* Program+Gen.swift in Sources */ = {isa = PBXBuildFile; fileRef = B55F53BB2524D7F3001979EE /* Program+Gen.swift */; };
 		B53F8C09251A5F8000468947 /* Tree.swift in Sources */ = {isa = PBXBuildFile; fileRef = B53F8C08251A5F8000468947 /* Tree.swift */; };
 		B5618757252CC2D2002717B1 /* TreeTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5618756252CC2D2002717B1 /* TreeTest.swift */; };
 		B5618785252CC3EA002717B1 /* Tree+Gen.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5618784252CC3EA002717B1 /* Tree+Gen.swift */; };
@@ -1244,8 +1247,11 @@
 		8BD6974D23F5AE18000A512F /* BowAllTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = BowAllTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		B507D290252A315C002541E4 /* CoyonedaNaturalTransformationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoyonedaNaturalTransformationTests.swift; sourceTree = "<group>"; };
 		B52120FE2523AC2300705BCD /* Exists.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Exists.swift; sourceTree = "<group>"; };
+		B55BE656252332BA005297CA /* Program.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Program.swift; sourceTree = "<group>"; };
+		B55BE68425234AD1005297CA /* ProgramTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProgramTest.swift; sourceTree = "<group>"; };
 		B53F8C08251A5F8000468947 /* Tree.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Tree.swift; sourceTree = "<group>"; };
 		B55F52B125247256001979EE /* ExistsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExistsTests.swift; sourceTree = "<group>"; };
+		B55F53BB2524D7F3001979EE /* Program+Gen.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Program+Gen.swift"; sourceTree = "<group>"; };
 		B5618756252CC2D2002717B1 /* TreeTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TreeTest.swift; sourceTree = "<group>"; };
 		B5618784252CC3EA002717B1 /* Tree+Gen.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Tree+Gen.swift"; sourceTree = "<group>"; };
 		B568E5BE2529D1A200AD334B /* FunctionK+Coyoneda.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FunctionK+Coyoneda.swift"; sourceTree = "<group>"; };
@@ -1666,6 +1672,7 @@
 				11D8967C2523763A006A65EC /* Cofree+Gen.swift */,
 				11B6FD7C2525C37F00A5AD54 /* CoyonedaGen.swift */,
 				117DC13622AE578A00EF65F0 /* Free+Gen.swift */,
+				B55F53BB2524D7F3001979EE /* Program+Gen.swift */,
 				11D896C225237A6D006A65EC /* Yoneda+Gen.swift */,
 			);
 			path = BowFreeGenerators;
@@ -1770,6 +1777,7 @@
 				11D894FB251CEB58006A65EC /* FunctionK+Free.swift */,
 				B568E5BE2529D1A200AD334B /* FunctionK+Coyoneda.swift */,
 				8BA0F43E217E2E9200969984 /* Yoneda.swift */,
+				B55BE656252332BA005297CA /* Program.swift */,
 			);
 			path = BowFree;
 			sourceTree = "<group>";
@@ -1782,6 +1790,7 @@
 				8BA0F38D217E2DEF00969984 /* FreeTest.swift */,
 				11D896C525237A7D006A65EC /* YonedaTest.swift */,
 				B507D290252A315C002541E4 /* CoyonedaNaturalTransformationTests.swift */,
+				B55BE68425234AD1005297CA /* ProgramTest.swift */,
 			);
 			path = BowFreeTests;
 			sourceTree = "<group>";
@@ -2959,6 +2968,7 @@
 			files = (
 				B507D2BE252A347A002541E4 /* CoyonedaNaturalTransformationTests.swift in Sources */,
 				11B6FDC22525C48200A5AD54 /* CofreeTest.swift in Sources */,
+				B55BE68525234AD1005297CA /* ProgramTest.swift in Sources */,
 				1122947F219D8E25006D66C5 /* FreeTest.swift in Sources */,
 				11B6FDAB2525C47600A5AD54 /* CoyonedaTest.swift in Sources */,
 				11B6FDEF2525C49000A5AD54 /* YonedaTest.swift in Sources */,
@@ -3110,6 +3120,7 @@
 			files = (
 				11B6FD7D2525C37F00A5AD54 /* CoyonedaGen.swift in Sources */,
 				11D896C325237A6D006A65EC /* Yoneda+Gen.swift in Sources */,
+				B55F53BC2524D7F3001979EE /* Program+Gen.swift in Sources */,
 				11D8967D2523763A006A65EC /* Cofree+Gen.swift in Sources */,
 				117DC13722AE578A00EF65F0 /* Free+Gen.swift in Sources */,
 			);
@@ -3211,6 +3222,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 0;
 			files = (
+				B55BE657252332BA005297CA /* Program.swift in Sources */,
 				11E7188E219D82BD00B94845 /* Cofree.swift in Sources */,
 				11E7188F219D82BD00B94845 /* Coyoneda.swift in Sources */,
 				B568E5BF2529D1A200AD334B /* FunctionK+Coyoneda.swift in Sources */,

--- a/Sources/BowFree/Program.swift
+++ b/Sources/BowFree/Program.swift
@@ -66,27 +66,27 @@ public extension Program where F: Monad {
 }
 
 extension ProgramPartial: Functor {
-    public static func map<A, B>(_ fa: Kind<ProgramPartial<F>, A>, _ f: @escaping (A) -> B) -> Kind<ProgramPartial<F>, B> {
+    public static func map<A, B>(_ fa: ProgramOf<F, A>, _ f: @escaping (A) -> B) -> ProgramOf<F, B> {
         Program(asFree: fa^.asFree.map(f)^)
     }
 }
 
 extension ProgramPartial: Applicative {
-    public static func pure<A>(_ a: A) -> Kind<ProgramPartial<F>, A> {
+    public static func pure<A>(_ a: A) -> ProgramOf<F, A> {
         Program(asFree: Free<CoyonedaPartial<F>, A>.pure(a)^)
     }
 
-    public static func ap<A, B>(_ ff: Kind<ProgramPartial<F>, (A) -> B>, _ fa: Kind<ProgramPartial<F>, A>) -> Kind<ProgramPartial<F>, B> {
+    public static func ap<A, B>(_ ff: ProgramOf<F, (A) -> B>, _ fa: ProgramOf<F, A>) -> ProgramOf<F, B> {
         Program(asFree: ff^.asFree.ap(fa^.asFree)^)
     }
 }
 
 extension ProgramPartial: Monad {
-    public static func flatMap<A, B>(_ fa: Kind<ProgramPartial<F>, A>, _ f: @escaping (A) -> Kind<ProgramPartial<F>, B>) -> Kind<ProgramPartial<F>, B> {
+    public static func flatMap<A, B>(_ fa: ProgramOf<F, A>, _ f: @escaping (A) -> ProgramOf<F, B>) -> ProgramOf<F, B> {
         Program(asFree: fa^.asFree.flatMap { f($0)^.asFree }^)
     }
 
-    public static func tailRecM<A, B>(_ a: A, _ f: @escaping (A) -> Kind<ProgramPartial<F>, Either<A, B>>) -> Kind<ProgramPartial<F>, B> {
+    public static func tailRecM<A, B>(_ a: A, _ f: @escaping (A) -> ProgramOf<F, Either<A, B>>) -> ProgramOf<F, B> {
         Program(asFree: Free.tailRecM(a, { f($0)^.asFree })^)
     }
 }

--- a/Sources/BowFree/Program.swift
+++ b/Sources/BowFree/Program.swift
@@ -15,9 +15,11 @@ public typealias ProgramOf<F, A> = Kind<ProgramPartial<F>, A>
 /// As opposed to `Free`, `Program` does not require `F` to be a functor, which means that evaluation of `map` calls are deferred
 /// and left for the later interpretation in another monad.
 public final class Program<F, A>: ProgramOf<F, A> {
-    let asFree: Free<CoyonedaPartial<F>, A>
+    /// Internal representation of `Program`
+    public let asFree: Free<CoyonedaPartial<F>, A>
 
-    init(asFree: Free<CoyonedaPartial<F>, A>) {
+    /// Initializes a `Program` instance from the corresponding `Free<CoyonedaPartial<F>>`.
+    public init(asFree: Free<CoyonedaPartial<F>, A>) {
         self.asFree = asFree
     }
 

--- a/Sources/BowFree/Program.swift
+++ b/Sources/BowFree/Program.swift
@@ -1,0 +1,92 @@
+import Foundation
+import Bow
+
+/// Witness for the `Program<F, A>` data type. To be used in simulated Higher Kinded Types.
+public final class ForProgram {}
+
+/// Partial application of the `Program` type constructor, omitting the last parameter.
+public final class ProgramPartial<F>: Kind<ForProgram, F> {}
+
+/// Higher Kinded Type alias to improve readability.
+public typealias ProgramOf<F, A> = Kind<ProgramPartial<F>, A>
+
+/// Program is a type that, given any type constructor, is able to provide a Monad instance, that can be interpreted into a more restrictive one.
+///
+/// As opposed to `Free`, `Program` does not require `F` to be a functor, which means that evaluation of `map` calls are deferred
+/// and left for the later interpretation in another monad.
+public final class Program<F, A>: ProgramOf<F, A> {
+    let asFree: Free<CoyonedaPartial<F>, A>
+
+    init(asFree: Free<CoyonedaPartial<F>, A>) {
+        self.asFree = asFree
+    }
+
+    /// Safe downcast.
+    ///
+    /// - Parameter fa: Value in the higher-kind form.
+    /// - Returns: Value cast to `Program`.
+    public static func fix(_ fa: ProgramOf<F, A>) -> Program<F, A> {
+        return fa as! Program<F, A>
+    }
+
+    /// Lifts a value in the context of `F` into the `Program` context.
+    ///
+    /// - Parameter fa: A value in the context of `F`.
+    /// - Returns: A `Program` value.
+    public static func liftF(_ fa: Kind<F, A>) -> Program<F, A> {
+        return fa |> (Coyoneda.liftCoyoneda
+                        >>> Free.liftF
+                        >>> Program.init)
+    }
+
+    /// Interprets this `Program` value into the provided Monad.
+    ///
+    /// - Parameter f: A natural transformation from `F` into the desired Monad.
+    /// - Returns: A value in the interpreted Monad.
+    public func foldMapK<M: Monad>(_ f: FunctionK<F, M>) -> Kind<M, A> {
+        f.transformAndReduce.free().invoke(asFree)^.run()
+    }
+}
+
+/// Safe downcast.
+///
+/// - Parameter fa: Value in higher-kind form.
+/// - Returns: Value cast to `Program`.
+public postfix func ^<F, A>(_ fa: ProgramOf<F, A>) -> Program<F, A> {
+    return Program.fix(fa)
+}
+
+public extension Program where F: Monad {
+    /// Folds this program structure using the same Monad.
+    ///
+    /// - Returns: Folded value.
+    func run() -> Kind<F, A> {
+        self.foldMapK(FunctionK<F, F>.id)
+    }
+}
+
+extension ProgramPartial: Functor {
+    public static func map<A, B>(_ fa: Kind<ProgramPartial<F>, A>, _ f: @escaping (A) -> B) -> Kind<ProgramPartial<F>, B> {
+        Program(asFree: fa^.asFree.map(f)^)
+    }
+}
+
+extension ProgramPartial: Applicative {
+    public static func pure<A>(_ a: A) -> Kind<ProgramPartial<F>, A> {
+        Program(asFree: Free<CoyonedaPartial<F>, A>.pure(a)^)
+    }
+
+    public static func ap<A, B>(_ ff: Kind<ProgramPartial<F>, (A) -> B>, _ fa: Kind<ProgramPartial<F>, A>) -> Kind<ProgramPartial<F>, B> {
+        Program(asFree: ff^.asFree.ap(fa^.asFree)^)
+    }
+}
+
+extension ProgramPartial: Monad {
+    public static func flatMap<A, B>(_ fa: Kind<ProgramPartial<F>, A>, _ f: @escaping (A) -> Kind<ProgramPartial<F>, B>) -> Kind<ProgramPartial<F>, B> {
+        Program(asFree: fa^.asFree.flatMap { f($0)^.asFree }^)
+    }
+
+    public static func tailRecM<A, B>(_ a: A, _ f: @escaping (A) -> Kind<ProgramPartial<F>, Either<A, B>>) -> Kind<ProgramPartial<F>, B> {
+        Program(asFree: Free.tailRecM(a, { f($0)^.asFree })^)
+    }
+}

--- a/Tests/BowFreeGenerators/Program+Gen.swift
+++ b/Tests/BowFreeGenerators/Program+Gen.swift
@@ -1,0 +1,18 @@
+import Bow
+@testable import BowFree
+import BowGenerators
+import SwiftCheck
+
+// MARK: Instance of `ArbitraryK` for `Free`
+
+extension ProgramPartial: ArbitraryK where F: ArbitraryK {
+    public static func generate<A: Arbitrary>() -> ProgramOf<F, A> {
+        Program<F, A>.arbitrary.generate
+    }
+}
+
+extension Program: Arbitrary where F: ArbitraryK, A: Arbitrary {
+    public static var arbitrary: Gen<Program<F, A>> {
+        Free<CoyonedaPartial<F>, A>.arbitrary.map(Program.init)
+    }
+}

--- a/Tests/BowFreeTests/ProgramTest.swift
+++ b/Tests/BowFreeTests/ProgramTest.swift
@@ -1,0 +1,113 @@
+import XCTest
+import Bow
+import BowFree
+import BowFreeGenerators
+import BowLaws
+
+fileprivate final class ForOpsF {}
+fileprivate typealias OpsFPartial = ForOpsF
+fileprivate typealias OpsFOf<A> = Kind<ForOpsF, A>
+
+fileprivate class OpsF<A>: OpsFOf<A> {
+    enum _OpsF {
+        case read((String) -> A)
+        case write(String, A)
+    }
+    
+    let value: _OpsF
+    
+    private init(_ value: _OpsF) {
+        self.value = value
+    }
+    
+    static func read(_ callback: @escaping (String) -> A) -> OpsF<A> {
+        OpsF(.read(callback))
+    }
+    
+    static func write(_ content: String, _ next: A) -> OpsF<A> {
+        OpsF(.write(content, next))
+    }
+}
+
+fileprivate postfix func ^<A>(_ value: OpsFOf<A>) -> OpsF<A> {
+    value as! OpsF<A>
+}
+
+fileprivate typealias Ops<A> = Program<OpsFPartial, A>
+
+fileprivate func read() -> Ops<String> {
+    Ops.liftF(OpsF.read(id))
+}
+
+fileprivate func write(content: String) -> Ops<Void> {
+    Ops.liftF(OpsF.write(content, ()))
+}
+
+fileprivate func program() -> Ops<Void> {
+    let name = Ops<String>.var()
+    
+    return binding(
+        |<-write(content: "What's your name?"),
+        name <- read(),
+        |<-write(content: "Hello \(name.get)!"),
+        yield: ()
+    )^
+}
+
+fileprivate class StateInterpreter: FunctionK<OpsFPartial, StatePartial<([String], [String])>> {
+    
+    override func invoke<A>(
+        _ fa: OpsFOf<A>
+    ) -> StateOf<([String], [String]), A> {
+        switch fa^.value {
+        
+        case .read(let callback):
+            return State { state -> (([String], [String]), A) in
+                let input = state.0[0]
+                let remaining = Array(state.0.dropFirst())
+                return ((remaining, state.1), callback(input))
+            }
+            
+        case .write(let content, let next):
+            return State { state -> (([String], [String]), A) in
+                let outputs = state.1 + [content]
+                return ((state.0, outputs), next)
+            }
+        }
+    }
+}
+
+extension ProgramPartial: EquatableK where F: Monad & EquatableK {
+    public static func eq<A>(
+        _ lhs: ProgramOf<F, A>,
+        _ rhs: ProgramOf<F, A>
+    ) -> Bool where A: Equatable {
+        lhs^.run() == rhs^.run()
+    }
+}
+
+class ProgramTest: XCTestCase {
+    func testInterpretsProgram() {
+        let state = program().foldMapK(StateInterpreter())^
+        let final = state.runS((["Bow"], []))
+        let outputs = ["What's your name?", "Hello Bow!"]
+        XCTAssertEqual(final.0, [String]())
+        XCTAssertEqual(final.1, outputs)
+    }
+    
+    func testFunctorLaws() {
+        FunctorLaws<ProgramPartial<ForId>>.check()
+    }
+    
+    func testApplicativeLaws() {
+        ApplicativeLaws<ProgramPartial<ForId>>.check()
+    }
+
+    func testSelectiveLaws() {
+        SelectiveLaws<ProgramPartial<ForId>>.check()
+    }
+    
+    func testMonadLaws() {
+        MonadLaws<ProgramPartial<ForId>>.check()
+    }
+}


### PR DESCRIPTION
## Goal

(Re)Introduce[1] Free-er monads in Bow. `Program` allows you to get a monad from any type constructor. Unlike `Free`, it doesn't require `F` to be a functor, so not only does it defer the evaluation of `flatMap` calls for later interpretation into another monad, but also (unlike Free) defers calls to `map`.

Reference: [free-operational](http://hackage.haskell.org/package/free-operational-0.5.0.0/docs/Control-Monad-Operational-Simple.html)

**Do we need both `Free` and `Program`?**
Yes. When you use `Free`, certain properties can be enforced in the Functor implementation of `F`, meaning that those properties will be fulfilled no matter what interpreter you use later [2].

When you use `Program`, you cannot enforce properties on the Functor implementation of F, because it's just not a functor. But, on the other hand, you don't have to implement the Functor instance. So `Program` is easier to use, but you cannot guarantee custom properties hold. Context will tell what option is best for you.

## Implementation details

`Program` is just `Free<Coyoneda<F>>`. `Free` needs a functor, since `F` is not a functor, we use `Coyoneda<F>` which is the free functor of `F` and defers evaluation of `map`. So, at the end, `Program` defers the evaluation of `flatMap` calls for later interpretation into another monad, but unlike `Free`, it also defers calls to `map` (thanks to the inner `Coyoneda`).

## Testing details

I used the same test program found in the `Free` tests, but you can see how it is not a functor here!

## Name
I'm not really happy with the name *Program*. I took it from Haskell, but it doesn't really tell what this type is about IMHO. 

On the other hand, *Freer* is too similar to `Free` and I think this can cause confusion or problems in code.

A third option would be to come up with a new name that tries to capture the essence of this data type but is not similar to `Free`. Something like `EvenFreer`? But then it would be more difficult to relate this type to its Haskell and Scala counterpart.

What's your view on the naming issue?

## Notes
[1] The previous interpretation of Free was actually the Free-er monad! So we are just bringing it back.
[2] See [Purify code using free monads (*Proofs* section)](http://www.haskellforall.com/2012/07/purify-code-using-free-monads.html) for an example.