### PR TITLE
Typed monad comprehensions

### DIFF
--- a/Bow.xcodeproj/project.pbxproj
+++ b/Bow.xcodeproj/project.pbxproj
@@ -382,6 +382,7 @@
 		B5BF5086252B0F4A0060AD0D /* LazyFunction1.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5BF5085252B0F4A0060AD0D /* LazyFunction1.swift */; };
 		B5BF50F7252B24AF0060AD0D /* LazyFunction1Test.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5BF509D252B23D30060AD0D /* LazyFunction1Test.swift */; };
 		B5BF510F252B253D0060AD0D /* LazyFunction1+Gen.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5BF510E252B253D0060AD0D /* LazyFunction1+Gen.swift */; };
+		B5D4BF262550513600C1A661 /* MonadComprehensionTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5D4BF252550513600C1A661 /* MonadComprehensionTest.swift */; };
 		B8B910C0234D7F2600E44271 /* Semiring.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8B910BF234D7F2600E44271 /* Semiring.swift */; };
 		B8B910C4234D846900E44271 /* SemiringLaws.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8B910C3234D846900E44271 /* SemiringLaws.swift */; };
 		B8B910C6234DDA4000E44271 /* BoolInstancesTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8B910C5234DDA4000E44271 /* BoolInstancesTest.swift */; };
@@ -1271,6 +1272,7 @@
 		B5BF5085252B0F4A0060AD0D /* LazyFunction1.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LazyFunction1.swift; sourceTree = "<group>"; };
 		B5BF509D252B23D30060AD0D /* LazyFunction1Test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LazyFunction1Test.swift; sourceTree = "<group>"; };
 		B5BF510E252B253D0060AD0D /* LazyFunction1+Gen.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "LazyFunction1+Gen.swift"; sourceTree = "<group>"; };
+		B5D4BF252550513600C1A661 /* MonadComprehensionTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MonadComprehensionTest.swift; sourceTree = "<group>"; };
 		B8B910BF234D7F2600E44271 /* Semiring.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Semiring.swift; sourceTree = "<group>"; };
 		B8B910C3234D846900E44271 /* SemiringLaws.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SemiringLaws.swift; sourceTree = "<group>"; };
 		B8B910C5234DDA4000E44271 /* BoolInstancesTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoolInstancesTest.swift; sourceTree = "<group>"; };
@@ -1738,6 +1740,7 @@
 				8BA0F38B217E2DEF00969984 /* PartialApplicationTest.swift */,
 				8BA0F393217E2DEF00969984 /* PredefTest.swift */,
 				11DDCD27217F1FC200844D9D /* ReverseTest.swift */,
+				B5D4BF252550513600C1A661 /* MonadComprehensionTest.swift */,
 			);
 			path = Syntax;
 			sourceTree = "<group>";
