### PR TITLE
Make Exists conform to CustomStringConvertible

### DIFF
--- a/Bow.xcodeproj/project.pbxproj
+++ b/Bow.xcodeproj/project.pbxproj
@@ -382,6 +382,7 @@
 		B5BF5086252B0F4A0060AD0D /* LazyFunction1.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5BF5085252B0F4A0060AD0D /* LazyFunction1.swift */; };
 		B5BF50F7252B24AF0060AD0D /* LazyFunction1Test.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5BF509D252B23D30060AD0D /* LazyFunction1Test.swift */; };
 		B5BF510F252B253D0060AD0D /* LazyFunction1+Gen.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5BF510E252B253D0060AD0D /* LazyFunction1+Gen.swift */; };
+		B5DFCB512553FCD2008D3546 /* Exists+Gen.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5DFCB502553FCD2008D3546 /* Exists+Gen.swift */; };
 		B8B910C0234D7F2600E44271 /* Semiring.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8B910BF234D7F2600E44271 /* Semiring.swift */; };
 		B8B910C4234D846900E44271 /* SemiringLaws.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8B910C3234D846900E44271 /* SemiringLaws.swift */; };
 		B8B910C6234DDA4000E44271 /* BoolInstancesTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8B910C5234DDA4000E44271 /* BoolInstancesTest.swift */; };
@@ -1271,6 +1272,7 @@
 		B5BF5085252B0F4A0060AD0D /* LazyFunction1.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LazyFunction1.swift; sourceTree = "<group>"; };
 		B5BF509D252B23D30060AD0D /* LazyFunction1Test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LazyFunction1Test.swift; sourceTree = "<group>"; };
 		B5BF510E252B253D0060AD0D /* LazyFunction1+Gen.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "LazyFunction1+Gen.swift"; sourceTree = "<group>"; };
+		B5DFCB502553FCD2008D3546 /* Exists+Gen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Exists+Gen.swift"; sourceTree = "<group>"; };
 		B8B910BF234D7F2600E44271 /* Semiring.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Semiring.swift; sourceTree = "<group>"; };
 		B8B910C3234D846900E44271 /* SemiringLaws.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SemiringLaws.swift; sourceTree = "<group>"; };
 		B8B910C5234DDA4000E44271 /* BoolInstancesTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoolInstancesTest.swift; sourceTree = "<group>"; };
@@ -1477,6 +1479,7 @@
 				112097AE22A7EE46007F3D9C /* Either+Gen.swift */,
 				112097CD22A81BE8007F3D9C /* EitherK+Gen.swift */,
 				720C1E0023FD8079001C5B7D /* Endo+Gen.swift */,
+				B5DFCB502553FCD2008D3546 /* Exists+Gen.swift */,
 				11E7F5EB22D8C81B00C78F06 /* Eval+Gen.swift */,
 				112097B422A7F21F007F3D9C /* Id+Gen.swift */,
 				112097B822A7FAF6007F3D9C /* Ior+Gen.swift */,
@@ -2904,6 +2907,7 @@
 				B5618785252CC3EA002717B1 /* Tree+Gen.swift in Sources */,
 				1171ED5423C4E4B0005362E0 /* TracedT+Gen.swift in Sources */,
 				112097D822A90644007F3D9C /* Kleisli+Gen.swift in Sources */,
+				B5DFCB512553FCD2008D3546 /* Exists+Gen.swift in Sources */,
 				720C1E0223FD808F001C5B7D /* Endo+Gen.swift in Sources */,
 				B58B9C1625481DCF008BA4A7 /* Yoneda+Gen.swift in Sources */,
 				112097BB22A7FC86007F3D9C /* NonEmptyArray+Gen.swift in Sources */,

--- a/Sources/Bow/Data/Exists.swift
+++ b/Sources/Bow/Data/Exists.swift
@@ -44,3 +44,15 @@ fileprivate final class ExistsPrivate<F, A>: AnyExistsPrivate<F> {
         f.invoke(fa)
     }
 }
+
+extension Exists: CustomStringConvertible {
+    public var description: String {
+        (fa as! CustomStringConvertible).description
+    }
+}
+
+extension ExistsPrivate: CustomStringConvertible {
+    var description: String {
+        (fa as? CustomStringConvertible)?.description ?? "\(fa)"
+    }
+}

