### PR TITLE
Introduce HashableK typeclass

### DIFF
--- a/Bow.xcodeproj/project.pbxproj
+++ b/Bow.xcodeproj/project.pbxproj
@@ -363,6 +363,8 @@
 		8BA0F65B217E2E9200969984 /* FunctorFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BA0F4AE217E2E9200969984 /* FunctorFilter.swift */; };
 		8BB969AD2398661D005520D6 /* Queue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BB969AB239863F0005520D6 /* Queue.swift */; };
 		B507D2BE252A347A002541E4 /* CoyonedaNaturalTransformationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B507D290252A315C002541E4 /* CoyonedaNaturalTransformationTests.swift */; };
+		B53976272540113100D8ECB8 /* HashableK.swift in Sources */ = {isa = PBXBuildFile; fileRef = B53976262540113100D8ECB8 /* HashableK.swift */; };
+		B53976552540116A00D8ECB8 /* HashableKLaws.swift in Sources */ = {isa = PBXBuildFile; fileRef = B53976542540116A00D8ECB8 /* HashableKLaws.swift */; };
 		B55BE657252332BA005297CA /* Program.swift in Sources */ = {isa = PBXBuildFile; fileRef = B55BE656252332BA005297CA /* Program.swift */; };
 		B55BE68525234AD1005297CA /* ProgramTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = B55BE68425234AD1005297CA /* ProgramTest.swift */; };
 		B55F53BC2524D7F3001979EE /* Program+Gen.swift in Sources */ = {isa = PBXBuildFile; fileRef = B55F53BB2524D7F3001979EE /* Program+Gen.swift */; };
@@ -1247,6 +1249,8 @@
 		8BD6974D23F5AE18000A512F /* BowAllTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = BowAllTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		B507D290252A315C002541E4 /* CoyonedaNaturalTransformationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoyonedaNaturalTransformationTests.swift; sourceTree = "<group>"; };
 		B52120FE2523AC2300705BCD /* Exists.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Exists.swift; sourceTree = "<group>"; };
+		B53976262540113100D8ECB8 /* HashableK.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HashableK.swift; sourceTree = "<group>"; };
+		B53976542540116A00D8ECB8 /* HashableKLaws.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HashableKLaws.swift; sourceTree = "<group>"; };
 		B55BE656252332BA005297CA /* Program.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Program.swift; sourceTree = "<group>"; };
 		B55BE68425234AD1005297CA /* ProgramTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProgramTest.swift; sourceTree = "<group>"; };
 		B53F8C08251A5F8000468947 /* Tree.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Tree.swift; sourceTree = "<group>"; };
@@ -1814,6 +1818,7 @@
 				609CC1482364FC5B00096D5D /* DivisibleLaws.swift */,
 				1166A07822119E640032CD4E /* EqualityFunctions.swift */,
 				8BA0F3BF217E2DEF00969984 /* EquatableKLaws.swift */,
+				B53976542540116A00D8ECB8 /* HashableKLaws.swift */,
 				11A435602212C59F000C5E31 /* EquatableLaws.swift */,
 				8BA0F3D6217E2DEF00969984 /* FoldableLaws.swift */,
 				8BA0F3C1217E2DEF00969984 /* FunctorFilterLaws.swift */,
@@ -2136,6 +2141,7 @@
 				8BA0F4A0217E2E9200969984 /* Foldable.swift */,
 				8BA0F4AB217E2E9200969984 /* Functor.swift */,
 				8BA0F4AE217E2E9200969984 /* FunctorFilter.swift */,
+				B53976262540113100D8ECB8 /* HashableK.swift */,
 				8BA0F499217E2E9200969984 /* Invariant.swift */,
 				8BA0F4A4217E2E9200969984 /* Monad.swift */,
 				8BA0F4AD217E2E9200969984 /* MonadCombine.swift */,
@@ -2941,6 +2947,7 @@
 				606B29EB2360763C002334B2 /* SemigroupalLaws.swift in Sources */,
 				1122942D219D8BDE006D66C5 /* MonadErrorLaws.swift in Sources */,
 				606B29EE2360765D002334B2 /* DivideLaws.swift in Sources */,
+				B53976552540116A00D8ECB8 /* HashableKLaws.swift in Sources */,
 				1122942E219D8BDE006D66C5 /* MonadFilterLaws.swift in Sources */,
 				1122942F219D8BDE006D66C5 /* MonadLaws.swift in Sources */,
 				11229430219D8BDE006D66C5 /* MonadStateLaws.swift in Sources */,