@@ -3259,6 +3262,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 0;
 			files = (
+				B5D4BF262550513600C1A661 /* MonadComprehensionTest.swift in Sources */,
 				8BA0F409217E2DEF00969984 /* TryTest.swift in Sources */,
 				8BA0F406217E2DEF00969984 /* StoreTTest.swift in Sources */,
 				B5BF50F7252B24AF0060AD0D /* LazyFunction1Test.swift in Sources */,

--- a/Sources/Bow/Typeclasses/MonadComprehensions/BindingExpression.swift
+++ b/Sources/Bow/Typeclasses/MonadComprehensions/BindingExpression.swift
@@ -3,25 +3,64 @@
 /// In a binding expression of the form `x <- fx`, `x` is the variable to be bound and `fx` is the
 /// monadic effect that we want to bind to the variable.
 public class BindingExpression<F: Monad> {
-    internal let bound: BoundVar<F, Any>
-    internal let fa: () -> Kind<F, Any>
-    
-    init(_ bound: BoundVar<F, Any>, _ fa: @escaping () -> Kind<F, Any>) {
-        self.bound = bound
-        self.fa = fa
+    private let exists: Exists<_BindingExpressionPartial<F>>
+
+    init<A>(_ bound: BoundVar<F, A>, _ fa: @escaping () -> Kind<F, A>) {
+        self.exists = Exists(_BindingExpression(bound: bound, fa: fa))
     }
     
     internal func yield<A>(_ f: @escaping () -> A) -> Kind<F, A> {
-        fa().map { x in
-            self.bound.bind(x)
-            return f()
-        }
+        exists.run(Yield(f))
     }
     
     internal func bind<A>(_ partial: Eval<Kind<F, A>>) -> Kind<F, A> {
-        fa().flatMap { x in
-            self.bound.bind(x)
-            return partial.value()
+        exists.run(Bind(partial))
+    }
+}
+
+private final class Yield<F: Monad, A>: CokleisliK<_BindingExpressionPartial<F>, Kind<F, A>> {
+    init(_ f: @escaping () -> A) {
+        self.f = f
+    }
+
+    let f: () -> A
+
+    override func invoke<R>(_ existential: _BindingExpressionOf<F, R>) -> Kind<F, A> {
+        existential^.fa().map { x in
+            existential^.bound.bind(x)
+            return self.f()
         }
     }
+}
+
+private final class Bind<F: Monad, A>: CokleisliK<_BindingExpressionPartial<F>, Kind<F, A>> {
+    init(_ partial: Eval<Kind<F, A>>) {
+        self.partial = partial
+    }
+
+    let partial: Eval<Kind<F, A>>
+
+    override func invoke<R>(_ existential: _BindingExpressionOf<F, R>) -> Kind<F, A> {
+        existential^.fa().flatMap { x in
+            existential^.bound.bind(x)
+            return self.partial.value()
+        }
+    }
+}
+
+private final class _ForBindingExpression {}
+private final class _BindingExpressionPartial<F: Monad>: Kind<_ForBindingExpression, F> {}
+private typealias _BindingExpressionOf<F: Monad, A> = Kind<_BindingExpressionPartial<F>, A>
+private final class _BindingExpression<F: Monad, A>: _BindingExpressionOf<F, A> {
+    init(bound: BoundVar<F, A>, fa: @escaping () -> Kind<F, A>) {
+        self.bound = bound
+        self.fa = fa
+    }
+
+    let bound: BoundVar<F, A>
+    let fa: () -> Kind<F, A>
+}
+
+private postfix func ^<F, A>(_ fa: _BindingExpressionOf<F, A>) -> _BindingExpression<F, A> {
+    fa as! _BindingExpression<F, A>
 }

--- a/Sources/Bow/Typeclasses/MonadComprehensions/BindingOperator.swift
+++ b/Sources/Bow/Typeclasses/MonadComprehensions/BindingOperator.swift
@@ -1,10 +1,6 @@
 infix operator <- : AssignmentPrecedence
 prefix operator |<-
 
-internal func erased<F: Functor, A>(_ value: Kind<F, A>) -> Kind<F, Any> {
-    value.map { x in x as Any }
-}
-
 /// Creates a binding expression.
 ///
 /// - Parameters:
@@ -14,7 +10,7 @@ internal func erased<F: Functor, A>(_ value: Kind<F, A>) -> Kind<F, Any> {
 public func <-<F: Monad, A>(
     _ bound: BoundVar<F, A>,
     _ fa: @autoclosure @escaping () -> Kind<F, A>) -> BindingExpression<F> {
-    BindingExpression(bound.erased, fa >>> erased)
+    BindingExpression(bound, fa)
 }
 
 /// Creates a binding expression.
@@ -27,8 +23,8 @@ public func <-<F: Monad, A, B>(
     _ bounds: (BoundVar<F, A>, BoundVar<F, B>),
     _ fa: @autoclosure @escaping () -> Kind<F, (A, B)>) -> BindingExpression<F> {
     BindingExpression(
-        BoundVar2(bounds.0, bounds.1).erased,
-        fa >>> erased)
+        BoundVar2(bounds.0, bounds.1),
+        fa)
 }
 
 /// Creates a binding expression.
@@ -41,8 +37,8 @@ public func <-<F: Monad, A, B, C>(
     _ bounds: (BoundVar<F, A>, BoundVar<F, B>, BoundVar<F, C>),
     _ fa: @autoclosure @escaping () -> Kind<F, (A, B, C)>) -> BindingExpression<F> {
     BindingExpression(
-        BoundVar3(bounds.0, bounds.1, bounds.2).erased,
-        fa >>> erased)
+        BoundVar3(bounds.0, bounds.1, bounds.2),
+        fa)
 }
 
 /// Creates a binding expression.
@@ -55,8 +51,8 @@ public func <-<F: Monad, A, B, C, D>(
     _ bounds: (BoundVar<F, A>, BoundVar<F, B>, BoundVar<F, C>, BoundVar<F, D>),
     _ fa: @autoclosure @escaping () -> Kind<F, (A, B, C, D)>) -> BindingExpression<F> {
     BindingExpression(
-        BoundVar4(bounds.0, bounds.1, bounds.2, bounds.3).erased,
-        fa >>> erased)
+        BoundVar4(bounds.0, bounds.1, bounds.2, bounds.3),
+        fa)
 }
 
 /// Creates a binding expression.
@@ -69,8 +65,8 @@ public func <-<F: Monad, A, B, C, D, E>(
     _ bounds: (BoundVar<F, A>, BoundVar<F, B>, BoundVar<F, C>, BoundVar<F, D>, BoundVar<F, E>),
     _ fa: @autoclosure @escaping () -> Kind<F, (A, B, C, D, E)>) -> BindingExpression<F> {
     BindingExpression(
-        BoundVar5(bounds.0, bounds.1, bounds.2, bounds.3, bounds.4).erased,
-        fa >>> erased)
+        BoundVar5(bounds.0, bounds.1, bounds.2, bounds.3, bounds.4),
+        fa)
 }
 
 /// Creates a binding expression.