--- a/Sources/Bow/Data/Exists.swift
+++ b/Sources/Bow/Data/Exists.swift
@@ -56,3 +56,15 @@ extension ExistsPrivate: CustomStringConvertible {
         (fa as? CustomStringConvertible)?.description ?? "\(fa)"
     }
 }
+
+extension Exists: CustomDebugStringConvertible {
+    public var debugDescription: String {
+        (fa as! CustomDebugStringConvertible).debugDescription
+    }
+}
+
+extension ExistsPrivate: CustomDebugStringConvertible {
+    var debugDescription: String {
+        (fa as? CustomDebugStringConvertible)?.debugDescription ?? "\(fa)"
+    }
+}

--- a/Tests/BowGenerators/Data/Exists+Gen.swift
+++ b/Tests/BowGenerators/Data/Exists+Gen.swift
@@ -1,0 +1,18 @@
+import Bow
+import SwiftCheck
+
+// MARK: Instance of Arbitrary for Exists
+
+extension Exists: Arbitrary where F: ArbitraryK {
+    public static var arbitrary: Gen<Exists<F>> {
+        Gen.one(of: [
+            KindOf<F, Int>.arbitrary.map { Exists($0.value) },
+            KindOf<F, String>.arbitrary.map { Exists($0.value) },
+            KindOf<F, Function0<Int>>.arbitrary.map { Exists($0.value) },
+            KindOf<F, Function0<String>>.arbitrary.map { Exists($0.value) },
+            KindOf<F, Function1<Int, Int>>.arbitrary.map { Exists($0.value) },
+            KindOf<F, ArrayK<Int>>.arbitrary.map { Exists($0.value) },
+            KindOf<F, Option<Int>>.arbitrary.map { Exists($0.value) },
+        ])
+    }
+}

--- a/Tests/BowTests/Data/ExistsTests.swift
+++ b/Tests/BowTests/Data/ExistsTests.swift
@@ -124,6 +124,25 @@ class ExistsTests: XCTestCase {
         }
     }
 
+    func testCustomDebugStringConvertibleWhenInnerTypeIs() {
+        property("""
+            Description matches inner type's description
+            when the inner type conforms to CustomStringConvertible
+        """) <~ forAll { (array: ArrayK<String>) in
+            return Exists(array).debugDescription == array.debugDescription
+        }
+    }
+
+    func testDebugDescriptionDefaultsToStringInterpolation() {
+        property("""
+            Description defaults to string interpolation
+            when the inner type does not conform to CustomStringConvertible
+        """) <~ forAll { (array: ArrayK<Function0<Int>>) in
+
+            return Exists(array).debugDescription == "\(array)"
+        }
+    }
+
     class F: CokleisliK<ArrayKPartial, Int64> {
         override func invoke<A>(_ fa: ArrayKOf<A>) -> Int64 {
             fa^.count

--- a/Tests/BowTests/Data/ExistsTests.swift
+++ b/Tests/BowTests/Data/ExistsTests.swift
@@ -98,6 +98,32 @@ class ExistsTests: XCTestCase {
         }
     }
 
+    func testCustomStringConvertibleLaws() {
+        CustomStringConvertibleLaws<Exists<ForArrayK>>.check()
+        CustomStringConvertibleLaws<Exists<ForId>>.check()
+        CustomStringConvertibleLaws<Exists<ForOption>>.check()
+    }
+
+    func testDescriptionMatchesInnerTypeDescription() {
+        property("""
+            Description matches inner type's description
+            when the inner type conforms to CustomStringConvertible
+        """) <~ forAll { (array: ArrayK<Int>) in
+            
+            Exists(array).description == array.description
+        }
+    }
+
+    func testDescriptionDefaultsToStringInterpolation() {
+        property("""
+            Description defaults to string interpolation
+            when the inner type does not conform to CustomStringConvertible
+        """) <~ forAll { (array: ArrayK<Function0<Int>>) in
+
+            return Exists(array).description == "\(array)"
+        }
+    }
+
     class F: CokleisliK<ArrayKPartial, Int64> {
         override func invoke<A>(_ fa: ArrayKOf<A>) -> Int64 {
             fa^.count


### PR DESCRIPTION
## Goal

Make `Exists` conform to `CustomStringConvertible` and `CustomDebugStringConvertible`.

## Implementation details

`Exists` might not always be truly `CustomStringConvertible`, because the inner type might not conform to `CustomStringConvertible`.

When `Exists` holds a value of an inner type that is not `CustomStringConvertible` it will use `\(fa)` as description.

For `CustomDebugStringConvertible` the behavior is the same.