### PR TITLE
Remove Kinds from optics

### DIFF
--- a/Sources/BowOptics/AffineTraversal.swift
+++ b/Sources/BowOptics/AffineTraversal.swift
@@ -1,23 +1,8 @@
 import Foundation
 import Bow
 
-/// Witness for the `PAffineTraversal<S, T, A, B>` data type. To be used in simulated Higher Kinded Types.
-public final class ForPAffineTraversal {}
-
-/// Partial application of the PAffineTraversal type constructor, omitting the last parameter.
-public final class PAffineTraversalPartial<S, T, A>: Kind3<ForPAffineTraversal, S, T, A> {}
-
-/// Higher Kinded Type alias to improve readability over `Kind4<ForPAffineTraversal, S, T, A, B>`
-public typealias PAffineTraversalOf<S, T, A, B> = Kind<PAffineTraversalPartial<S, T, A>, B>
-
 /// AffineTraversal is a type alias for `PAffineTraversal` which fixes the type arguments and restricts the `PAffineTraversal` to monomorphic updates.
 public typealias AffineTraversal<S, A> = PAffineTraversal<S, S, A, A>
-
-/// Witness for the `AffineTraversal<S, A>` data type. To be used in simulated Higher Kinded Types.
-public typealias ForAffineTraversal = ForPAffineTraversal
-
-/// Partial application of the AffineTraversal type constructor, omitting the last parameter.
-public typealias AffineTraversalPartial<S> = Kind<ForAffineTraversal, S>
 
 /// An AffineTraversal is an optic that allows to see into a structure and getting, setting or modifying an optional focus.
 ///
@@ -32,7 +17,7 @@ public typealias AffineTraversalPartial<S> = Kind<ForAffineTraversal, S>
 ///     - `T`: Modified source.
 ///     - `A`: Focus.
 ///     - `B`: Modified focus.