@@ -83,8 +79,8 @@ public func <-<F: Monad, A, B, C, D, E, G>(
     _ bounds: (BoundVar<F, A>, BoundVar<F, B>, BoundVar<F, C>, BoundVar<F, D>, BoundVar<F, E>, BoundVar<F, G>),
     _ fa: @autoclosure @escaping () -> Kind<F, (A, B, C, D, E, G)>) -> BindingExpression<F> {
     BindingExpression(
-        BoundVar6(bounds.0, bounds.1, bounds.2, bounds.3, bounds.4, bounds.5).erased,
-        fa >>> erased)
+        BoundVar6(bounds.0, bounds.1, bounds.2, bounds.3, bounds.4, bounds.5),
+        fa)
 }
 
 /// Creates a binding expression.
@@ -97,8 +93,8 @@ public func <-<F: Monad, A, B, C, D, E, G, H>(
     _ bounds: (BoundVar<F, A>, BoundVar<F, B>, BoundVar<F, C>, BoundVar<F, D>, BoundVar<F, E>, BoundVar<F, G>, BoundVar<F, H>),
     _ fa: @autoclosure @escaping () -> Kind<F, (A, B, C, D, E, G, H)>) -> BindingExpression<F> {
     BindingExpression(
-        BoundVar7(bounds.0, bounds.1, bounds.2, bounds.3, bounds.4, bounds.5, bounds.6).erased,
-        fa >>> erased)
+        BoundVar7(bounds.0, bounds.1, bounds.2, bounds.3, bounds.4, bounds.5, bounds.6),
+        fa)
 }
 
 /// Creates a binding expression.
@@ -111,8 +107,8 @@ public func <-<F: Monad, A, B, C, D, E, G, H, I>(
     _ bounds: (BoundVar<F, A>, BoundVar<F, B>, BoundVar<F, C>, BoundVar<F, D>, BoundVar<F, E>, BoundVar<F, G>, BoundVar<F, H>, BoundVar<F, I>),
     _ fa: @autoclosure @escaping () -> Kind<F, (A, B, C, D, E, G, H, I)>) -> BindingExpression<F> {
     BindingExpression(
-        BoundVar8(bounds.0, bounds.1, bounds.2, bounds.3, bounds.4, bounds.5, bounds.6, bounds.7).erased,
-        fa >>> erased)
+        BoundVar8(bounds.0, bounds.1, bounds.2, bounds.3, bounds.4, bounds.5, bounds.6, bounds.7),
+        fa)
 }
 
 /// Creates a binding expression.
