### PR TITLE
CI: fix homebrew fails

### DIFF
--- a/.github/workflows/nef-compile.yml
+++ b/.github/workflows/nef-compile.yml
@@ -12,7 +12,7 @@ jobs:
       run: sudo xcode-select -s /Applications/Xcode_12.app/Contents/Developer
     - name: Compile documentation
       run: |
-        brew update
+        brew update-reset
         brew install nef
         gem install cocoapods -v 1.9.1
         nef compile --project Documentation.app


### PR DESCRIPTION
This PR fixes CI about Homebrew fails:
```
Please make sure you have the correct access rights
and the repository exists.
Error: Fetching /usr/local/Homebrew/Library/Taps/local/homebrew-openssl failed!
Fetching /usr/local/Homebrew/Library/Taps/local/homebrew-python2 failed!
fatal: invalid upstream 'origin/master'
fatal: invalid upstream 'origin/master'
```