@@ -3369,6 +3376,7 @@
 				8BA0F62B217E2E9200969984 /* NonEmptyReducible.swift in Sources */,
 				8BA0F503217E2E9200969984 /* BooleanFunctions.swift in Sources */,
 				8BA0F4F3217E2E9200969984 /* Function1.swift in Sources */,
+				B53976272540113100D8ECB8 /* HashableK.swift in Sources */,
 				115488D123BFA0CC00A6DE92 /* EnvT.swift in Sources */,
 				8BA0F5CF217E2E9200969984 /* Const.swift in Sources */,
 				609CC14D2365410500096D5D /* Decidable.swift in Sources */,

--- a/Sources/Bow/Arrow/Function0.swift
+++ b/Sources/Bow/Arrow/Function0.swift
@@ -60,6 +60,14 @@ extension Function0Partial: EquatableK {
     }
 }
 
+// MARK: Instance of HashableK for Function0
+extension Function0Partial: HashableK {
+    public static func hash<A>(_ fa: Function0Of<A>, into hasher: inout Hasher) where A : Hashable {
+        hasher.combine(fa^.invoke())
+    }
+}
+
+
 // MARK: Instance of Functor for Function0
 extension Function0Partial: Functor {
     public static func map<A, B>(

--- a/Sources/Bow/Data/ArrayK.swift
+++ b/Sources/Bow/Data/ArrayK.swift
@@ -183,6 +183,13 @@ extension ArrayKPartial: EquatableK {
     }
 }
 
+// MARK: Instance of HashableK for ArrayK
+extension ArrayKPartial: HashableK {
+    public static func hash<A>(_ fa: ArrayKOf<A>, into hasher: inout Hasher) where A : Hashable {
+        fa^.array.hash(into: &hasher)
+    }
+}
+
 // MARK: Instance of Functor for ArrayK
 extension ArrayKPartial: Functor {
     public static func map<A, B>(

--- a/Sources/Bow/Data/Const.swift
+++ b/Sources/Bow/Data/Const.swift
@@ -68,6 +68,13 @@ extension ConstPartial: EquatableK where A: Equatable {
     }
 }
 
+// MARK: Instance of HashableK for Const
+extension ConstPartial: HashableK where A: Hashable {
+    public static func hash<T>(_ fa: ConstOf<A, T>, into hasher: inout Hasher) where T: Hashable {
+        hasher.combine(fa^.value)
+    }
+}
+
 // MARK: Instance of Functor for Const
 extension ConstPartial: Functor {
     public static func map<C, B>(

--- a/Sources/Bow/Data/DictionaryK.swift
+++ b/Sources/Bow/Data/DictionaryK.swift
@@ -124,6 +124,14 @@ extension DictionaryKPartial: EquatableK {
     }
 }
 
+// MARK: Instance of HashableK for DictionaryK
+
+extension DictionaryKPartial: HashableK {
+    public static func hash<A>(_ fa: DictionaryKOf<K, A>, into hasher: inout Hasher) where A : Hashable {
+        hasher.combine(fa^.asDictionary())
+    }
+}
+
 // MARK: Instance of Functor for DictionaryK
 
 extension DictionaryKPartial: Functor {

--- a/Sources/Bow/Data/EitherK.swift
+++ b/Sources/Bow/Data/EitherK.swift
@@ -90,6 +90,13 @@ extension EitherKPartial: EquatableK where F: EquatableK, G: EquatableK {
     }
 }
 
+// MARK: Instance of HashableK for EitherK.
+extension EitherKPartial: HashableK where F: HashableK, G: HashableK {
+    public static func hash<A>(_ fa: EitherKOf<F, G, A>, into hasher: inout Hasher) where A : Hashable {
+        hasher.combine(fa^.run)
+    }
+}
+
 // MARK: Instance of Invariant for EitherK.
 extension EitherKPartial: Invariant where F: Invariant, G: Invariant {
     public static func imap<A, B>(

--- a/Sources/Bow/Data/Eval.swift
+++ b/Sources/Bow/Data/Eval.swift
@@ -284,3 +284,10 @@ extension EvalPartial: EquatableK {
         lhs^.value() == rhs^.value()
     }
 }
+
+// MARK: Instance of HashableK for Eval
+extension EvalPartial: HashableK {
+    public static func hash<A>(_ fa: EvalOf<A>, into hasher: inout Hasher) where A : Hashable {
+        hasher.combine(fa^.value())
+    }
+}

--- a/Sources/Bow/Data/Id.swift
+++ b/Sources/Bow/Data/Id.swift
@@ -61,6 +61,13 @@ extension IdPartial: EquatableK {
     }
 }
 
+// MARK: Instance of HashableK for Id
+extension IdPartial: HashableK  {
+    public static func hash<A>(_ fa: IdOf<A>, into hasher: inout Hasher) where A : Hashable {
+        hasher.combine(fa^.value)
+    }
+}
+
 // MARK: Instance of Functor for Id
 extension IdPartial: Functor {
     public static func map<A, B>(

--- a/Sources/Bow/Data/Ior.swift
+++ b/Sources/Bow/Data/Ior.swift
@@ -11,7 +11,7 @@ public typealias IorOf<A, B> = Kind<IorPartial<A>, B>
 
 /// Ior represents an inclusive-or of two different types. It may have a value of the left type, the right type or both at the same time.
 public final class Ior<A, B>: IorOf<A, B> {
-    private let value: _Ior<A, B>
+    fileprivate let value: _Ior<A, B>
     
     private init(_ value: _Ior<A, B>) {
         self.value = value
@@ -189,6 +189,9 @@ private enum _Ior<A, B> {
     case both(A, B)
 }
 
+extension _Ior: Equatable where A: Equatable, B: Equatable {}
+extension _Ior: Hashable where A: Hashable, B: Hashable {}
+
 // MARK: Conformance to CustomStringConvertible
 extension Ior: CustomStringConvertible {
     public var description: String {
@@ -212,20 +215,14 @@ extension IorPartial: EquatableK where L: Equatable {
     public static func eq<A: Equatable>(
         _ lhs: IorOf<L, A>,
         _ rhs: IorOf<L, A>) -> Bool {
-        lhs^.fold(
-            { (la: L) -> Bool in
-                rhs^.fold({ ra in la == ra },
-                          constant(false),
-                          constant(false)) },
-            { (lb: A) -> Bool in
-                rhs^.fold(constant(false),
-                          { rb in lb == rb },
-                          constant(false)) },
-            { (la: L, lb: A) -> Bool in
-                rhs^.fold(constant(false),
-                          constant(false),
-                          { ra, rb in la == ra && lb == rb }) }
-        )
+        lhs^.value == rhs^.value
+    }
+}
+
+// MARK: Instance of HashableK for Ior
+extension IorPartial: HashableK where L: Hashable {
+    public static func hash<A>(_ fa: IorOf<L, A>, into hasher: inout Hasher) where A : Hashable {
+        hasher.combine(fa^.value)
     }
 }
 

--- a/Sources/Bow/Data/NonEmptyArray.swift
+++ b/Sources/Bow/Data/NonEmptyArray.swift
@@ -181,6 +181,14 @@ extension NonEmptyArrayPartial: EquatableK {
     }
 }
 
+// MARK: Instance of HashableK for NonEmptyArray
+extension NonEmptyArrayPartial: HashableK {
+    public static func hash<A>(_ fa: NonEmptyArrayOf<A>, into hasher: inout Hasher) where A : Hashable {
+        hasher.combine(fa^.head)
+        hasher.combine(fa^.tail)
+    }
+}
+
 // MARK: Instance of Functor for NonEmptyArray
 extension NonEmptyArrayPartial: Functor {
     public static func map<A, B>(

--- a/Sources/Bow/Data/Option.swift
+++ b/Sources/Bow/Data/Option.swift
@@ -11,7 +11,7 @@ public typealias OptionOf<A> = Kind<ForOption, A>
 
 /// Represents optional values. Instances of this type may represent the presence of a value (`some`) or absence of it (`none`). This type is isomorphic to native Swift `Optional<A>` (usually written `A?`), with the addition of behaving as a Higher Kinded Type.
 public final class Option<A>: OptionOf<A> {
-    private let value: A?
+    fileprivate let value: A?
     /// Constructs an instance of `Option` with presence of a value of the type parameter.
     ///
     /// It equivalent to `Option<A>.pure(_:)`.
@@ -156,8 +156,15 @@ extension OptionPartial: EquatableK {
     public static func eq<A: Equatable>(
         _ lhs: OptionOf<A>,
         _ rhs: OptionOf<A>) -> Bool {
-        lhs^.fold({ rhs^.fold(constant(true), constant(false)) },
-                  { a in rhs^.fold(constant(false), { b in a == b })})
+
+        lhs^.value == rhs^.value
+    }
+}
+
+// MARK: Instance of HashableK for Option
+extension OptionPartial: HashableK {
+    public static func hash<A>(_ fa: OptionOf<A>, into hasher: inout Hasher) where A : Hashable {
+        hasher.combine(fa^.value)
     }
 }
 

--- a/Sources/Bow/Data/Tree.swift
+++ b/Sources/Bow/Data/Tree.swift
@@ -70,6 +70,14 @@ extension TreePartial: EquatableK {
     }
 }
 
+// MARK: Instance of HashableK for Tree
+extension TreePartial: HashableK {
+    public static func hash<A>(_ fa: TreeOf<A>, into hasher: inout Hasher) where A : Hashable {
+        hasher.combine(fa^.root)
+        hasher.combine(fa^.subForest)
+    }
+}
+
 // MARK: Instance of Functor for Tree
 extension TreePartial: Functor {
     public static func map<A, B>(

--- a/Sources/Bow/Data/Try.swift
+++ b/Sources/Bow/Data/Try.swift
@@ -22,14 +22,14 @@ public typealias TryOf<A> = Kind<ForTry, A>
 
 /// Describes the result of an operation that may have thrown errors or succeeded. The type parameter corresponds to the result type of the operation.
 public final class Try<A>: TryOf<A> {
-    private let value: _Try<A>
+    fileprivate let value: Either<Error, A>
 
     /// Creates a successful Try value.
     ///
     /// - Parameter value: Value to be wrapped in a successful Try.
     /// - Returns: A `Try` value wrapping the successful value.
     public static func success(_ value: A) -> Try<A> {
-        Try(.success(value))
+        Try(.right(value))
     }
     
     /// Creates a failed Try value.
@@ -37,7 +37,7 @@ public final class Try<A>: TryOf<A> {
     /// - Parameter error: An error.
     /// - Returns: A `Try` value wrapping the error.
     public static func failure(_ error: Error) -> Try<A> {
-        Try(.failure(error))
+        Try(.left(error))
     }
 
     /// Creates a failed Try value.
@@ -61,7 +61,7 @@ public final class Try<A>: TryOf<A> {
         }
     }
 
-    private init(_ value: _Try<A>) {
+    private init(_ value: Either<Error, A>) {
         self.value = value
     }
 
@@ -80,15 +80,13 @@ public final class Try<A>: TryOf<A> {
     ///   - fa: Closure to apply if the contained value in this `Try` is a successful value.
     /// - Returns: Result of applying the corresponding closure to this value.
     public func fold<B>(_ fe: (Error) -> B, _ fa: (A) throws -> B) -> B {
-        switch value {
-        case let .success(a):
+        value.fold(fe, { a in
             do {
                 return try fa(a)
             } catch let error {
                 return fe(error)
             }
-        case let .failure(e): return fe(e)
-        }
+        })
     }
 
     /// Checks if this value is a failure.
@@ -189,11 +187,6 @@ public postfix func ^<A>(_ fa: TryOf<A>) -> Try<A> {
     Try.fix(fa)
 }
 
-private enum _Try<A> {
-    case success(A)
-    case failure(Error)
-}
-
 // MARK: Conformance of Try to CustomStringConvertible
 extension Try: CustomStringConvertible where A: CustomStringConvertible {
     public var description : String {
@@ -220,6 +213,14 @@ extension TryPartial: EquatableK {
                                   constant(false))},
             { a in rhs^.fold(constant(false),
                              { b in a == b }) })
+    }
+}
+
+// MARK: Instance of HashableK for Try
+extension TryPartial: HashableK {
+    public static func hash<A>(_ fa: TryOf<A>, into hasher: inout Hasher) where A : Hashable {
+        fa^.value.foldRun { hasher.combine("\($0)") }
+                       _: { hasher.combine($0) }
     }
 }
 

--- a/Sources/Bow/Data/Zipper.swift
+++ b/Sources/Bow/Data/Zipper.swift
@@ -146,9 +146,16 @@ extension ZipperPartial: EquatableK {
     public static func eq<A: Equatable>(
         _ lhs: ZipperOf<A>,
         _ rhs: ZipperOf<A>) -> Bool {
-        lhs^.left == rhs^.left &&
-            lhs^.focus == rhs^.focus &&
-            lhs^.right == rhs^.right
+
+        lhs^.asArray() == rhs^.asArray()
+    }
+}
+
+// MARK: Instance of HashableK for Zipper
+
+extension ZipperPartial: HashableK {
+    public static func hash<A>(_ fa: ZipperOf<A>, into hasher: inout Hasher) where A : Hashable {
+        hasher.combine(fa^.asArray())
     }
 }
 

--- a/Sources/Bow/Transformers/EitherT.swift
+++ b/Sources/Bow/Transformers/EitherT.swift
@@ -154,6 +154,13 @@ extension EitherTPartial: EquatableK where F: EquatableK, L: Equatable {
     }
 }
 
+// MARK: Instance of HashableK for EitherT
+extension EitherTPartial: HashableK where F: HashableK, L: Hashable {
+    public static func hash<A>(_ fa: EitherTOf<F, L, A>, into hasher: inout Hasher) where A : Hashable {
+        hasher.combine(fa^.value)
+    }
+}
+
 // MARK: Instance of Invariant for EitherT
 extension EitherTPartial: Invariant where F: Functor {}
 

--- a/Sources/Bow/Transformers/OptionT.swift
+++ b/Sources/Bow/Transformers/OptionT.swift
@@ -209,6 +209,13 @@ extension OptionTPartial: EquatableK where F: EquatableK {
     }
 }
 
+// MARK: Instance of HashableK for OptionT
+extension OptionTPartial: HashableK where F: HashableK {
+    public static func hash<A>(_ fa: OptionTOf<F, A>, into hasher: inout Hasher) where A : Hashable {
+        hasher.combine(fa^.value)
+    }
+}
+
 // MARK: Instance of Invariant for OptionT
 extension OptionTPartial: Invariant where F: Functor {}
 

--- a/Sources/Bow/Transformers/WriterT.swift
+++ b/Sources/Bow/Transformers/WriterT.swift
@@ -249,6 +249,16 @@ extension WriterTPartial: EquatableK where F: EquatableK & Functor, W: Equatable
     }
 }
 
+// MARK: Instance of HashableK for WriterT
+extension WriterTPartial: HashableK where F: HashableK & Functor, W: Hashable {
+    public static func hash<A>(_ fa: WriterTOf<F, W, A>, into hasher: inout Hasher) where A : Hashable {
+        let fa0 = fa^.value.map { t in t.0 }
+        let fa1 = fa^.value.map { t in t.1 }
+        hasher.combine(fa0)
+        hasher.combine(fa1)
+    }
+}
+
 // MARK: Instance of Invariant for WriterT
 extension WriterTPartial: Invariant where F: Functor {}
 

--- a/Sources/Bow/Typeclasses/HashableK.swift
+++ b/Sources/Bow/Typeclasses/HashableK.swift
@@ -1,0 +1,27 @@
+import Foundation
+
+
+
+/// EquatableK provides capabilities to compute a hash value at the kind level.
+public protocol HashableK: EquatableK {
+
+    /// Hashes the essential components of a value wrapped by this kind, provided
+    /// that the wrapped type conforms to `Hashable`.
+    ///
+    /// Implementations of this method must obey the following laws:
+    ///
+    /// 1. Coherence with equality
+    ///
+    ///         eq(fa1, fa2) -> fa1.hashValue == fa2.hashValue
+    ///
+    /// - Parameters:
+    ///   - fa: A value wrapped by this kind.
+    ///   - hasher: The hasher to use when combining the components of this instance.
+    static func hash<A: Hashable>(_ fa: Kind<Self, A>, into hasher: inout Hasher)
+}
+
+extension Kind: Hashable where F: HashableK, A: Hashable {
+    public func hash(into hasher: inout Hasher) {
+        F.hash(self, into: &hasher)
+    }
+}

--- a/Sources/BowFree/Yoneda.swift
+++ b/Sources/BowFree/Yoneda.swift
@@ -165,6 +165,14 @@ extension YonedaPartial: EquatableK where F: EquatableK {
     }
 }
 
+// MARK: Instance of HashableK for Yoneda
+
+extension YonedaPartial: HashableK where F: HashableK {
+    public static func hash<A: Hashable>(_ fa: YonedaOf<F, A>, into hasher: inout Hasher) {
+        hasher.combine(fa^.lower())
+    }
+}
+
 // MARK: Instance of Foldable for Yoneda
 
 extension YonedaPartial: Foldable where F: Foldable {

--- a/Tests/BowFreeTests/YonedaTest.swift
+++ b/Tests/BowFreeTests/YonedaTest.swift
@@ -5,6 +5,14 @@ import BowFreeGenerators
 import BowLaws
 
 class YonedaTest: XCTestCase {
+    func testEquatableKLaws() {
+        EquatableKLaws<YonedaPartial<IdPartial>, Int>.check()
+    }
+
+    func testHashableKLaws() {
+        HashableKLaws<YonedaPartial<IdPartial>, Int>.check()
+    }
+
     func testFunctorLaws() {
         FunctorLaws<YonedaPartial<IdPartial>>.check()
     }

--- a/Tests/BowLaws/HashableKLaws.swift
+++ b/Tests/BowLaws/HashableKLaws.swift
@@ -9,7 +9,15 @@ public class HashableKLaws<F: HashableK & ArbitraryK, A: Arbitrary & Hashable> {
     }
     
     private static func coherenceWithEquality() {
-        property("Equal objects have equal hash") <~ forAll { (fa1: KindOf<F, A>, fa2: KindOf<F, A>) in
+        let generator: Gen<(KindOf<F, A>, KindOf<F, A>)> = {
+          let equal = KindOf<F, A>.arbitrary.map { fa in (fa, fa) }
+          let distinct = Gen.zip(KindOf<F, A>.arbitrary, KindOf<F, A>.arbitrary)
+          return Gen.one(of: [equal, distinct])
+        }()
+
+        property("Equal objects have equal hash") <~ forAllNoShrink(generator) { (tuple: (KindOf<F, A>, KindOf<F, A>)) in
+            let fa1 = tuple.0
+            let fa2 = tuple.1
             return (fa1.value == fa2.value) ==> {
                 var hasher1 = Hasher()
                 var hasher2 = Hasher()

--- a/Tests/BowLaws/HashableKLaws.swift
+++ b/Tests/BowLaws/HashableKLaws.swift
@@ -1,0 +1,22 @@
+import SwiftCheck
+import Bow
+import BowGenerators
+
+public class HashableKLaws<F: HashableK & ArbitraryK, A: Arbitrary & Hashable> {
+    
+    public static func check() {
+        coherenceWithEquality()
+    }
+    
+    private static func coherenceWithEquality() {
+        property("Equal objects have equal hash") <~ forAll { (fa1: KindOf<F, A>, fa2: KindOf<F, A>) in
+            return (fa1.value == fa2.value) ==> {
+                var hasher1 = Hasher()
+                var hasher2 = Hasher()
+                fa1.value.hash(into: &hasher1)
+                fa2.value.hash(into: &hasher2)
+                return hasher1.finalize() == hasher2.finalize()
+            }
+        }
+    }
+}

--- a/Tests/BowTests/Arrow/Function0Test.swift
+++ b/Tests/BowTests/Arrow/Function0Test.swift
@@ -6,6 +6,10 @@ class Function0Test: XCTestCase {
     func testEquatableLaws() {
         EquatableKLaws<Function0Partial, Int>.check()
     }
+
+    func testHashableLaws() {
+        HashableKLaws<Function0Partial, Int>.check()
+    }
     
     func testFunctorLaws() {
         FunctorLaws<Function0Partial>.check()

--- a/Tests/BowTests/Data/ArrayKTest.swift
+++ b/Tests/BowTests/Data/ArrayKTest.swift
@@ -7,6 +7,10 @@ class ArrayKTest: XCTestCase {
     func testEquatableLaws() {
         EquatableKLaws<ArrayKPartial, Int>.check()
     }
+
+    func testHashableKLaws() {
+        HashableKLaws<ArrayKPartial, Int>.check()
+    }
     
     func testFunctorLaws() {
         FunctorLaws<ArrayKPartial>.check()

--- a/Tests/BowTests/Data/ConstTest.swift
+++ b/Tests/BowTests/Data/ConstTest.swift
@@ -6,6 +6,10 @@ class ConstTest: XCTestCase {
     func testEquatableLaws() {
         EquatableKLaws<ConstPartial<Int>, Int>.check()
     }
+
+    func testHashableLaws() {
+        HashableKLaws<ConstPartial<Int>, Int>.check()
+    }
     
     func testFunctorLaws() {
         FunctorLaws<ConstPartial<Int>>.check()

--- a/Tests/BowTests/Data/DictionaryKTest.swift
+++ b/Tests/BowTests/Data/DictionaryKTest.swift
@@ -14,6 +14,10 @@ class DictionaryKTest: XCTestCase {
     func testEquatableKLaws() {
         EquatableLaws<DictionaryK<String, Int>>.check()
     }
+
+    func testHashableKLaws() {
+        HashableKLaws<DictionaryKPartial<String>, Int>.check()
+    }
     
     func testFunctorLaws() {
         FunctorLaws<DictionaryKPartial<String>>.check()

--- a/Tests/BowTests/Data/EitherKTest.swift
+++ b/Tests/BowTests/Data/EitherKTest.swift
@@ -8,6 +8,10 @@ class EitherKTest: XCTestCase {
     func testEquatableLaws() {
         EquatableKLaws<EitherKPartial<ForId, ForId>, Int>.check()
     }
+
+    func testHashableLaws() {
+        HashableKLaws<EitherKPartial<ForId, ForId>, Int>.check()
+    }
     
     func testFunctorLaws() {
         FunctorLaws<EitherKPartial<ForId, ForId>>.check()

--- a/Tests/BowTests/Data/EitherTest.swift
+++ b/Tests/BowTests/Data/EitherTest.swift
@@ -6,6 +6,10 @@ class EitherTest: XCTestCase {
     func testEquatableLaws() {
         EquatableKLaws<EitherPartial<Int>, Int>.check()
     }
+
+    func testHashableLaws() {
+        HashableKLaws<EitherPartial<Int>, Int>.check()
+    }
     
     func testFunctorLaws() {
         FunctorLaws<EitherPartial<Int>>.check()

--- a/Tests/BowTests/Data/EvalTest.swift
+++ b/Tests/BowTests/Data/EvalTest.swift
@@ -30,4 +30,8 @@ class EvalTest: XCTestCase {
     func testEquatableKLaws() {
         EquatableKLaws<EvalPartial, Int>.check()
     }
+
+    func testHashableKLaws() {
+        HashableKLaws<EvalPartial, Int>.check()
+    }
 }

--- a/Tests/BowTests/Data/IdTest.swift
+++ b/Tests/BowTests/Data/IdTest.swift
@@ -6,6 +6,10 @@ class IdTest: XCTestCase {
     func testEquatableLaws() {
         EquatableKLaws<IdPartial, Int>.check()
     }
+
+    func testHashableKLaws() {
+        HashableKLaws<IdPartial, Int>.check()
+    }
     
     func testFunctorLaws() {
         FunctorLaws<IdPartial>.check()

--- a/Tests/BowTests/Data/IorTest.swift
+++ b/Tests/BowTests/Data/IorTest.swift
@@ -7,6 +7,10 @@ class IorTest: XCTestCase {
     func testEquatableLaws() {
         EquatableKLaws<IorPartial<Int>, Int>.check()
     }
+
+    func testHashableKLaws() {
+        HashableKLaws<IorPartial<Int>, Int>.check()
+    }
     
     func testFunctorLaws() {
         FunctorLaws<IorPartial<Int>>.check()

--- a/Tests/BowTests/Data/NonEmptyArrayTest.swift
+++ b/Tests/BowTests/Data/NonEmptyArrayTest.swift
@@ -7,6 +7,10 @@ class NonEmptyArrayTest: XCTestCase {
     func testEquatableLaws() {
         EquatableKLaws<NonEmptyArrayPartial, Int>.check()
     }
+
+    func testHashableKLaws() {
+        HashableKLaws<NonEmptyArrayPartial, Int>.check()
+    }
     
     func testFunctorLaws() {
         FunctorLaws<NonEmptyArrayPartial>.check()

--- a/Tests/BowTests/Data/OptionTest.swift
+++ b/Tests/BowTests/Data/OptionTest.swift
@@ -7,6 +7,10 @@ class OptionTest: XCTestCase {
     func testEquatableLaws() {
         EquatableKLaws<OptionPartial, Int>.check()
     }
+
+    func testHashableKLaws() {
+        HashableKLaws<OptionPartial, Int>.check()
+    }
     
     func testFunctorLaws() {
         FunctorLaws<OptionPartial>.check()

--- a/Tests/BowTests/Data/TreeTest.swift
+++ b/Tests/BowTests/Data/TreeTest.swift
@@ -11,6 +11,10 @@ class TreeTest: XCTestCase {
     func testEquatableLaws() {
         EquatableKLaws<TreePartial, Int>.check()
     }
+
+    func testHashableLaws() {
+        HashableKLaws<TreePartial, Int>.check()
+    }
     
     func testFunctorLaws() {
         FunctorLaws<TreePartial>.check()

--- a/Tests/BowTests/Data/TryTest.swift
+++ b/Tests/BowTests/Data/TryTest.swift
@@ -6,6 +6,10 @@ class TryTest: XCTestCase {
     func testEquatableLaws() {
         EquatableKLaws<TryPartial, Int>.check()
     }
+
+    func testHashableKLaws() {
+        HashableKLaws<TryPartial, Int>.check()
+    }
     
     func testFunctorLaws() {
         FunctorLaws<TryPartial>.check()

--- a/Tests/BowTests/Data/ValidatedTest.swift
+++ b/Tests/BowTests/Data/ValidatedTest.swift
@@ -7,6 +7,10 @@ class ValidatedTest: XCTestCase {
     func testEquatableLaws() {
         EquatableKLaws<ValidatedPartial<Int>, Int>.check()
     }
+
+    func testHashableKLaws() {
+        HashableKLaws<ValidatedPartial<Int>, Int>.check()
+    }
     
     func testFunctorLaws() {
         FunctorLaws<ValidatedPartial<Int>>.check()

--- a/Tests/BowTests/Data/ZipperTest.swift
+++ b/Tests/BowTests/Data/ZipperTest.swift
@@ -7,6 +7,10 @@ class ZipperTest: XCTestCase {
     func testEquatableLaws() {
         EquatableKLaws<ZipperPartial, Int>.check()
     }
+
+    func testHashableKLaws() {
+        HashableKLaws<ZipperPartial, Int>.check()
+    }
     
     func testFunctorLaws() {
         FunctorLaws<ZipperPartial>.check()

--- a/Tests/BowTests/Transformers/EitherTTest.swift
+++ b/Tests/BowTests/Transformers/EitherTTest.swift
@@ -7,6 +7,10 @@ class EitherTTest: XCTestCase {
     func testEquatableLaws() {
         EquatableKLaws<EitherTPartial<ForId, Int>, Int>.check()
     }
+
+    func testHashableKLaws() {
+        HashableKLaws<EitherTPartial<ForId, Int>, Int>.check()
+    }
     
     func testFunctorLaws() {
         FunctorLaws<EitherTPartial<ForId, Int>>.check()

--- a/Tests/BowTests/Transformers/OptionTTest.swift
+++ b/Tests/BowTests/Transformers/OptionTTest.swift
@@ -7,6 +7,10 @@ class OptionTTest: XCTestCase {
     func testEquatableLaws() {
         EquatableKLaws<OptionTPartial<ForId>, Int>.check()
     }
+
+    func testHashableKLaws() {
+        HashableKLaws<OptionTPartial<ForId>, Int>.check()
+    }
     
     func testFunctorLaws() {
         FunctorLaws<OptionTPartial<ForId>>.check()

--- a/Tests/BowTests/Transformers/WriterTTest.swift
+++ b/Tests/BowTests/Transformers/WriterTTest.swift
@@ -6,6 +6,10 @@ class WriterTTest: XCTestCase {
     func testEquatableLaws() {
         EquatableKLaws<WriterTPartial<ForId, Int>, Int>.check()
     }
+
+    func testHashableLaws() {
+        HashableKLaws<WriterTPartial<ForId, Int>, Int>.check()
+    }
     
     func testFunctorLaws() {
         FunctorLaws<WriterTPartial<ForId, Int>>.check()


### PR DESCRIPTION
## Goal

Let values of appropriate higher-kinded types be hashable.

I want this because in order to generate an `ArrowOf<KindOf<F, A>, B>` in a property-based test, `KindOf<F, A> ~ Kind<F, A>` needs to be hashable. With this we'll be able write property-based tests for `ComonadTrans` (PR coming soon).