@@ -125,8 +121,8 @@ public func <-<F: Monad, A, B, C, D, E, G, H, I, J>(
     _ bounds: (BoundVar<F, A>, BoundVar<F, B>, BoundVar<F, C>, BoundVar<F, D>, BoundVar<F, E>, BoundVar<F, G>, BoundVar<F, H>, BoundVar<F, I>, BoundVar<F, J>),
     _ fa: @autoclosure @escaping () -> Kind<F, (A, B, C, D, E, G, H, I, J)>) -> BindingExpression<F> {
     BindingExpression(
-        BoundVar9(bounds.0, bounds.1, bounds.2, bounds.3, bounds.4, bounds.5, bounds.6, bounds.7, bounds.8).erased,
-        fa >>> erased)
+        BoundVar9(bounds.0, bounds.1, bounds.2, bounds.3, bounds.4, bounds.5, bounds.6, bounds.7, bounds.8),
+        fa)
 }
 
 /// Creates a binding expression.
@@ -139,8 +135,8 @@ public func <-<F: Monad, A, B, C, D, E, G, H, I, J, K>(
     _ bounds: (BoundVar<F, A>, BoundVar<F, B>, BoundVar<F, C>, BoundVar<F, D>, BoundVar<F, E>, BoundVar<F, G>, BoundVar<F, H>, BoundVar<F, I>, BoundVar<F, J>, BoundVar<F, K>),
     _ fa: @autoclosure @escaping () -> Kind<F, (A, B, C, D, E, G, H, I, J, K)>) -> BindingExpression<F> {
     BindingExpression(
-        BoundVar10(bounds.0, bounds.1, bounds.2, bounds.3, bounds.4, bounds.5, bounds.6, bounds.7, bounds.8, bounds.9).erased,
-        fa >>> erased)
+        BoundVar10(bounds.0, bounds.1, bounds.2, bounds.3, bounds.4, bounds.5, bounds.6, bounds.7, bounds.8, bounds.9),
+        fa)
 }
 
 /// Creates a binding expression that discards the produced value.
