### PR TITLE
Add stackSafeFlatMap

### DIFF
--- a/Sources/Bow/Typeclasses/Monad.swift
+++ b/Sources/Bow/Typeclasses/Monad.swift
@@ -148,6 +148,25 @@ public extension Monad {
         _ f: @escaping (A) -> Kind<Self, B>) -> Kind<Self, A> {
         flatMap(fa) { a in f(a).as(a) }
     }
+
+    /// A stack safe version of `flatMap`, based on `tailRecM`.
+    ///
+    /// - Parameters:
+    ///   - fa: First computation.
+    ///   - f: A function describing the second computation, which depends on the value of the first.
+    /// - Returns: Result of composing the two computations.
+    static func stackSafeFlatMap<A, B>(
+        _ fa: Kind<Self, A>,
+        _ f: @escaping (A) -> Kind<Self, B>) -> Kind<Self, B> {
+
+        tailRecM(Option<A>.none()) { (w: Option<A>) -> Kind<Self, Either<Option<A>, B>> in
+            w.fold({
+                map(fa) { .left(.some($0)) }
+            }) { i in
+                map(f(i)) { .right($0) }
+            }
+        }
+    }
 }
 
 // MARK: Syntax for Monad

--- a/Sources/Bow/Typeclasses/Monad.swift
+++ b/Sources/Bow/Typeclasses/Monad.swift
@@ -197,6 +197,15 @@ public extension Kind where F: Monad {
         F.tailRecM(a, f)
     }
 
+    /// A stack safe version of `flatMap`, based on `tailRecM`.
+    ///
+    /// - Parameters:
+    ///   - f: A function describing the second computation, which depends on the value of the first.
+    /// - Returns: Result of composing the two computations.
+    func stackSafeFlatMap<B>(_ f: @escaping (A) -> Kind<F, B>) -> Kind<F, B> {
+        F.stackSafeFlatMap(self, f)
+    }
+
     /// Flattens a nested structure of the context implementing this instance into a single layer.
     ///
     /// This is a convenience method to call `Monad.flatten` as a static method of this type.

--- a/Tests/BowLaws/MonadLaws.swift
+++ b/Tests/BowLaws/MonadLaws.swift
@@ -14,7 +14,7 @@ public class MonadLaws<F: Monad & EquatableK & ArbitraryK> {
             stackSafety()
         }
         tailRecMConsistentFlatMap()
-        tailRecMConsistentFlatMapAndMap()
+        stackSafeFlatMapConsistentWithFlatMap()
         monadComprehensions()
         flatten()
     }
@@ -106,19 +106,10 @@ public class MonadLaws<F: Monad & EquatableK & ArbitraryK> {
         }
     }
 
-    /// It is possible to implement flatMap from tailRecM and map
-    /// and it should agree with the flatMap implementation.
-    private static func tailRecMConsistentFlatMapAndMap() {
-        property("tailRecM is consistent with flatMap and map") <~ forAll { (fa: KindOf<F, Int>, f: ArrowOf<Int, KindOf<F, String>>) in
+    private static func stackSafeFlatMapConsistentWithFlatMap() {
+        property("stackSafeFlatMap is consistent with flatMap") <~ forAll { (fa: KindOf<F, Int>, f: ArrowOf<Int, KindOf<F, String>>) in
             let f = { f.getArrow($0).value }
-            let tailRecAndMap = F.tailRecM(Option<Int>.empty()) { (w: Option<Int>) -> Kind<F, Either<Option<Int>, String>> in
-                w.fold({
-                    F.map(fa.value) { .left(.some($0)) }
-                }) { i in
-                    F.map(f(i)) { .right($0) }
-                }
-            }
-            return F.flatMap(fa.value, f) == tailRecAndMap
+            return F.flatMap(fa.value, f) == F.stackSafeFlatMap(fa.value, f)
         }
     }
 


### PR DESCRIPTION
## Goal

Provide a default implementation of `flatMap` based on `tailRecM`. 

Useful when you want a fully stack safe monad, or when you don't want to specialize the implementation of flatMap.