-public class PAffineTraversal<S, T, A, B>: PAffineTraversalOf<S, T, A, B> {
+public class PAffineTraversal<S, T, A, B> {
     private let setFunc: (S, B) -> T
     private let getOrModifyFunc: (S) -> Either<T, A>
     

--- a/Sources/BowOptics/Fold.swift
+++ b/Sources/BowOptics/Fold.swift
@@ -1,15 +1,6 @@
 import Foundation
 import Bow
 
-/// Witness for the `Fold<S, A>` data type. To be used in simulated Higher Kinded Types.
-public final class ForFold {}
-
-/// Partial application of the Fold type constructor, omitting the last parameter.
-public final class FoldPartial<S>: Kind<ForFold, S> {}
-
-/// Higher Kinded Type alias to improve readability over `Kind2<ForFold, S, A>`.
-public typealias FoldOf<S, A> = Kind<FoldPartial<S>, A>
-
 /// A Fold is an optic that allows to focus into a structure and get multiple results.
 ///
 /// Fold is a generalization of an instance of `Foldable` and it is implemented in terms of `foldMap`.
@@ -17,7 +8,7 @@ public typealias FoldOf<S, A> = Kind<FoldPartial<S>, A>
 /// Type parameters:
 ///     - `S`: Source.
 ///     - `A`: Focus.
-open class Fold<S, A>: FoldOf<S, A> {
+open class Fold<S, A> {
     /// Creates a Fold that has no focus.
     public static var void: Fold<S, A> {
         return AffineTraversal<S, A>.void.asFold

--- a/Sources/BowOptics/Getter.swift
+++ b/Sources/BowOptics/Getter.swift
@@ -1,15 +1,6 @@
 import Foundation
 import Bow
 
-/// Witness for the `Getter<S, A>` data type. To be used in simulated Higher Kinded Types.
-public final class ForGetter {}
-
-/// Partial application of the Getter type constructor, omitting the last parameter.
-public final class GetterPartial<S>: Kind<ForGetter, S> {}
-
-/// Higher Kinded Type alias to improve readability over `Kind2<ForGetter, S, A>`
-public typealias GetterOf<S, A> = Kind<GetterPartial<S>, A>
-
 /// A `Getter` is an optic that allows to see into a structure and getting a focus.
 ///
 /// It can be seen as a function `(S) -> A` meaning that we can look into an `S` and get an `A`.
@@ -17,7 +8,7 @@ public typealias GetterOf<S, A> = Kind<GetterPartial<S>, A>
 /// Parameters:
 ///     - `S`: source of the `Getter`.
 ///     - `A`: focus of the `Getter`.
-public class Getter<S, A>: GetterOf<S, A> {
+public class Getter<S, A> {
     private let getFunc: (S) -> A
     
     /// Composes a `Getter` with another `Getter`.

--- a/Sources/BowOptics/Iso.swift
+++ b/Sources/BowOptics/Iso.swift
@@ -1,26 +1,8 @@
 import Foundation
 import Bow
 
-/// Witness for the `PIso<S, T, A, B>` data type. To be used in simulated Higher Kinded Types.
-public final class ForPIso {}
-
-/// Partial application of the PIso type constructor, omitting the last parameter.
-public final class PIsoPartial<S, T, A>: Kind3<ForPIso, S, T, A> {}
-
-/// Higher Kinded Type alias to improve readability over Kind4<ForPIso, S, T, A, B>
-public typealias PIsoOf<S, T, A, B> = Kind<PIsoPartial<S, T, A>, B>
-
 /// `Iso` is a type alias for `PIso` which fixes the type arguments and restricts the `PIso` to monomorphic updates.
 public typealias Iso<S, A> = PIso<S, S, A, A>
-
-/// Witness for the `Iso<S, A>`data type. To be used in simulated Higher Kinded Types.
-public typealias ForIso = ForPIso
-
-/// Higher Kinded Type alias to improve readability over Kind4<ForPIso, S, S, A, A>
-public typealias IsoOf<S, A> = PIsoOf<S, S, A, A>
-
-/// Partial application of the Iso type constructor, omitting the last parameter.
-public typealias IsoPartial<S> = Kind<ForIso, S>
 
 /// An Iso is a loss less invertible optic that defines an isomorphism between a type `S` and `A`.
 ///
@@ -30,7 +12,7 @@ public typealias IsoPartial<S> = Kind<ForIso, S>
 /// - `T`: Modified source of a `PIso`.
 /// - `A`: Focus of a `PIso`.
 /// - `B`: Modified target of a `PIso`.
-public class PIso<S, T, A, B>: PIsoOf<S, T, A, B> {
+public class PIso<S, T, A, B> {
     private let getFunc: (S) -> A
     private let reverseGetFunc: (B) -> T
 

--- a/Sources/BowOptics/Lens.swift
+++ b/Sources/BowOptics/Lens.swift
@@ -1,23 +1,8 @@
 import Foundation
 import Bow
 
-/// Witness for the `PLens<S, T, A, B>` data type. To be used in simulated Higher Kinded Types.
-public final class ForPLens {}
-
-/// Partial application of the PLens type constructor, omitting the last parameter.
-public final class PLensPartial<S, T, A>: Kind3<ForPLens, S, T, A> {}
-
-/// Higher Kinded Type alias to improve readability over `Kind4<ForPLens, S, T, A, B>`
-public typealias PLensOf<S, T, A, B> = Kind<PLensPartial<S, T, A>, B>
-
 /// Lens is a type alias for `PLens` which fixes the type arguments and restricts the `PLens` to monomorphic updates.
 public typealias Lens<S, A> = PLens<S, S, A, A>
-
-/// Witness for the `Lens<S, A>` data type. To be used in simulated Higher Kinded Types.
-public typealias ForLens = ForPLens
-
-/// Partial application of the Lens type constructor, omitting the last parameter.
-public typealias LensPartial<S> = Kind<ForLens, S>
 
 /// A Lens (or Functional Reference) is an optic that can focus into a structure for getting, setting or modifying the focus (target).
 ///
@@ -32,7 +17,7 @@ public typealias LensPartial<S> = Kind<ForLens, S>
 ///     - `T` is the modified source of a PLens.
 ///     - `A` is the focus of a PLens.
 ///     - `B` is the modified focus of a PLens.
-public class PLens<S, T, A, B>: PLensOf<S, T, A, B> {
+public class PLens<S, T, A, B> {
     private let getFunc: (S) -> A
     private let setFunc: (S, B) -> T
     

--- a/Sources/BowOptics/Prism.swift
+++ b/Sources/BowOptics/Prism.swift
@@ -1,23 +1,8 @@
 import Foundation
 import Bow
 
-/// Witness for the `PPrism<S, T, A, B>` data type. To be used in simulated Higher Kinded Types.
-public final class ForPPrism {}
-
-/// Partial application of the PPrism type constructor, omitting the last parameter.
-public final class PPrismPartial<S, T, A>: Kind3<ForPPrism, S, T, A> {}
-
-/// Higher Kinded Type alias to improve readability over `Kind4<ForPPrism, S, T, A, B>`.
-public typealias PPrismOf<S, T, A, B> = Kind<PPrismPartial<S, T, A>, B>
-
 /// Prism is a type alias for PPrism which fixes the type arguments and restricts the PPrism to monomorphic updates.
 public typealias Prism<S, A> = PPrism<S, S, A, A>
-
-/// Witness for the `Prism<S, A>` data type. To be used in simulated Higher Kinded Types.
-public typealias ForPrism = ForPPrism
-
-/// Partial application of the `Prism` type constructor, omitting the last parameter.
-public typealias PrismPartial<S> = Kind<ForPrism, S>
 
 /// A Prism is a loss less invertible optic that can look into a structure and optionally find its focus. It is mostly used for finding a focus that is only present under certain conditions, like in a sum type.
 ///
@@ -32,7 +17,7 @@ public typealias PrismPartial<S> = Kind<ForPrism, S>
 ///     - `T`: Modified source.
 ///     - `A`: Focus.
 ///     - `B`: Modified focus.
-public class PPrism<S, T, A, B>: PPrismOf<S, T, A, B> {
+public class PPrism<S, T, A, B> {
     private let getOrModifyFunc: (S) -> Either<T, A>
     private let reverseGetFunc: (B) -> T
 

--- a/Sources/BowOptics/Setter.swift
+++ b/Sources/BowOptics/Setter.swift
@@ -1,23 +1,8 @@
 import Foundation
 import Bow
 
-/// Witness for the `PSetter<S, T, A, B>` data type. To be used in simulated Higher Kinded Types.
-public final class ForPSetter {}
-
-/// Partial application of the PSetter type constructor, omitting the last parameter.
-public final class PSetterPartial<S, T, A>: Kind3<ForPSetter, S, T, A> {}
-
-/// Higher Kinded Type alias to improve readability over `Kind4<ForPSetter, S, T, A, B>`.
-public typealias PSetterOf<S, T, A, B> = Kind<PSetterPartial<S, T, A>, B>
-
 /// Setter is a type alias for `PSetter` which fixes the type arguments and restricts the `PSetter` to monomorphic updates.
 public typealias Setter<S, A> = PSetter<S, S, A, A>
-
-/// Witness for the `Setter<S, A>` data type. To be used in simulated Higher Kinded Types.
-public typealias ForSetter = ForPSetter
-
-/// Higher Kinded Type alias to improve readability over `Kind2<ForSetter, S, A>`.
-public typealias SetterPartial<S> = Kind<ForSetter, S>
 
 /// A Setter is an optic that allows to see into a structure and set or modify its focus.
 ///
@@ -30,7 +15,7 @@ public typealias SetterPartial<S> = Kind<ForSetter, S>
 ///     - `T`: Modified source of the PSetter.
 ///     - `A`: Focus of the PSetter.
 ///     - `B`: Modified focus of the PSetter.
-public class PSetter<S, T, A, B>: PSetterOf<S, T, A, B> {
+public class PSetter<S, T, A, B> {
     private let modifyFunc: (S, @escaping (A) -> B) -> T
     private let setFunc: (S, B) -> T
     

--- a/Sources/BowOptics/Traversal.swift
+++ b/Sources/BowOptics/Traversal.swift
@@ -1,26 +1,8 @@
 import Foundation
 import Bow
 
-/// Witness for the `PTraversal<S, T, A, B>` data type. To be used in simulated Higher Kinded Types.
-public final class ForPTraversal {}
-
-/// Partial application of the PTraversal type constructor, omitting the last parameter.
-public final class PTraversalPartial<S, T, A>: Kind3<ForPTraversal, S, T, A> {}
-
-/// Higher Kinded Type alias to improve readability over Kind4<ForPIso, S, T, A, B>.
-public typealias PTraversalOf<S, T, A, B> = Kind<PTraversalPartial<S, T, A>, B>
-
 /// Traversal is a type alias for PTraversal which fixes the type arguments and restricts the PTraversal to monomorphic updates.
 public typealias Traversal<S, A> = PTraversal<S, S, A, A>
-
-/// Witness for the `Traversal<S, A>` data type. To be used in simulated Higher Kinded Types.
-public typealias ForTraversal = ForPTraversal
-
-/// Higher Kinded Type alias to imprope readability over Kind4<ForPTraversal, S, S, A, A>
-public typealias TraversalOf<S, A> = PTraversalOf<S, S, A, A>
-
-/// Partial application of the Traversal type constructor, omitting the last parameter.
-public typealias TraversalPartial<S> = Kind<ForPTraversal, S>
 
 /// A Traversal is an optic that allows to see into a structure with 0 to N foci.
 ///
@@ -31,9 +13,9 @@ public typealias TraversalPartial<S> = Kind<ForPTraversal, S>
 ///     - `T`: Modified source.
 ///     - `A`: Focus.
 ///     - `B`: Modified focus.
-open class PTraversal<S, T, A, B>: PTraversalOf<S, T, A, B> {
+open class PTraversal<S, T, A, B> {
     
-    /// Modifies the source wiht an `Applicative` function.
+    /// Modifies the source with an `Applicative` function.
     ///
     /// - Parameters:
     ///   - s: Source.


### PR DESCRIPTION
## Goal

Remove Kinds from optics.

## Implementation details

The only necessary change was to remove the boilerplate associated to the declaration of the optics. This was never used and adds an overhead on the optics. As a result, some of the optics (except for Fold and Traversal) can be implemented as structs.