@@ -148,5 +144,5 @@ public func <-<F: Monad, A, B, C, D, E, G, H, I, J, K>(
 /// - Parameter fa: Monadic effect.
 /// - Returns: A binding expression.
 public prefix func |<-<F: Monad, A>(_ fa: @autoclosure @escaping () -> Kind<F, A>) -> BindingExpression<F> {
-    BindingExpression(BoundVar(), fa >>> erased)
+    BindingExpression(BoundVar(), fa)
 }

--- a/Sources/Bow/Typeclasses/MonadComprehensions/BoundVar.swift
+++ b/Sources/Bow/Typeclasses/MonadComprehensions/BoundVar.swift
@@ -21,10 +21,6 @@ public class BoundVar<F: Monad, A> {
     public var get: A {
         return value!
     }
-    
-    internal var erased: BoundVar<F, Any> {
-        ErasedBoundVar<F, A>(self)
-    }
 }
 
 // MARK: Creation of variables for Monad Comprehensions
@@ -45,18 +41,6 @@ public extension Kind where F: Monad {
     /// - Returns: A bound variable.
     static func `var`() -> BoundVar<F, A> {
         F.var(A.self)
-    }
-}
-
-private class ErasedBoundVar<F: Monad, A>: BoundVar<F, Any> {
-    private var boundVar: BoundVar<F, A>
-    
-    fileprivate init(_ boundVar: BoundVar<F, A>) {
-        self.boundVar = boundVar
-    }
-    
-    override func bind(_ value: Any) {
-        boundVar.bind(value as! A)
     }
 }
 

--- a/Tests/BowTests/Syntax/MonadComprehensionTest.swift
+++ b/Tests/BowTests/Syntax/MonadComprehensionTest.swift
@@ -1,0 +1,87 @@
+import XCTest
+import SwiftCheck
+import Bow
+import BowLaws
+
+class MonadComprehensionTest: XCTestCase {
+    func testMonadComprehesionsDontEraseToAny() {
+        let fa = IdCrashingOnAnyPartial.pure(1)
+        let fb = IdCrashingOnAnyPartial.pure(2)
+        let fc = IdCrashingOnAnyPartial.pure(3)
+        let fd = IdCrashingOnAnyPartial.pure(4)
+
+        let x = IdCrashingOnAnyOf<Int>.var()
+        let y = IdCrashingOnAnyOf<Int>.var()
+        let z = IdCrashingOnAnyOf<Int>.var()
+        let w = IdCrashingOnAnyOf<Int>.var()
+
+        let result = binding(
+            x <-- fa,
+            y <-- fb,
+            z <-- fc,
+            w <-- fd,
+            yield: x.get + y.get + z.get + w.get)
+
+        XCTAssertEqual(result^.value, 10)
+    }
+}
+
+fileprivate final class ForIdCrashingOnAny {}
+fileprivate typealias IdCrashingOnAnyPartial = ForIdCrashingOnAny
+fileprivate typealias IdCrashingOnAnyOf<A> = Kind<IdCrashingOnAnyPartial, A>
+fileprivate final class IdCrashingOnAny<A>: IdCrashingOnAnyOf<A> {
+    let value: A
+
+    init(_ value: A) {
+        self.value = value
+    }
+
+    static func fix(_ fa: IdCrashingOnAnyOf<A>) -> IdCrashingOnAny<A> {
+        fa as! IdCrashingOnAny<A>
+    }
+}
+
+fileprivate postfix func ^<A>(_ fa: IdCrashingOnAnyOf<A>) -> IdCrashingOnAny<A> {
+    IdCrashingOnAny.fix(fa)
+}
+
+extension IdCrashingOnAnyPartial: Functor {
+    public static func map<A, B>(_ fa: IdCrashingOnAnyOf<A>, _ f: @escaping (A) -> B) -> Kind<IdCrashingOnAnyPartial, B> {
+        IdCrashingOnAny<B>(f(fa^.value))
+    }
+}
+
+extension IdCrashingOnAnyPartial: Applicative {
+    static func pure<A>(_ a: A) -> Kind<IdCrashingOnAnyPartial, A> {
+        IdCrashingOnAny(a)
+    }
+}
+
+extension IdCrashingOnAnyPartial: Monad {
+    public static func flatMap<A, B>(
+        _ fa: IdCrashingOnAnyOf<A>,
+        _ f: @escaping (A) -> IdCrashingOnAnyOf<B>) -> IdCrashingOnAnyOf<B> {
+        XCTAssertNotEqual(
+            String(describing: A.self),
+            "Any",
+            "Monad comprehensions should not erase `Kind<F, A>` to `Kind<F, Any>`"
+        )
+        return f(fa^.value)
+    }
+
+    public static func tailRecM<A, B>(
+        _ a: A,
+        _ f: @escaping (A) -> IdCrashingOnAnyOf<Either<A, B>>) -> IdCrashingOnAnyOf<B> {
+        _tailRecM(a, f).run()
+    }
+
+    private static func _tailRecM<A, B>(
+        _ a: A,
+        _ f: @escaping (A) -> IdCrashingOnAnyOf<Either<A, B>>) -> Trampoline<IdCrashingOnAnyOf<B>> {
+        .defer {
+            f(a)^.value.fold(
+                { left in _tailRecM(left, f) },
+                { right in .done(IdCrashingOnAny(right)) })
+        }
+    }
+}


### PR DESCRIPTION
## Goal

When using monad comprehensions, `flatMap` is called with values of type `Kind<F, Any>` and erased functions. From a result point of view, this is fine, as checked by the "Monad comprehensions equivalence to flatMap"  law.

However, when debugging, the situation is a little weird because if I set a breakpoint on the implementation of `flatMap` for a Monad, I cannot  know what's the inner type of my Monad at that point, because I always see `Kind<F, Any>`.

This PR fixes this.

## Implementation details

Instead of erasing to `Any`, `BindingExpression` now uses `Exists`. This allows us to call `flatMap` with the right type, instead of Any.

## Testing details

The test is a little bit weird, but I couldn't think of any other way to test this.
